### PR TITLE
Add persistent UAV IDs, station Continue/shift-exit handling, and registry de-duplication

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -243,7 +243,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public String newUavPlayerUUID;
    private int delayedUavInventoryTicks;
+   private UUID uavPersistentUUID;
    private UUID uavOwnerUUID;
+   private boolean deletingNewUavForShiftExit;
    private UUID linkedUavStationUUID;
    private int linkedUavStationDimension;
    private double linkedUavStationX;
@@ -328,7 +330,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.missileDetector = new MCH_MissileDetector(this, world);
       this.uavStation = null;
       this.delayedUavInventoryTicks = 0;
+      this.uavPersistentUUID = null;
       this.uavOwnerUUID = null;
+      this.deletingNewUavForShiftExit = false;
       this.linkedUavStationUUID = null;
       this.linkedUavStationDimension = 0;
       this.linkedUavStationX = 0.0D;
@@ -579,11 +583,25 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    }
 
+   public UUID getUavPersistentUUID() {
+      return getUavPersistentUUID(true);
+   }
+
+   public UUID getUavPersistentUUID(boolean createIfMissing) {
+      if(this.uavPersistentUUID == null && createIfMissing && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
+      return this.uavPersistentUUID;
+   }
+
    public UUID getOwnerUUID() {
       return this.uavOwnerUUID;
    }
 
    public void setOwnerUUID(UUID uuid) {
+      if(!super.worldObj.isRemote && this.uavOwnerUUID != null && !this.uavOwnerUUID.equals(uuid)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.uavOwnerUUID = uuid;
       if(uuid != null && !super.worldObj.isRemote) {
          MCH_UavRegistry.register(this);
@@ -1174,6 +1192,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       this.dismountedUserCtrl = nbt.getBoolean("AcDismounted");
+      this.uavPersistentUUID = parseUUID(nbt.getString("MCH_UavPersistentUUID"));
+      if(this.uavPersistentUUID == null && (this.isUAV() || this.isNewUAV())) {
+         this.uavPersistentUUID = this.getUniqueID();
+      }
       this.uavOwnerUUID = parseUUID(nbt.getString("MCH_UavOwnerUUID"));
       this.linkedUavStationUUID = parseUUID(nbt.getString("MCH_UavStationUUID"));
       this.linkedUavStationDimension = nbt.getInteger("MCH_UavStationDim");
@@ -1185,6 +1207,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.UavStationPosZ = MathHelper.floor_double(this.linkedUavStationZ);
       if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
          MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
       }
    }
 
@@ -1214,6 +1239,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       nbt.setTag("AcWeaponsAmmo", W_NBTTag.newTagIntArray("AcWeaponsAmmo", wa_list));
       nbt.setInteger("AcDamage", this.getDamageTaken());
       nbt.setBoolean("AcDismounted", this.dismountedUserCtrl);
+      UUID persistentId = this.getUavPersistentUUID(false);
+      if(persistentId == null && (this.isUAV() || this.isNewUAV())) {
+         persistentId = this.getUniqueID();
+         this.uavPersistentUUID = persistentId;
+      }
+      nbt.setString("MCH_UavPersistentUUID", persistentId == null ? "" : persistentId.toString());
       nbt.setString("MCH_UavOwnerUUID", this.uavOwnerUUID == null ? "" : this.uavOwnerUUID.toString());
       nbt.setString("MCH_UavStationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
       nbt.setInteger("MCH_UavStationDim", this.linkedUavStationDimension);
@@ -4784,7 +4815,16 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void setCommonUniqueId(String uniqId) {
+      if(!super.worldObj.isRemote && this.commonUniqueId != null && !this.commonUniqueId.equals(uniqId)) {
+         MCH_UavRegistry.unregister(this);
+      }
       this.commonUniqueId = uniqId;
+      if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
+         MCH_UavRegistry.register(this);
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.linkUav(this);
+         }
+      }
    }
 
 
@@ -4824,6 +4864,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    public void setDead(boolean dropItems) {
       if(!super.worldObj.isRemote && this.isNewUAV()) {
+         if(!this.deletingNewUavForShiftExit && this.uavStation != null && !this.uavStation.isDead) {
+            this.uavStation.clearStoredUavAfterDestroyed(this);
+         }
          restoreStoredPilot("uav_destroyed");
       }
       MCH_UavRegistry.unregister(this);
@@ -4868,10 +4911,87 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
 
-   private void preserveNewUavStationLink() {
-      if(!super.worldObj.isRemote && this.isNewUAV() && this.uavStation != null && !this.uavStation.isDead) {
-         this.uavStation.linkUav(this);
-         this.uavStation.setControlAircract(this);
+   private MCH_EntityUavStation findLinkedUavStationForShiftExit() {
+      if(this.uavStation != null && !this.uavStation.isDead) {
+         return this.uavStation;
+      }
+      if(super.worldObj.isRemote || this.linkedUavStationDimension != super.dimension) {
+         return null;
+      }
+
+      int sx = this.linkedUavStationX != 0.0D ? MathHelper.floor_double(this.linkedUavStationX) : this.UavStationPosX;
+      int sy = this.linkedUavStationY != 0.0D ? MathHelper.floor_double(this.linkedUavStationY) : this.UavStationPosY;
+      int sz = this.linkedUavStationZ != 0.0D ? MathHelper.floor_double(this.linkedUavStationZ) : this.UavStationPosZ;
+      super.worldObj.getChunkFromBlockCoords(sx, sz);
+
+      MCH_EntityUavStation fallback = null;
+      List list = super.worldObj.loadedEntityList;
+      for(int i = 0; i < list.size(); ++i) {
+         Object obj = list.get(i);
+         if(obj instanceof MCH_EntityUavStation) {
+            MCH_EntityUavStation station = (MCH_EntityUavStation)obj;
+            if(station.isDead) {
+               continue;
+            }
+            if(this.linkedUavStationUUID != null && this.linkedUavStationUUID.equals(station.getUniqueID())) {
+               this.uavStation = station;
+               return station;
+            }
+            if(fallback == null && station.dimension == super.dimension && station.getDistanceSq((double)sx, (double)sy, (double)sz) < 16.0D) {
+               fallback = station;
+            }
+         }
+      }
+      if(fallback != null) {
+         this.uavStation = fallback;
+      }
+      return fallback;
+   }
+
+   private void storePendingNewUavShiftExit(Entity rider) {
+      if(!(rider instanceof EntityPlayer) || this.getItem() == null) {
+         return;
+      }
+      NBTTagCompound pending = new NBTTagCompound();
+      pending.setString("StationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
+      pending.setInteger("StationDim", this.linkedUavStationDimension);
+      pending.setDouble("StationX", this.linkedUavStationX);
+      pending.setDouble("StationY", this.linkedUavStationY);
+      pending.setDouble("StationZ", this.linkedUavStationZ);
+      pending.setDouble("UavX", super.posX);
+      pending.setDouble("UavY", super.posY);
+      pending.setDouble("UavZ", super.posZ);
+      ItemStack stack = new ItemStack(this.getItem(), 1, 0);
+      NBTTagCompound itemTag = new NBTTagCompound();
+      stack.writeToNBT(itemTag);
+      pending.setTag("UavItem", itemTag);
+      ((EntityPlayer)rider).getEntityData().setTag("MCH_PendingNewUavShiftExit", pending);
+   }
+
+   private void clearPendingNewUavShiftExit(Entity rider) {
+      if(rider instanceof EntityPlayer) {
+         ((EntityPlayer)rider).getEntityData().removeTag("MCH_PendingNewUavShiftExit");
+      }
+   }
+
+   private void deleteNewUavAfterShiftExit(Entity rider) {
+      if(super.worldObj.isRemote || !this.isNewUAV()) {
+         return;
+      }
+      storePendingNewUavShiftExit(rider);
+      MCH_EntityUavStation station = findLinkedUavStationForShiftExit();
+      if(station != null && !station.isDead) {
+         station.prepareNewUavShiftExit(this);
+         clearPendingNewUavShiftExit(rider);
+      } else {
+         MCH_Lib.Log((Entity)this, "Unable to find linked UAV station for new UAV %d during shift-exit; saved pending Continue state on rider", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+      }
+      MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+      this.deletingNewUavForShiftExit = true;
+      try {
+         this.setDead(false);
+      } finally {
+         this.deletingNewUavForShiftExit = false;
       }
    }
 
@@ -4910,12 +5030,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                      newuavvariable = true;
                      //here
                      if(!this.worldObj.isRemote) {
-                      preserveNewUavStationLink();
                       rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                       rByEntity.mountEntity((Entity) null);
                       if(rByEntity instanceof EntityPlayerMP) {
                          MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
                       }
+                      deleteNewUavAfterShiftExit(rByEntity);
                      }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
@@ -5118,8 +5238,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                      entity.mountEntity((Entity) null);
                   }
                }
-               preserveNewUavStationLink();
                entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
+               deleteNewUavAfterShiftExit(entity);
                return false;
             }
             MCH_EntitySeat[] arr$ = this.seats;
@@ -5131,8 +5251,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                   entity.mountEntity((Entity) null);
                }
             }
-            preserveNewUavStationLink();
             entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
+            deleteNewUavAfterShiftExit(entity);
             return false;
          }
       }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -78,6 +78,12 @@ public class MCH_EntityUavStation
       private double linkedUavY;
       private double linkedUavZ;
       private boolean hasStoredUavLink;
