### PR TITLE
Fix stable walking on moving ship and carrier decks

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -2,6 +2,7 @@ package mcheli.aircraft;
 
 import mcheli.aircraft.MCH_BoundingBox;
 import mcheli.aircraft.MCH_EntityAircraft;
+import mcheli.ship.MCH_EntityShip;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -34,6 +35,55 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
       double dy = y1 - y2;
       double dz = z1 - z2;
       return dx * dx + dy * dy + dz * dz;
+   }
+
+   /**
+    * Aircraft hit boxes are composite for ray tracing and damage, but only ships
+    * expose those boxes as walkable world collision.  Resolving against each
+    * component independently also prevents the small primary aircraft box from
+    * blocking horizontal movement when a player is merely touching a deck box.
+    */
+   private boolean hasDeckCollision() {
+      return this.ac instanceof MCH_EntityShip;
+   }
+
+   @Override
+   public double calculateXOffset(AxisAlignedBB other, double offset) {
+      if(!this.hasDeckCollision()) {
+         return offset;
+      }
+
+      offset = super.calculateXOffset(other, offset);
+      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+         offset = bb.boundingBox.calculateXOffset(other, offset);
+      }
+      return offset;
+   }
+
+   @Override
+   public double calculateYOffset(AxisAlignedBB other, double offset) {
+      if(!this.hasDeckCollision()) {
+         return offset;
+      }
+
+      offset = super.calculateYOffset(other, offset);
+      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+         offset = bb.boundingBox.calculateYOffset(other, offset);
+      }
+      return offset;
+   }
+
+   @Override
+   public double calculateZOffset(AxisAlignedBB other, double offset) {
+      if(!this.hasDeckCollision()) {
+         return offset;
+      }
+
+      offset = super.calculateZOffset(other, offset);
+      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+         offset = bb.boundingBox.calculateZOffset(other, offset);
+      }
+      return offset;
    }
 
    public boolean intersectsWith(AxisAlignedBB aabb) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityHitBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityHitBox.java
@@ -44,11 +44,11 @@ public class MCH_EntityHitBox extends W_Entity {
    }
 
    public AxisAlignedBB getCollisionBox(Entity par1Entity) {
-      return par1Entity.boundingBox;
+      return null;
    }
 
    public AxisAlignedBB getBoundingBox() {
-      return super.boundingBox;
+      return null;
    }
 
    public boolean canBePushed() {

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -47,11 +47,11 @@ public class MCH_EntitySeat extends W_Entity {
    }
 
    public AxisAlignedBB getCollisionBox(Entity entity) {
-      return entity.boundingBox;
+      return null;
    }
 
    public AxisAlignedBB getBoundingBox() {
-      return this.boundingBox;
+      return null;
    }
 
    public boolean canBePushed() {

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -1,5 +1,6 @@
 package mcheli.ship;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -788,6 +789,12 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
     }
 
     protected void onUpdate_Client() {
+        double oldX = super.posX;
+        double oldY = super.posY;
+        double oldZ = super.posZ;
+        float oldYaw = this.getRotYaw();
+        List<Entity> deckEntities = this.getEntitiesStandingOnDeck();
+
         if(this.getRiddenByEntity() != null && W_Lib.isClientPlayer(this.getRiddenByEntity())) {
             this.getRiddenByEntity().rotationPitch = this.getRiddenByEntity().prevRotationPitch;
         }
@@ -807,6 +814,8 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
                 super.motionZ *= 0.99D;
             }
         }
