### PR TITLE
Add TRACK hitbox type and independent vehicle track HP disabling ground movement

### DIFF
--- a/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
+++ b/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
@@ -1,5 +1,5 @@
 package mcheli.aircraft;
 
 public enum EnumBoundingBoxType {
-    DEFAULT, ENGINE, TURRENT
+    DEFAULT, ENGINE, TURRENT, TRACK
 }

--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -40,6 +40,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
       boolean ret = false;
       double dist = 1.0E7D;
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(super.intersectsWith(aabb)) {
          dist = this.getDistSq(aabb, this);
          ret = true;
@@ -57,6 +58,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
 
             ret = true;
@@ -165,6 +167,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
 
    public MovingObjectPosition calculateIntercept(Vec3 v1, Vec3 v2) {
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       MovingObjectPosition mop = super.calculateIntercept(v1, v2);
       double dist = 1.0E7D;
       if(mop != null) {
@@ -183,6 +186,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
                mop = mop2;
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
          }
       }

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -197,6 +197,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public MCH_BoundingBox[] extraBoundingBox;
    //public wheelBoundingBox[] extrawheelboundingbox;
    public float lastBBDamageFactor;
+   public EnumBoundingBoxType lastHitBoundingBoxType;
    private final MCH_AircraftInventory inventory;
    private double fuelConsumption;
    private int fuelSuppliedCount;
@@ -335,6 +336,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //this.extrawheelboundingbox = new wheelBoundingBox[0];
       W_Reflection.setBoundingBox(this, new MCH_AircraftBoundingBox(this));
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       this.inventory = new MCH_AircraftInventory(this);
       this.fuelConsumption = 0.0D;
       this.fuelSuppliedCount = 0;
@@ -1190,6 +1192,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //System.out.println("damage taken: " + getDamageTaken());
       float damageFactor = this.lastBBDamageFactor;
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(this.isEntityInvulnerable()) {
          return false;
       } else if(super.isDead) {

--- a/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
@@ -6,6 +6,7 @@ import mcheli.MCH_Config;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_AircraftInfo;
+import mcheli.aircraft.EnumBoundingBoxType;
 import mcheli.aircraft.MCH_EntityAircraft;
 import mcheli.aircraft.MCH_PacketStatusRequest;
 import mcheli.vehicle.MCH_VehicleInfo;
@@ -27,6 +28,7 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
    public boolean isUsedPlayer;
    public float lastRiderYaw;
    public float lastRiderPitch;
+   private int trackDamageTaken;
 
 
    public MCH_EntityVehicle(World world) {
@@ -41,7 +43,20 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
       this.isUsedPlayer = false;
       this.lastRiderYaw = 0.0F;
       this.lastRiderPitch = 0.0F;
+      this.trackDamageTaken = 0;
       super.weapons = this.createWeapon(0);
+   }
+
+   public int getTrackMaxHP() {
+      return this.vehicleInfo != null?Math.max(1, this.vehicleInfo.trackMaxHP):1;
+   }
+
+   public int getTrackHP() {
+      return Math.max(0, this.getTrackMaxHP() - this.trackDamageTaken);
+   }
+
+   public boolean isTrackDestroyed() {
+      return this.getTrackHP() <= 0;
    }
 
    public String getKindName() {
@@ -84,10 +99,12 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
 
    protected void writeEntityToNBT(NBTTagCompound par1NBTTagCompound) {
       super.writeEntityToNBT(par1NBTTagCompound);
+      par1NBTTagCompound.setInteger("TrackDamage", this.trackDamageTaken);
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
       super.readEntityFromNBT(par1NBTTagCompound);
+      this.trackDamageTaken = Math.max(0, par1NBTTagCompound.getInteger("TrackDamage"));
       if(this.vehicleInfo == null) {
          this.vehicleInfo = MCH_VehicleInfoManager.get(this.getTypeName());
          if(this.vehicleInfo == null) {
@@ -244,6 +261,13 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
 
    protected void onUpdate_ControlOnGround() {
       if(!super.worldObj.isRemote) {
+         if(this.isTrackDestroyed()) {
+            super.throttleUp = false;
+            super.throttleDown = false;
+            this.setCurrentThrottle(0.0D);
+            return;
+         }
+
          boolean move = false;
          float yaw = super.rotationYaw;
          double x = 0.0D;
@@ -281,6 +305,19 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
          }
       }
 
+   }
+
+   public boolean attackEntityFrom(net.minecraft.util.DamageSource damageSource, float damage) {
+      EnumBoundingBoxType hitType = this.lastHitBoundingBoxType;
+      boolean attacked = super.attackEntityFrom(damageSource, damage);
+      if(attacked && !super.worldObj.isRemote && hitType == EnumBoundingBoxType.TRACK && !this.isDestroyed()) {
+         this.trackDamageTaken += Math.max(1, (int)damage);
+         if(this.trackDamageTaken > this.getTrackMaxHP()) {
+            this.trackDamageTaken = this.getTrackMaxHP();
+         }
+      }
+
+      return attacked;
    }
 
    protected void onUpdate_Particle() {

--- a/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
@@ -12,6 +12,7 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
    public MCH_ItemVehicle item = null;
    public boolean isEnableMove = false;
    public boolean isEnableRot = false;
+   public int trackMaxHP = 100;
    public List partList = new ArrayList();
 
 
@@ -49,6 +50,16 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
          super.loadItemData("minrotationpitch", data);
       } else if(item.compareTo("rotationpitchmax") == 0) {
          super.loadItemData("maxrotationpitch", data);
+      } else if(item.equalsIgnoreCase("trackmaxhp")) {
+         this.trackMaxHP = this.toInt(data, 1, 1000000);
+      } else if(item.equalsIgnoreCase("addtrackhitbox")) {
+         String[] s = data.split("\\s*,\\s*");
+         if(s.length >= 5) {
+            float df = s.length >= 6?this.toFloat(s[5]):1.0F;
+            mcheli.aircraft.MCH_BoundingBox bb = new mcheli.aircraft.MCH_BoundingBox((double)this.toFloat(s[0]), (double)this.toFloat(s[1]), (double)this.toFloat(s[2]), this.toFloat(s[3]), this.toFloat(s[4]), df);
+            bb.boundingBoxType = mcheli.aircraft.EnumBoundingBoxType.TRACK;
+            this.extraBoundingBox.add(bb);
+         }
       } else {
          String[] s;
          float rb;


### PR DESCRIPTION
### Motivation
- Introduce dedicated track hitboxes so tracked vehicles can take separate damage to their tracks. 
- Make track damage disable only the tracked-vehicle movement (not necessarily the hull) when track HP reaches zero.
- Expose simple config/TXT parameters to define track hitboxes and per-vehicle track durability.

### Description
- Added `TRACK` to `EnumBoundingBoxType` and a `lastHitBoundingBoxType` field on `MCH_EntityAircraft` so code can tell which hitbox type was struck at collision time (`src/main/java/mcheli/aircraft/EnumBoundingBoxType.java`, `src/main/java/mcheli/aircraft/MCH_EntityAircraft.java`).
- Updated `MCH_AircraftBoundingBox` collision/intercept logic to set `lastHitBoundingBoxType` when an `extraBoundingBox` is the closest hit so downstream damage code can detect `TRACK` hits (`src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java`).
- Extended vehicle config parsing in `MCH_VehicleInfo` with `trackMaxHP` and `addtrackhitbox` (TXT keys `TrackMaxHP` and `AddTrackHitBox`), where `AddTrackHitBox` creates an `MCH_BoundingBox` tagged as `TRACK` (`src/main/java/mcheli/vehicle/MCH_VehicleInfo.java`).
- Added per-vehicle track runtime state to `MCH_EntityVehicle`: `trackDamageTaken`, accessors `getTrackMaxHP()`, `getTrackHP()` and `isTrackDestroyed()`, NBT persistence under key `TrackDamage`, and clamping (`src/main/java/mcheli/vehicle/MCH_EntityVehicle.java`).
- When `isTrackDestroyed()` is true, ground control is disabled in `onUpdate_ControlOnGround()` (throttle forced to 0 and movement inputs ignored), preventing ground movement for that vehicle instance (`src/main/java/mcheli/vehicle/MCH_EntityVehicle.java`).
- Vehicles now increment `trackDamageTaken` (clamped to `TrackMaxHP`) when a hit occurs on a bounding box that was classified as `TRACK`; this is handled by checking `lastHitBoundingBoxType` in an overridden `attackEntityFrom` on `MCH_EntityVehicle` and applying track-only damage independently of hull HP (`src/main/java/mcheli/vehicle/MCH_EntityVehicle.java`).
- Minor cleanup to avoid duplicate assignment when setting hitbox type from the bounding-box loop in `MCH_AircraftBoundingBox`.

### Testing
- Attempted to run `./gradlew compileJava -x test`, but it failed with a local permission error on `gradlew` in this environment; no compile produced.
- Attempted `bash ./gradlew compileJava -x test` to download Gradle, but the wrapper download was blocked by the environment proxy (HTTP 403), so compilation could not be completed.
- No automated tests or successful compilation runs completed in this environment; changes committed but compilation should be validated in a networked/dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a94421c648329a79d17fc52d1081c)