### PR TITLE
UAV: add runtime registry, persistent pilot inventory, station linking and ammo transfer

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -16,6 +16,8 @@ import mcheli.aircraft.MCH_EntityAircraft;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.aircraft.MCH_ItemAircraft;
 import mcheli.aircraft.MCH_PacketAircraftLocation;
+import mcheli.uav.MCH_UavInventory;
+import mcheli.uav.MCH_UavRegistry;
 import mcheli.chain.MCH_ItemChain;
 import mcheli.command.MCH_Command;
 import mcheli.lweapon.MCH_ItemLightWeaponBase;
@@ -31,6 +33,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
@@ -185,6 +188,23 @@ public class MCH_EventHook extends W_EventHook {
  //     }
  //  }
 
+   @SubscribeEvent
+   public void onLivingDeathEvent(LivingDeathEvent event) {
+      if(event.entity instanceof EntityPlayerMP) {
+         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.entity, "player_death");
+      }
+   }
+
+   @SubscribeEvent
+   public void onPlayerTick(TickEvent.PlayerTickEvent event) {
+      if(event.phase == TickEvent.Phase.END && event.player instanceof EntityPlayerMP && !event.player.worldObj.isRemote) {
+         if(MCH_UavInventory.hasStoredPilotInventory(event.player) && !(event.player.ridingEntity instanceof MCH_EntityAircraft)) {
+            MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.player, "not_piloting");
+         }
+      }
+   }
+
+
 
 
    public void entitySpawn(EntityJoinWorldEvent event) {
@@ -209,6 +229,9 @@ public class MCH_EventHook extends W_EventHook {
          //   }
          //}
          MCH_EntityAircraft b = (MCH_EntityAircraft)event.entity;
+         if(!event.world.isRemote && (b.isUAV() || b.isNewUAV())) {
+            MCH_UavRegistry.register(b);
+         }
          if(!b.worldObj.isRemote && !b.isCreatedSeats()) {
             b.createSeats(UUID.randomUUID().toString());
          }
@@ -237,6 +260,10 @@ public class MCH_EventHook extends W_EventHook {
          if(!e.worldObj.isRemote && event.entity instanceof EntityPlayerMP) {
             MCH_Lib.DbgLog(false, "EntityJoinWorldEvent:" + event.entity, new Object[0]);
             MCH_PacketNotifyServerSettings.send((EntityPlayerMP)event.entity);
+            MCH_UavRegistry.rebuildUavRegistry(event.entity.worldObj);
+            if(MCH_UavInventory.hasStoredPilotInventory((EntityPlayer)event.entity)) {
+               MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.entity, "player_join");
+            }
          }
       }
 
@@ -281,7 +308,6 @@ public class MCH_EventHook extends W_EventHook {
            if (ac != null &&
                      ac.getAcInfo() != null) {
                if (ac.isNewUAV()) {
-                  System.out.println("new uav in eventhook");
                      event.setCanceled(true);
                      return;
                    }

--- a/src/main/java/mcheli/aircraft/MCH_AircraftGuiContainer.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftGuiContainer.java
@@ -64,7 +64,7 @@ extends Container {
         if (this.aircraft.getGuiInventory().isUseableByPlayer(player)) {
             return true;
         }
-        if (this.aircraft.isUAV() && (us = this.aircraft.getUavStation()) != null) {
+        if ((this.aircraft.isUAV() || this.aircraft.isNewUAV()) && (us = this.aircraft.getUavStation()) != null) {
             double x = us.posX + (double)us.posUavX;
             double z = us.posZ + (double)us.posUavZ;
             if (this.aircraft.posX < x + 10.0 && this.aircraft.posX > x - 10.0 && this.aircraft.posZ < z + 10.0 && this.aircraft.posZ > z - 10.0) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -22,6 +22,8 @@ import mcheli.particles.MCH_ParticlesUtil;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.tank.MCH_EntityTank;
 import mcheli.uav.MCH_EntityUavStation;
+import mcheli.uav.MCH_UavInventory;
+import mcheli.uav.MCH_UavRegistry;
 import mcheli.weapon.*;
 import mcheli.wrapper.*;
 import net.minecraft.block.Block;
@@ -240,6 +242,13 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public EntityPlayer storedRider;
 
    public String newUavPlayerUUID;
+   private int delayedUavInventoryTicks;
+   private UUID uavOwnerUUID;
+   private UUID linkedUavStationUUID;
+   private int linkedUavStationDimension;
+   private double linkedUavStationX;
+   private double linkedUavStationY;
+   private double linkedUavStationZ;
    //public static boolean isNewUAV = MCH_AircraftInfo.isNewUAV;
    //public static Entity rider = lastRidingEntity;
    //MCH_EntityAircraft MCH_EntityUavStation;
@@ -318,6 +327,13 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.setDespawnCount(0);
       this.missileDetector = new MCH_MissileDetector(this, world);
       this.uavStation = null;
+      this.delayedUavInventoryTicks = 0;
+      this.uavOwnerUUID = null;
+      this.linkedUavStationUUID = null;
+      this.linkedUavStationDimension = 0;
+      this.linkedUavStationX = 0.0D;
+      this.linkedUavStationY = 0.0D;
+      this.linkedUavStationZ = 0.0D;
       this.modeSwitchCooldown = 0;
       this.partHatch = null;
       this.partCanopy = null;
@@ -539,14 +555,47 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public void setUavStation(MCH_EntityUavStation uavSt) {
       this.uavStation = uavSt;
+      if(uavSt != null) {
+         this.linkedUavStationUUID = uavSt.getUniqueID();
+         this.linkedUavStationDimension = uavSt.dimension;
+         this.linkedUavStationX = uavSt.posX;
+         this.linkedUavStationY = uavSt.posY;
+         this.linkedUavStationZ = uavSt.posZ;
+         this.UavStationPosX = MathHelper.floor_double(uavSt.posX);
+         this.UavStationPosY = MathHelper.floor_double(uavSt.posY);
+         this.UavStationPosZ = MathHelper.floor_double(uavSt.posZ);
+         if(uavSt.getOwnerUUID() != null) {
+            this.setOwnerUUID(uavSt.getOwnerUUID());
+         }
+      }
       if(!super.worldObj.isRemote) {
          if(uavSt != null) {
             this.getDataWatcher().updateObject(22, Integer.valueOf(W_Entity.getEntityId(uavSt)));
+            MCH_UavRegistry.register(this);
          } else {
             this.getDataWatcher().updateObject(22, Integer.valueOf(0));
          }
       }
 
+   }
+
+   public UUID getOwnerUUID() {
+      return this.uavOwnerUUID;
+   }
+
+   public void setOwnerUUID(UUID uuid) {
+      this.uavOwnerUUID = uuid;
+      if(uuid != null && !super.worldObj.isRemote) {
+         MCH_UavRegistry.register(this);
+      }
+   }
+
+   public UUID getLinkedUavStationUUID() {
+      return this.linkedUavStationUUID;
+   }
+
+   public boolean isLinkedToStation(MCH_EntityUavStation station) {
+      return station != null && this.linkedUavStationUUID != null && this.linkedUavStationUUID.equals(station.getUniqueID());
    }
 
    public float getStealth() {
@@ -565,7 +614,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public MCH_EntityUavStation getUavStation() {
-      System.out.println("getUavStation() called, isUAV: " + isUAV() + ", isNewUAV: " + isNewUAV() + ", uavStation: " + this.uavStation);
       return (isUAV() || isNewUAV()) ? this.uavStation : null;
       //todone store uav pos, not here! in updatecontrol.
          }
@@ -785,33 +833,16 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       if (getRiddenByEntity() != null) {
          if (isUAV()) {
-            System.out.println("is normal UAV");
             // For normal UAVs, perform the standard dismount.
             Entity rider = getRiddenByEntity();
             if (rider != null) {
                rider.mountEntity(null);
             }
          } else if (isNewUAV()) {
-            System.out.println("New UAV detected, performing special dismount logic.");
             Entity rider = getRiddenByEntity();
             if (rider instanceof EntityPlayer) {
                EntityPlayer player = (EntityPlayer) rider;
-                  System.out.println("Calling unmountEntity() for new UAV.");
                   this.unmountEntity(); // ← this triggers the correct logic and teleport
-
-               System.out.println("UavStationPos: " +
-                       this.UavStationPosX + ", " +
-                       this.UavStationPosY + ", " +
-                       this.UavStationPosZ);
-
-               System.out.println("storedStationPos: " +
-                       storedStationX + ", " +
-                       storedStationY + ", " +
-                       storedStationZ);
-
-               System.out.println("aircraftxyz " + aircraftX + ", " +
-                       aircraftY + ", " +
-                       aircraftZ + ", ");
 
                //System.out.println("uavposxyz" + MCH_EntityUavStation.posUavX + ", " +
                //        super.posY + ", " +
@@ -1143,6 +1174,18 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       this.dismountedUserCtrl = nbt.getBoolean("AcDismounted");
+      this.uavOwnerUUID = parseUUID(nbt.getString("MCH_UavOwnerUUID"));
+      this.linkedUavStationUUID = parseUUID(nbt.getString("MCH_UavStationUUID"));
+      this.linkedUavStationDimension = nbt.getInteger("MCH_UavStationDim");
+      this.linkedUavStationX = nbt.getDouble("MCH_UavStationX");
+      this.linkedUavStationY = nbt.getDouble("MCH_UavStationY");
+      this.linkedUavStationZ = nbt.getDouble("MCH_UavStationZ");
+      this.UavStationPosX = MathHelper.floor_double(this.linkedUavStationX);
+      this.UavStationPosY = MathHelper.floor_double(this.linkedUavStationY);
+      this.UavStationPosZ = MathHelper.floor_double(this.linkedUavStationZ);
+      if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
+         MCH_UavRegistry.register(this);
+      }
    }
 
    protected void writeEntityToNBT(NBTTagCompound nbt) {
@@ -1171,6 +1214,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       nbt.setTag("AcWeaponsAmmo", W_NBTTag.newTagIntArray("AcWeaponsAmmo", wa_list));
       nbt.setInteger("AcDamage", this.getDamageTaken());
       nbt.setBoolean("AcDismounted", this.dismountedUserCtrl);
+      nbt.setString("MCH_UavOwnerUUID", this.uavOwnerUUID == null ? "" : this.uavOwnerUUID.toString());
+      nbt.setString("MCH_UavStationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
+      nbt.setInteger("MCH_UavStationDim", this.linkedUavStationDimension);
+      nbt.setDouble("MCH_UavStationX", this.linkedUavStationX);
+      nbt.setDouble("MCH_UavStationY", this.linkedUavStationY);
+      nbt.setDouble("MCH_UavStationZ", this.linkedUavStationZ);
    }
 
    public boolean attackEntityFrom(DamageSource damageSource, float org_damage) {
@@ -2359,15 +2408,34 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
    }
 
+
+   private void updateDelayedUavInventoryStore() {
+      if(super.worldObj.isRemote || !this.isNewUAV()) {
+         return;
+      }
+      Entity rider = super.riddenByEntity;
+      if(rider instanceof EntityPlayerMP) {
+         ++this.delayedUavInventoryTicks;
+         if(this.delayedUavInventoryTicks == 200) {
+            MCH_UavInventory.storeAndClearPilotInventory((EntityPlayerMP)rider, this.getUniqueID().toString());
+         }
+      } else {
+         this.delayedUavInventoryTicks = 0;
+      }
+   }
+
    public void updateControl() {
       if(!super.worldObj.isRemote) {
+         updateDelayedUavInventoryStore();
 
          if (this.uavStation != null) {
             //this fires before we have successfully binded to UAV.
             UavStationPosX = (int) this.uavStation.posX;
             UavStationPosY = (int) this.uavStation.posY;
             UavStationPosZ = (int) this.uavStation.posZ;
-            System.out.println("[MCH] UAV Station Position: " + UavStationPosX + ", " + UavStationPosY + ", " + UavStationPosZ);
+            if(this.isNewUAV()) {
+               this.uavStation.updateLinkedUavPosition(this);
+            }
          }
          //don't do that in updatecontrol, uav station might be unloaded during update control
          //actually wait, let's see what it's printing
@@ -3191,6 +3259,107 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          --this.supplyAmmoWait;
       }
 
+   }
+
+
+   public boolean canAcceptAmmo(ItemStack stack) {
+      return this.getAmmoSpaceRemaining(stack) > 0;
+   }
+
+   public int getAmmoSpaceRemaining(ItemStack stack) {
+      if(stack == null || stack.stackSize <= 0 || this.getWeaponNum() <= 0) {
+         return 0;
+      }
+      int space = 0;
+      for(int wid = 0; wid < this.getWeaponNum(); ++wid) {
+         MCH_WeaponSet ws = this.getWeapon(wid);
+         if(ws != null && isRoundItemForWeapon(ws, stack)) {
+            int weaponSpace = ws.getAllAmmoNum() - (ws.getRestAllAmmoNum() + ws.getAmmoNum());
+            if(weaponSpace > 0) {
+               space += weaponSpace;
+            }
+         }
+      }
+      return space;
+   }
+
+   public int trySupplyAmmoFromStack(ItemStack stack, EntityPlayer player) {
+      if(super.worldObj.isRemote || stack == null || stack.stackSize <= 0 || this.isDestroyed()) {
+         return 0;
+      }
+
+      int consumed = 0;
+      for(int wid = 0; wid < this.getWeaponNum() && stack.stackSize > 0; ++wid) {
+         MCH_WeaponSet ws = this.getWeapon(wid);
+         int used = trySupplyAmmoToWeapon(ws, stack);
+         if(used > 0) {
+            consumed += used;
+            if(ws.getAmmoNum() <= 0) {
+               ws.reloadMag();
+            }
+            MCH_PacketNotifyAmmoNum.sendAmmoNum(this, player, wid);
+         }
+      }
+
+      if(consumed > 0) {
+         MCH_PacketNotifyAmmoNum.sendAllAmmoNum(this, player);
+      }
+      return consumed;
+   }
+
+   private int trySupplyAmmoToWeapon(MCH_WeaponSet ws, ItemStack stack) {
+      if(ws == null || stack == null || ws.getInfo() == null || ws.getInfo().roundItems == null || ws.getInfo().roundItems.size() != 1) {
+         return 0;
+      }
+      int space = ws.getAllAmmoNum() - (ws.getRestAllAmmoNum() + ws.getAmmoNum());
+      if(space <= 0) {
+         return 0;
+      }
+
+      Iterator i$ = ws.getInfo().roundItems.iterator();
+      while(i$.hasNext()) {
+         MCH_WeaponInfo.RoundItem ri = (MCH_WeaponInfo.RoundItem)i$.next();
+         if(ri != null && ri.itemStack != null && stack.isItemEqual(ri.itemStack)) {
+            int itemCost = ri.num <= 0 ? 1 : ri.num;
+            int supplied = ws.getInfo().suppliedNum <= 0 ? 1 : ws.getInfo().suppliedNum;
+            int packages = stack.stackSize / itemCost;
+            if(packages <= 0) {
+               return 0;
+            }
+            int packagesNeeded = (space + supplied - 1) / supplied;
+            if(packages > packagesNeeded) {
+               packages = packagesNeeded;
+            }
+            int ammoToAdd = packages * supplied;
+            if(ammoToAdd > space) {
+               ammoToAdd = space;
+            }
+            int before = ws.getRestAllAmmoNum() + ws.getAmmoNum();
+            ws.setRestAllAmmoNum(ws.getRestAllAmmoNum() + ammoToAdd);
+            int after = ws.getRestAllAmmoNum() + ws.getAmmoNum();
+            if(after > before) {
+               int consumed = packages * itemCost;
+               stack.stackSize -= consumed;
+               return consumed;
+            }
+            return 0;
+         }
+      }
+      return 0;
+   }
+
+   private boolean isRoundItemForWeapon(MCH_WeaponSet ws, ItemStack stack) {
+      if(ws == null || stack == null || ws.getInfo() == null || ws.getInfo().roundItems == null || ws.getInfo().roundItems.size() != 1) {
+         return false;
+      }
+      Iterator i$ = ws.getInfo().roundItems.iterator();
+      while(i$.hasNext()) {
+         MCH_WeaponInfo.RoundItem ri = (MCH_WeaponInfo.RoundItem)i$.next();
+         if(ri != null && ri.itemStack != null && stack.isItemEqual(ri.itemStack)) {
+            return true;
+         }
+      }
+      return false;
    }
 
    public void supplyAmmo(int weaponID) {
@@ -4541,11 +4710,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public void onUnmountPlayerSeat(MCH_EntitySeat seat, Entity entity) {
 
       if (this.isNewUAV()) {
-         System.out.println("isNewUAV() is true, hopefully teleporting player to UAV station.");
          //teleport player to UAV station.
          //doesn't working
             if (entity instanceof EntityPlayer) {
-               System.out.println("is player" + " unmounting from UAV. Teleporting to UAV station. Position: " + this.UavStationPosX + ", " + this.UavStationPosY + ", " + this.UavStationPosZ);
                 ((EntityPlayer) entity).setPositionAndUpdate(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                 //entity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
             }
@@ -4620,6 +4787,28 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.commonUniqueId = uniqId;
    }
 
+
+   private static UUID parseUUID(String value) {
+      if(value == null || value.isEmpty()) {
+         return null;
+      }
+      try {
+         return UUID.fromString(value);
+      } catch (IllegalArgumentException e) {
+         return null;
+      }
+   }
+
+   private void restoreStoredPilot(String reason) {
+      Entity rider = super.riddenByEntity;
+      if(!(rider instanceof EntityPlayerMP) && this.lastRiddenByEntity instanceof EntityPlayerMP) {
+         rider = this.lastRiddenByEntity;
+      }
+      if(rider instanceof EntityPlayerMP) {
+         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rider, reason);
+      }
+   }
+
    public void setDead() {
       this.setDead(false);
       for (ChunkCoordinates coord : activeLights) {
@@ -4634,6 +4823,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void setDead(boolean dropItems) {
+      if(!super.worldObj.isRemote && this.isNewUAV()) {
+         restoreStoredPilot("uav_destroyed");
+      }
+      MCH_UavRegistry.unregister(this);
       super.dropContentsWhenDead = dropItems;
       super.setDead();
       if(this.getRiddenByEntity() != null) {
@@ -4674,6 +4867,14 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       MCH_Lib.DbgLog(super.worldObj, "setDead:" + (this.getAcInfo() != null?this.getAcInfo().name:"null"), new Object[0]);
    }
 
+
+   private void preserveNewUavStationLink() {
+      if(!super.worldObj.isRemote && this.isNewUAV() && this.uavStation != null && !this.uavStation.isDead) {
+         this.uavStation.linkUav(this);
+         this.uavStation.setControlAircract(this);
+      }
+   }
+
    public void unmountEntity() {
       if(!this.isRidePlayer()) {
          this.switchHoveringMode(false);
@@ -4706,13 +4907,15 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                           rByEntity.mountEntity((Entity)null);
                         }
                    } else if (isNewUAV()) {
-                     System.out.println("is new uav, mounting to uav station.");
                      newuavvariable = true;
                      //here
                      if(!this.worldObj.isRemote) {
-                      System.out.println("Mounting player to UAV station. Position: " + this.UavStationPosX + ", " + this.UavStationPosY + ", " + this.UavStationPosZ);
+                      preserveNewUavStationLink();
                       rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                       rByEntity.mountEntity((Entity) null);
+                      if(rByEntity instanceof EntityPlayerMP) {
+                         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
+                      }
                      }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
@@ -4869,13 +5072,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          }
 
       } else {
-         System.out.println("isNewUAV() is true, setting position to UAV station.");
          //new uav only
             if (rByEntity != null) {
-               System.out.println("not null");
                 MCH_AircraftInfo info = this.getAcInfo();
                 if (info != null && info.unmountPosition != null) {
-                    System.out.println("info not null");
                     rByEntity.setPosition(info.unmountPosition.xCoord, info.unmountPosition.yCoord, info.unmountPosition.zCoord);
                    rByEntity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
                 }
@@ -4906,7 +5106,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             return false;
          }
       } else {
-         System.out.println("isNewUAV() is true, unmounting entity to UAV station.");
          if (entity != null) {
             MCH_AircraftInfo info = this.getAcInfo();
             if (info != null && info.unmountPosition != null) {
@@ -4919,7 +5118,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                      entity.mountEntity((Entity) null);
                   }
                }
-               System.out.println("Mounting entity to UAV station. Position: " + this.UavStationPosX + ", " + this.UavStationPosY + ", " + this.UavStationPosZ);
+               preserveNewUavStationLink();
                entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
                return false;
             }
@@ -4932,7 +5131,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                   entity.mountEntity((Entity) null);
                }
             }
-            System.out.println("Mounting entity to UAV station. Position: " + this.UavStationPosX + ", " + this.UavStationPosY + ", " + this.UavStationPosZ);
+            preserveNewUavStationLink();
             entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
             return false;
          }
@@ -6546,7 +6745,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             if(udx > 0) {
                if(this.uavStation == null) {
                   //this is the bugged state when we first place newUAV, probably want to fetch xyz of station here maybe?
-                  System.out.println("is null");
                   Entity uavEntity = super.worldObj.getEntityByID(udx);
                   if(uavEntity instanceof MCH_EntityUavStation) {
                      this.uavStation = (MCH_EntityUavStation)uavEntity;

--- a/src/main/java/mcheli/aircraft/MCH_ItemAircraftDispenseBehavior.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemAircraftDispenseBehavior.java
@@ -18,7 +18,7 @@ public class MCH_ItemAircraftDispenseBehavior extends BehaviorDefaultDispenseIte
       double z = bs.getZ() + (double)enumfacing.getFrontOffsetZ() * 2.0D;
       if(itemStack.getItem() instanceof MCH_ItemAircraft) {
          MCH_EntityAircraft ac = ((MCH_ItemAircraft)itemStack.getItem()).onTileClick(itemStack, bs.getWorld(), 0.0F, (int)x, (int)y, (int)z);
-         if(ac != null && !ac.isUAV()) {
+         if(ac != null && !ac.isUAV() && !ac.isNewUAV()) {
             if(!bs.getWorld().isRemote) {
                ac.getAcDataFromItem(itemStack);
                bs.getWorld().spawnEntityInWorld(ac);

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -3,6 +3,7 @@ package mcheli.uav;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.util.List;
+import java.util.UUID;
 import mcheli.MCH_Config;
 import mcheli.MCH_Explosion;
 import mcheli.MCH_Lib;
@@ -31,6 +32,7 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -68,6 +70,16 @@ public class MCH_EntityUavStation
 
       public int assignedUavId = -1; // fallback tracking
       public String assignedUavUUID = "";
+      private UUID ownerUUID;
+      private UUID linkedUavEntityUUID;
+      private String linkedUavCommonId = "";
+      private int linkedUavDimension;
+      private double linkedUavX;
+      private double linkedUavY;
+      private double linkedUavZ;
+      private boolean hasStoredUavLink;
+      private boolean awaitingLoadedUav;
+      private int pendingContinueTicks;
 
 
 
@@ -80,11 +92,9 @@ public class MCH_EntityUavStation
              }
 
              public void storeStationPosition() {
-                 System.out.println("Storing station position: " + this.posX + ", " + this.posY + ", " + this.posZ);
                  storedStationX = this.posX;
                  storedStationY = this.posY;
                  storedStationZ = this.posZ;
-                    System.out.println("Stored station position: " + storedStationX + ", " + storedStationY + ", " + storedStationZ);
              }
 
       public MCH_EntityUavStation(World world) {
@@ -112,6 +122,10 @@ public class MCH_EntityUavStation
            setControlAircract((MCH_EntityAircraft)null);
            setLastControlAircraft((MCH_EntityAircraft)null);
            this.loadedLastControlAircraftGuid = "";
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
          }
       protected double aircraftY;
       protected double aircraftZ;
@@ -170,8 +184,70 @@ public class MCH_EntityUavStation
       public void setControlAircract(MCH_EntityAircraft ac) {
            this.controlAircraft = ac;
            if (ac != null && !ac.isDead ) {
+                linkUav(ac);
                 setLastControlAircraft(ac);
               }
+         }
+
+      public UUID getOwnerUUID() {
+           return this.ownerUUID;
+         }
+
+      public void setOwnerUUID(UUID uuid) {
+           this.ownerUUID = uuid;
+         }
+
+      public void linkUav(MCH_EntityAircraft ac) {
+           if(ac == null) {
+                return;
+           }
+           this.assignedUav = ac;
+           this.assignedUavId = ac.getEntityId();
+           this.assignedUavUUID = ac.getUniqueID().toString();
+           this.linkedUavEntityUUID = ac.getUniqueID();
+           this.linkedUavCommonId = ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId();
+           updateLinkedUavPosition(ac);
+           ac.setUavStation(this);
+           if(this.ownerUUID != null) {
+                ac.setOwnerUUID(this.ownerUUID);
+           }
+           this.hasStoredUavLink = true;
+           this.awaitingLoadedUav = false;
+           setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
+           MCH_UavRegistry.register(ac);
+         }
+
+      public void updateLinkedUavPosition(MCH_EntityAircraft ac) {
+           if(ac != null) {
+                this.linkedUavDimension = ac.dimension;
+                this.linkedUavX = ac.posX;
+                this.linkedUavY = ac.posY;
+                this.linkedUavZ = ac.posZ;
+           }
+         }
+
+      public boolean hasContinuableUavLink() {
+           return getLastControlAircraftEntityId().intValue() != 0 ||
+                  (this.assignedUav != null && !this.assignedUav.isDead) ||
+                  this.assignedUavId > 0 ||
+                  (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
+                  this.linkedUavEntityUUID != null ||
+                  (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+         }
+
+      public void unlinkInvalidUav() {
+           this.assignedUav = null;
+           this.assignedUavId = -1;
+           this.assignedUavUUID = "";
+           this.linkedUavEntityUUID = null;
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityAircraft)null);
+           setLastControlAircraftEntityId(0);
          }
 
 
@@ -209,6 +285,14 @@ public class MCH_EntityUavStation
               }
 
            nbt.setString("LastCtrlAc", s);
+           nbt.setString("OwnerUUID", this.ownerUUID == null ? "" : this.ownerUUID.toString());
+           nbt.setString("LinkedUavEntityUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
+           nbt.setString("LinkedUavCommonId", this.linkedUavCommonId == null ? "" : this.linkedUavCommonId);
+           nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
+           nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
+           nbt.setDouble("LinkedUavX", this.linkedUavX);
+           nbt.setDouble("LinkedUavY", this.linkedUavY);
+           nbt.setDouble("LinkedUavZ", this.linkedUavZ);
 
           if (this.assignedUav != null && !this.assignedUav.isDead) {
               nbt.setInteger("AssignedUavId", this.assignedUav.getEntityId());
@@ -231,6 +315,27 @@ public class MCH_EntityUavStation
           }
           if (nbt.hasKey("AssignedUavUUID")) {
               this.assignedUavUUID = nbt.getString("AssignedUavUUID");
+          }
+          this.ownerUUID = parseUavUUID(nbt.getString("OwnerUUID"));
+          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          this.linkedUavCommonId = nbt.getString("LinkedUavCommonId");
+          this.linkedUavDimension = nbt.getInteger("LinkedUavDimension");
+          this.hasStoredUavLink = nbt.getBoolean("HasStoredUavLink");
+          this.linkedUavX = nbt.getDouble("LinkedUavX");
+          this.linkedUavY = nbt.getDouble("LinkedUavY");
+          this.linkedUavZ = nbt.getDouble("LinkedUavZ");
+          if(this.linkedUavEntityUUID == null) {
+              this.linkedUavEntityUUID = parseUavUUID(this.assignedUavUUID);
+          }
+          boolean hasLinkedUavIdentity = this.linkedUavEntityUUID != null ||
+                  (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
+                  this.assignedUavId > 0 ||
+                  (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+          this.awaitingLoadedUav = hasLinkedUavIdentity;
+          this.hasStoredUavLink = this.hasStoredUavLink || hasLinkedUavIdentity;
+          if(this.awaitingLoadedUav) {
+              setLastControlAircraftEntityId(-1);
           }
          }
 
@@ -453,19 +558,21 @@ public class MCH_EntityUavStation
 
           //I don't know if this should go in the EntityAircraft class or this class's onupdate method
           // but fuck you here you go!
+          if (!this.worldObj.isRemote) {
+              relinkStoredUav(false);
+          }
+
           if (this.assignedUav == null && this.assignedUavId > 0 && !this.worldObj.isRemote) {
               Entity e = this.worldObj.getEntityByID(this.assignedUavId);
               if (e instanceof MCH_EntityAircraft) {
-                  this.assignedUav = (MCH_EntityAircraft)e;
-                  System.out.println("Re-linked UAV by ID: " + this.assignedUav.getEntityId());
+                  linkUav((MCH_EntityAircraft)e);
               }
               else if (!this.assignedUavUUID.isEmpty()) {
                   for (Object obj : this.worldObj.loadedEntityList) {
                       if (obj instanceof MCH_EntityAircraft) {
                           MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
                           if (ac.getUniqueID().toString().equals(this.assignedUavUUID)) {
-                              this.assignedUav = ac;
-                              System.out.println("Re-linked UAV by UUID: " + this.assignedUavUUID);
+                              linkUav(ac);
                               break;
                           }
                       }
@@ -491,10 +598,6 @@ public class MCH_EntityUavStation
           if (this.riddenByEntity instanceof EntityPlayer && this.controlAircraft != null && this.controlAircraft.getAcInfo().isNewUAV) {
 
               if(!this.worldObj.isRemote) {
-                  System.out.println("storing station position" +
-                          this.posX + " " + this.posY + " " + this.posZ +
-                          " for new UAV: " + this.controlAircraft.getAcInfo().displayName +
-                          " controlled by: " + ((EntityPlayer)this.riddenByEntity).getDisplayName());
                   isridingnewuav = true;
                   this.storeStationPosition();
 
@@ -549,13 +652,16 @@ public class MCH_EntityUavStation
          }
 
       public MCH_EntityAircraft getAndSearchLastControlAircraft() {
+           if (getLastControlAircraft() == null && !this.worldObj.isRemote) {
+                relinkStoredUav(false);
+              }
            if (getLastControlAircraft() == null) {
                 int id = getLastControlAircraftEntityId().intValue();
                 if (id > 0) {
                      Entity entity = this.worldObj.getEntityByID(id);
                      if (entity instanceof MCH_EntityAircraft) {
                           MCH_EntityAircraft ac = (MCH_EntityAircraft)entity;
-                          if (ac.isUAV()) {
+                          if (ac.isUAV() || ac.isNewUAV()) {
                                setLastControlAircraft(ac);
                              }
                         }
@@ -568,6 +674,9 @@ public class MCH_EntityUavStation
       public void setLastControlAircraft(MCH_EntityAircraft ac) {
            MCH_Lib.DbgLog(this.worldObj, "MCH_EntityUavStation.setLastControlAircraft:" + ac, new Object[0]);
            this.lastControlAircraft = ac;
+           if(ac != null && !this.worldObj.isRemote) {
+                setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
+           }
          }
 
       public Integer getLastControlAircraftEntityId() {
@@ -580,6 +689,129 @@ public class MCH_EntityUavStation
               }
          }
 
+      private boolean isWaitingForLinkedUav() {
+           return this.hasStoredUavLink ||
+                  this.awaitingLoadedUav ||
+                  this.pendingContinueTicks > 0 ||
+                  (this.controlAircraft != null && !this.controlAircraft.isDead) ||
+                  (this.lastControlAircraft != null && !this.lastControlAircraft.isDead);
+         }
+
+      private boolean canCreateUavFromSlot(ItemStack item) {
+           return item != null && item.stackSize > 0 && !hasContinuableUavLink() && !isWaitingForLinkedUav();
+         }
+
+      private void markLinkedUavUnloaded() {
+           if(!this.worldObj.isRemote && (hasContinuableUavLink() || this.hasStoredUavLink)) {
+                this.awaitingLoadedUav = true;
+                setLastControlAircraftEntityId(-1);
+           }
+         }
+
+
+
+      private UUID parseUavUUID(String value) {
+           if(value == null || value.isEmpty()) {
+                return null;
+           }
+           try {
+                return UUID.fromString(value);
+           } catch (IllegalArgumentException e) {
+                return null;
+           }
+         }
+
+      public MCH_EntityAircraft findLinkedUavEntity(World world) {
+           if(this.assignedUav != null && !this.assignedUav.isDead) {
+                return this.assignedUav;
+           }
+           MCH_EntityAircraft ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+           if(ac == null) {
+                loadLinkedUavChunk(world);
+                ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+           }
+           return ac;
+         }
+
+      private void loadLinkedUavChunk(World world) {
+           if(world == null || world.isRemote || (this.linkedUavX == 0.0D && this.linkedUavY == 0.0D && this.linkedUavZ == 0.0D)) {
+                return;
+           }
+           int x = MathHelper.floor_double(this.linkedUavX);
+           int z = MathHelper.floor_double(this.linkedUavZ);
+           world.getChunkFromBlockCoords(x, z);
+         }
+
+      private boolean relinkStoredUav(boolean requireLoaded) {
+           MCH_EntityAircraft ac = findLinkedUavEntity(this.worldObj);
+           if(ac != null && !ac.isDead) {
+                linkUav(ac);
+                setLastControlAircraft(ac);
+                setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
+                return true;
+           }
+           this.awaitingLoadedUav = !requireLoaded;
+           markLinkedUavUnloaded();
+           return false;
+         }
+
+      private boolean isValidLinkedUav(MCH_EntityAircraft ac, EntityPlayer player) {
+           if(ac == null || ac.isDead || ac.isDestroyed()) {
+                return false;
+           }
+           if(player != null) {
+                setOwnerUUID(player.getUniqueID());
+                if(ac.getOwnerUUID() != null && !ac.getOwnerUUID().equals(player.getUniqueID())) {
+                     return false;
+                }
+           }
+           if(this.linkedUavDimension != 0 && ac.dimension != this.linkedUavDimension) {
+                return false;
+           }
+           return ac.isUAV() || ac.isNewUAV();
+         }
+
+
+
+      private void notifyInitialUavStateOnce(EntityPlayerMP player, MCH_EntityAircraft ac) {
+           if(player != null && ac != null && ac.isNewUAV() && ac.ticksExisted < 40) {
+                W_EntityPlayer.addChatMessage(player, "UAV is initializing and cannot move yet. You can still reload/resupply it from the station or your inventory.");
+           }
+         }
+
+      public boolean transferAmmoToLinkedUav(EntityPlayerMP player) {
+           if(this.worldObj.isRemote) {
+                return false;
+           }
+           ItemStack stack = getStackInSlot(0);
+           if(stack == null || stack.stackSize <= 0) {
+                return false;
+           }
+           MCH_EntityAircraft ac = findLinkedUavEntity(this.worldObj);
+           if(!isValidLinkedUav(ac, player)) {
+                return false;
+           }
+           int before = stack.stackSize;
+           int consumed = ac.trySupplyAmmoFromStack(stack, player);
+           if(consumed <= 0) {
+                return false;
+           }
+           if(stack.stackSize <= 0) {
+                setInventorySlotContents(0, (ItemStack)null);
+           } else if(stack.stackSize != before) {
+                setInventorySlotContents(0, stack);
+           }
+           if(player != null) {
+                player.inventoryContainer.detectAndSendChanges();
+           }
+           MCH_Lib.DbgLog(this.worldObj, "Transferred %d UAV ammo item(s) from station %d to UAV %d", new Object[] { Integer.valueOf(consumed), Integer.valueOf(W_Entity.getEntityId((Entity)this)), Integer.valueOf(W_Entity.getEntityId((Entity)ac)) });
+           return true;
+         }
+
+      public boolean canStationAmmoFeedLinkedUav(ItemStack stack) {
+           MCH_EntityAircraft ac = findLinkedUavEntity(this.worldObj);
+           return ac != null && ac.canAcceptAmmo(stack);
+         }
 
       public void searchLastControlAircraft() {
           //makes a box around the station to search for the last controlled aircraft, for regular non-new UAVs
@@ -591,9 +823,11 @@ public class MCH_EntityUavStation
                           if (ac.getCommonUniqueId().equals(this.loadedLastControlAircraftGuid)) {
                                String n = (ac.getAcInfo() != null) ? (ac.getAcInfo()).displayName : ("no info : " + ac);
                                MCH_Lib.DbgLog(this.worldObj, "MCH_EntityUavStation.searchLastControlAircraft:found" + n, new Object[0]);
+                               linkUav(ac);
                                setLastControlAircraft(ac);
                                setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
                                this.loadedLastControlAircraftGuid = "";
+                               this.awaitingLoadedUav = false;
                                return;
                              }
                         }
@@ -629,12 +863,18 @@ public class MCH_EntityUavStation
                       this.motionZ = 0.0D;
                       setRotation(this.rotationYaw, this.rotationPitch);
                       if (this.riddenByEntity != null) {
+                            if (this.pendingContinueTicks > 0) {
+                                  --this.pendingContinueTicks;
+                                  if(this.pendingContinueTicks % 10 == 0) {
+                                        controlLastAircraft(this.riddenByEntity, false);
+                                      }
+                                }
                             if (this.riddenByEntity.isDead) {
                                   unmountEntity(true);
                                   this.riddenByEntity = null;
                                 } else {
                                   ItemStack item = getStackInSlot(0);
-                                  if (item != null && item.stackSize > 0) {
+                                  if (canCreateUavFromSlot(item)) {
                                         handleItem(this.riddenByEntity, item);
                                         if (item.stackSize == 0) {
                                               setInventorySlotContents(0, (ItemStack)null);
@@ -671,35 +911,70 @@ public class MCH_EntityUavStation
 
 
              public void controlLastAircraft(Entity user) {
+                 controlLastAircraft(user, true);
+             }
 
-                 MCH_EntityAircraft lastAc = getLastControlAircraft();
+             private void controlLastAircraft(Entity user, boolean notify) {
+
+                 if(!hasContinuableUavLink() && !this.hasStoredUavLink) {
+                     if(notify && user instanceof EntityPlayer) {
+                         W_EntityPlayer.addChatMessage((EntityPlayer)user, "No linked UAV is stored in this station.");
+                     }
+                     return;
+                 }
+                 MCH_EntityAircraft lastAc = getAndSearchLastControlAircraft();
+                 if (lastAc == null && relinkStoredUav(false)) {
+                     lastAc = getLastControlAircraft();
+                 }
                  if (lastAc != null && !lastAc.isDead) {
 
-                     lastAc.setUavStation(this);
+                     if(!isValidLinkedUav(lastAc, user instanceof EntityPlayer ? (EntityPlayer)user : null)) { return; }
+                     linkUav(lastAc);
                      setControlAircract(lastAc);
                      //this.assignedUav = uav;
 
                      if(this.riddenByEntity instanceof EntityPlayer) {
                          lastAc.storedRider = (EntityPlayer)this.riddenByEntity;
+                         setOwnerUUID(((EntityPlayer)this.riddenByEntity).getUniqueID());
+                         if(this.riddenByEntity instanceof EntityPlayerMP) {
+                             EntityPlayerMP player = (EntityPlayerMP)this.riddenByEntity;
+                             transferAmmoToLinkedUav(player);
+                             notifyInitialUavStateOnce(player, lastAc);
+                         }
                      }
 
                      // Store the current station position
-                     System.out.println("stationposition" + storedStationX + " " + storedStationY + " " + storedStationZ);
                      storeStationPosition();
 
                      if (this.controlAircraft != null &&
                              this.controlAircraft.getAcInfo() != null &&
-                             this.controlAircraft.getAcInfo().isNewUAV &&
-                             this.controlAircraft.ticksExisted >= 10) {
+                             this.controlAircraft.getAcInfo().isNewUAV) {
+                         if(this.controlAircraft.ticksExisted < 10) {
+                             this.pendingContinueTicks = 60;
+                             if(notify && user instanceof EntityPlayer) {
+                                 W_EntityPlayer.addChatMessage((EntityPlayer)user, "Linked UAV loaded; waiting for entity initialization before taking control.");
+                             }
+                             return;
+                         }
                          this.riddenByEntity.mountEntity((Entity)this.controlAircraft);
                      }
+                     this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);
+                 } else {
+                     this.pendingContinueTicks = 60;
+                     markLinkedUavUnloaded();
+                     if(notify && user instanceof EntityPlayer) {
+                         W_EntityPlayer.addChatMessage((EntityPlayer)user, "Linked UAV chunk is loading; continue will retry shortly.");
+                     }
                  }
 
              }
 
 
      public void handleItem(Entity user, ItemStack itemStack) {
+           if (isWaitingForLinkedUav()) {
+                return;
+           }
            if (user != null && !user.isDead && itemStack != null && itemStack.stackSize == 1 &&
                      !this.worldObj.isRemote) {
                 Object ac = null;
@@ -735,7 +1010,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemHeli) {
                      MCH_HeliInfo hi1 = MCH_HeliInfoManager.getFromItem(item);
-                     if (hi1 != null && hi1.isUAV) {
+                     if (hi1 != null && (hi1.isUAV || hi1.isNewUAV)) {
                          if (!hi1.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -746,7 +1021,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemTank) {
                      MCH_TankInfo hi2 = MCH_TankInfoManager.getFromItem(item);
-                     if (hi2 != null && hi2.isUAV) {
+                     if (hi2 != null && (hi2.isUAV || hi2.isNewUAV)) {
                           if (!hi2.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -768,12 +1043,14 @@ public class MCH_EntityUavStation
                           MCH_Lib.DbgLog(this.worldObj, "Create UAV: %s : %s", new Object[] { item.getUnlocalizedName(), item });
                           user.rotationYaw = this.rotationYaw - 180.0F;
                           if (!((MCH_EntityAircraft)ac).isTargetDrone()) {
-                               ((MCH_EntityAircraft)ac).setUavStation(this);
+                               this.setOwnerUUID(user instanceof EntityPlayer ? ((EntityPlayer)user).getUniqueID() : this.ownerUUID);
+                               ((MCH_EntityAircraft)ac).setOwnerUUID(this.ownerUUID);
+                               linkUav((MCH_EntityAircraft)ac);
                                setControlAircract((MCH_EntityAircraft)ac);
                              }
 
                           this.worldObj.spawnEntityInWorld((Entity)ac);
-                          this.assignedUav = (MCH_EntityAircraft) ac;
+                          linkUav((MCH_EntityAircraft) ac);
                           if (!((MCH_EntityAircraft)ac).isTargetDrone()) {
                                ((MCH_EntityAircraft)ac).setFuel((int)(((MCH_EntityAircraft)ac).getMaxFuel() * 0.05F));
                                W_EntityPlayer.closeScreen(user);
@@ -795,8 +1072,9 @@ public class MCH_EntityUavStation
 
       public boolean interactFirst(EntityPlayer player) {
 
-          if(this.riddenByEntity instanceof EntityPlayer){
+          if(player != null) {
               this.newUavPlayerUUID = player.getUniqueID().toString();
+              this.setOwnerUUID(player.getUniqueID());
           }
 
            int kind = getKind();
@@ -821,6 +1099,10 @@ public class MCH_EntityUavStation
            if (!this.worldObj.isRemote) {
                 player.mountEntity((Entity)this);
                 player.openGui(MCH_MOD.instance, 0, player.worldObj, (int)this.posX, (int)this.posY, (int)this.posZ);
+                if (hasContinuableUavLink() || this.hasStoredUavLink) {
+                     this.pendingContinueTicks = 80;
+                     controlLastAircraft(player);
+                }
               }
 
            return true;
@@ -848,10 +1130,14 @@ public class MCH_EntityUavStation
                  }
 
                  if (getControlAircract() != null) {
-                     getControlAircract().setUavStation((MCH_EntityUavStation) null);
+                     if(!getControlAircract().isNewUAV()) {
+                         getControlAircract().setUavStation((MCH_EntityUavStation) null);
+                     }
                  }
 
-                 setControlAircract((MCH_EntityAircraft) null);
+                 if(getControlAircract() == null || !getControlAircract().isNewUAV()) {
+                     setControlAircract((MCH_EntityAircraft) null);
+                 }
                  if (this.worldObj.isRemote) {
                      W_EntityPlayer.closeScreen(rByEntity);
                  }

--- a/src/main/java/mcheli/uav/MCH_GuiUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_GuiUavStation.java
@@ -58,7 +58,7 @@ public class MCH_GuiUavStation
                      info = MCH_TankInfoManager.getFromItem(item.getItem());
                    }
 
-                if (item != null && (item == null || info == null || !((MCH_AircraftInfo)info).isUAV || !((MCH_AircraftInfo)info).isNewUAV)) {
+                if (item != null && (item == null || info == null || (!((MCH_AircraftInfo)info).isUAV && !((MCH_AircraftInfo)info).isNewUAV))) {
                      if (item != null) {
                           drawString("Not UAV", 8, 6, 16711680);
                         }
@@ -85,20 +85,19 @@ public class MCH_GuiUavStation
            drawTexturedModalRect(x, y, 0, 0, this.xSize, this.ySize);
          }
 
+
+      public void updateScreen() {
+           super.updateScreen();
+           if (this.buttonContinue != null) {
+                this.buttonContinue.enabled = this.uavStation != null && !this.uavStation.isDead && this.uavStation.hasContinuableUavLink();
+           }
+         }
+
       protected void actionPerformed(GuiButton btn) {
-                     System.out.println("actionPerformed fired");
            if (btn != null && btn.enabled) {
-                        System.out.println("btn enabled");
                 if (btn.id == 256) {
                               this.uavStation.setContinuePressed(true);
-                     if (this.uavStation != null && !this.uavStation.isDead && this.uavStation.getLastControlAircraft() != null && !(this.uavStation.getLastControlAircraft()).isDead) {
-                          //System.out.println("found uav station and last control aircraft");
-                         MCH_EntityAircraft aircraft = getCurrentAircraft(this.uavStation.getLastControlAircraft());
-                         //MCH_EntityAircraft aircraft1 = getCurrentAircraft(aircraft);
-                         if (aircraft != null) {
-                             //System.out.println("aircraft isnt null");
-                             //aircraft.castuavid(this.mc.thePlayer);
-                         }
+                     if (this.uavStation != null && !this.uavStation.isDead && this.uavStation.hasContinuableUavLink()) {
                           MCH_UavPacketStatus pos = new MCH_UavPacketStatus();
                           pos.posUavX = (byte)this.uavStation.posUavX;
                           pos.posUavY = (byte)this.uavStation.posUavY;
@@ -107,7 +106,6 @@ public class MCH_GuiUavStation
                           W_Network.sendToServer((W_PacketBase)pos);
                         }
 
-                     this.buttonContinue.enabled = false;
                    } else {
                      int[] pos1 = { this.uavStation.posUavX, this.uavStation.posUavY, this.uavStation.posUavZ };
                      int i = btn.id >> 4 & 0xF;
@@ -153,10 +151,7 @@ public class MCH_GuiUavStation
               }
 
            this.buttonContinue = new GuiButton(256, x - 80 + 3, y + 44, 50, 20, "Continue");
-           this.buttonContinue.enabled = false;
-           if (this.uavStation != null && !this.uavStation.isDead && this.uavStation.getAndSearchLastControlAircraft() != null) {
-                this.buttonContinue.enabled = true;
-              }
+           this.buttonContinue.enabled = this.uavStation != null && !this.uavStation.isDead && this.uavStation.hasContinuableUavLink();
 
            this.buttonList.add(this.buttonContinue);
          }

--- a/src/main/java/mcheli/uav/MCH_ItemUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_ItemUavStation.java
@@ -29,8 +29,6 @@ public class MCH_ItemUavStation extends W_Item {
 
    public MCH_EntityUavStation createUavStation(World world, double x, double y, double z, int kind) {
       MCH_EntityUavStation uavst = new MCH_EntityUavStation(world);
-      System.out.println("UavStation pos" + x + " " + y + " " + z);
-
       uavst.setPosition(x, y + (double)uavst.yOffset, z);
       //uavst.storeStationPosition();
       //no more

--- a/src/main/java/mcheli/uav/MCH_UavInventory.java
+++ b/src/main/java/mcheli/uav/MCH_UavInventory.java
@@ -1,0 +1,150 @@
+package mcheli.uav;
+
+import mcheli.MCH_Lib;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+
+/** Persistent, idempotent inventory hand-off used while a player pilots a new UAV. */
+public final class MCH_UavInventory {
+    private static final String TAG = "MCH_UavPilotInventory";
+    private static final String STORED = "Stored";
+    private static final String INVENTORY = "Inventory";
+    private static final String UAV_UUID = "UavUUID";
+    private static final String REASON = "Reason";
+    private static final String INVENTORY_CLEARED = "InventoryCleared";
+
+    private MCH_UavInventory() {}
+
+    public static boolean hasStoredPilotInventory(EntityPlayer player) {
+        return player != null && getTag(player).getBoolean(STORED);
+    }
+
+    public static void storePilotInventory(EntityPlayerMP player, String uavUuid) {
+        if (player == null || player.worldObj == null || player.worldObj.isRemote) {
+            return;
+        }
+        NBTTagCompound tag = getTag(player);
+        if (tag.getBoolean(STORED)) {
+            return;
+        }
+        NBTTagList list = new NBTTagList();
+        player.inventory.writeToNBT(list);
+        tag.setTag(INVENTORY, list);
+        tag.setBoolean(STORED, true);
+        tag.setString(UAV_UUID, uavUuid == null ? "" : uavUuid);
+        tag.setString(REASON, "stored");
+        tag.setBoolean(INVENTORY_CLEARED, false);
+        player.inventoryContainer.detectAndSendChanges();
+        MCH_Lib.DbgLog(player.worldObj, "Stored UAV pilot inventory snapshot for %s", new Object[] { player.getCommandSenderName() });
+    }
+
+
+    public static void storeAndClearPilotInventory(EntityPlayerMP player, String uavUuid) {
+        if (player == null || player.worldObj == null || player.worldObj.isRemote) {
+            return;
+        }
+        NBTTagCompound tag = getTag(player);
+        if (tag.getBoolean(STORED) && tag.getBoolean(INVENTORY_CLEARED)) {
+            return;
+        }
+
+        NBTTagList list = new NBTTagList();
+        player.inventory.writeToNBT(list);
+        tag.setTag(INVENTORY, list);
+        tag.setBoolean(STORED, true);
+        tag.setString(UAV_UUID, uavUuid == null ? "" : uavUuid);
+        tag.setString(REASON, "delayed_clear");
+        tag.setBoolean(INVENTORY_CLEARED, true);
+        player.inventory.clearInventory(null, -1);
+        player.inventoryContainer.detectAndSendChanges();
+        MCH_Lib.DbgLog(player.worldObj, "Stored and cleared delayed UAV pilot inventory for %s", new Object[] { player.getCommandSenderName() });
+    }
+
+    public static boolean restorePilotInventory(EntityPlayerMP player, String reason) {
+        if (player == null || player.worldObj == null || player.worldObj.isRemote) {
+            return false;
+        }
+        NBTTagCompound tag = getTag(player);
+        if (!tag.getBoolean(STORED)) {
+            return false;
+        }
+
+        boolean inventoryWasCleared = !tag.hasKey(INVENTORY_CLEARED) || tag.getBoolean(INVENTORY_CLEARED);
+        if (!inventoryWasCleared) {
+            clearStoredPilotInventory(player);
+            player.inventoryContainer.detectAndSendChanges();
+            MCH_Lib.DbgLog(player.worldObj, "Cleared UAV pilot inventory snapshot for %s (%s)", new Object[] { player.getCommandSenderName(), reason });
+            return true;
+        }
+
+        ItemStack[] current = copyInventory(player);
+        player.inventory.clearInventory(null, -1);
+        try {
+            if (tag.hasKey(INVENTORY)) {
+                player.inventory.readFromNBT(tag.getTagList(INVENTORY, 10));
+            }
+        } catch (Throwable t) {
+            MCH_Lib.Log(player, "Failed to restore UAV pilot inventory for %s: %s", new Object[] { player.getCommandSenderName(), t.toString() });
+        }
+
+        clearStoredPilotInventory(player);
+        restoreOrDropCurrentItems(player, current);
+        player.inventoryContainer.detectAndSendChanges();
+        MCH_Lib.DbgLog(player.worldObj, "Restored UAV pilot inventory for %s (%s)", new Object[] { player.getCommandSenderName(), reason });
+        return true;
+    }
+
+    public static void clearStoredPilotInventory(EntityPlayer player) {
+        if (player != null) {
+            player.getEntityData().removeTag(TAG);
+        }
+    }
+
+    private static NBTTagCompound getTag(EntityPlayer player) {
+        NBTTagCompound root = player.getEntityData();
+        if (!root.hasKey(TAG)) {
+            root.setTag(TAG, new NBTTagCompound());
+        }
+        return root.getCompoundTag(TAG);
+    }
+
+    private static ItemStack[] copyInventory(EntityPlayer player) {
+        int main = player.inventory.mainInventory.length;
+        int armor = player.inventory.armorInventory.length;
+        ItemStack[] stacks = new ItemStack[main + armor];
+        for (int i = 0; i < main; ++i) {
+            stacks[i] = player.inventory.mainInventory[i] == null ? null : player.inventory.mainInventory[i].copy();
+        }
+        for (int i = 0; i < armor; ++i) {
+            stacks[main + i] = player.inventory.armorInventory[i] == null ? null : player.inventory.armorInventory[i].copy();
+        }
+        return stacks;
+    }
+
+    private static void restoreOrDropCurrentItems(EntityPlayerMP player, ItemStack[] stacks) {
+        for (int i = 0; i < stacks.length; ++i) {
+            ItemStack stack = stacks[i];
+            if (stack == null || stack.stackSize <= 0) {
+                continue;
+            }
+            ItemStack copy = stack.copy();
+            if (!player.inventory.addItemStackToInventory(copy) || copy.stackSize > 0) {
+                dropStack(player, copy.stackSize > 0 ? copy : stack);
+            }
+        }
+    }
+
+    private static void dropStack(EntityPlayerMP player, ItemStack stack) {
+        if (stack == null || stack.stackSize <= 0) {
+            return;
+        }
+        EntityItem item = player.dropPlayerItemWithRandomChoice(stack, false);
+        if (item != null) {
+            item.delayBeforeCanPickup = 40;
+        }
+    }
+}

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -1,0 +1,103 @@
+package mcheli.uav;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import mcheli.aircraft.MCH_EntityAircraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.world.World;
+
+/** Runtime lookup cache only; persistent truth lives on aircraft/station/player NBT. */
+public final class MCH_UavRegistry {
+    private static final Map<String, MCH_EntityAircraft> BY_ENTITY_UUID = new HashMap<String, MCH_EntityAircraft>();
+    private static final Map<String, MCH_EntityAircraft> BY_COMMON_ID = new HashMap<String, MCH_EntityAircraft>();
+    private static final Map<String, MCH_EntityAircraft> BY_OWNER = new HashMap<String, MCH_EntityAircraft>();
+
+    private MCH_UavRegistry() {}
+
+    public static void register(MCH_EntityAircraft ac) {
+        if (!isValidUav(ac)) {
+            return;
+        }
+        BY_ENTITY_UUID.put(ac.getUniqueID().toString(), ac);
+        if (ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
+            BY_COMMON_ID.put(ac.getCommonUniqueId(), ac);
+        }
+        if (ac.getOwnerUUID() != null) {
+            BY_OWNER.put(ac.getOwnerUUID().toString(), ac);
+        }
+    }
+
+    public static void unregister(MCH_EntityAircraft ac) {
+        if (ac == null) {
+            return;
+        }
+        BY_ENTITY_UUID.remove(ac.getUniqueID().toString());
+        if (ac.getCommonUniqueId() != null) {
+            BY_COMMON_ID.remove(ac.getCommonUniqueId());
+        }
+        if (ac.getOwnerUUID() != null) {
+            BY_OWNER.remove(ac.getOwnerUUID().toString());
+        }
+    }
+
+    public static MCH_EntityAircraft findLinkedUav(World world, UUID entityUuid, String commonId, UUID owner) {
+        boolean hasStableLink = entityUuid != null || (commonId != null && !commonId.isEmpty());
+        MCH_EntityAircraft ac = getLive(BY_ENTITY_UUID.get(entityUuid == null ? "" : entityUuid.toString()), world);
+        if (ac != null) return ac;
+        ac = getLive(BY_COMMON_ID.get(commonId == null ? "" : commonId), world);
+        if (ac != null) return ac;
+        if (!hasStableLink) {
+            ac = getLive(BY_OWNER.get(owner == null ? "" : owner.toString()), world);
+            if (ac != null) return ac;
+        }
+        return searchLoaded(world, entityUuid, commonId, hasStableLink ? null : owner);
+    }
+
+    public static MCH_EntityAircraft findByOwner(World world, UUID owner) {
+        return findLinkedUav(world, null, null, owner);
+    }
+
+    public static void rebuildUavRegistry(World world) {
+        if (world == null) return;
+        searchLoaded(world, null, null, null);
+    }
+
+    private static MCH_EntityAircraft searchLoaded(World world, UUID entityUuid, String commonId, UUID owner) {
+        if (world == null) return null;
+        List list = world.loadedEntityList;
+        MCH_EntityAircraft first = null;
+        for (int i = 0; i < list.size(); ++i) {
+            Object obj = list.get(i);
+            if (obj instanceof MCH_EntityAircraft) {
+                MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
+                if (isValidUav(ac)) {
+                    register(ac);
+                    boolean entityMatch = entityUuid != null && entityUuid.equals(ac.getUniqueID());
+                    boolean commonMatch = commonId != null && !commonId.isEmpty() && commonId.equals(ac.getCommonUniqueId());
+                    boolean ownerMatch = owner != null && owner.equals(ac.getOwnerUUID());
+                    if (entityUuid == null && (commonId == null || commonId.isEmpty()) && owner == null && first == null) {
+                        first = ac;
+                    } else if (entityMatch || commonMatch || ownerMatch) {
+                        return ac;
+                    }
+                }
+            }
+        }
+        return first;
+    }
+
+    private static MCH_EntityAircraft getLive(MCH_EntityAircraft ac, World world) {
+        if (isValidUav(ac) && (world == null || ac.worldObj == world)) {
+            return ac;
+        }
+        unregister(ac);
+        return null;
+    }
+
+    private static boolean isValidUav(MCH_EntityAircraft ac) {
+        return ac != null && !ac.isDead && (ac.isUAV() || ac.isNewUAV());
+    }
+}


### PR DESCRIPTION
### Motivation
- Add robust support for the new UAV workflow by persisting pilot inventories while piloting, tracking UAV<>station associations, and enabling station→UAV ammo resupply. 
- Provide a runtime lookup cache so stations can find linked UAVs across entity reloads/chunk loads and support owner-based linking and continuity. 
- Fix fragile edge cases around player join/death/tick and UAV spawn/unmount to avoid lost items, broken links, and unreliable control handoff.

### Description
- Introduced `MCH_UavInventory` to snapshot, optionally clear, and restore a player's inventory while they pilot a new UAV; adds idempotent store/restore semantics and NBT-backed per-player tag storage. 
- Added `MCH_UavRegistry` as a lightweight runtime cache to find UAV entities by entity UUID, common ID, or owner UUID and to rebuild registry from loaded entities. 
- Extended `MCH_EntityAircraft` with owner/linked-station UUID fields, delayed pilot-inventory handling, ammo supply helpers (`canAcceptAmmo`, `trySupplyAmmoFromStack`, etc.), NBT serialization/deserialization for new fields, and logic to restore pilot inventories on UAV destruction/unmount. 
- Enhanced `MCH_EntityUavStation` to persist and re-link to UAVs (by entity UUID, common ID, assigned id, owner), manage pending link/load retries, transfer ammo from the station slot to a linked UAV, and communicate owner/linked-UAV info via NBT. 
- Hooked `MCH_EventHook` for player death/tick to restore stored pilot inventories and to register/rebuild UAV registry on relevant events. 
- Updated GUI (`MCH_GuiUavStation`), dispenser behavior, and UAV station item code to respect the new new-UAV checks, enable the Continue button conditionally, and avoid creating new UAVs when a linked UAV should be used. 
- Removed/cleaned several debug prints and added safe UUID parsing helpers and utility functions to preserve station<>UAV links across loads. 

### Testing
- Performed an automated project build (compile) of the mod with the changes; the build completed successfully (no compile errors). 
- No automated unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20d9b7fe488323aa557f55efc836aa)