### PR TITLE
Fix vehicle seat and rack state after chunk reload

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -1234,7 +1234,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       this.pendingRackPosX = nbt.hasKey("MCH_RackPosX")?nbt.getDouble("MCH_RackPosX"):super.posX;
       this.pendingRackPosY = nbt.hasKey("MCH_RackPosY")?nbt.getDouble("MCH_RackPosY"):super.posY;
       this.pendingRackPosZ = nbt.hasKey("MCH_RackPosZ")?nbt.getDouble("MCH_RackPosZ"):super.posZ;
-      this.pendingRackRestoreTicks = this.pendingRackParentUniqueId.isEmpty()?0:200;
+      this.pendingRackRestoreTicks = this.pendingRackParentUniqueId.isEmpty()?0:1200;
       this.uavPersistentUUID = parseUUID(nbt.getString("MCH_UavPersistentUUID"));
       if(this.uavPersistentUUID == null && (this.isUAV() || this.isNewUAV())) {
          this.uavPersistentUUID = this.getUniqueID();
@@ -5022,20 +5022,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void onUpdate_Seats() {
-      boolean b = false;
+      boolean missingSeat = this.repairSeatReferences();
 
-      for(int i = 0; i < this.seats.length; ++i) {
-         if(this.seats[i] != null) {
-            if(!this.seats[i].isDead) {
-               this.seats[i].fallDistance = 0.0F;
-            }
-         } else {
-            b = true;
-         }
-      }
-
-      if(b) {
-         if(this.seatSearchCount > 40) {
+      if(missingSeat) {
+         if(this.seatSearchCount == 0 || this.seatSearchCount > 40) {
             if(super.worldObj.isRemote) {
                MCH_PacketSeatListRequest.requestSeatList(this);
             } else {
@@ -5046,18 +5036,78 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          }
 
          ++this.seatSearchCount;
+      } else {
+         this.seatSearchCount = 0;
       }
 
    }
 
-   public void searchSeat() {
-      List list = super.worldObj.getEntitiesWithinAABB(MCH_EntitySeat.class, super.boundingBox.expand(60.0D, 60.0D, 60.0D));
+   /**
+    * Drops seat and rider references which survived longer than their tracked
+    * entities. Aircraft have a much larger tracking range than seats, so a
+    * client can keep this aircraft while its old seat instances are removed.
+    * A non-null dead seat must be treated as missing so the seat-list request
+    * can bind the newly spawned entity after the player returns.
+    */
+   private boolean repairSeatReferences() {
+      boolean missingSeat = false;
+      if(this.seats == null) {
+         return this.getSeatNum() > 0;
+      }
 
-      for(int i = 0; i < list.size(); ++i) {
-         MCH_EntitySeat seat = (MCH_EntitySeat)list.get(i);
-         if(!seat.isDead && seat.parentUniqueID.equals(this.getCommonUniqueId()) && seat.seatID >= 0 && seat.seatID < this.getSeatNum() && this.seats[seat.seatID] == null) {
-            this.seats[seat.seatID] = seat;
+      if(!super.worldObj.isRemote && super.riddenByEntity != null
+              && (super.riddenByEntity.isDead || super.riddenByEntity.ridingEntity != this)) {
+         super.riddenByEntity = null;
+      }
+
+      for(int i = 0; i < this.seats.length; ++i) {
+         MCH_EntitySeat seat = this.seats[i];
+         if(seat != null && (seat.isDead || seat.worldObj != super.worldObj || seat.seatID != i
+                 || (seat.parentUniqueID != null && !seat.parentUniqueID.isEmpty()
+                 && !seat.parentUniqueID.equals(this.getCommonUniqueId()))
+                 || (seat.getParent() != null && seat.getParent() != this))) {
+            if(seat.getParent() == this) {
+               seat.setParent(null);
+            }
+            this.seats[i] = null;
+            seat = null;
+         }
+
+         if(seat == null) {
+            missingSeat = true;
+         } else {
+            seat.seatID = i;
+            seat.parentUniqueID = this.getCommonUniqueId();
             seat.setParent(this);
+            seat.fallDistance = 0.0F;
+            if(!super.worldObj.isRemote && seat.riddenByEntity != null
+                    && (seat.riddenByEntity.isDead || seat.riddenByEntity.ridingEntity != seat)) {
+               seat.riddenByEntity = null;
+            }
+         }
+      }
+      return missingSeat;
+   }
+
+   public void searchSeat() {
+      this.repairSeatReferences();
+      if(this.seats == null || this.getCommonUniqueId().isEmpty()) {
+         return;
+      }
+
+      // Do not use an AABB around the aircraft here. Rack seats on large ships
+      // can be more than 60 blocks from the carrier entity's origin.
+      List list = super.worldObj.loadedEntityList;
+      for(int i = 0; i < list.size(); ++i) {
+         Object entity = list.get(i);
+         if(entity instanceof MCH_EntitySeat) {
+            MCH_EntitySeat seat = (MCH_EntitySeat)entity;
+            if(!seat.isDead && this.getCommonUniqueId().equals(seat.parentUniqueID)
+                    && seat.seatID >= 0 && seat.seatID < this.seats.length
+                    && (this.seats[seat.seatID] == null || this.seats[seat.seatID] == seat)) {
+               this.seats[seat.seatID] = seat;
+               seat.setParent(this);
+            }
          }
       }
 


### PR DESCRIPTION
### Motivation
- Vehicles (planes/ships/vehicles) could become unrideable after chunks containing seats/racks unload and later reload due to stale client/server seat and rider references that were never repaired.
- The change ensures aircraft/vehicle seat and rack bindings are reconciled after entity reload so interactions (ride/rack/mount) work without requiring player relog.

### Description
- Add `repairSeatReferences()` to `MCH_EntityAircraft` to invalidate dead, cross-world, mismatched-ID, or incorrectly parented `MCH_EntitySeat` references and to clear stale pilot/passenger links on the server.
- Call `repairSeatReferences()` from `onUpdate_Seats()` and make the aircraft request an immediate seat-list resync when missing seats are discovered, with periodic retries (`seatSearchCount`) until seats are rebound.
- Change `searchSeat()` to scan `world.loadedEntityList` by persistent/common unique ID instead of using a 60-block AABB around the aircraft, allowing seat discovery for rack seats on large carriers.
- Increase the rack-parent restoration window from `200` ticks to `1200` ticks to give carrier and mounted-aircraft chunks more time to load and allow mount restoration to succeed.

### Testing
- Ran `git diff --check` and repository diffs to validate the edits (succeeded).
- Executed repository assertions that look for the new repair/resync code paths (custom `python3` checks; succeeded).
- Attempted to run a full `gradlew compileJava`, but the build failed to download the wrapper/ForgeGradle due to an environment proxy returning HTTP 403 (blocked by environment), so a full compile could not be completed.
- Attempted `gradle compileJava --offline`, which failed because the required ForgeGradle plugin metadata is not cached offline (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24c26d63ac8323b46a9b1c75d967fd)