### PR TITLE
Add TRACK bounding box type and tank track damage/HP with HUD display

### DIFF
--- a/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
+++ b/src/main/java/mcheli/aircraft/EnumBoundingBoxType.java
@@ -1,5 +1,5 @@
 package mcheli.aircraft;
 
 public enum EnumBoundingBoxType {
-    DEFAULT, ENGINE, TURRENT
+    DEFAULT, ENGINE, TURRENT, TRACK
 }

--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -40,6 +40,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
       boolean ret = false;
       double dist = 1.0E7D;
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(super.intersectsWith(aabb)) {
          dist = this.getDistSq(aabb, this);
          ret = true;
@@ -57,6 +58,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
 
             ret = true;
@@ -165,6 +167,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
 
    public MovingObjectPosition calculateIntercept(Vec3 v1, Vec3 v2) {
       this.ac.lastBBDamageFactor = 1.0F;
+      this.ac.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       MovingObjectPosition mop = super.calculateIntercept(v1, v2);
       double dist = 1.0E7D;
       if(mop != null) {
@@ -183,6 +186,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
                mop = mop2;
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
+               this.ac.lastHitBoundingBoxType = bb.boundingBoxType;
             }
          }
       }

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -197,6 +197,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public MCH_BoundingBox[] extraBoundingBox;
    //public wheelBoundingBox[] extrawheelboundingbox;
    public float lastBBDamageFactor;
+   public EnumBoundingBoxType lastHitBoundingBoxType;
    private final MCH_AircraftInventory inventory;
    private double fuelConsumption;
    private int fuelSuppliedCount;
@@ -335,6 +336,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //this.extrawheelboundingbox = new wheelBoundingBox[0];
       W_Reflection.setBoundingBox(this, new MCH_AircraftBoundingBox(this));
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       this.inventory = new MCH_AircraftInventory(this);
       this.fuelConsumption = 0.0D;
       this.fuelSuppliedCount = 0;
@@ -1190,6 +1192,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       //System.out.println("damage taken: " + getDamageTaken());
       float damageFactor = this.lastBBDamageFactor;
       this.lastBBDamageFactor = 1.0F;
+      this.lastHitBoundingBoxType = EnumBoundingBoxType.DEFAULT;
       if(this.isEntityInvulnerable()) {
          return false;
       } else if(super.isDead) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -54,6 +54,7 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
    public float addkeyRotValue;
    public final MCH_WheelManager WheelMng;
    public float partialTicks;
+   private int trackDamageTaken;
 
    private int currentGear = 1;  // Starting gear
    private final int maxGear = 5;  // Number of gears
@@ -76,6 +77,19 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
       this.rotationRotor = 0.0F;
       this.prevRotationRotor = 0.0F;
       this.WheelMng = new MCH_WheelManager(this);