+      private ItemStack lastUavItemStack;
+      private boolean hasStoredUavRespawnPosition;
+      private double storedUavRespawnX;
+      private double storedUavRespawnY;
+      private double storedUavRespawnZ;
+      private boolean respawnStoredUavAtSavedPosition;
       private boolean awaitingLoadedUav;
       private int pendingContinueTicks;
 
@@ -124,6 +130,12 @@ public class MCH_EntityUavStation
            this.loadedLastControlAircraftGuid = "";
            this.linkedUavCommonId = "";
            this.hasStoredUavLink = false;
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.storedUavRespawnX = 0.0D;
+           this.storedUavRespawnY = 0.0D;
+           this.storedUavRespawnZ = 0.0D;
+           this.respawnStoredUavAtSavedPosition = false;
            this.awaitingLoadedUav = false;
            this.pendingContinueTicks = 0;
          }
@@ -203,8 +215,9 @@ public class MCH_EntityUavStation
            }
            this.assignedUav = ac;
            this.assignedUavId = ac.getEntityId();
-           this.assignedUavUUID = ac.getUniqueID().toString();
-           this.linkedUavEntityUUID = ac.getUniqueID();
+           UUID persistentId = ac.getUavPersistentUUID();
+           this.assignedUavUUID = persistentId == null ? ac.getUniqueID().toString() : persistentId.toString();
+           this.linkedUavEntityUUID = persistentId == null ? ac.getUniqueID() : persistentId;
            this.linkedUavCommonId = ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId();
            updateLinkedUavPosition(ac);
            ac.setUavStation(this);
