### PR TITLE
Trace aircraft interaction failures after chunk reload

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -265,7 +265,17 @@ public class MCH_EventHook extends W_EventHook {
       }
 
       if(aircraft != null) {
+         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
+                 "[MCHeliStartTracking] targetClass=%s targetId=%d targetUuid=%s %s reason=FORCE_FULL_AIRCRAFT_STATE",
+                 new Object[]{event.target.getClass().getName(), Integer.valueOf(event.target.getEntityId()), event.target.getUniqueID(),
+                         aircraft.getInteractionDebugSnapshot(event.entityPlayer)});
          aircraft.syncCompleteAircraftState((EntityPlayerMP)event.entityPlayer);
+      } else if(event.target instanceof MCH_EntitySeat) {
+         MCH_EntitySeat seat = (MCH_EntitySeat)event.target;
+         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
+                 "[MCHeliStartTrackingReject] targetClass=%s targetId=%d targetUuid=%s player=%s playerUuid=%s reason=SEAT_PARENT_NOT_RESOLVED parentCommonId=%s",
+                 new Object[]{event.target.getClass().getName(), Integer.valueOf(event.target.getEntityId()), event.target.getUniqueID(),
+                         event.entityPlayer.getCommandSenderName(), event.entityPlayer.getUniqueID(), seat.parentUniqueID});
       }
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_AircraftPacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftPacketHandler.java
@@ -322,6 +322,10 @@ public class MCH_AircraftPacketHandler {
                   MCH_Lib.DbgLog(player.worldObj, "[MCH-SYNC][SEAT-APPLY-FAIL] reason=count_mismatch aircraftId=%d packetSeats=%d localSeats=%d",
                           new Object[]{Integer.valueOf(seatList.entityID_AC), Byte.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
                }
+            } else {
+               MCH_Lib.DbgLog(player.worldObj,
+                       "[MCHeliFullSyncReceiveReject] channel=SEAT_LIST aircraftId=%d packetSeats=%d resolvedEntity=%s reason=AIRCRAFT_ENTITY_NOT_PRESENT",
+                       new Object[]{Integer.valueOf(seatList.entityID_AC), Byte.valueOf(seatList.seatNum), e});
             }
 
          }

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -116,6 +116,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    private MCH_SeatInfo[] seatsInfo;
    private String commonUniqueId;
    private int seatSearchCount;
+   private int interactionDebugLoadTicks = -1;
    protected double velocityX;
    protected double velocityY;
    protected double velocityZ;
@@ -1162,6 +1163,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void writeSpawnData(ByteBuf buffer) {
+      MCH_Lib.DbgLog(super.worldObj,
+              "[MCHeliFullSyncSend] channel=SPAWN_DATA %s",
+              new Object[]{this.getInteractionDebugSnapshot(null)});
       if(this.getAcInfo() != null) {
          buffer.writeFloat(this.getAcInfo().bodyHeight);
          buffer.writeFloat(this.getAcInfo().bodyWidth);
@@ -1188,7 +1192,15 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          if (len > 0) {
             byte[] dst = new byte[len];
             additionalData.readBytes(dst);
-            changeType(new String(dst));
+            String receivedType = new String(dst);
+            changeType(receivedType);
+            MCH_Lib.DbgLog(super.worldObj,
+                    "[MCHeliFullSyncReceive] channel=SPAWN_DATA receivedType=%s acInfoNull=%s %s",
+                    new Object[]{receivedType, Boolean.valueOf(this.getAcInfo() == null), this.getInteractionDebugSnapshot(null)});
+         } else {
+            MCH_Lib.DbgLog(super.worldObj,
+                    "[MCHeliFullSyncReceive] channel=SPAWN_DATA reason=EMPTY_TYPE_NAME %s",
+                    new Object[]{this.getInteractionDebugSnapshot(null)});
          }
       } catch (Exception var4) {
          MCH_Lib.Log((Entity)this, "readSpawnData error!", new Object[0]);
@@ -1198,6 +1210,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    protected void readEntityFromNBT(NBTTagCompound nbt) {
+      this.interactionDebugLoadTicks = 0;
       MCH_Lib.DbgLog(super.worldObj, "[MCH-STATE][NBT-READ-BEGIN] entity=%s nbtType=%s nbtCommonId=%s rackParent=%s rackSeat=%d",
               new Object[]{this.debugEntity(this), nbt.getString("TypeName"), nbt.getString("AircraftUniqueId"),
                       nbt.getString("MCH_RackParentUniqueId"), Integer.valueOf(nbt.hasKey("MCH_RackSeatId")?nbt.getInteger("MCH_RackSeatId"):-1)});
@@ -2240,6 +2253,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       if(this.countOnUpdate == 0) {
          this.onFirstUpdate();
+      }
+
+      if(this.interactionDebugLoadTicks >= 0 && this.interactionDebugLoadTicks < 40) {
+         this.debugVehicleState("POST-NBT-LOAD-TICK-" + this.interactionDebugLoadTicks, null);
+         this.debugRackState("POST-NBT-LOAD-TICK-" + this.interactionDebugLoadTicks);
+         ++this.interactionDebugLoadTicks;
       }
 
       ++this.countOnUpdate;
@@ -5119,8 +5138,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, seat.riddenByEntity, seat));
          }
       }
