### PR TITLE
Fix AddRack vehicle release position on ships

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -2831,12 +2831,21 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       System.out.println("unmount fired");
       //if this is a newUAV go back to the fuckin station pos.
       Vec3 v = Vec3.createVectorHelper(super.posX, super.posY, super.posZ);
+      float yaw = this.getRotYaw();
+      float pitch = this.getRotPitch();
       if(super.ridingEntity instanceof MCH_EntitySeat) {
          MCH_EntityAircraft ac = ((MCH_EntitySeat)super.ridingEntity).getParent();
          MCH_SeatInfo seatInfo = ac.getSeatInfo(this);
          if(seatInfo instanceof MCH_SeatRackInfo) {
-            v = ((MCH_SeatRackInfo)seatInfo).getEntryPos();
-            v = ac.getTransformedPosition(v);
+            MCH_SeatRackInfo rackInfo = (MCH_SeatRackInfo)seatInfo;
+            Vec3 rackUnmountPosition = ac.getRackUnmountPosition(rackInfo);
+            if(rackUnmountPosition != null) {
+               v = rackUnmountPosition;
+               yaw = ac.getRotYaw() + rackInfo.fixYaw;
+               pitch = rackInfo.fixPitch;
+            } else {
+               v = ac.getTransformedPosition(rackInfo.getEntryPos());
+            }
          }
       } else if(super.ridingEntity instanceof EntityMinecartEmpty) {
          this.dismountedUserCtrl = true;
@@ -2848,9 +2857,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          //TODO GET UAV STATION POSITION HERE
          //this.setLocationAndAngles(getUavStation().uav);
       } else {
-         this.setLocationAndAngles(v.xCoord, v.yCoord, v.zCoord, this.getRotYaw(), this.getRotPitch());
+         this.setLocationAndAngles(v.xCoord, v.yCoord, v.zCoord, yaw, pitch);
          this.mountEntity((Entity) null);
-         this.setLocationAndAngles(v.xCoord, v.yCoord, v.zCoord, this.getRotYaw(), this.getRotPitch());
+         this.setLocationAndAngles(v.xCoord, v.yCoord, v.zCoord, yaw, pitch);
       }
    }
 
@@ -4811,7 +4820,17 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       int sid = this.getSeatIdByEntity(entity);
       this.camera.initCamera(sid, entity);
       MCH_SeatInfo seatInfo = this.getSeatInfo(seat.seatID + 1);
-      if(seatInfo != null) {
+      if(seatInfo instanceof MCH_SeatRackInfo) {
+         Vec3 rackUnmountPosition = this.getRackUnmountPosition((MCH_SeatRackInfo)seatInfo);
+         if(rackUnmountPosition != null) {
+            entity.setLocationAndAngles(rackUnmountPosition.xCoord, rackUnmountPosition.yCoord, rackUnmountPosition.zCoord,
+                  this.getRotYaw() + seatInfo.fixYaw, seatInfo.fixPitch);
+            this.listUnmountReserve.add(new MCH_EntityAircraft.UnmountReserve(entity, rackUnmountPosition.xCoord,
+                  rackUnmountPosition.yCoord, rackUnmountPosition.zCoord));
+         } else {
+            this.setUnmountPosition(entity, Vec3.createVectorHelper(seatInfo.pos.xCoord, 0.0D, seatInfo.pos.zCoord));
+         }
+      } else if(seatInfo != null) {
          this.setUnmountPosition(entity, Vec3.createVectorHelper(seatInfo.pos.xCoord, 0.0D, seatInfo.pos.zCoord));
       }
 
@@ -4820,6 +4839,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          this.switchHoveringMode(false);
       }
 