@@ -223,6 +236,9 @@ public class MCH_EntityUavStation
                 this.linkedUavX = ac.posX;
                 this.linkedUavY = ac.posY;
                 this.linkedUavZ = ac.posZ;
+                if(ac.isNewUAV() && this.lastUavItemStack != null) {
+                     storeUavRespawnPosition(ac);
+                }
            }
          }
 
@@ -233,7 +249,8 @@ public class MCH_EntityUavStation
                   (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
                   this.linkedUavEntityUUID != null ||
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
-                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
+                  this.lastUavItemStack != null;
          }
 
       public void unlinkInvalidUav() {
@@ -243,6 +260,12 @@ public class MCH_EntityUavStation
            this.linkedUavEntityUUID = null;
            this.linkedUavCommonId = "";
            this.hasStoredUavLink = false;
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.storedUavRespawnX = 0.0D;
+           this.storedUavRespawnY = 0.0D;
+           this.storedUavRespawnZ = 0.0D;
+           this.respawnStoredUavAtSavedPosition = false;
            this.awaitingLoadedUav = false;
            this.pendingContinueTicks = 0;
            this.controlAircraft = null;
@@ -286,17 +309,28 @@ public class MCH_EntityUavStation
 
            nbt.setString("LastCtrlAc", s);
            nbt.setString("OwnerUUID", this.ownerUUID == null ? "" : this.ownerUUID.toString());
+           nbt.setString("LinkedUavPersistentUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavEntityUUID", this.linkedUavEntityUUID == null ? "" : this.linkedUavEntityUUID.toString());
            nbt.setString("LinkedUavCommonId", this.linkedUavCommonId == null ? "" : this.linkedUavCommonId);
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
            nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
+           nbt.setBoolean("HasStoredUavRespawnPosition", this.hasStoredUavRespawnPosition);
+           nbt.setDouble("StoredUavRespawnX", this.storedUavRespawnX);
+           nbt.setDouble("StoredUavRespawnY", this.storedUavRespawnY);
+           nbt.setDouble("StoredUavRespawnZ", this.storedUavRespawnZ);
            nbt.setDouble("LinkedUavX", this.linkedUavX);
            nbt.setDouble("LinkedUavY", this.linkedUavY);
            nbt.setDouble("LinkedUavZ", this.linkedUavZ);
+           if(this.lastUavItemStack != null) {
+                NBTTagCompound itemTag = new NBTTagCompound();
+                this.lastUavItemStack.writeToNBT(itemTag);
+                nbt.setTag("LastUavItem", itemTag);
+              }
 
           if (this.assignedUav != null && !this.assignedUav.isDead) {
               nbt.setInteger("AssignedUavId", this.assignedUav.getEntityId());
-              nbt.setString("AssignedUavUUID", this.assignedUav.getUniqueID().toString());
+              UUID persistentId = this.assignedUav.getUavPersistentUUID();
+              nbt.setString("AssignedUavUUID", persistentId == null ? this.assignedUav.getUniqueID().toString() : persistentId.toString());
           }
          }
 
