### PR TITLE
UAV persistence: stable UUIDs, duplicate pruning, and station-continue fixes

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -243,7 +243,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public String newUavPlayerUUID;
    private int delayedUavInventoryTicks;
+   private UUID uavPersistentUUID;
    private UUID uavOwnerUUID;
+   private boolean deletingNewUavForShiftExit;
    private UUID linkedUavStationUUID;
    private int linkedUavStationDimension;
    private double linkedUavStationX;
@@ -328,7 +330,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.missileDetector = new MCH_MissileDetector(this, world);
       this.uavStation = null;
       this.delayedUavInventoryTicks = 0;
+      this.uavPersistentUUID = null;
       this.uavOwnerUUID = null;
+      this.deletingNewUavForShiftExit = false;
       this.linkedUavStationUUID = null;
       this.linkedUavStationDimension = 0;
       this.linkedUavStationX = 0.0D;
@@ -579,11 +583,25 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    }
 
+   public UUID getUavPersistentUUID() {
+      return getUavPersistentUUID(true);
+   }
+
+   public UUID getUavPersistentUUID(boolean createIfMissing) {
+      if(this.uavPersistentUUID == null && createIfMissing && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
+      return this.uavPersistentUUID;
+   }
+
    public UUID getOwnerUUID() {
       return this.uavOwnerUUID;
    }
 
    public void setOwnerUUID(UUID uuid) {
+      if(!super.worldObj.isRemote && this.uavOwnerUUID != null && !this.uavOwnerUUID.equals(uuid)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.uavOwnerUUID = uuid;
       if(uuid != null && !super.worldObj.isRemote) {
          MCH_UavRegistry.register(this);
@@ -1174,6 +1192,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       this.dismountedUserCtrl = nbt.getBoolean("AcDismounted");
+      this.uavPersistentUUID = parseUUID(nbt.getString("MCH_UavPersistentUUID"));
+      if(this.uavPersistentUUID == null && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
       this.uavOwnerUUID = parseUUID(nbt.getString("MCH_UavOwnerUUID"));
       this.linkedUavStationUUID = parseUUID(nbt.getString("MCH_UavStationUUID"));
       this.linkedUavStationDimension = nbt.getInteger("MCH_UavStationDim");
@@ -1185,6 +1207,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.UavStationPosZ = MathHelper.floor_double(this.linkedUavStationZ);
       if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
          MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
       }
    }
 
@@ -1214,6 +1239,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       nbt.setTag("AcWeaponsAmmo", W_NBTTag.newTagIntArray("AcWeaponsAmmo", wa_list));
       nbt.setInteger("AcDamage", this.getDamageTaken());
       nbt.setBoolean("AcDismounted", this.dismountedUserCtrl);
+      UUID persistentId = this.getUavPersistentUUID(false);
+      if(persistentId == null && (this.isUAV() || this.isNewUAV())) {
+         persistentId = this.getUniqueID();
+         this.uavPersistentUUID = persistentId;
+      }
+      nbt.setString("MCH_UavPersistentUUID", persistentId == null ? "" : persistentId.toString());
       nbt.setString("MCH_UavOwnerUUID", this.uavOwnerUUID == null ? "" : this.uavOwnerUUID.toString());
       nbt.setString("MCH_UavStationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
       nbt.setInteger("MCH_UavStationDim", this.linkedUavStationDimension);
@@ -4784,7 +4815,16 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void setCommonUniqueId(String uniqId) {
+      if(!super.worldObj.isRemote && this.commonUniqueId != null && !this.commonUniqueId.equals(uniqId)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.commonUniqueId = uniqId;
+      if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
+         MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
+      }
    }
 
 
@@ -4824,6 +4864,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public void setDead(boolean dropItems) {
       if(!super.worldObj.isRemote && this.isNewUAV()) {
+         if(!this.deletingNewUavForShiftExit && this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.clearStoredUavAfterDestroyed(this);
+         }
          restoreStoredPilot("uav_destroyed");
       }
       MCH_UavRegistry.unregister(this);
@@ -4868,10 +4911,19 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
 
-   private void preserveNewUavStationLink() {
-      if(!super.worldObj.isRemote && this.isNewUAV() && this.uavStation != null && !this.uavStation.isDead) {
-         this.uavStation.linkUav(this);
-         this.uavStation.setControlAircract(this);
+   private void deleteNewUavAfterShiftExit() {
+      if(super.worldObj.isRemote || !this.isNewUAV()) {
+         return;
+      }
+      if(this.uavStation != null && !this.uavStation.isDead) {
+         this.uavStation.prepareNewUavShiftExit(this);
+      }
+      MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+      this.deletingNewUavForShiftExit = true;
+      try {
+         this.setDead(false);
+      } finally {
+         this.deletingNewUavForShiftExit = false;
       }
    }
 
@@ -4910,12 +4962,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                      newuavvariable = true;
                      //here
                      if(!this.worldObj.isRemote) {
-                      preserveNewUavStationLink();
                       rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                       rByEntity.mountEntity((Entity) null);
                       if(rByEntity instanceof EntityPlayerMP) {
                          MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
                       }
+                      deleteNewUavAfterShiftExit();
                      }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
@@ -5118,8 +5170,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                      entity.mountEntity((Entity) null);
                   }
                }
-               preserveNewUavStationLink();
                entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
+               deleteNewUavAfterShiftExit();
                return false;
             }
             MCH_EntitySeat[] arr$ = this.seats;
@@ -5131,8 +5183,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                   entity.mountEntity((Entity) null);
                }
             }
-            preserveNewUavStationLink();
             entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
+            deleteNewUavAfterShiftExit();
             return false;
          }
       }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -78,6 +78,9 @@ public class MCH_EntityUavStation
       private double linkedUavY;
       private double linkedUavZ;
       private boolean hasStoredUavLink;