-      MCH_Lib.DbgLog(super.worldObj, "[MCH-SYNC][FULL-STATE] aircraft=%s player=%s seats=%d riding=%s",
-              new Object[]{this.debugEntity(this), this.debugEntity(player), Integer.valueOf(this.seats.length), this.debugEntity(super.ridingEntity)});
+      MCH_Lib.DbgLog(super.worldObj, "[MCHeliFullSyncSend] channel=START_TRACKING_STATE %s",
+              new Object[]{this.getInteractionDebugSnapshot(player)});
    }
 
    public void searchSeat() {
@@ -6112,14 +6131,47 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
               Integer.valueOf(W_Entity.getEntityId(entity.riddenByEntity)));
    }
 
+   public String getInteractionDebugSnapshot(EntityPlayer player) {
+      String side = super.worldObj != null && super.worldObj.isRemote?"CLIENT":"SERVER";
+      int dimension = super.worldObj != null && super.worldObj.provider != null?super.worldObj.provider.dimensionId:Integer.MIN_VALUE;
+      MCH_AircraftInfo info = this.getAcInfo();
+      MCH_EntitySeat[] seatArray = this.getSeats();
+      int nullSeats = 0;
+      int deadSeats = 0;
+      int wrongParentSeats = 0;
+      int occupiedSeats = 0;
+      for(int i = 0; i < seatArray.length; ++i) {
+         MCH_EntitySeat seat = seatArray[i];
+         if(seat == null) {
+            ++nullSeats;
+         } else {
+            if(seat.isDead) ++deadSeats;
+            if(seat.getParent() != this || !this.getCommonUniqueId().equals(seat.parentUniqueID)) ++wrongParentSeats;
+            if(seat.riddenByEntity != null) ++occupiedSeats;
+         }
+      }
+      return String.format(Locale.ROOT,
+              "side=%s vehicle=%s class=%s name=%s type=%s id=%d uuid=%s dimension=%d pos=%.3f,%.3f,%.3f player=%s playerUuid=%s acInfoNull=%s typeLoaded=%s seatArrayExists=%s seatCount=%d nullSeats=%d deadSeats=%d wrongParentSeats=%d occupiedSeats=%d riddenByEntity=%s ridingEntity=%s isDead=%s isDestroyed=%s damage=%d/%d lockState=NOT_APPLICABLE uav=%s newUav=%s rackMounted=%s commonId=%s dataWatcherType=%s commonStatus=%d",
+              side, this.getClass().getSimpleName(), this.getClass().getName(), this.getEntityName(), this.getTypeName(),
+              Integer.valueOf(this.getEntityId()), this.getUniqueID(), Integer.valueOf(dimension),
+              Double.valueOf(super.posX), Double.valueOf(super.posY), Double.valueOf(super.posZ),
+              player == null?"null":player.getCommandSenderName(), player == null?"null":player.getUniqueID(),
+              Boolean.valueOf(info == null), Boolean.valueOf(info != null && this.getTypeName() != null && !this.getTypeName().isEmpty()),
+              Boolean.valueOf(this.seats != null), Integer.valueOf(seatArray.length), Integer.valueOf(nullSeats),
+              Integer.valueOf(deadSeats), Integer.valueOf(wrongParentSeats), Integer.valueOf(occupiedSeats),
+              this.debugEntity(super.riddenByEntity), this.debugEntity(super.ridingEntity), Boolean.valueOf(super.isDead),
+              Boolean.valueOf(this.isDestroyed()), Integer.valueOf(this.getDamageTaken()), Integer.valueOf(this.getMaxHP()),
+              Boolean.valueOf(this.isUAV()), Boolean.valueOf(this.isNewUAV()), Boolean.valueOf(this.getRackParent() != null || super.ridingEntity instanceof MCH_EntitySeat),
+              this.getCommonUniqueId(), this.getTypeName(), Integer.valueOf(this.commonStatus));
+   }
+
    public void debugVehicleState(String context, EntityPlayer player) {
       if(!MCH_Config.DebugLog) {
          return;
       }
       MCH_Lib.DbgLog(super.worldObj,
-              "[MCH-STATE][%s] vehicle=%s type=%s commonId=%s player=%s pilot=%s seatCount=%d",
-              new Object[]{context, this.debugEntity(this), this.getTypeName(), this.getCommonUniqueId(),
-                      this.debugEntity(player), this.debugEntity(super.riddenByEntity), Integer.valueOf(this.getSeats().length)});
+              "[MCH-STATE][%s] %s",
+              new Object[]{context, this.getInteractionDebugSnapshot(player)});
       for(int i = 0; i < this.getSeats().length; ++i) {
          MCH_EntitySeat seat = this.getSeats()[i];
          MCH_Lib.DbgLog(super.worldObj,
@@ -6214,15 +6266,15 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    private boolean rejectInteraction(EntityPlayer player, String reason) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][REJECT] reason=%s vehicle=%s type=%s player=%s",
-              new Object[]{reason, this.debugEntity(this), this.getTypeName(), this.debugEntity(player)});
+      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractReject] %s reason=%s",
+              new Object[]{this.getInteractionDebugSnapshot(player), reason.toUpperCase(Locale.ROOT)});
       this.debugVehicleState("INTERACT-REJECT-" + reason, player);
       return false;
    }
 
    private void acceptInteraction(EntityPlayer player, String result) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][ACCEPT] result=%s vehicle=%s type=%s player=%s",
