### PR TITLE
Use persistent UAV UUIDs and prevent duplicate UAVs after chunk/world reload

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -243,6 +243,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public String newUavPlayerUUID;
    private int delayedUavInventoryTicks;
+   private UUID uavPersistentUUID;
    private UUID uavOwnerUUID;
    private UUID linkedUavStationUUID;
    private int linkedUavStationDimension;
@@ -328,6 +329,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.missileDetector = new MCH_MissileDetector(this, world);
       this.uavStation = null;
       this.delayedUavInventoryTicks = 0;
+      this.uavPersistentUUID = null;
       this.uavOwnerUUID = null;
       this.linkedUavStationUUID = null;
       this.linkedUavStationDimension = 0;
@@ -579,11 +581,25 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    }
 
+   public UUID getUavPersistentUUID() {
+      return getUavPersistentUUID(true);
+   }
+
+   public UUID getUavPersistentUUID(boolean createIfMissing) {
+      if(this.uavPersistentUUID == null && createIfMissing && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
+      return this.uavPersistentUUID;
+   }
+
    public UUID getOwnerUUID() {
       return this.uavOwnerUUID;
    }
 
    public void setOwnerUUID(UUID uuid) {
+      if(!super.worldObj.isRemote && this.uavOwnerUUID != null && !this.uavOwnerUUID.equals(uuid)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.uavOwnerUUID = uuid;
       if(uuid != null && !super.worldObj.isRemote) {
          MCH_UavRegistry.register(this);
@@ -1174,6 +1190,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       this.dismountedUserCtrl = nbt.getBoolean("AcDismounted");
+      this.uavPersistentUUID = parseUUID(nbt.getString("MCH_UavPersistentUUID"));
+      if(this.uavPersistentUUID == null && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
       this.uavOwnerUUID = parseUUID(nbt.getString("MCH_UavOwnerUUID"));
       this.linkedUavStationUUID = parseUUID(nbt.getString("MCH_UavStationUUID"));
       this.linkedUavStationDimension = nbt.getInteger("MCH_UavStationDim");
@@ -1185,6 +1205,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.UavStationPosZ = MathHelper.floor_double(this.linkedUavStationZ);
       if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
          MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
       }
    }
 
@@ -1214,6 +1237,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       nbt.setTag("AcWeaponsAmmo", W_NBTTag.newTagIntArray("AcWeaponsAmmo", wa_list));
       nbt.setInteger("AcDamage", this.getDamageTaken());
       nbt.setBoolean("AcDismounted", this.dismountedUserCtrl);
+      UUID persistentId = this.getUavPersistentUUID(false);
+      if(persistentId == null && (this.isUAV() || this.isNewUAV())) {
+         persistentId = this.getUniqueID();
+         this.uavPersistentUUID = persistentId;
+      }
+      nbt.setString("MCH_UavPersistentUUID", persistentId == null ? "" : persistentId.toString());
       nbt.setString("MCH_UavOwnerUUID", this.uavOwnerUUID == null ? "" : this.uavOwnerUUID.toString());
       nbt.setString("MCH_UavStationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
       nbt.setInteger("MCH_UavStationDim", this.linkedUavStationDimension);
@@ -4784,7 +4813,16 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void setCommonUniqueId(String uniqId) {
+      if(!super.worldObj.isRemote && this.commonUniqueId != null && !this.commonUniqueId.equals(uniqId)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.commonUniqueId = uniqId;
+      if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
+         MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
+      }
    }
 
 

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -203,8 +203,9 @@ public class MCH_EntityUavStation
            }
            this.assignedUav = ac;
            this.assignedUavId = ac.getEntityId();
-           this.assignedUavUUID = ac.getUniqueID().toString();
-           this.linkedUavEntityUUID = ac.getUniqueID();
+           UUID persistentId = ac.getUavPersistentUUID();
+           this.assignedUavUUID = persistentId == null ? ac.getUniqueID().toString() : persistentId.toString();
+           this.linkedUavEntityUUID = persistentId == null ? ac.getUniqueID() : persistentId;
            this.linkedUavCommonId = ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId();
            updateLinkedUavPosition(ac);
            ac.setUavStation(this);
@@ -286,6 +287,7 @@ public class MCH_EntityUavStation
 
            nbt.setString("LastCtrlAc", s);
            nbt.setString("OwnerUUID", this.ownerUUID == null ? "" : this.ownerUUID.toString());
+           nbt.setString("LinkedUavPersistentUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavEntityUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavCommonId", this.linkedUavCommonId == null ? "" : this.linkedUavCommonId);
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
@@ -296,7 +298,8 @@ public class MCH_EntityUavStation
 
           if (this.assignedUav != null && !this.assignedUav.isDead) {
               nbt.setInteger("AssignedUavId", this.assignedUav.getEntityId());
-              nbt.setString("AssignedUavUUID", this.assignedUav.getUniqueID().toString());
+              UUID persistentId = this.assignedUav.getUavPersistentUUID();
+              nbt.setString("AssignedUavUUID", persistentId == null ? this.assignedUav.getUniqueID().toString() : persistentId.toString());
           }
          }
 
@@ -317,7 +320,10 @@ public class MCH_EntityUavStation
               this.assignedUavUUID = nbt.getString("AssignedUavUUID");
           }
           this.ownerUUID = parseUavUUID(nbt.getString("OwnerUUID"));
-          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavPersistentUUID"));
+          if(this.linkedUavEntityUUID == null) {
+              this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          }
           this.linkedUavCommonId = nbt.getString("LinkedUavCommonId");
           this.linkedUavDimension = nbt.getInteger("LinkedUavDimension");
           this.hasStoredUavLink = nbt.getBoolean("HasStoredUavLink");
@@ -571,7 +577,8 @@ public class MCH_EntityUavStation
                   for (Object obj : this.worldObj.loadedEntityList) {
                       if (obj instanceof MCH_EntityAircraft) {
                           MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
-                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID)) {
+                          UUID persistentId = ac.getUavPersistentUUID();
+                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID) || (persistentId != null && persistentId.toString().equals(this.assignedUavUUID))) {
                               linkUav(ac);
                               break;
                           }
