### PR TITLE
Expand aircraft LOD tracking range and fix LOD fog rendering

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -1,6 +1,7 @@
 package mcheli;
 
 import java.util.ArrayList;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,6 +32,7 @@ import mcheli.wrapper.W_EventHook;
 import mcheli.wrapper.W_Lib;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
@@ -40,6 +42,7 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -47,10 +50,51 @@ import net.minecraftforge.event.entity.EntityEvent.CanUpdate;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.world.WorldEvent;
 
 public class MCH_EventHook extends W_EventHook {
 
    int acloaded = 0;
+
+
+   @SubscribeEvent
+   public void worldLoad(WorldEvent.Load event) {
+      if(event.world instanceof WorldServer && !event.world.isRemote) {
+         this.expandAircraftLODTrackingRange((WorldServer)event.world);
+      }
+
+   }
+
+   private void expandAircraftLODTrackingRange(WorldServer world) {
+      double farDistance = MCH_Config.AircraftLODFarDistance != null?MCH_Config.AircraftLODFarDistance.prmDouble:0.0D;
+      if(farDistance <= 0.0D) {
+         return;
+      }
+
+      int range = (int)Math.min(2147483647.0D, Math.max(600.0D, Math.ceil(farDistance)));
+      EntityTracker tracker = world.getEntityTracker();
+      Field[] fields = EntityTracker.class.getDeclaredFields();
+
+      for(int i = 0; i < fields.length; ++i) {
+         Field field = fields[i];
+         if(field.getType() == Integer.TYPE) {
+            try {
+               field.setAccessible(true);
+               int currentRange = field.getInt(tracker);
+               if(currentRange < range) {
+                  field.setInt(tracker, range);
+                  MCH_Lib.Log(world, "Expanded EntityTracker max range from %d to %d for aircraft LODs", new Object[]{Integer.valueOf(currentRange), Integer.valueOf(range)});
+               }
+            } catch(Exception e) {
+               MCH_Lib.Log(world, "Failed to expand EntityTracker range for aircraft LODs: %s", new Object[]{e.toString()});
+            }
+
+            return;
+         }
+      }
+
+      MCH_Lib.Log(world, "Failed to find EntityTracker max range field for aircraft LODs", new Object[0]);
+   }
 
    public void commandEvent(CommandEvent event) {
       MCH_Command.onCommandEvent(event);

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -280,6 +280,14 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.commonStatus = 0;
       super.dropContentsWhenDead = false;
       super.ignoreFrustumCheck = true;
+      /*
+       * Vanilla's EntityTracker only starts tracking distant entities in chunks the
+       * player is already watching unless forceSpawn is true.  Aircraft LODs are
+       * explicitly intended to be visible beyond the normal chunk/render distance,
+       * so force tracking to use the mod's configured AircraftLODFarDistance range
+       * instead of silently cutting off near the server/client view-distance edge.
+       */
+      super.forceSpawn = true;
       this.flareDv = new MCH_Flare(world, this);
       this.chaff = new MCH_Chaff(world, this);
       this.maintenance = new MCH_Maintenance(world, this);

--- a/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
@@ -126,6 +126,17 @@ public abstract class MCH_RenderAircraft extends W_Render {
       GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);
       GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
       GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
+      /*
+       * Far LODs are intentionally allowed to render past the normal terrain fog line.
+       * If fog is left enabled here, Minecraft fades this simple line silhouette to the
+       * fog color right when it becomes useful, which looks exactly like the aircraft
+       * disappeared before the LOD could take over.  Keep the state local to the LOD
+       * pass so normal close-range aircraft/world rendering still uses vanilla fog.
+       */
+      GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_LINE_BIT | GL11.GL_CURRENT_BIT);
+      GL11.glDisable(GL11.GL_FOG);
+      GL11.glEnable(GL11.GL_BLEND);
+      GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
       GL11.glDisable(3553);
       GL11.glDisable(2896);
       GL11.glDisable(2884);
@@ -159,10 +170,7 @@ public abstract class MCH_RenderAircraft extends W_Render {
       tessellator.addVertex((double)(-halfWidth), (double)(-height * 0.5F), (double)(-length));
       tessellator.draw();
 
-      GL11.glLineWidth(1.0F);
-      GL11.glEnable(2884);
-      GL11.glEnable(2896);
-      GL11.glEnable(3553);
+      GL11.glPopAttrib();
       GL11.glPopMatrix();
    }
 


### PR DESCRIPTION
### Motivation

- Ensure aircraft LODs remain tracked and visible at the configured far distance instead of being cut off by vanilla tracking/view-distance limits.
- Prevent far LOD silhouettes from being faded into terrain fog so they remain visible at long range.
- Allow distant aircraft entities to be force-tracked so LODs render reliably beyond normal chunk boundaries.

### Description

- Added a `@SubscribeEvent` handler `worldLoad(WorldEvent.Load)` that calls `expandAircraftLODTrackingRange(WorldServer)` to increase the server `EntityTracker` range based on `MCH_Config.AircraftLODFarDistance` using reflection.
- Implemented `expandAircraftLODTrackingRange` to locate an integer field on `EntityTracker` and set it to the configured range while logging success/failure via `MCH_Lib.Log`.
- Set `forceSpawn = true` in `MCH_EntityAircraft` constructor to force distant aircraft to be tracked/updated even when outside normal watched chunks.
- Updated LOD rendering in `MCH_RenderAircraft` to locally disable fog and enable blending (via `glPushAttrib`/`glPopAttrib`) so far LOD silhouettes do not fade into fog while preserving normal fog state for other rendering.

### Testing

- Ran a project build with `./gradlew build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225e9455f48323bbf0aff050fd441e)