+      private ItemStack lastUavItemStack;
+      private boolean hasStoredUavRespawnPosition;
+      private boolean respawnStoredUavAtSavedPosition;
       private boolean awaitingLoadedUav;
       private int pendingContinueTicks;
 
@@ -124,6 +127,9 @@ public class MCH_EntityUavStation
            this.loadedLastControlAircraftGuid = "";
            this.linkedUavCommonId = "";
            this.hasStoredUavLink = false;
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.respawnStoredUavAtSavedPosition = false;
            this.awaitingLoadedUav = false;
            this.pendingContinueTicks = 0;
          }
@@ -203,8 +209,9 @@ public class MCH_EntityUavStation
            }
            this.assignedUav = ac;
            this.assignedUavId = ac.getEntityId();
-           this.assignedUavUUID = ac.getUniqueID().toString();
-           this.linkedUavEntityUUID = ac.getUniqueID();
+           UUID persistentId = ac.getUavPersistentUUID();
+           this.assignedUavUUID = persistentId == null ? ac.getUniqueID().toString() : persistentId.toString();
+           this.linkedUavEntityUUID = persistentId == null ? ac.getUniqueID() : persistentId;
            this.linkedUavCommonId = ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId();
            updateLinkedUavPosition(ac);
            ac.setUavStation(this);
@@ -233,7 +240,8 @@ public class MCH_EntityUavStation
                   (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
                   this.linkedUavEntityUUID != null ||
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
-                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
+                  this.lastUavItemStack != null;
          }
 
       public void unlinkInvalidUav() {
@@ -243,6 +251,9 @@ public class MCH_EntityUavStation
            this.linkedUavEntityUUID = null;
            this.linkedUavCommonId = "";
            this.hasStoredUavLink = false;
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.respawnStoredUavAtSavedPosition = false;
            this.awaitingLoadedUav = false;
            this.pendingContinueTicks = 0;
            this.controlAircraft = null;
@@ -286,17 +297,25 @@ public class MCH_EntityUavStation
 
            nbt.setString("LastCtrlAc", s);
            nbt.setString("OwnerUUID", this.ownerUUID == null ? "" : this.ownerUUID.toString());
+           nbt.setString("LinkedUavPersistentUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavEntityUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavCommonId", this.linkedUavCommonId == null ? "" : this.linkedUavCommonId);
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
            nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
+           nbt.setBoolean("HasStoredUavRespawnPosition", this.hasStoredUavRespawnPosition);
            nbt.setDouble("LinkedUavX", this.linkedUavX);
            nbt.setDouble("LinkedUavY", this.linkedUavY);
            nbt.setDouble("LinkedUavZ", this.linkedUavZ);
+           if(this.lastUavItemStack != null) {
+                NBTTagCompound itemTag = new NBTTagCompound();
+                this.lastUavItemStack.writeToNBT(itemTag);
+                nbt.setTag("LastUavItem", itemTag);
+              }
 
           if (this.assignedUav != null && !this.assignedUav.isDead) {
               nbt.setInteger("AssignedUavId", this.assignedUav.getEntityId());
-              nbt.setString("AssignedUavUUID", this.assignedUav.getUniqueID().toString());
+              UUID persistentId = this.assignedUav.getUavPersistentUUID();
+              nbt.setString("AssignedUavUUID", persistentId == null ? this.assignedUav.getUniqueID().toString() : persistentId.toString());
           }
          }
 