+
+        this.finishDeckMovement(deckEntities, oldX, oldY, oldZ, oldYaw);
 
         if(this.isDestroyed()) {
             if(MCH_Lib.getBlockIdY(this, 3, -3) == 0) {
@@ -836,6 +845,11 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
     }
 
     private void onUpdate_Server() {
+        double oldX = super.posX;
+        double oldY = super.posY;
+        double oldZ = super.posZ;
+        float oldYaw = this.getRotYaw();
+        List<Entity> deckEntities = this.getEntitiesStandingOnDeck();
         this.updateCollisionBox();
         Entity rdnEnt = this.getRiddenByEntity();
         double prevMotion = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
@@ -980,6 +994,7 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         }
 
         this.moveEntity(super.motionX, super.motionY, super.motionZ);
+        this.finishDeckMovement(deckEntities, oldX, oldY, oldZ, oldYaw);
         //super.motionY *= 0.95D;
 
         if(this.getAcInfo().throttleUpDown > 0.0F) {
@@ -997,6 +1012,77 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
             super.riddenByEntity = null;
         }
 
+    }
+
+    private List<Entity> getEntitiesStandingOnDeck() {
+        List<Entity> standing = new ArrayList<Entity>();
+        if(this.getAcInfo() == null) {
+            return standing;
+        }
+
+        AxisAlignedBB search = this.getDeckSearchBox();
+        List entities = super.worldObj.getEntitiesWithinAABB(EntityPlayer.class, search);
+        for(Object value : entities) {
+            Entity entity = (Entity)value;
+            if(entity != this.getRiddenByEntity() && entity.ridingEntity == null && !entity.isDead
+                    && entity.motionY <= 0.05D && this.isStandingOnDeck(entity.boundingBox)) {
+                standing.add(entity);
+            }
+        }
+        return standing;
+    }
+
+    private AxisAlignedBB getDeckSearchBox() {
+        AxisAlignedBB search = AxisAlignedBB.getBoundingBox(super.boundingBox.minX, super.boundingBox.minY,
+                super.boundingBox.minZ, super.boundingBox.maxX, super.boundingBox.maxY, super.boundingBox.maxZ);
+        for(MCH_BoundingBox bb : super.extraBoundingBox) {
+            AxisAlignedBB box = bb.boundingBox;
+            search = search.func_111270_a(box);
+        }
+        return search.expand(0.25D, 0.35D, 0.25D);
+    }
+
+    private boolean isStandingOnDeck(AxisAlignedBB entityBox) {
+        if(this.isOnTopOf(entityBox, super.boundingBox)) {
+            return true;
+        }
+        for(MCH_BoundingBox bb : super.extraBoundingBox) {
+            if(this.isOnTopOf(entityBox, bb.boundingBox)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isOnTopOf(AxisAlignedBB entityBox, AxisAlignedBB deckBox) {
+        final double horizontalInset = 1.0E-4D;
+        final double verticalTolerance = 0.2D;
+        return entityBox.maxX > deckBox.minX + horizontalInset
+                && entityBox.minX < deckBox.maxX - horizontalInset
+                && entityBox.maxZ > deckBox.minZ + horizontalInset
+                && entityBox.minZ < deckBox.maxZ - horizontalInset
+                && entityBox.minY >= deckBox.maxY - verticalTolerance
+                && entityBox.minY <= deckBox.maxY + verticalTolerance;
+    }
+
+    private void finishDeckMovement(List<Entity> deckEntities, double oldX, double oldY, double oldZ, float oldYaw) {
+        double moveY = super.posY - oldY;
+        float yawChange = (float)MCH_Lib.getRotateDiff(oldYaw, this.getRotYaw());
+
+        // Extra boxes are normally updated before onUpdateAircraft. Refresh them at
+        // the final ship position so world collision never sees last tick's deck.
+        this.updateExtraBoundingBox();
+
+        for(Entity entity : deckEntities) {
+            if(!entity.isDead && entity.ridingEntity == null) {
+                double relativeX = entity.posX - oldX;
+                double relativeZ = entity.posZ - oldZ;
+                Vec3 rotated = MCH_Lib.RotVec3(relativeX, 0.0D, relativeZ, -yawChange, 0.0F);
+                entity.setPosition(super.posX + rotated.xCoord, entity.posY + moveY, super.posZ + rotated.zCoord);
+                entity.onGround = true;
+                entity.fallDistance = 0.0F;
+            }
+        }
     }
 
     private void collisionEntity(AxisAlignedBB bb) {


### PR DESCRIPTION
### Motivation
- Players standing on ship/carrier deck bounding boxes experienced jitter and sluggish horizontal movement because aircraft collision used the small primary box for resolution while extra deck boxes were only used for hit detection and updated at the wrong time. 
- Seats and hitbox helper entities were treated like solid blocks, allowing standing on them and interfering with correct deck behavior. 
- The ship should carry players that stand on deck smoothly (including yaw/vertical motion) and update deck collision geometry in sync with movement.

### Description
- Use ship-only composite collision resolution by resolving `calculateXOffset`, `calculateYOffset`, and `calculateZOffset` against the aircraft primary box and each `extraBoundingBox` when the aircraft is a ship, implemented in `MCH_AircraftBoundingBox` (adds `hasDeckCollision()` and three overrides). 
- Prevent helper entities from acting like blocks by returning `null` from `getCollisionBox` / `getBoundingBox` in `MCH_EntitySeat` and `MCH_EntityHitBox` so seats/hitboxes are non-solid for world-collision logic. 
- Detect players standing on deck before ship movement and carry them with the ship on both client and server by capturing old ship pose, collecting deck-standing players, refreshing `extraBoundingBox` after movement, and applying translation + yaw rotation in `finishDeckMovement`; helpers added: `getEntitiesStandingOnDeck`, `getDeckSearchBox`, `isStandingOnDeck`, `isOnTopOf`, and `finishDeckMovement` in `MCH_EntityShip`. 
- Refresh `extraBoundingBox` immediately after ship movement to avoid the previous one-tick mismatch between ship position and deck collision surfaces. 

### Testing
- Ran `git diff --check` and `git diff --stat` to validate whitespace and diff sanity, which reported no problems. (succeeded) 
- Ran `gradle --version` as an environment check, which succeeded locally. (succeeded) 
- Attempted to run the project compile with the Gradle wrapper via `bash gradlew compileJava --no-daemon`, but the wrapper could not download Gradle due to the environment proxy returning `HTTP/1.1 403 Forbidden`, so a full automated compile could not be completed in this environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24980fc484832392c7388f3b6af547)