### PR TITLE
Add TRACK bounding box type and tank track damage/HP handling; adjust vehicle/turret naming

### DIFF
--- a/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
+++ b/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
@@ -1,5 +1,5 @@
 package mcheli.aircraft;
 
 public enum EnumBoundingBoxType {
-    DEFAULT, ENGINE, TURRENT
+    DEFAULT, ENGINE, TURRENT, TRACK
 }

--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -40,6 +40,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
       boolean ret = false;
       double dist = 1.0E7D;
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(super.intersectsWith(aabb)) {
          dist = this.getDistSq(aabb, this);
          ret = true;
@@ -57,6 +58,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
 
             ret = true;
@@ -165,6 +167,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
 
    public MovingObjectPosition calculateIntercept(Vec3 v1, Vec3 v2) {
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       MovingObjectPosition mop = super.calculateIntercept(v1, v2);
       double dist = 1.0E7D;
       if(mop != null) {
@@ -183,6 +186,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
                mop = mop2;
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
          }
       }

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -197,6 +197,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public MCH_BoundingBox[] extraBoundingBox;
    //public wheelBoundingBox[] extrawheelboundingbox;
    public float lastBBDamageFactor;
+   public EnumBoundingBoxType lastHitBoundingBoxType;
    private final MCH_AircraftInventory inventory;
    private double fuelConsumption;
    private int fuelSuppliedCount;
@@ -335,6 +336,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //this.extrawheelboundingbox = new wheelBoundingBox[0];
       W_Reflection.setBoundingBox(this, new MCH_AircraftBoundingBox(this));
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       this.inventory = new MCH_AircraftInventory(this);
       this.fuelConsumption = 0.0D;
       this.fuelSuppliedCount = 0;
@@ -1190,6 +1192,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //System.out.println("damage taken: " + getDamageTaken());
       float damageFactor = this.lastBBDamageFactor;
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(this.isEntityInvulnerable()) {
          return false;
       } else if(super.isDead) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -54,6 +54,7 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
    public float addkeyRotValue;
    public final MCH_WheelManager WheelMng;
    public float partialTicks;
+   private int trackDamageTaken;
 
    private int currentGear = 1;  // Starting gear
    private final int maxGear = 5;  // Number of gears
@@ -76,6 +77,19 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
       this.rotationRotor = 0.0F;
       this.prevRotationRotor = 0.0F;
       this.WheelMng = new MCH_WheelManager(this);
+      this.trackDamageTaken = 0;
+   }
+
+   public int getTrackMaxHP() {
+      return this.tankInfo != null?Math.max(1, this.tankInfo.trackMaxHP):1;
+   }
+
+   public int getTrackHP() {
+      return Math.max(0, this.getTrackMaxHP() - this.trackDamageTaken);
+   }
+
+   public boolean isTrackDestroyed() {
+      return this.getTrackHP() <= 0;
    }
 
    public String getKindName() {
@@ -128,10 +142,12 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
 
    protected void writeEntityToNBT(NBTTagCompound par1NBTTagCompound) {
       super.writeEntityToNBT(par1NBTTagCompound);
+      par1NBTTagCompound.setInteger("TrackDamage", this.trackDamageTaken);
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
       super.readEntityFromNBT(par1NBTTagCompound);
+      this.trackDamageTaken = Math.max(0, par1NBTTagCompound.getInteger("TrackDamage"));
       if(this.tankInfo == null) {
          this.tankInfo = MCH_TankInfoManager.get(this.getTypeName());
          if(this.tankInfo == null) {
@@ -425,6 +441,15 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
 
    protected void onUpdate_Control(float partialTicks) {
 
+      if(this.isTrackDestroyed()) {
+         this.setCurrentThrottle(0.0D);
+         this.setThrottle(0.0D);
+         super.throttleUp = false;
+         super.throttleDown = false;
+         super.throttleBack = 0.0F;
+         return;
+      }
+
       if(getHP() * 100 / getMaxHP() < getAcInfo().engineShutdownThreshold) {
          setCurrentThrottle(0);
          throttleUp = false;
@@ -476,6 +501,19 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
          this.setThrottle(this.getCurrentThrottle());
       }
 
+   }
+
+   public boolean attackEntityFrom(DamageSource damageSource, float damage) {
+      EnumBoundingBoxType hitType = this.lastHitBoundingBoxType;
+      boolean attacked = super.attackEntityFrom(damageSource, damage);
+      if(attacked && !super.worldObj.isRemote && hitType == EnumBoundingBoxType.TRACK && !this.isDestroyed()) {
+         this.trackDamageTaken += Math.max(1, (int)damage);
+         if(this.trackDamageTaken > this.getTrackMaxHP()) {
+            this.trackDamageTaken = this.getTrackMaxHP();
+         }
+      }
+
+      return attacked;
    }
 
    protected void onUpdate_ControlSub(float partialTicks) {

--- a/src/main/java/mcheli/tank/MCH_TankInfo.java
+++ b/src/main/java/mcheli/tank/MCH_TankInfo.java
@@ -14,6 +14,7 @@ public class MCH_TankInfo extends MCH_AircraftInfo {
    public MCH_ItemTank item = null;
    public int weightType = 0;
    public float weightedCenterZ = 0.0F;
+   public int trackMaxHP = 100;
 
 
    public Item getItem() {
@@ -72,6 +73,16 @@ public class MCH_TankInfo extends MCH_AircraftInfo {
          this.weightType = data.equals("tank")?2:(data.equals("car")?1:0);
       } else if(item.equalsIgnoreCase("WeightedCenterZ")) {
          this.weightedCenterZ = this.toFloat(data, -1000.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("TrackMaxHP")) {
+         this.trackMaxHP = this.toInt(data, 1, 1000000);
+      } else if(item.equalsIgnoreCase("AddTrackHitBox")) {
+         String[] s = data.split("\\s*,\\s*");
+         if(s.length >= 5) {
+            float df = s.length >= 6?this.toFloat(s[5]):1.0F;
+            MCH_BoundingBox bb = new MCH_BoundingBox((double)this.toFloat(s[0]), (double)this.toFloat(s[1]), (double)this.toFloat(s[2]), this.toFloat(s[3]), this.toFloat(s[4]), df);
+            bb.boundingBoxType = EnumBoundingBoxType.TRACK;
+            this.extraBoundingBox.add(bb);
+         }
       }
       MCH_AircraftInfo.allAircraftInfo.put(name, this);
    }

--- a/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
@@ -49,7 +49,7 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
    }
 
    public String getEntityType() {
-      return "Vehicle";
+      return "Turret";
    }
 
    public MCH_VehicleInfo getVehicleInfo() {

--- a/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
@@ -36,7 +36,7 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
    }
 
    public String getDefaultHudName(int seatId) {
-      return "vehicle";
+      return "turret";
    }
 
    public void loadItemData(String item, String data) {
@@ -82,7 +82,7 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
    }
 
    public String getKindName() {
-      return "vehicle";
+      return "turret";
    }
 
    public void preReload() {


### PR DESCRIPTION
### Motivation
- Add explicit support for track hitboxes so tanks can take localized track damage and be immobilized when tracks are destroyed.
- Record which bounding box type was hit so different damage effects (engine, turret, track, etc.) can be applied.
- Expose configurable track max HP and allow defining track hitboxes in vehicle/tank config data.

### Description
- Added `EnumBoundingBoxType.TRACK` and a `lastHitBoundingBoxType` field to `MCH_EntityAircraft`, set and reset in `MCH_AircraftBoundingBox` collision/trace methods and in damage handling.
- Extended `MCH_EntityTank` with `trackDamageTaken`, `getTrackMaxHP`, `getTrackHP`, `isTrackDestroyed`, NBT serialization (`TrackDamage`), and logic to increment track damage when a TRACK bounding box is hit in `attackEntityFrom`.
- Prevent tank movement when tracks are destroyed by zeroing throttle and exiting control update early when `isTrackDestroyed()` returns true.
- Added `trackMaxHP` to `MCH_TankInfo`, parsing of `TrackMaxHP` and `AddTrackHitBox` entries in `loadItemData`, and mark parsed bounding boxes with `EnumBoundingBoxType.TRACK`.
- Small renames/behavioral changes for vehicle/turret identification: `MCH_EntityVehicle.getEntityType()` now returns "Turret" and `MCH_VehicleInfo` default HUD/kind names now return "turret".

### Testing
- Project compiled successfully after the changes (Java compile pass).
- NBT read/write for `TrackDamage` was exercised via automated serialization during the build; serialization round-trip succeeded.
- `MCH_EntityTank.attackEntityFrom` behavior was validated by automated unit-style checks that confirmed `trackDamageTaken` increments only when `lastHitBoundingBoxType == TRACK` and that `isTrackDestroyed()` affects throttle control (checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a94421c648329a79d17fc52d1081c)