@@ -317,13 +351,21 @@ public class MCH_EntityUavStation
               this.assignedUavUUID = nbt.getString("AssignedUavUUID");
           }
           this.ownerUUID = parseUavUUID(nbt.getString("OwnerUUID"));
-          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavPersistentUUID"));
+          if(this.linkedUavEntityUUID == null) {
+              this.linkedUavEntityUUID = parseUavUUID(nbt.getString("LinkedUavEntityUUID"));
+          }
           this.linkedUavCommonId = nbt.getString("LinkedUavCommonId");
           this.linkedUavDimension = nbt.getInteger("LinkedUavDimension");
           this.hasStoredUavLink = nbt.getBoolean("HasStoredUavLink");
+          this.hasStoredUavRespawnPosition = nbt.getBoolean("HasStoredUavRespawnPosition");
+          this.storedUavRespawnX = nbt.getDouble("StoredUavRespawnX");
+          this.storedUavRespawnY = nbt.getDouble("StoredUavRespawnY");
+          this.storedUavRespawnZ = nbt.getDouble("StoredUavRespawnZ");
           this.linkedUavX = nbt.getDouble("LinkedUavX");
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
+          this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
           if(this.linkedUavEntityUUID == null) {
               this.linkedUavEntityUUID = parseUavUUID(this.assignedUavUUID);
           }
@@ -331,7 +373,16 @@ public class MCH_EntityUavStation
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
                   this.assignedUavId > 0 ||
                   (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
-                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty());
+                  (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
+                  this.lastUavItemStack != null;
+          if(this.lastUavItemStack != null && !this.hasStoredUavRespawnPosition) {
+              this.hasStoredUavRespawnPosition = this.linkedUavY != 0.0D || this.linkedUavX != 0.0D || this.linkedUavZ != 0.0D;
+              if(this.hasStoredUavRespawnPosition) {
+                  this.storedUavRespawnX = this.linkedUavX;
+                  this.storedUavRespawnY = this.linkedUavY;
+                  this.storedUavRespawnZ = this.linkedUavZ;
+              }
+          }
           this.awaitingLoadedUav = hasLinkedUavIdentity;
           this.hasStoredUavLink = hasLinkedUavIdentity;
           if(this.awaitingLoadedUav) {
@@ -571,7 +622,8 @@ public class MCH_EntityUavStation
                   for (Object obj : this.worldObj.loadedEntityList) {
                       if (obj instanceof MCH_EntityAircraft) {
                           MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
-                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID)) {
+                          UUID persistentId = ac.getUavPersistentUUID();
+                          if (ac.getUniqueID().toString().equals(this.assignedUavUUID) || (persistentId != null && persistentId.toString().equals(this.assignedUavUUID))) {
                               linkUav(ac);
                               break;
                           }
@@ -630,11 +682,19 @@ public class MCH_EntityUavStation
            this.prevPosX = this.posX;
            this.prevPosY = this.posY;
            this.prevPosZ = this.posZ;
-           if (getControlAircract() != null && ((getControlAircract()).isDead || getControlAircract().isDestroyed())) {
+           if (getControlAircract() != null && getControlAircract().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getControlAircract())) });
+                unlinkInvalidUav();
+              } else if (getControlAircract() != null && getControlAircract().isDead) {
+                markLinkedUavUnloaded();
                 setControlAircract((MCH_EntityAircraft)null);
               }
 
-           if (getLastControlAircraft() != null && ((getLastControlAircraft()).isDead || getLastControlAircraft().isDestroyed())) {
+           if (getLastControlAircraft() != null && getLastControlAircraft().isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Last linked UAV %d is destroyed; clearing station link", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)getLastControlAircraft())) });
+                unlinkInvalidUav();
+              } else if (getLastControlAircraft() != null && getLastControlAircraft().isDead) {
+                markLinkedUavUnloaded();
                 setLastControlAircraft((MCH_EntityAircraft)null);
               }
 
@@ -756,6 +816,131 @@ public class MCH_EntityUavStation
                 return false;
            }
            return ac.isUAV() || ac.isNewUAV();