@@ -630,11 +637,19 @@ public class MCH_EntityUavStation
            this.prevPosX = this.posX;
            this.prevPosY = this.posY;
            this.prevPosZ = this.posZ;
-           if (getControlAircract() != null && ((getControlAircract()).isDead || getControlAircract().isDestroyed())) {
+           if (getControlAircract() != null && getControlAircract().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getControlAircract())) });
+                unlinkInvalidUav();
+              } else if (getControlAircract() != null && getControlAircract().isDead) {
+                markLinkedUavUnloaded();
                 setControlAircract((MCH_EntityAircraft)null);
               }
 
-           if (getLastControlAircraft() != null && ((getLastControlAircraft()).isDead || getLastControlAircraft().isDestroyed())) {
+           if (getLastControlAircraft() != null && getLastControlAircraft().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Last linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getLastControlAircraft())) });
+                unlinkInvalidUav();
+              } else if (getLastControlAircraft() != null && getLastControlAircraft().isDead) {
+                markLinkedUavUnloaded();
                 setLastControlAircraft((MCH_EntityAircraft)null);
               }
 
@@ -1015,6 +1030,15 @@ public class MCH_EntityUavStation
                    }
 
                 if (ac != null) {
+                    MCH_EntityAircraft linked = findLinkedUavEntity(this.worldObj);
+                    if(linked != null && !linked.isDead && isValidLinkedUav(linked, user instanceof EntityPlayer ? (EntityPlayer)user : null)) {
+                        MCH_Lib.Log((Entity)this, "Avoided spawning duplicate UAV from station %d; reusing linked UAV %d (%s)", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)), Integer.valueOf(W_Entity.getEntityId((Entity)linked)), linked.getUavPersistentUUID() == null ? "" : linked.getUavPersistentUUID().toString() });
+                        ((MCH_EntityAircraft)ac).setDead(false);
+                        linkUav(linked);
+                        setControlAircract(linked);
+                        W_EntityPlayer.closeScreen(user);
+                        return;
+                    }
                     if(MCH_Config.ItemDamage.prmBool) {
 
                         ((MCH_EntityAircraft)ac).getAcDataFromItem(itemStack);

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import mcheli.MCH_Lib;
 import mcheli.aircraft.MCH_EntityAircraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 
 /** Runtime lookup cache only; persistent truth lives on aircraft/station/player NBT. */
 public final class MCH_UavRegistry {
+    private static final Map<String, MCH_EntityAircraft> BY_PERSISTENT_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_ENTITY_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_COMMON_ID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_OWNER = new HashMap<String, MCH_EntityAircraft>();
@@ -20,6 +22,14 @@ public final class MCH_UavRegistry {
     public static void register(MCH_EntityAircraft ac) {
         if (!isValidUav(ac)) {
             return;
+        }
+        MCH_EntityAircraft canonical = pruneDuplicate(ac);
+        if (canonical != ac) {
+            return;
+        }
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            BY_PERSISTENT_UUID.put(persistentId.toString(), ac);
         }
         BY_ENTITY_UUID.put(ac.getUniqueID().toString(), ac);
         if (ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
@@ -34,18 +44,24 @@ public final class MCH_UavRegistry {
         if (ac == null) {
             return;
         }
-        BY_ENTITY_UUID.remove(ac.getUniqueID().toString());
+        removeIfSame(BY_ENTITY_UUID, ac.getUniqueID().toString(), ac);
+        UUID persistentId = ac.getUavPersistentUUID(false);
+        if (persistentId != null) {
+            removeIfSame(BY_PERSISTENT_UUID, persistentId.toString(), ac);
+        }
         if (ac.getCommonUniqueId() != null) {
-            BY_COMMON_ID.remove(ac.getCommonUniqueId());
+            removeIfSame(BY_COMMON_ID, ac.getCommonUniqueId(), ac);
         }
         if (ac.getOwnerUUID() != null) {
-            BY_OWNER.remove(ac.getOwnerUUID().toString());
+            removeIfSame(BY_OWNER, ac.getOwnerUUID().toString(), ac);
         }
     }
 
-    public static MCH_EntityAircraft findLinkedUav(World world, UUID entityUuid, String commonId, UUID owner) {
-        boolean hasStableLink = entityUuid != null || (commonId != null && !commonId.isEmpty());
-        MCH_EntityAircraft ac = getLive(BY_ENTITY_UUID.get(entityUuid == null ? "" : entityUuid.toString()), world);
+    public static MCH_EntityAircraft findLinkedUav(World world, UUID persistentUuid, String commonId, UUID owner) {
+        boolean hasStableLink = persistentUuid != null || (commonId != null && !commonId.isEmpty());
+        MCH_EntityAircraft ac = getLive(BY_PERSISTENT_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
+        if (ac != null) return ac;
+        ac = getLive(BY_ENTITY_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
         if (ac != null) return ac;
         ac = getLive(BY_COMMON_ID.get(commonId == null ? "" : commonId), world);
         if (ac != null) return ac;
@@ -53,7 +69,7 @@ public final class MCH_UavRegistry {
             ac = getLive(BY_OWNER.get(owner == null ? "" : owner.toString()), world);
             if (ac != null) return ac;
         }
-        return searchLoaded(world, entityUuid, commonId, hasStableLink ? null : owner);
+        return searchLoaded(world, persistentUuid, commonId, hasStableLink ? null : owner);
     }
 
     public static MCH_EntityAircraft findByOwner(World world, UUID owner) {
@@ -75,7 +91,11 @@ public final class MCH_UavRegistry {
                 MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
                 if (isValidUav(ac)) {
                     register(ac);
-                    boolean entityMatch = entityUuid != null && entityUuid.equals(ac.getUniqueID());
+                    if (ac.isDead) {
+                        continue;
+                    }
+                    UUID persistentId = ac.getUavPersistentUUID();
+                    boolean entityMatch = entityUuid != null && (entityUuid.equals(persistentId) || entityUuid.equals(ac.getUniqueID()));
                     boolean commonMatch = commonId != null && !commonId.isEmpty() && commonId.equals(ac.getCommonUniqueId());
                     boolean ownerMatch = owner != null && owner.equals(ac.getOwnerUUID());
                     if (entityUuid == null && (commonId == null || commonId.isEmpty()) && owner == null && first == null) {
@@ -95,6 +115,43 @@ public final class MCH_UavRegistry {
         }
         unregister(ac);
         return null;
+    }
+
+    private static void removeIfSame(Map<String, MCH_EntityAircraft> map, String key, MCH_EntityAircraft ac) {
+        if (key != null && map.get(key) == ac) {
+            map.remove(key);
+        }
+    }
+
+    private static MCH_EntityAircraft pruneDuplicate(MCH_EntityAircraft ac) {
+        MCH_EntityAircraft duplicate = null;
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            duplicate = getLive(BY_PERSISTENT_UUID.get(persistentId.toString()), ac.worldObj);
+        }
+        if (duplicate == null && ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
+            duplicate = getLive(BY_COMMON_ID.get(ac.getCommonUniqueId()), ac.worldObj);
+        }
+        if (duplicate == null || duplicate == ac) {
+            return ac;
+        }
+
+        MCH_EntityAircraft keep = chooseCanonical(duplicate, ac);
+        MCH_EntityAircraft remove = keep == ac ? duplicate : ac;
+        MCH_Lib.Log(remove, "Duplicate UAV identity detected: keeping entity %d and removing duplicate %d (persistent=%s, common=%s)", new Object[] {
+                Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
+                persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
+        unregister(remove);
+        remove.setDead(false);
+        return keep;
+    }
+
+    private static MCH_EntityAircraft chooseCanonical(MCH_EntityAircraft a, MCH_EntityAircraft b) {
+        if (b.getRiddenByEntity() != null && a.getRiddenByEntity() == null) return b;
+        if (a.getRiddenByEntity() != null && b.getRiddenByEntity() == null) return a;
+        if (b.getUavStation() != null && a.getUavStation() == null) return b;
+        if (a.getUavStation() != null && b.getUavStation() == null) return a;
+        return a.ticksExisted >= b.ticksExisted ? a : b;
     }
 
     private static boolean isValidUav(MCH_EntityAircraft ac) {


### PR DESCRIPTION
### Motivation
- Fix duplication and reconnect bugs where a new UAV entity was spawned when the original UAV continued operating outside loaded chunks or after reloads, because the code relied on transient entity IDs instead of a stable persistent identity. 
- Ensure station <> UAV links survive chunk unload/reload, player relog/server restart, and station reconnects by using durable identifiers and rebuilding runtime caches.

### Description
- Added a stable persistent UAV UUID to `MCH_EntityAircraft` (`uavPersistentUUID`) and persistently save/load it in NBT so stations/registry can match the same UAV across reloads.  
- Updated `MCH_EntityUavStation` to store and prefer the persistent UAV UUID (with compatibility fallback to legacy entity UUID), to save linked UAV position/dimension/owner, and to avoid clearing links when the UAV is merely unloaded (clear links only when UAV is confirmed destroyed).  
- Reworked `MCH_UavRegistry` to index by persistent UUID first, rebuild from loaded entities, avoid removing cache entries unless they reference the same entity, and detect+prune duplicate UAV entities by choosing a canonical entity and unregistering/removing the duplicate with logging. 
- Added station-side safeguard during `handleItem`/spawn flow to reuse an already-linked UAV when present (preventing spawning a duplicate), and added logging where duplicates are detected or links are cleared. 

### Testing
- Ran `git diff --check` to validate no trivial whitespace/patch issues (succeeded).  
- Attempted `gradle compileJava` to build the project, but it failed due to external dependency resolution being blocked by environment/network (ForgeGradle metadata requests returned HTTP 403), so a full compile could not be completed in this environment.  
- Attempted `gradle compileJava --offline` but it failed because necessary ForgeGradle artifacts were not cached locally, so offline build was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e6be9a2483238cd8221d49e27f06)