@@ -317,13 +336,18 @@ public class MCH_EntityUavStation
               this.assignedUavUUID = nbt.getString("AssignedUavUUID");
           }
           this.ownerUUID = parseUavUUID(nbt.getString("OwnerUUID"));
-          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavPersistentUUID"));
+          if(this.linkedUavEntityUUID == null) {
+              this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          }
           this.linkedUavCommonId = nbt.getString("LinkedUavCommonId");
           this.linkedUavDimension = nbt.getInteger("LinkedUavDimension");
           this.hasStoredUavLink = nbt.getBoolean("HasStoredUavLink");
+          this.hasStoredUavRespawnPosition = nbt.getBoolean("HasStoredUavRespawnPosition");
           this.linkedUavX = nbt.getDouble("LinkedUavX");
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
+          this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
           if(this.linkedUavEntityUUID == null) {
               this.linkedUavEntityUUID = parseUavUUID(this.assignedUavUUID);
           }
@@ -331,7 +355,11 @@ public class MCH_EntityUavStation
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
                   this.assignedUavId > 0 ||
                   (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
-                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
+                  this.lastUavItemStack != null;
+          if(this.lastUavItemStack != null && !this.hasStoredUavRespawnPosition) {
+              this.hasStoredUavRespawnPosition = this.linkedUavY != 0.0D || this.linkedUavX != 0.0D || this.linkedUavZ != 0.0D;
+          }
           this.awaitingLoadedUav = hasLinkedUavIdentity;
           this.hasStoredUavLink = hasLinkedUavIdentity;
           if(this.awaitingLoadedUav) {
@@ -571,7 +599,8 @@ public class MCH_EntityUavStation
                   for (Object obj : this.worldObj.loadedEntityList) {
                       if (obj instanceof MCH_EntityAircraft) {
                           MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
-                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID)) {
+                          UUID persistentId = ac.getUavPersistentUUID();
+                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID) || (persistentId != null && persistentId.toString().equals(this.assignedUavUUID))) {
                               linkUav(ac);
                               break;
                           }
@@ -630,11 +659,19 @@ public class MCH_EntityUavStation
            this.prevPosX = this.posX;
            this.prevPosY = this.posY;
            this.prevPosZ = this.posZ;
-           if (getControlAircract() != null && ((getControlAircract()).isDead || getControlAircract().isDestroyed())) {
+           if (getControlAircract() != null && getControlAircract().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getControlAircract())) });
+                unlinkInvalidUav();
+              } else if (getControlAircract() != null && getControlAircract().isDead) {
+                markLinkedUavUnloaded();
                 setControlAircract((MCH_EntityAircraft)null);
               }
 
-           if (getLastControlAircraft() != null && ((getLastControlAircraft()).isDead || getLastControlAircraft().isDestroyed())) {
+           if (getLastControlAircraft() != null && getLastControlAircraft().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Last linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getLastControlAircraft())) });
+                unlinkInvalidUav();
+              } else if (getLastControlAircraft() != null && getLastControlAircraft().isDead) {
+                markLinkedUavUnloaded();
                 setLastControlAircraft((MCH_EntityAircraft)null);
               }
 
@@ -756,6 +793,64 @@ public class MCH_EntityUavStation
                 return false;
            }
            return ac.isUAV() || ac.isNewUAV();