+         }
+
+
+      private boolean applyPendingNewUavShiftExit(Entity user) {
+           if(this.worldObj.isRemote || !(user instanceof EntityPlayer)) {
+                return false;
+           }
+           NBTTagCompound entityData = ((EntityPlayer)user).getEntityData();
+           if(entityData == null || !entityData.hasKey("MCH_PendingNewUavShiftExit")) {
+                return false;
+           }
+           NBTTagCompound pending = entityData.getCompoundTag("MCH_PendingNewUavShiftExit");
+           String stationUuid = pending.getString("StationUUID");
+           double stationX = pending.getDouble("StationX");
+           double stationY = pending.getDouble("StationY");
+           double stationZ = pending.getDouble("StationZ");
+           boolean uuidMatches = stationUuid != null && !stationUuid.isEmpty() && stationUuid.equals(this.getUniqueID().toString());
+           boolean positionMatches = this.getDistanceSq(stationX, stationY, stationZ) <= 64.0D;
+           if(!uuidMatches && !positionMatches) {
+                return false;
+           }
+           if(pending.hasKey("StationDim") && pending.getInteger("StationDim") != this.dimension) {
+                return false;
+           }
+           if(!pending.hasKey("UavItem")) {
+                entityData.removeTag("MCH_PendingNewUavShiftExit");
+                return false;
+           }
+
+           ItemStack stack = ItemStack.loadItemStackFromNBT(pending.getCompoundTag("UavItem"));
+           if(stack == null || stack.getItem() == null) {
+                entityData.removeTag("MCH_PendingNewUavShiftExit");
+                return false;
+           }
+
+           this.lastUavItemStack = stack.copy();
+           this.lastUavItemStack.stackSize = 1;
+           this.storedUavRespawnX = pending.getDouble("UavX");
+           this.storedUavRespawnY = pending.getDouble("UavY");
+           this.storedUavRespawnZ = pending.getDouble("UavZ");
+           this.hasStoredUavRespawnPosition = true;
+           this.assignedUav = null;
+           this.assignedUavId = -1;
+           this.assignedUavUUID = "";
+           this.linkedUavEntityUUID = null;
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityAircraft)null);
+           setLastControlAircraftEntityId(-1);
+           entityData.removeTag("MCH_PendingNewUavShiftExit");
+           MCH_Lib.Log((Entity)this, "Applied pending shifted-out new UAV Continue state at %.2f, %.2f, %.2f", new Object[] { Double.valueOf(this.storedUavRespawnX), Double.valueOf(this.storedUavRespawnY), Double.valueOf(this.storedUavRespawnZ) });
+           return true;
+         }
+
+      private void storeUavRespawnPosition(MCH_EntityAircraft ac) {
+           if(ac == null) {
+                return;
+           }
+           this.storedUavRespawnX = ac.posX;
+           this.storedUavRespawnY = ac.posY;
+           this.storedUavRespawnZ = ac.posZ;
+           this.hasStoredUavRespawnPosition = true;
+         }
+
+      public void prepareNewUavShiftExit(MCH_EntityAircraft ac) {
+           if(this.worldObj.isRemote || ac == null) {
+                return;
+           }
+           updateLinkedUavPosition(ac);
+           storeUavRespawnPosition(ac);
+           MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; deleting drone entity and keeping station launch state for Continue", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.storedUavRespawnX), Double.valueOf(this.storedUavRespawnY), Double.valueOf(this.storedUavRespawnZ) });
+           this.assignedUav = null;
+           this.assignedUavId = -1;
+           this.assignedUavUUID = "";
+           this.linkedUavEntityUUID = null;
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityAircraft)null);
+           setLastControlAircraftEntityId(-1);
+         }
+
+      public void clearStoredUavAfterDestroyed(MCH_EntityAircraft ac) {
+           if(this.worldObj.isRemote) {
+                return;
+           }
+           if(ac != null) {
+                updateLinkedUavPosition(ac);
+                MCH_Lib.Log((Entity)this, "Linked new UAV %d was destroyed at %.2f, %.2f, %.2f; disabling stored Continue relaunch", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
+           }
+           this.lastUavItemStack = null;
+           this.hasStoredUavRespawnPosition = false;
+           this.storedUavRespawnX = 0.0D;
+           this.storedUavRespawnY = 0.0D;
+           this.storedUavRespawnZ = 0.0D;
+           this.respawnStoredUavAtSavedPosition = false;
+           unlinkInvalidUav();
+         }
+
+      private boolean continueWithStoredUavItem(Entity user) {
+           if(user == null || this.lastUavItemStack == null || this.worldObj.isRemote) {
+                return false;
+           }
+           ItemStack stack = this.lastUavItemStack.copy();
+           stack.stackSize = 1;
+           MCH_Lib.Log((Entity)this, "Continue requested after shifted-out new UAV; relaunching stored UAV item %s", new Object[] { stack.getItem() == null ? "null" : stack.getItem().getUnlocalizedName() });
+           this.respawnStoredUavAtSavedPosition = true;
+           try {
+                handleItem(user, stack);
+           } finally {
+                this.respawnStoredUavAtSavedPosition = false;
+           }
+           MCH_EntityAircraft ac = getControlAircract();
+           if(ac != null && !ac.isDead) {
+                if(this.riddenByEntity != null && ac.isNewUAV()) {
+                     this.riddenByEntity.mountEntity((Entity)ac);
+                }
+                return true;
+           }
+           return false;
          }
 
 
@@ -903,6 +1088,7 @@ public class MCH_EntityUavStation
 
              private void controlLastAircraft(Entity user, boolean notify) {
 
+                 applyPendingNewUavShiftExit(user);
                  if(!hasContinuableUavLink()) {
                      if(notify && user instanceof EntityPlayer) {
                          W_EntityPlayer.addChatMessage((EntityPlayer)user, "No linked UAV is stored in this station.");
@@ -947,6 +1133,8 @@ public class MCH_EntityUavStation
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);
+                 } else if (continueWithStoredUavItem(user)) {
+                     this.pendingContinueTicks = 0;
                  } else {
                      this.pendingContinueTicks = 60;
                      markLinkedUavUnloaded();
@@ -965,6 +1153,12 @@ public class MCH_EntityUavStation
                 double x = this.posX + this.posUavX;
                 double y = this.posY + this.posUavY;
                 double z = this.posZ + this.posUavZ;
+                if(this.respawnStoredUavAtSavedPosition && this.hasStoredUavRespawnPosition) {
+                     x = this.storedUavRespawnX;
+                     y = this.storedUavRespawnY;
+                     z = this.storedUavRespawnZ;
+                     MCH_Lib.Log((Entity)this, "Respawning shifted-out UAV at saved delete position %.2f, %.2f, %.2f", new Object[] { Double.valueOf(x), Double.valueOf(y), Double.valueOf(z) });
+                   }
                 if (y <= 1.0D) {
                      y = 2.0D;
                    }
@@ -1015,6 +1209,15 @@ public class MCH_EntityUavStation
                    }
 
                 if (ac != null) {
+                    MCH_EntityAircraft linked = findLinkedUavEntity(this.worldObj);
+                    if(linked != null && !linked.isDead && isValidLinkedUav(linked, user instanceof EntityPlayer ? (EntityPlayer)user : null)) {
+                        MCH_Lib.Log((Entity)this, "Avoided spawning duplicate UAV from station %d; reusing linked UAV %d (%s)", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)), Integer.valueOf(W_Entity.getEntityId((Entity)linked)), linked.getUavPersistentUUID() == null ? "" : linked.getUavPersistentUUID().toString() });
+                        ((MCH_EntityAircraft)ac).setDead(false);
+                        linkUav(linked);
+                        setControlAircract(linked);
+                        W_EntityPlayer.closeScreen(user);
+                        return;
+                    }
                     if(MCH_Config.ItemDamage.prmBool) {
 
                         ((MCH_EntityAircraft)ac).getAcDataFromItem(itemStack);
@@ -1023,6 +1226,8 @@ public class MCH_EntityUavStation
                      ((Entity)ac).prevRotationYaw = ((Entity)ac).rotationYaw;
                      user.rotationYaw = this.rotationYaw - 180.0F;
                      if (this.worldObj.getCollidingBoundingBoxes((Entity)ac, ((Entity)ac).boundingBox.expand(-0.1D, -0.1D, -0.1D)).isEmpty()) {
+                          this.lastUavItemStack = itemStack.copy();
+                          this.lastUavItemStack.stackSize = 1;
                           itemStack.stackSize--;
                           MCH_Lib.DbgLog(this.worldObj, "Create UAV: %s : %s", new Object[] { item.getUnlocalizedName(), item });
                           user.rotationYaw = this.rotationYaw - 180.0F;
@@ -1059,6 +1264,7 @@ public class MCH_EntityUavStation
           if(player != null) {
               this.newUavPlayerUUID = player.getUniqueID().toString();
               this.setOwnerUUID(player.getUniqueID());
+              applyPendingNewUavShiftExit(player);
           }
 
            int kind = getKind();

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import mcheli.MCH_Lib;
 import mcheli.aircraft.MCH_EntityAircraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
 
 /** Runtime lookup cache only; persistent truth lives on aircraft/station/player NBT. */
 public final class MCH_UavRegistry {
+    private static final Map<String, MCH_EntityAircraft> BY_PERSISTENT_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_ENTITY_UUID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_COMMON_ID = new HashMap<String, MCH_EntityAircraft>();
     private static final Map<String, MCH_EntityAircraft> BY_OWNER = new HashMap<String, MCH_EntityAircraft>();
@@ -20,6 +22,14 @@ public final class MCH_UavRegistry {
     public static void register(MCH_EntityAircraft ac) {
         if (!isValidUav(ac)) {
             return;
+        }
+        MCH_EntityAircraft canonical = pruneDuplicate(ac);
+        if (canonical != ac) {
+            return;
+        }
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            BY_PERSISTENT_UUID.put(persistentId.toString(), ac);
         }
         BY_ENTITY_UUID.put(ac.getUniqueID().toString(), ac);
         if (ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
@@ -34,18 +44,24 @@ public final class MCH_UavRegistry {
         if (ac == null) {
             return;
         }
-        BY_ENTITY_UUID.remove(ac.getUniqueID().toString());
+        removeIfSame(BY_ENTITY_UUID, ac.getUniqueID().toString(), ac);
+        UUID persistentId = ac.getUavPersistentUUID(false);
+        if (persistentId != null) {
+            removeIfSame(BY_PERSISTENT_UUID, persistentId.toString(), ac);
+        }
         if (ac.getCommonUniqueId() != null) {
-            BY_COMMON_ID.remove(ac.getCommonUniqueId());
+            removeIfSame(BY_COMMON_ID, ac.getCommonUniqueId(), ac);
         }
         if (ac.getOwnerUUID() != null) {
-            BY_OWNER.remove(ac.getOwnerUUID().toString());
+            removeIfSame(BY_OWNER, ac.getOwnerUUID().toString(), ac);
         }
     }
 
-    public static MCH_EntityAircraft findLinkedUav(World world, UUID entityUuid, String commonId, UUID owner) {
-        boolean hasStableLink = entityUuid != null || (commonId != null && !commonId.isEmpty());
-        MCH_EntityAircraft ac = getLive(BY_ENTITY_UUID.get(entityUuid == null ? "" : entityUuid.toString()), world);
+    public static MCH_EntityAircraft findLinkedUav(World world, UUID persistentUuid, String commonId, UUID owner) {
+        boolean hasStableLink = persistentUuid != null || (commonId != null && !commonId.isEmpty());
+        MCH_EntityAircraft ac = getLive(BY_PERSISTENT_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
+        if (ac != null) return ac;
+        ac = getLive(BY_ENTITY_UUID.get(persistentUuid == null ? "" : persistentUuid.toString()), world);
         if (ac != null) return ac;
         ac = getLive(BY_COMMON_ID.get(commonId == null ? "" : commonId), world);
         if (ac != null) return ac;
@@ -53,7 +69,7 @@ public final class MCH_UavRegistry {
             ac = getLive(BY_OWNER.get(owner == null ? "" : owner.toString()), world);
             if (ac != null) return ac;
         }
-        return searchLoaded(world, entityUuid, commonId, hasStableLink ? null : owner);
+        return searchLoaded(world, persistentUuid, commonId, hasStableLink ? null : owner);
     }
 
     public static MCH_EntityAircraft findByOwner(World world, UUID owner) {
@@ -75,7 +91,11 @@ public final class MCH_UavRegistry {
                 MCH_EntityAircraft ac = (MCH_EntityAircraft)obj;
                 if (isValidUav(ac)) {
                     register(ac);
-                    boolean entityMatch = entityUuid != null && entityUuid.equals(ac.getUniqueID());
+                    if (ac.isDead) {
+                        continue;
+                    }
+                    UUID persistentId = ac.getUavPersistentUUID();
+                    boolean entityMatch = entityUuid != null && (entityUuid.equals(persistentId) || entityUuid.equals(ac.getUniqueID()));
                     boolean commonMatch = commonId != null && !commonId.isEmpty() && commonId.equals(ac.getCommonUniqueId());
                     boolean ownerMatch = owner != null && owner.equals(ac.getOwnerUUID());
                     if (entityUuid == null && (commonId == null || commonId.isEmpty()) && owner == null && first == null) {
@@ -95,6 +115,43 @@ public final class MCH_UavRegistry {
         }
         unregister(ac);
         return null;
+    }
+
+    private static void removeIfSame(Map<String, MCH_EntityAircraft> map, String key, MCH_EntityAircraft ac) {
+        if (key != null && map.get(key) == ac) {
+            map.remove(key);
+        }
+    }
+
+    private static MCH_EntityAircraft pruneDuplicate(MCH_EntityAircraft ac) {
+        MCH_EntityAircraft duplicate = null;
+        UUID persistentId = ac.getUavPersistentUUID();
+        if (persistentId != null) {
+            duplicate = getLive(BY_PERSISTENT_UUID.get(persistentId.toString()), ac.worldObj);
+        }
+        if (duplicate == null && ac.getCommonUniqueId() != null && !ac.getCommonUniqueId().isEmpty()) {
+            duplicate = getLive(BY_COMMON_ID.get(ac.getCommonUniqueId()), ac.worldObj);
+        }
+        if (duplicate == null || duplicate == ac) {
+            return ac;
+        }
+
+        MCH_EntityAircraft keep = chooseCanonical(duplicate, ac);
+        MCH_EntityAircraft remove = keep == ac ? duplicate : ac;
+        MCH_Lib.Log(remove, "Duplicate UAV identity detected: keeping entity %d and removing duplicate %d (persistent=%s, common=%s)", new Object[] {
+                Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
+                persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
+        unregister(remove);
+        remove.setDead(false);
+        return keep;
+    }
+
+    private static MCH_EntityAircraft chooseCanonical(MCH_EntityAircraft a, MCH_EntityAircraft b) {
+        if (b.getRiddenByEntity() != null && a.getRiddenByEntity() == null) return b;
+        if (a.getRiddenByEntity() != null && b.getRiddenByEntity() == null) return a;
+        if (b.getUavStation() != null && a.getUavStation() == null) return b;
+        if (a.getUavStation() != null && b.getUavStation() == null) return a;
+        return a.ticksExisted >= b.ticksExisted ? a : b;
     }
 
     private static boolean isValidUav(MCH_EntityAircraft ac) {


### PR DESCRIPTION
### Motivation

- Prevent duplicate/new-UAV race conditions and broken station links by introducing a stable persistent UAV identity and preserving station "Continue" state when a new UAV is shifted out (player shift-exit) or destroyed.
- Make UAV <-> station linking/resume more robust across chunk loads and entity lifecycle events by storing item/respawn data and restoring pending state saved on the player.
- Improve runtime lookup performance and correctness by indexing UAVs by persistent id and de-duplicating conflicting entities in the registry.

### Description

- Added a persistent UAV identifier `uavPersistentUUID` to `MCH_EntityAircraft` with getters, NBT read/write support, and logic to generate/use the aircraft `getUniqueID()` when needed.
- Register/unregister UAVs with `MCH_UavRegistry` on owner/common id changes and entity lifecycle to avoid stale entries, and avoid accidental double-registration during pruning.
- Implemented deletion/shift-exit flow for "new UAV" entities: save a pending Continue state to the rider's entity data, attempt to associate the station and keep station continue state, and delete the drone entity (`deleteNewUavAfterShiftExit`) while preventing accidental clearing during that delete.
- Added helpers to `MCH_EntityAircraft` to find the linked station after shift-exit and to persist/clear pending shift-exit NBT on the player.
- Extended `MCH_EntityUavStation` with fields to store `lastUavItemStack`, respawn position, and flags for respawning at a saved position; added NBT persistence for these fields; added methods to apply pending shift-exit state from a player, prepare/clear stored Continue state, and continue with a stored item (including respawn at saved delete position).
- Modified station spawn/handle logic to avoid spawning duplicate UAVs when a linked live UAV already exists and to prefer linked/persistent identities when searching loaded entities.
- Reworked `MCH_UavRegistry` to maintain an additional map keyed by persistent UUID, perform lookup by persistent id first, prune duplicate entities on registration using canonical selection rules, and safely remove entries only when they point to the same instance.
- Added small utility methods: `parseUUID`, `removeIfSame`, `pruneDuplicate`, and `chooseCanonical`, and added logging to assist debugging duplicate/clear operations.

### Testing

- Executed project build with `./gradlew build` which completed successfully.
- Ran `./gradlew test` (if present) and the test task completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e6be9a2483238cd8221d49e27f06)