### PR TITLE
Avoid NoClassDefFoundError by removing W_ChunkPosition dependency in explosions

### DIFF
--- a/src/main/java/mcheli/MCH_Explosion.java
+++ b/src/main/java/mcheli/MCH_Explosion.java
@@ -20,7 +20,6 @@ import mcheli.particles.MCH_ParticlesUtil;
 import mcheli.weapon.MCH_EntityBaseBullet;
 import mcheli.wrapper.W_AxisAlignedBB;
 import mcheli.wrapper.W_Block;
-import mcheli.wrapper.W_ChunkPosition;
 import mcheli.wrapper.W_Entity;
 import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.block.Block;
@@ -342,9 +341,9 @@ public class MCH_Explosion extends Explosion {
 
          while(iterator.hasNext()) {
             chunkposition = (ChunkPosition)iterator.next();
-            i = W_ChunkPosition.getChunkPosX(chunkposition);
-            j = W_ChunkPosition.getChunkPosY(chunkposition);
-            k = W_ChunkPosition.getChunkPosZ(chunkposition);
+            i = chunkposition.chunkPosX;
+            j = chunkposition.chunkPosY;
+            k = chunkposition.chunkPosZ;
             l = W_WorldFunc.getBlockId(this.world, i, j, k);
             if(l > 0 && this.isDestroyBlock && this.explosionSizeBlock > 0.0F) {
                var10000 = MCH_MOD.config;
@@ -367,9 +366,9 @@ public class MCH_Explosion extends Explosion {
 
             while(iterator.hasNext()) {
                chunkposition = (ChunkPosition)iterator.next();
-               i = W_ChunkPosition.getChunkPosX(chunkposition);
-               j = W_ChunkPosition.getChunkPosY(chunkposition);
-               k = W_ChunkPosition.getChunkPosZ(chunkposition);
+               i = chunkposition.chunkPosX;
+               j = chunkposition.chunkPosY;
+               k = chunkposition.chunkPosZ;
                l = W_WorldFunc.getBlockId(this.world, i, j, k);
                b = W_WorldFunc.getBlock(this.world, i, j - 1, k);
                if(l == 0 && b != null && b.isOpaqueCube() && explosionRNG.nextInt(3) == 0) {
@@ -569,9 +568,9 @@ public class MCH_Explosion extends Explosion {
 
          while(var50.hasNext()) {
             ChunkPosition chunkposition = (ChunkPosition)var50.next();
-            i = W_ChunkPosition.getChunkPosX(chunkposition);
-            j = W_ChunkPosition.getChunkPosY(chunkposition);
-            k = W_ChunkPosition.getChunkPosZ(chunkposition);
+            i = chunkposition.chunkPosX;
+            j = chunkposition.chunkPosY;
+            k = chunkposition.chunkPosZ;
             W_WorldFunc.getBlockId(world, i, j, k);
             ++cnt;
             d0 = (double)((float)i + world.rand.nextFloat());
@@ -695,9 +694,9 @@ public class MCH_Explosion extends Explosion {
 
          while(var39.hasNext()) {
             ChunkPosition chunkposition = (ChunkPosition)var39.next();
-            i = W_ChunkPosition.getChunkPosX(chunkposition);
-            j = W_ChunkPosition.getChunkPosY(chunkposition);
-            k = W_ChunkPosition.getChunkPosZ(chunkposition);
+            i = chunkposition.chunkPosX;
+            j = chunkposition.chunkPosY;
+            k = chunkposition.chunkPosZ;
             W_WorldFunc.getBlockId(world, i, j, k);
             d0 = (double)((float)i + world.rand.nextFloat());
             d1 = (double)((float)j + world.rand.nextFloat());


### PR DESCRIPTION
### Motivation

- The server crashed on ticking entities with `NoClassDefFoundError: mcheli/wrapper/W_ChunkPosition` during non-MCHeli explosions (e.g. HBM TNT) because `MCH_Explosion` relied on a legacy wrapper class that wasn't present at runtime.
- The intent is to make explosions robust and compatible with other mods (Xenofactions/HFR hooks) by removing the fragile runtime linkage to the legacy wrapper.

### Description

- Removed the import of the legacy wrapper `mcheli.wrapper.W_ChunkPosition` from `MCH_Explosion` and replaced all calls to `W_ChunkPosition.getChunkPosX/Y/Z(...)` with direct reads of `ChunkPosition` fields (`chunkposition.chunkPosX`, `chunkposition.chunkPosY`, `chunkposition.chunkPosZ`).
- Updated all explosion code paths that iterate `affectedBlockPositions` (block destruction, fire placement, and particle spawning) to use the direct `ChunkPosition` fields so they no longer depend on the wrapper class.
- Kept the HFR/Xenofactions compatibility hook invocation but removed the failure point caused by the missing wrapper class.

### Testing

- Ran `git diff --check` with no whitespace or quick-diff errors and it passed.
- Executed a Python-based source regression assertion that verified `MCH_Explosion` no longer references `W_ChunkPosition` and that all coordinate reads use `chunkposition.chunkPosX/Y/Z`, and the assertion passed.
- Attempted to run `./gradlew compileJava` to perform a full compile, but the Gradle wrapper download failed in this environment due to an external proxy returning HTTP 403, so a full automated build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23d5039f7c83238a057b9eb534ef4d)