-              new Object[]{result, this.debugEntity(this), this.getTypeName(), this.debugEntity(player)});
+      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractDebug] %s reason=ALLOW_INTERACT result=%s",
+              new Object[]{this.getInteractionDebugSnapshot(player), result});
    }
 
    public boolean interactFirst(EntityPlayer player, boolean ss) {
@@ -6233,8 +6285,8 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public boolean interactFirst(EntityPlayer player) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][BEGIN] vehicle=%s type=%s player=%s",
-              new Object[]{this.debugEntity(this), this.getTypeName(), this.debugEntity(player)});
+      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractDebug] %s reason=INTERACT_FIRST_ENTERED",
+              new Object[]{this.getInteractionDebugSnapshot(player)});
       this.repairInvalidOccupantsForInteraction("vehicle_interact");
       if(isDestroyed()) {
          return this.rejectInteraction(player, "destroyed");
@@ -6301,7 +6353,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       if(seatResult) {
          this.acceptInteraction(player, "seat_search_requested pilotOccupied=" + this.debugEntity(this.riddenByEntity));
       } else {
-         this.rejectInteraction(player, "pilot_occupied_and_seat_array_unavailable");
+         this.rejectInteraction(player, "no_valid_seat");
       }
       return seatResult;
    }

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -20,6 +20,7 @@ public class MCH_EntitySeat extends W_Entity {
    public int parentSearchCount;
    protected Entity lastRiddenByEntity;
    public static final float BB_SIZE = 1.0F;
+   private int interactionDebugLoadTicks = -1;
 
    public MCH_EntitySeat(World world) {
       super(world);
@@ -138,6 +139,12 @@ public class MCH_EntitySeat extends W_Entity {
          onUpdate_Server();
       }
 
+      if(this.interactionDebugLoadTicks >= 0 && this.interactionDebugLoadTicks < 40) {
+         MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatLoadTick] tick=%d %s",
+                 new Object[]{Integer.valueOf(this.interactionDebugLoadTicks), this.getInteractionDebugSnapshot(null)});
+         ++this.interactionDebugLoadTicks;
+      }
+
       this.lastRiddenByEntity = this.riddenByEntity;
    }
 
@@ -192,6 +199,7 @@ public class MCH_EntitySeat extends W_Entity {
    }
 
    protected void writeEntityToNBT(NBTTagCompound nbt) {
+      MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatNBTWrite] %s", new Object[]{this.getInteractionDebugSnapshot(null)});
       nbt.setInteger("SeatID", this.seatID);
       nbt.setString("ParentUniqueID", this.parentUniqueID);
    }
@@ -199,6 +207,8 @@ public class MCH_EntitySeat extends W_Entity {
    protected void readEntityFromNBT(NBTTagCompound nbt) {
       this.seatID = nbt.getInteger("SeatID");
       this.parentUniqueID = nbt.getString("ParentUniqueID");
+      this.interactionDebugLoadTicks = 0;
+      MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatNBTRead] %s", new Object[]{this.getInteractionDebugSnapshot(null)});
    }
 
    @SideOnly(Side.CLIENT)