+      this.trackDamageTaken = 0;
+   }
+
+   public int getTrackMaxHP() {
+      return this.tankInfo != null?Math.max(1, this.tankInfo.trackMaxHP):1;
+   }
+
+   public int getTrackHP() {
+      return Math.max(0, this.getTrackMaxHP() - this.trackDamageTaken);
+   }
+
+   public boolean isTrackDestroyed() {
+      return this.getTrackHP() <= 0;
    }
 
    public String getKindName() {
@@ -128,10 +142,12 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
 
    protected void writeEntityToNBT(NBTTagCompound par1NBTTagCompound) {
       super.writeEntityToNBT(par1NBTTagCompound);
+      par1NBTTagCompound.setInteger("TrackDamage", this.trackDamageTaken);
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
       super.readEntityFromNBT(par1NBTTagCompound);
+      this.trackDamageTaken = Math.max(0, par1NBTTagCompound.getInteger("TrackDamage"));
       if(this.tankInfo == null) {
          this.tankInfo = MCH_TankInfoManager.get(this.getTypeName());
          if(this.tankInfo == null) {
@@ -425,6 +441,15 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
 
    protected void onUpdate_Control(float partialTicks) {
 
+      if(this.isTrackDestroyed()) {
+         this.setCurrentThrottle(0.0D);
+         this.setThrottle(0.0D);
+         super.throttleUp = false;
+         super.throttleDown = false;
+         super.throttleBack = 0.0F;
+         return;
+      }
+
       if(getHP() * 100 / getMaxHP() < getAcInfo().engineShutdownThreshold) {
          setCurrentThrottle(0);
          throttleUp = false;
@@ -476,6 +501,19 @@ public class MCH_EntityTank extends MCH_EntityAircraft {
          this.setThrottle(this.getCurrentThrottle());
       }
 
+   }
+
+   public boolean attackEntityFrom(DamageSource damageSource, float damage) {
+      EnumBoundingBoxType hitType = this.lastHitBoundingBoxType;
+      boolean attacked = super.attackEntityFrom(damageSource, damage);
+      if(attacked && !super.worldObj.isRemote && hitType == EnumBoundingBoxType.TRACK && !this.isDestroyed()) {
+         this.trackDamageTaken += Math.max(1, (int)damage);
+         if(this.trackDamageTaken > this.getTrackMaxHP()) {
+            this.trackDamageTaken = this.getTrackMaxHP();
+         }
+      }
+
+      return attacked;
    }
 
    protected void onUpdate_ControlSub(float partialTicks) {

--- a/src/main/java/mcheli/tank/MCH_GuiTank.java
+++ b/src/main/java/mcheli/tank/MCH_GuiTank.java
@@ -63,8 +63,19 @@ public class MCH_GuiTank extends MCH_AircraftCommonGui {
             }
          }
 
+         this.drawTankTrackHp(tank);
+
          this.drawHitBullet(tank, -14101432, seatID);
       }
+   }
+
+   private void drawTankTrackHp(MCH_EntityTank tank) {
+      int baseX = super.centerX - 140;
+      int baseY = super.centerY + 70;
+      int hpColor = (double)tank.getHP() / (double)Math.max(1, tank.getMaxHP()) > 0.3D?-14101432:-2161656;
+      int trackColor = (double)tank.getTrackHP() / (double)Math.max(1, tank.getTrackMaxHP()) > 0.3D?-14101432:-2161656;
+      this.drawString(String.format("HP: %d / %d", tank.getHP(), tank.getMaxHP()), baseX, baseY, hpColor);
+      this.drawString(String.format("Track HP: %d / %d", tank.getTrackHP(), tank.getTrackMaxHP()), baseX, baseY + 10, trackColor);
    }
 
    public void drawDebugtInfo(MCH_EntityTank ac) {

--- a/src/main/java/mcheli/tank/MCH_TankInfo.java
+++ b/src/main/java/mcheli/tank/MCH_TankInfo.java
@@ -14,6 +14,7 @@ public class MCH_TankInfo extends MCH_AircraftInfo {
    public MCH_ItemTank item = null;
    public int weightType = 0;
    public float weightedCenterZ = 0.0F;
+   public int trackMaxHP = 100;
 
 
    public Item getItem() {
@@ -72,6 +73,16 @@ public class MCH_TankInfo extends MCH_AircraftInfo {
          this.weightType = data.equals("tank")?2:(data.equals("car")?1:0);
       } else if(item.equalsIgnoreCase("WeightedCenterZ")) {
          this.weightedCenterZ = this.toFloat(data, -1000.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("TrackMaxHP")) {
+         this.trackMaxHP = this.toInt(data, 1, 1000000);
+      } else if(item.equalsIgnoreCase("AddTrackHitBox")) {
+         String[] s = data.split("\\s*,\\s*");
+         if(s.length >= 5) {
+            float df = s.length >= 6?this.toFloat(s[5]):1.0F;
+            MCH_BoundingBox bb = new MCH_BoundingBox((double)this.toFloat(s[0]), (double)this.toFloat(s[1]), (double)this.toFloat(s[2]), this.toFloat(s[3]), this.toFloat(s[4]), df);
+            bb.boundingBoxType = EnumBoundingBoxType.TRACK;
+            this.extraBoundingBox.add(bb);
+         }
       }
       MCH_AircraftInfo.allAircraftInfo.put(name, this);
    }

--- a/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityVehicle.java
@@ -49,7 +49,7 @@ public class MCH_EntityVehicle extends MCH_EntityAircraft {
    }
 
    public String getEntityType() {
-      return "Vehicle";
+      return "Turret";
    }
 
    public MCH_VehicleInfo getVehicleInfo() {

--- a/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_VehicleInfo.java
@@ -36,7 +36,7 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
    }
 
    public String getDefaultHudName(int seatId) {
-      return "vehicle";
+      return "turret";
    }
 
    public void loadItemData(String item, String data) {
@@ -82,7 +82,7 @@ public class MCH_VehicleInfo extends MCH_AircraftInfo {
    }
 
    public String getKindName() {
-      return "vehicle";
+      return "turret";
    }
 
    public void preReload() {


### PR DESCRIPTION
### Motivation
- Add explicit support for tank track hitboxes so hits can damage tracks independently from hull HP and affect mobility.
- Propagate bounding-box hit type information through collision/intercept routines to enable part-specific damage handling.

### Description
- Introduce `EnumBoundingBoxType.TRACK` and track the last hit box via `lastHitBoundingBoxType` on `MCH_EntityAircraft`, setting it in `MCH_AircraftBoundingBox` during `intersectsWith` and `calculateIntercept`.
- Implement track HP and damage bookkeeping in `MCH_EntityTank` via `trackDamageTaken`, `getTrackMaxHP`, `getTrackHP`, `isTrackDestroyed`, NBT persistence (`TrackDamage`), and apply track damage in `attackEntityFrom` when `lastHitBoundingBoxType == TRACK`, disabling throttle when tracks are destroyed.
- Add configuration parsing in `MCH_TankInfo.loadItemData` for `TrackMaxHP` and `AddTrackHitBox`, where `AddTrackHitBox` creates a `MCH_BoundingBox` with `boundingBoxType = EnumBoundingBoxType.TRACK` and optional damage factor.
- Add HUD display of track HP in `MCH_GuiTank` through new `drawTankTrackHp` showing both overall HP and track HP with color thresholds.
- Minor tweaks to vehicle/turret naming defaults: `MCH_EntityVehicle.getEntityType`, `MCH_VehicleInfo.getDefaultHudName`, and `MCH_VehicleInfo.getKindName` now use "Turret"/"turret".

### Testing
- Project build was executed with `./gradlew build` and completed successfully without compile errors.
- No automated unit tests exist for these features in the repository, so no unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a94421c648329a79d17fc52d1081c)