### PR TITLE
Fix vehicle and rack state after chunk reload

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -50,6 +50,7 @@ import net.minecraftforge.event.entity.EntityEvent.CanUpdate;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 public class MCH_EventHook extends W_EventHook {
@@ -240,6 +241,35 @@ public class MCH_EventHook extends W_EventHook {
    }
 
    @SubscribeEvent
+   public void onStartTracking(PlayerEvent.StartTracking event) {
+      if(!(event.entityPlayer instanceof EntityPlayerMP) || event.entityPlayer.worldObj.isRemote) {
+         return;
+      }
+
+      MCH_EntityAircraft aircraft = null;
+      if(event.target instanceof MCH_EntityAircraft) {
+         aircraft = (MCH_EntityAircraft)event.target;
+      } else if(event.target instanceof MCH_EntitySeat) {
+         MCH_EntitySeat seat = (MCH_EntitySeat)event.target;
+         aircraft = seat.getParent();
+         if(aircraft == null && seat.parentUniqueID != null && !seat.parentUniqueID.isEmpty()) {
+            for(Object object : event.entityPlayer.worldObj.loadedEntityList) {
+               if(object instanceof MCH_EntityAircraft
+                       && seat.parentUniqueID.equals(((MCH_EntityAircraft)object).getCommonUniqueId())) {
+                  aircraft = (MCH_EntityAircraft)object;
+                  seat.setParent(aircraft);
+                  break;
+               }
+            }
+         }
+      }
+
+      if(aircraft != null) {
+         aircraft.syncCompleteAircraftState((EntityPlayerMP)event.entityPlayer);
+      }
+   }
+
+   @SubscribeEvent
    public void onPlayerTick(TickEvent.PlayerTickEvent event) {
       if(event.phase == TickEvent.Phase.END && event.player instanceof EntityPlayerMP && !event.player.worldObj.isRemote) {
          if(MCH_UavInventory.hasStoredPilotInventory(event.player) && !(event.player.ridingEntity instanceof MCH_EntityAircraft)) {
@@ -261,6 +291,20 @@ public class MCH_EventHook extends W_EventHook {
                  "[MCH-TRACK][SEAT-JOIN] side=%s entityId=%d uuid=%s seatId=%d parentCommonId=%s parent=%s occupant=%s",
                  new Object[]{event.world.isRemote?"CLIENT":"SERVER", Integer.valueOf(joinedSeat.getEntityId()), joinedSeat.getUniqueID(),
                          Integer.valueOf(joinedSeat.seatID), joinedSeat.parentUniqueID, joinedSeat.getParent(), joinedSeat.riddenByEntity});
+         if(!event.world.isRemote && joinedSeat.parentUniqueID != null && !joinedSeat.parentUniqueID.isEmpty()) {
+            for(Object object : event.world.loadedEntityList) {
+               if(object instanceof MCH_EntityAircraft
+                       && joinedSeat.parentUniqueID.equals(((MCH_EntityAircraft)object).getCommonUniqueId())) {
+                  MCH_EntityAircraft parent = (MCH_EntityAircraft)object;
+                  joinedSeat.setParent(parent);
+                  if(joinedSeat.seatID >= 0 && joinedSeat.seatID < parent.getSeats().length) {
+                     parent.setSeat(joinedSeat.seatID, joinedSeat);
+                  }
+                  parent.repairSeatStateAfterLoad();
+                  break;
+               }
+            }
+         }
       } else if(W_Lib.isEntityLivingBase(event.entity) && !W_EntityPlayer.isPlayer(event.entity)) {
          MCH_Config var10002 = MCH_MOD.config;
          event.entity.renderDistanceWeight *= MCH_Config.MobRenderDistanceWeight.prmDouble;
@@ -291,6 +335,9 @@ public class MCH_EventHook extends W_EventHook {
          }
          if(!b.worldObj.isRemote && !b.isCreatedSeats()) {
             b.createSeats(UUID.randomUUID().toString());
+         }
+         if(!b.worldObj.isRemote) {
+            b.repairSeatStateAfterLoad();
          }
       } else if(W_EntityPlayer.isPlayer(event.entity)) {
          Entity e = event.entity;

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -44,6 +44,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.play.server.S12PacketEntityVelocity;
+import net.minecraft.network.play.server.S1BPacketEntityAttach;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.tileentity.TileEntity;
@@ -1280,8 +1281,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       nbt.setBoolean("AcGunnerStatus", getGunnerStatus());
       MCH_EntityAircraft rackParent = this.getRackParent();
       MCH_EntitySeat rackSeat = super.ridingEntity instanceof MCH_EntitySeat?(MCH_EntitySeat)super.ridingEntity:null;
-      if(rackParent != null && rackSeat != null) {
-         nbt.setString("MCH_RackParentUniqueId", rackParent.getCommonUniqueId() == null?"":rackParent.getCommonUniqueId());
+      String rackParentUniqueId = rackParent != null?rackParent.getCommonUniqueId():(rackSeat != null?rackSeat.parentUniqueID:"");
+      if(rackSeat != null && rackParentUniqueId != null && !rackParentUniqueId.isEmpty()) {
+         nbt.setString("MCH_RackParentUniqueId", rackParentUniqueId);
          nbt.setInteger("MCH_RackSeatId", rackSeat.seatID);
          nbt.setDouble("MCH_RackPosX", super.posX);
          nbt.setDouble("MCH_RackPosY", super.posY);
@@ -2994,6 +2996,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          if(object instanceof MCH_EntityAircraft) {
             MCH_EntityAircraft parent = (MCH_EntityAircraft)object;
             if(this.pendingRackParentUniqueId.equals(parent.getCommonUniqueId())) {
+               parent.repairInvalidOccupantsForInteraction("rack_restore");
+               parent.searchSeat();
                this.noCollisionEntities.put(parent, Integer.valueOf(10));
                parent.noCollisionEntities.put(this, Integer.valueOf(10));
                MCH_EntitySeat seat = parent.getSeat(this.pendingRackSeatId);
@@ -5065,7 +5069,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          MCH_EntitySeat seat = this.seats[i];
          if(seat == null) {
             missingSeat = true;
-         } else if(seat.isDead || seat.worldObj != super.worldObj || seat.seatID != i || seat.getParent() != this) {
+         } else if(seat.isDead || seat.worldObj != super.worldObj || seat.seatID != i) {
             missingSeat = true;
             if(this.seatSearchCount == 0 || this.seatSearchCount > 40) {
                MCH_Lib.DbgLog(super.worldObj,
@@ -5073,11 +5077,50 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                        new Object[]{this.debugEntity(this), Integer.valueOf(i), this.debugEntity(seat), Integer.valueOf(seat.seatID),
                                this.debugEntity(seat.getParent()), Boolean.valueOf(seat.worldObj == super.worldObj)});
             }
+            this.seats[i] = null;
+         } else if(seat.getParent() != this) {
+            if(this.getCommonUniqueId().equals(seat.parentUniqueID)) {
+               seat.setParent(this);
+            } else {
+               missingSeat = true;
+               this.seats[i] = null;
+            }
          } else {
             seat.fallDistance = 0.0F;
          }
       }
       return missingSeat;
+   }
+
+   public void repairSeatStateAfterLoad() {
+      if(super.worldObj.isRemote) {
+         return;
+      }
+      this.repairInvalidOccupantsForInteraction("tracking_or_chunk_load");
+      this.searchSeat();
+   }
+
+   public void syncCompleteAircraftState(EntityPlayerMP player) {
+      if(player == null || super.worldObj.isRemote || player.worldObj != super.worldObj) {
+         return;
+      }
+      this.repairSeatStateAfterLoad();
+      MCH_PacketSeatListResponse.sendSeatList(this, player);
+
+      if(super.ridingEntity != null) {
+         player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, this, super.ridingEntity));
+      }
+      if(super.riddenByEntity != null && super.riddenByEntity.ridingEntity == this) {
+         player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, super.riddenByEntity, this));
+      }
+      for(int i = 0; i < this.seats.length; ++i) {
+         MCH_EntitySeat seat = this.seats[i];
+         if(seat != null && seat.riddenByEntity != null && seat.riddenByEntity.ridingEntity == seat) {
+            player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, seat.riddenByEntity, seat));
+         }
+      }
+      MCH_Lib.DbgLog(super.worldObj, "[MCH-SYNC][FULL-STATE] aircraft=%s player=%s seats=%d riding=%s",
+              new Object[]{this.debugEntity(this), this.debugEntity(player), Integer.valueOf(this.seats.length), this.debugEntity(super.ridingEntity)});
    }
 
    public void searchSeat() {
@@ -6150,7 +6193,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       if(super.worldObj.isRemote) {
          return;
       }
-      if(super.riddenByEntity != null && (super.riddenByEntity.isDead || super.riddenByEntity.ridingEntity != this)) {
+      if(super.riddenByEntity != null && (super.riddenByEntity.isDead || super.riddenByEntity.ridingEntity != this
+              || !super.worldObj.loadedEntityList.contains(super.riddenByEntity))) {
          MCH_Lib.DbgLog(super.worldObj,
                  "[MCH-STATE][REPAIR] context=%s reason=invalid_pilot_backreference vehicle=%s stalePilot=%s",
                  new Object[]{context, this.debugEntity(this), this.debugEntity(super.riddenByEntity)});
@@ -6159,7 +6203,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       for(int i = 0; i < this.getSeats().length; ++i) {
          MCH_EntitySeat seat = this.getSeats()[i];
          if(seat != null && seat.riddenByEntity != null
-                 && (seat.riddenByEntity.isDead || seat.riddenByEntity.ridingEntity != seat)) {
+                 && (seat.riddenByEntity.isDead || seat.riddenByEntity.ridingEntity != seat
+                 || !super.worldObj.loadedEntityList.contains(seat.riddenByEntity))) {
             MCH_Lib.DbgLog(super.worldObj,
                     "[MCH-STATE][REPAIR] context=%s reason=invalid_seat_occupant_backreference vehicle=%s seat=%d staleOccupant=%s",
                     new Object[]{context, this.debugEntity(this), Integer.valueOf(i), this.debugEntity(seat.riddenByEntity)});

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -238,7 +238,8 @@ public class MCH_EntitySeat extends W_Entity {
          return false;
       }
       if(!this.worldObj.isRemote && this.riddenByEntity != null
-              && (this.riddenByEntity.isDead || this.riddenByEntity.ridingEntity != this)) {
+              && (this.riddenByEntity.isDead || this.riddenByEntity.ridingEntity != this
+              || !this.worldObj.loadedEntityList.contains(this.riddenByEntity))) {
          MCH_Lib.DbgLog(this.worldObj,
                  "[MCH-STATE][REPAIR] context=seat_interact reason=invalid_seat_occupant_backreference seatId=%d staleOccupantId=%d staleOccupantUuid=%s dead=%s",
                  new Object[]{Integer.valueOf(this.seatID), Integer.valueOf(this.riddenByEntity.getEntityId()),


### PR DESCRIPTION
### Motivation
- Players could lose the ability to mount/ride vehicles or to use carrier racks after the chunk containing seats/carriers unloaded and reloaded due to stale entity/back-reference state and missing client syncs.
- The bug appears to be caused by transient entity pointers and client tracking not receiving a full aircraft/seat state when entities reappear rather than any config data problem.
- The change aims to repair server-side seat/rack state after NBT reload and to force a full state resync to players when they start tracking an aircraft so relogging is no longer required.

### Description
- Add server-side tracking hook `onStartTracking(PlayerEvent.StartTracking)` and new `syncCompleteAircraftState` to push a full aircraft state to the tracking player (seat list + mount attachments via `S1BPacketEntityAttach`) so clients receive a complete, consistent mapping when they start tracking an aircraft or its seat. (files: `MCH_EventHook.java`, `MCH_EntityAircraft.java`)
- Make rack persistence more resilient by writing the rack parent unique id from either the live rack parent or the rack seat's `parentUniqueID` when saving to NBT, and repair carrier state before restoring a mounted child so stale rack occupants do not block restoration. (file: `MCH_EntityAircraft.java`)
- Repair and harden seat array/state restoration on load by clearing dead/wrong-world/stale seat references, re-resolving seats by `parentUniqueID`, and setting parents/back-references when seats rejoin the world. (files: `MCH_EntityAircraft.java`, `MCH_EventHook.java`)
- Cleanup stale rider/passenger references by treating a missing referenced entity (not present in `loadedEntityList`) as invalid and clearing the back-reference during interaction checks for both seats and aircraft. (files: `MCH_EntitySeat.java`, `MCH_EntityAircraft.java`)
- Minor safety: attempt to attach newly-joined seats to their parent immediately during `EntityJoinWorldEvent` and call seat-repair to rebuild mappings without waiting for relog/tracking.

### Testing
- Ran repository checks: `git diff --check` and automated source assertions that verify new hooks and methods (`onStartTracking`, `syncCompleteAircraftState`, `repairSeatStateAfterLoad`, rack persistence needles) and they passed.
- Performed static/manual validation of diffs and ran `git commit` to ensure code changes are self-consistent and the working tree is clean after the patch.
- Attempted to build with `./gradlew compileJava` but the wrapper download failed due to an environment proxy returning HTTP 403, and `gradle compileJava --offline` failed because legacy ForgeGradle artifacts were not present in the local cache, so a full compile/test run could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d1b37b2c8323930190a1a6588054)