+         }
+
+
+      public void prepareNewUavShiftExit(MCH_EntityAircraft ac) {
+           if(this.worldObj.isRemote || ac == null) {
+                return;
+           }
+           updateLinkedUavPosition(ac);
+           this.hasStoredUavRespawnPosition = true;
+           MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; deleting drone entity and keeping station launch state for Continue", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
+           this.assignedUav = null;
+           this.assignedUavId = -1;
+           this.assignedUavUUID = "";
+           this.linkedUavEntityUUID = null;
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityAircraft)null);
+           setLastControlAircraftEntityId(0);
+         }
+
+      public void clearStoredUavAfterDestroyed(MCH_EntityAircraft ac) {
+           if(this.worldObj.isRemote) {
+                return;
+           }
+           if(ac != null) {
+                updateLinkedUavPosition(ac);
+                MCH_Lib.Log((Entity)this, "Linked new UAV %d was destroyed at %.2f, %.2f, %.2f; disabling stored Continue relaunch", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
+           }
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.respawnStoredUavAtSavedPosition = false;
+           unlinkInvalidUav();
+         }
+
+      private boolean continueWithStoredUavItem(Entity user) {
+           if(user == null || this.lastUavItemStack == null || this.worldObj.isRemote) {
+                return false;
+           }
+           ItemStack stack = this.lastUavItemStack.copy();
+           stack.stackSize = 1;
+           MCH_Lib.Log((Entity)this, "Continue requested after shifted-out new UAV; relaunching stored UAV item %s", new Object[] { stack.getItem() == null ? "null" : stack.getItem().getUnlocalizedName() });
+           this.respawnStoredUavAtSavedPosition = true;
+           try {
+                handleItem(user, stack);
+           } finally {
+                this.respawnStoredUavAtSavedPosition = false;
+           }
+           MCH_EntityAircraft ac = getControlAircract();
+           if(ac != null && !ac.isDead) {
+                if(this.riddenByEntity != null && ac.isNewUAV()) {
+                     this.riddenByEntity.mountEntity((Entity)ac);
+                }
+                return true;
+           }
+           return false;
          }
 
 
@@ -947,6 +1042,8 @@ public class MCH_EntityUavStation
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);
+                 } else if (continueWithStoredUavItem(user)) {
+                     this.pendingContinueTicks = 0;
                  } else {
                      this.pendingContinueTicks = 60;
                      markLinkedUavUnloaded();
@@ -965,6 +1062,12 @@ public class MCH_EntityUavStation
                 double x = this.posX + this.posUavX;
                 double y = this.posY + this.posUavY;
                 double z = this.posZ + this.posUavZ;
+                if(this.respawnStoredUavAtSavedPosition && this.hasStoredUavRespawnPosition) {
+                     x = this.linkedUavX;
+                     y = this.linkedUavY;
+                     z = this.linkedUavZ;
+                     MCH_Lib.Log((Entity)this, "Respawning shifted-out UAV at saved delete position %.2f, %.2f, %.2f", new Object[] { Double.valueOf(x), Double.valueOf(y), Double.valueOf(z) });
+                   }
                 if (y <= 1.0D) {
                      y = 2.0D;
                    }
@@ -1015,6 +1118,15 @@ public class MCH_EntityUavStation
                    }
 
                 if (ac != null) {
+                    MCH_EntityAircraft linked = findLinkedUavEntity(this.worldObj);
+                    if(linked != null && !linked.isDead && isValidLinkedUav(linked, user instanceof EntityPlayer ? (EntityPlayer)user : null)) {
+                        MCH_Lib.Log((Entity)this, "Avoided spawning duplicate UAV from station %d; reusing linked UAV %d (%s)", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)), Integer.valueOf(W_Entity.getEntityId((Entity)linked)), linked.getUavPersistentUUID() == null ? "" : linked.getUavPersistentUUID().toString() });
+                        ((MCH_EntityAircraft)ac).setDead(false);
+                        linkUav(linked);
+                        setControlAircract(linked);
+                        W_EntityPlayer.closeScreen(user);
+                        return;
+                    }
                     if(MCH_Config.ItemDamage.prmBool) {
 
                         ((MCH_EntityAircraft)ac).getAcDataFromItem(itemStack);
@@ -1023,6 +1135,8 @@ public class MCH_EntityUavStation
                      ((Entity)ac).prevRotationYaw = ((Entity)ac).rotationYaw;
                      user.rotationYaw = this.rotationYaw - 180.0F;
                      if (this.worldObj.getCollidingBoundingBoxes((Entity)ac, ((Entity)ac).boundingBox.expand(-0.1D, -0.1D, -0.1D)).isEmpty()) {
+                          this.lastUavItemStack = itemStack.copy();
+                          this.lastUavItemStack.stackSize = 1;
                           itemStack.stackSize--;
                           MCH_Lib.DbgLog(this.worldObj, "Create UAV: %s : %s", new Object[] { item.getUnlocalizedName(), item });
                           user.rotationYaw = this.rotationYaw - 180.0F;

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import mcheli.MCH_Lib;
 import mcheli.aircraft.MCH_EntityAircraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 
 /** Runtime lookup cache only; persistent truth lives on aircraft/station/player NBT. */
 public final class MCH_UavRegistry {
+    private static final Map<String, MCH_EntityAircraft> BY_PERSISTENT_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_ENTITY_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_COMMON_ID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_OWNER = new HashMap<String, MCH_EntityAircraft>();
@@ -20,6 +22,14 @@ public final class MCH_UavRegistry {
     public static void register(MCH_EntityAircraft ac) {
         if (!isValidUav(ac)) {
             return;
+        }
+        MCH_EntityAircraft canonical = pruneDuplicate(ac);
+        if (canonical != ac) {
+            return;
+        }
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            BY_PERSISTENT_UUID.put(persistentId.toString(), ac);
         }
         BY_ENTITY_UUID.put(ac.getUniqueID().toString(), ac);
         if (ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
@@ -34,18 +44,24 @@ public final class MCH_UavRegistry {
         if (ac == null) {
             return;
         }
-        BY_ENTITY_UUID.remove(ac.getUniqueID().toString());
+        removeIfSame(BY_ENTITY_UUID, ac.getUniqueID().toString(), ac);
+        UUID persistentId = ac.getUavPersistentUUID(false);
+        if (persistentId != null) {
+            removeIfSame(BY_PERSISTENT_UUID, persistentId.toString(), ac);
+        }
         if (ac.getCommonUniqueId() != null) {
-            BY_COMMON_ID.remove(ac.getCommonUniqueId());
+            removeIfSame(BY_COMMON_ID, ac.getCommonUniqueId(), ac);
         }
         if (ac.getOwnerUUID() != null) {
-            BY_OWNER.remove(ac.getOwnerUUID().toString());
+            removeIfSame(BY_OWNER, ac.getOwnerUUID().toString(), ac);
         }
     }
 
-    public static MCH_EntityAircraft findLinkedUav(World world, UUID entityUuid, String commonId, UUID owner) {
-        boolean hasStableLink = entityUuid != null || (commonId != null && !commonId.isEmpty());
-        MCH_EntityAircraft ac = getLive(BY_ENTITY_UUID.get(entityUuid == null ? "" : entityUuid.toString()), world);
+    public static MCH_EntityAircraft findLinkedUav(World world, UUID persistentUuid, String commonId, UUID owner) {
+        boolean hasStableLink = persistentUuid != null || (commonId != null && !commonId.isEmpty());
+        MCH_EntityAircraft ac = getLive(BY_PERSISTENT_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
+        if (ac != null) return ac;
+        ac = getLive(BY_ENTITY_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
         if (ac != null) return ac;
         ac = getLive(BY_COMMON_ID.get(commonId == null ? "" : commonId), world);
         if (ac != null) return ac;
@@ -53,7 +69,7 @@ public final class MCH_UavRegistry {
             ac = getLive(BY_OWNER.get(owner == null ? "" : owner.toString()), world);
             if (ac != null) return ac;
         }
-        return searchLoaded(world, entityUuid, commonId, hasStableLink ? null : owner);
+        return searchLoaded(world, persistentUuid, commonId, hasStableLink ? null : owner);
     }
 
     public static MCH_EntityAircraft findByOwner(World world, UUID owner) {
@@ -75,7 +91,11 @@ public final class MCH_UavRegistry {
                 MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
                 if (isValidUav(ac)) {
                     register(ac);
-                    boolean entityMatch = entityUuid != null && entityUuid.equals(ac.getUniqueID());
+                    if (ac.isDead) {
+                        continue;
+                    }
+                    UUID persistentId = ac.getUavPersistentUUID();
+                    boolean entityMatch = entityUuid != null && (entityUuid.equals(persistentId) || entityUuid.equals(ac.getUniqueID()));
                     boolean commonMatch = commonId != null && !commonId.isEmpty() && commonId.equals(ac.getCommonUniqueId());
                     boolean ownerMatch = owner != null && owner.equals(ac.getOwnerUUID());
                     if (entityUuid == null && (commonId == null || commonId.isEmpty()) && owner == null && first == null) {
@@ -95,6 +115,43 @@ public final class MCH_UavRegistry {
         }
         unregister(ac);
         return null;
+    }
+
+    private static void removeIfSame(Map<String, MCH_EntityAircraft> map, String key, MCH_EntityAircraft ac) {
+        if (key != null && map.get(key) == ac) {
+            map.remove(key);
+        }
+    }
+
+    private static MCH_EntityAircraft pruneDuplicate(MCH_EntityAircraft ac) {
+        MCH_EntityAircraft duplicate = null;
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            duplicate = getLive(BY_PERSISTENT_UUID.get(persistentId.toString()), ac.worldObj);
+        }
+        if (duplicate == null && ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
+            duplicate = getLive(BY_COMMON_ID.get(ac.getCommonUniqueId()), ac.worldObj);
+        }
+        if (duplicate == null || duplicate == ac) {
+            return ac;
+        }
+
+        MCH_EntityAircraft keep = chooseCanonical(duplicate, ac);
+        MCH_EntityAircraft remove = keep == ac ? duplicate : ac;
+        MCH_Lib.Log(remove, "Duplicate UAV identity detected: keeping entity %d and removing duplicate %d (persistent=%s, common=%s)", new Object[] {
+                Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
+                persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
+        unregister(remove);
+        remove.setDead(false);
+        return keep;
+    }
+
+    private static MCH_EntityAircraft chooseCanonical(MCH_EntityAircraft a, MCH_EntityAircraft b) {
+        if (b.getRiddenByEntity() != null && a.getRiddenByEntity() == null) return b;
+        if (a.getRiddenByEntity() != null && b.getRiddenByEntity() == null) return a;
+        if (b.getUavStation() != null && a.getUavStation() == null) return b;
+        if (a.getUavStation() != null && b.getUavStation() == null) return a;
+        return a.ticksExisted >= b.ticksExisted ? a : b;
     }
 
     private static boolean isValidUav(MCH_EntityAircraft ac) {


### PR DESCRIPTION
### Motivation
- Ensure UAV entities have a stable persistent identity so stations can reliably re-link, continue, or respawn previously-launched UAVs. 
- Avoid spawning duplicate UAV entities when a station relaunches or a UAV is shifted out/in, and preserve station "continue" state for new-UAV shift-exit flows. 
- Improve registry correctness when aircraft/station ownership or common IDs change so lookups stay consistent.

### Description
- Add a persistent UAV UUID field to `MCH_EntityAircraft` (`uavPersistentUUID`) with accessor `getUavPersistentUUID(boolean createIfMissing)` and persist it to NBT as `MCH_UavPersistentUUID`.  Load fallback to the entity UUID when missing. 
- Unregister/register aircraft from `MCH_UavRegistry` on owner/common-id changes and when appropriate during initialization to keep runtime caches consistent. 
- Add logic to delete a new-UAV entity after a player shift-exit while preserving the station's stored respawn/continue state (`deleteNewUavAfterShiftExit`, `prepareNewUavShiftExit`, `clearStoredUavAfterDestroyed`). 
- Extend `MCH_EntityUavStation` to store the last spawned UAV item (`lastUavItemStack`), respawn-position flags, and support respawning a stored UAV item at the saved delete position (`respawnStoredUavAtSavedPosition` / `continueWithStoredUavItem`). 
- Prevent duplicate UAV spawn by detecting existing linked UAVs (using persistent UUID or entity UUID) in `handleItem` and reusing the linked entity instead of creating a new one. 
- Replace and expand `MCH_UavRegistry` maps to include `BY_PERSISTENT_UUID`, add careful removal (`removeIfSame`), search by persistent UUID, and add duplicate-pruning logic (`pruneDuplicate` / `chooseCanonical`) to pick a canonical live entity and remove the duplicate. 
- Use new NBT keys and backwards-compatible reads/writes (`LinkedUavPersistentUUID` etc.) and add small logging messages to aid debugging of link/duplicate events.

### Testing
- Project compiled successfully using the build task (`./gradlew build`) with the modified sources. 
- Ran the project's automated test suite (`./gradlew test`) and all tests completed without failure. 
- Verified registry lookup paths by exercising station relink/continue flows in an automated integration smoke test harness and confirmed duplicate-pruning and station re-link logic executed (no test regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e6be9a2483238cd8221d49e27f06)