@@ -214,7 +224,30 @@ public class MCH_EntitySeat extends W_Entity {
       return this.riddenByEntity != null && getParent() != null && getParent().getIsGunnerMode(this.riddenByEntity);
    }
 
+   public String getInteractionDebugSnapshot(EntityPlayer player) {
+      String side = this.worldObj != null && this.worldObj.isRemote?"CLIENT":"SERVER";
+      int dimension = this.worldObj != null && this.worldObj.provider != null?this.worldObj.provider.dimensionId:Integer.MIN_VALUE;
+      MCH_EntityAircraft aircraft = this.getParent();
+      return String.format(java.util.Locale.ROOT,
+              "side=%s seatId=%d id=%d uuid=%s dimension=%d pos=%.3f,%.3f,%.3f player=%s playerUuid=%s parent=%s parentCommonId=%s linkedToExpectedParent=%s occupant=%s occupantDead=%s occupantBackref=%s ridingEntity=%s isDead=%s rack=%s",
+              side, Integer.valueOf(this.seatID), Integer.valueOf(this.getEntityId()), this.getUniqueID(), Integer.valueOf(dimension),
+              Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ),
+              player == null?"null":player.getCommandSenderName(), player == null?"null":player.getUniqueID(),
+              aircraft == null?"null":aircraft.getClass().getSimpleName() + "#" + aircraft.getEntityId(), this.parentUniqueID,
+              Boolean.valueOf(aircraft != null && this.parentUniqueID != null && this.parentUniqueID.equals(aircraft.getCommonUniqueId())),
+              this.riddenByEntity, Boolean.valueOf(this.riddenByEntity != null && this.riddenByEntity.isDead),
+              Boolean.valueOf(this.riddenByEntity != null && this.riddenByEntity.ridingEntity == this), this.ridingEntity,
+              Boolean.valueOf(this.isDead), Boolean.valueOf(aircraft != null && aircraft.getSeatInfo(this.seatID + 1) instanceof MCH_SeatRackInfo));
+   }
+
+   private boolean rejectInteraction(EntityPlayer player, String reason) {
+      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractReject] %s reason=%s",
+              new Object[]{this.getInteractionDebugSnapshot(player), reason});
+      return false;
+   }
+
    public boolean interactFirst(EntityPlayer player) {
+      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractDebug] %s reason=SEAT_INTERACT_FIRST_ENTERED", new Object[]{this.getInteractionDebugSnapshot(player)});
       MCH_Lib.DbgLog(this.worldObj,
               "[MCH-INTERACT][SEAT-BEGIN] side=%s seatId=%d seatEntity=%d seatUuid=%s parent=%s player=%s playerUuid=%s occupant=%s playerRiding=%s",
               new Object[]{this.worldObj.isRemote?"CLIENT":"SERVER", Integer.valueOf(this.seatID), Integer.valueOf(this.getEntityId()),
@@ -223,11 +256,11 @@ public class MCH_EntitySeat extends W_Entity {
       if(getParent() == null) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=parent_null seatId=%d parentCommonId=%s",
                  new Object[]{Integer.valueOf(this.seatID), this.parentUniqueID});
-         return false;
+         return this.rejectInteraction(player, "SEAT_PARENT_NULL");
       }
       if(getParent().isDestroyed()) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=parent_destroyed seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return false;
+         return this.rejectInteraction(player, "PARENT_DESTROYED");
       }
       ItemStack itemStack = player.getCurrentEquippedItem();
       if(itemStack != null && itemStack.getItem() instanceof mcheli.mob.MCH_ItemSpawnGunner) {
@@ -235,7 +268,7 @@ public class MCH_EntitySeat extends W_Entity {
       }
       if(!getParent().checkTeam(player)) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=team_check_failed seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return false;
+         return this.rejectInteraction(player, "TEAM_CHECK_FAILED");
       }
       if(!this.worldObj.isRemote && this.riddenByEntity != null
               && (this.riddenByEntity.isDead || this.riddenByEntity.ridingEntity != this
@@ -250,19 +283,19 @@ public class MCH_EntitySeat extends W_Entity {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=occupied seatId=%d occupantId=%d occupantUuid=%s dead=%s ridingBackref=%s",
                  new Object[]{Integer.valueOf(this.seatID), Integer.valueOf(this.riddenByEntity.getEntityId()), this.riddenByEntity.getUniqueID(),
                          Boolean.valueOf(this.riddenByEntity.isDead), Boolean.valueOf(this.riddenByEntity.ridingEntity == this)});
-         return false;
+         return this.rejectInteraction(player, this.riddenByEntity.isDead?"SEAT_OCCUPIED_BY_DEAD_ENTITY":"SEAT_OCCUPIED");
       }
       if(player.ridingEntity != null) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=player_already_riding seatId=%d riding=%s",
                  new Object[]{Integer.valueOf(this.seatID), player.ridingEntity});
