### PR TITLE
Keep aircraft LODs visible past fog

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
@@ -126,6 +126,17 @@ public abstract class MCH_RenderAircraft extends W_Render {
       GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);
       GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
       GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
+      /*
+       * Far LODs are intentionally allowed to render past the normal terrain fog line.
+       * If fog is left enabled here, Minecraft fades this simple line silhouette to the
+       * fog color right when it becomes useful, which looks exactly like the aircraft
+       * disappeared before the LOD could take over.  Keep the state local to the LOD
+       * pass so normal close-range aircraft/world rendering still uses vanilla fog.
+       */
+      GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LINE_BIT | GL11.GL_CURRENT_BIT);
+      GL11.glDisable(GL11.GL_FOG);
+      GL11.glEnable(GL11.GL_BLEND);
+      GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
       GL11.glDisable(3553);
       GL11.glDisable(2896);
       GL11.glDisable(2884);
@@ -159,10 +170,7 @@ public abstract class MCH_RenderAircraft extends W_Render {
       tessellator.addVertex((double)(-halfWidth), (double)(-height * 0.5F), (double)(-length));
       tessellator.draw();
 
-      GL11.glLineWidth(1.0F);
-      GL11.glEnable(2884);
-      GL11.glEnable(2896);
-      GL11.glEnable(3553);
+      GL11.glPopAttrib();
       GL11.glPopMatrix();
    }
 


### PR DESCRIPTION
### Motivation

- Far-distance LOD silhouettes for aircraft/vehicles were effectively disappearing at the fog line because Minecraft's fog was left enabled during the LOD render pass, causing the simple line silhouette to be fogged to the horizon color. 
- The change keeps the LOD distance logic intact but ensures LOD silhouettes remain visible past the terrain fog so the switch from full model to LOD is visually reliable.

### Description

- Modified `MCH_RenderAircraft.renderAircraftLOD` to wrap LOD rendering state changes in `glPushAttrib`/`glPopAttrib` so OpenGL enable/color/line state is preserved and restored after the LOD pass. 
- Disable `GL_FOG` for the LOD pass and enable alpha blending with `glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)` so the line silhouette remains visible beyond the fog line. 
- Kept the existing LOD drawing (line silhouette) and distance gating unchanged (`EnableAircraftLODRender`, `AircraftLODStartDistance`, `AircraftLODFarDistance`). 
- File changed: `src/main/java/mcheli/aircraft/MCH_RenderAircraft.java` (around `renderAircraftLOD`).

### Testing

- `./gradlew compileJava` (wrapper) failed because the wrapper attempted to download Gradle and the environment/proxy returned HTTP 403 so the build could not run. 
- `bash ./gradlew compileJava` likewise failed due to the Gradle wrapper download being blocked by a proxy (HTTP 403). 
- `gradle compileJava` failed because dependency metadata for ForgeGradle could not be fetched from remote repositories (HTTP 403), so a full compile/test could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225e9455f48323bbf0aff050fd441e)