+   }
+
+   protected Vec3 getRackUnmountPosition(MCH_SeatRackInfo rackInfo) {
+      return null;
    }
 
    public boolean isCreatedSeats() {
@@ -5420,19 +5443,28 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          if(this.getSeatInfo(sid + 1) instanceof MCH_SeatRackInfo && seat != null && seat.riddenByEntity != null) {
             MCH_SeatRackInfo info = (MCH_SeatRackInfo)this.getSeatInfo(sid + 1);
             Entity entity = seat.riddenByEntity;
-            Vec3 pos = info.getEntryPos();
-            if(entity instanceof MCH_EntityAircraft) {
-               if(pos.zCoord >= (double)this.getAcInfo().bbZ) {
-                  pos = pos.addVector(0.0D, 0.0D, 12.0D);
-               } else {
-                  pos = pos.addVector(0.0D, 0.0D, -12.0D);
+            Vec3 rackUnmountPosition = this.getRackUnmountPosition(info);
+            if(rackUnmountPosition != null) {
+               seat.posX = entity.posX = rackUnmountPosition.xCoord;
+               seat.posY = entity.posY = rackUnmountPosition.yCoord;
+               seat.posZ = entity.posZ = rackUnmountPosition.zCoord;
+               entity.rotationYaw = this.getRotYaw() + info.fixYaw;
+               entity.rotationPitch = info.fixPitch;
+            } else {
+               Vec3 pos = info.getEntryPos();
+               if(entity instanceof MCH_EntityAircraft) {
+                  if(pos.zCoord >= (double)this.getAcInfo().bbZ) {
+                     pos = pos.addVector(0.0D, 0.0D, 12.0D);
+                  } else {
+                     pos = pos.addVector(0.0D, 0.0D, -12.0D);
+                  }
                }
-            }
 
-            Vec3 v = MCH_Lib.RotVec3(pos.xCoord, pos.yCoord, pos.zCoord, -this.getRotYaw(), -this.getRotPitch(), -this.getRotRoll());
-            seat.posX = entity.posX = super.posX + v.xCoord;
-            seat.posY = entity.posY = super.posY + v.yCoord;
-            seat.posZ = entity.posZ = super.posZ + v.zCoord;
+               Vec3 v = MCH_Lib.RotVec3(pos.xCoord, pos.yCoord, pos.zCoord, -this.getRotYaw(), -this.getRotPitch(), -this.getRotRoll());
+               seat.posX = entity.posX = super.posX + v.xCoord;
+               seat.posY = entity.posY = super.posY + v.yCoord;
+               seat.posZ = entity.posZ = super.posZ + v.zCoord;
+            }
             MCH_EntityAircraft.UnmountReserve ur = new MCH_EntityAircraft.UnmountReserve(entity, entity.posX, entity.posY, entity.posZ);
             ur.cnt = 8;
             this.listUnmountReserve.add(ur);

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -136,6 +136,12 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         World.MAX_ENTITY_RADIUS = Math.max(World.MAX_ENTITY_RADIUS, requiredRadius + 2.0D);
     }
 
+    @Override
+    protected Vec3 getRackUnmountPosition(MCH_SeatRackInfo rackInfo) {
+        Vec3 rackPosition = this.getTransformedPosition(rackInfo.pos);
+        return rackPosition.addVector(0.0D, 10.0D, 0.0D);
+    }
+
     public Item getItem() {
         return this.getShipInfo() != null?this.getShipInfo().item:null;
     }


### PR DESCRIPTION
### Motivation

- Prevent vehicles mounted in an `AddRack` on large ships/carriers from being released at the parent vehicle's global `UnmountPosition`, which can teleport them far away on large ships. 

### Description

- Add a rack-specific hook `getRackUnmountPosition(MCH_SeatRackInfo)` in `MCH_EntityAircraft` and override it in `MCH_EntityShip` to return the rack world position plus 10 blocks on Y. 
- Use the hook in the rack release paths (`onUnmountPlayerSeat`, `unmountEntityFromRack`) and in `unmountAircraft` so mounted vehicles are spawned at the rack world position when available. 
- Preserve rack/ship rotation by applying `ship yaw + rack.fixYaw` and `rack.fixPitch` to the released entity when using the rack position. 
- Keep existing behavior as a fallback: if the hook returns `null`, the code falls back to the original seat/parent `UnmountPosition` logic so normal passenger-seat unmounting and non-ship racks are unaffected.

### Testing

- Ran code-level checks: `git diff --check` and repository assertions confirming inserted calls to `getRackUnmountPosition` and the ship override; these checks passed. 
- Ran targeted Python assertions verifying the new rack-path changes, world transform usage and the `+10` Y offset and rotation handling; assertions passed. 
- Attempted to run `./gradlew compileJava` and `gradle compileJava --offline` but a full Java build was blocked by the environment (Gradle wrapper download was rejected by network proxy and required ForgeGradle metadata was not available offline).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24ae3ffdf08323a477f9d4b23ae0c2)