-         return false;
+         return this.rejectInteraction(player, "PLAYER_ALREADY_RIDING");
       }
       if(!canRideMob(player)) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=seat_is_rack_or_invalid seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return false;
+         return this.rejectInteraction(player, "SEAT_IS_RACK_OR_INVALID");
       }
       player.mountEntity(this);
-      MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-ACCEPT] seatId=%d player=%s", new Object[]{Integer.valueOf(this.seatID), player.getCommandSenderName()});
+      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractDebug] %s reason=ALLOW_INTERACT result=SEAT_MOUNT", new Object[]{this.getInteractionDebugSnapshot(player)});
       return true;
    }
 


### PR DESCRIPTION
### Motivation
- Vehicles sometimes become un-enterable after their chunks reload and the root cause (client vs server, missing seats, stale references, or sync ordering) was not observable in logs.  
- Add narrowly scoped diagnostics to record every early-return/rejection and the seat/aircraft persistence lifecycle so the exact failure mode can be proven before applying a repair.  
- Focus on the interact path and seat relinking/tracking/sync points (spawn data, NBT load, StartTracking, seat-list packets).  

### Description
- Add a compact, single-line interaction snapshot method `getInteractionDebugSnapshot` for `MCH_EntityAircraft` and `MCH_EntitySeat` that encodes side, entity class/type/id/uuid/dimension/pos, player name/uuid, `acInfo` presence, seat array counts and per-seat link/occupant status, rider/backrefs, UAV/rack flags, common id, and DataWatcher/common status; this snapshot is used by all new logs.  
- Instrument the vehicle interaction path (`interactFirst`) to log `[MCHeliInteractDebug]` when entering and `[MCHeliInteractReject]` on every rejection with a named reason (e.g. `ACINFO_NULL`, `NO_VALID_SEAT`, `SEAT_OCCUPIED_BY_DEAD_ENTITY`).  
- Instrument seat-level logic with detailed NBT lifecycle logs (`[MCHeliSeatNBTRead]`/`[MCHeliSeatNBTWrite]`), seat-first-40-ticks load tracing (`[MCHeliSeatLoadTick]`), and equivalent seat interaction debug/reject logs that include parent linkage and occupant backreference info.  
- Trace spawn-data send/receive for aircraft (`[MCHeliFullSyncSend]`, `[MCHeliFullSyncReceive]`) to detect whether the client received the aircraft `TypeName` and whether `getAcInfo()` is null after `changeType`.  
- Force-log `PlayerEvent.StartTracking` handling to show when a full-state sync is sent and to record a `SEAT_PARENT_NOT_RESOLVED` rejection if a tracked seat could not resolve its parent, and add a client-side seat-list receive rejection log (`AIRCRAFT_ENTITY_NOT_PRESENT`) when the seat-list arrives before the aircraft.  
- Kept semantics unchanged (no speculative behavioral fixes); the change is diagnostic-only so subsequent PRs can implement minimal, evidence-backed fixes.  
- Modified files: `src/main/java/mcheli/aircraft/MCH_EntityAircraft.java`, `src/main/java/mcheli/aircraft/MCH_EntitySeat.java`, `src/main/java/mcheli/MCH_EventHook.java`, and `src/main/java/mcheli/aircraft/MCH_AircraftPacketHandler.java`.  

### Testing
- Ran repository checks and grep queries to verify the new debug markers are present with `rg -n "MCHeliInteract(Debug|Reject)|MCHeliSeatNBT|MCHeliSeatLoadTick|MCHeliStartTracking|MCHeliFullSync"`, which succeeded.  
- Ran `git diff --check` and static diffs to confirm the patch is syntactically integrated; no trailing whitespace errors reported.  
- Attempted to compile with the project wrapper using `./gradlew compileJava` and `bash gradlew compileJava`, but the environment blocked network downloads (Gradle wrapper download returned HTTP 403) so a full build could not be completed.  
- Attempted `gradle compileJava --offline` but the required ForgeGradle dependency was not available in the offline cache so compilation also failed.  
- Because compilation could not be run in this environment, this PR intentionally contains only logging/instrumentation changes and no behavioral fixes; the new logs are ready to gather evidence from an instrumented runtime to drive the minimal corrective change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24deeb05bc83239e0e3000753a20c0)