### PR TITLE
Fix vehicle/seat desync after chunk unload/reload (seat relink & full re-sync)

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -265,17 +265,7 @@ public class MCH_EventHook extends W_EventHook {
       }
 
       if(aircraft != null) {
-         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
-                 "[MCHeliStartTracking] targetClass=%s targetId=%d targetUuid=%s %s reason=FORCE_FULL_AIRCRAFT_STATE",
-                 new Object[]{event.target.getClass().getName(), Integer.valueOf(event.target.getEntityId()), event.target.getUniqueID(),
-                         aircraft.getInteractionDebugSnapshot(event.entityPlayer)});
          aircraft.syncCompleteAircraftState((EntityPlayerMP)event.entityPlayer);
-      } else if(event.target instanceof MCH_EntitySeat) {
-         MCH_EntitySeat seat = (MCH_EntitySeat)event.target;
-         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
-                 "[MCHeliStartTrackingReject] targetClass=%s targetId=%d targetUuid=%s player=%s playerUuid=%s reason=SEAT_PARENT_NOT_RESOLVED parentCommonId=%s",
-                 new Object[]{event.target.getClass().getName(), Integer.valueOf(event.target.getEntityId()), event.target.getUniqueID(),
-                         event.entityPlayer.getCommandSenderName(), event.entityPlayer.getUniqueID(), seat.parentUniqueID});
       }
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_AircraftPacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftPacketHandler.java
@@ -322,10 +322,6 @@ public class MCH_AircraftPacketHandler {
                   MCH_Lib.DbgLog(player.worldObj, "[MCH-SYNC][SEAT-APPLY-FAIL] reason=count_mismatch aircraftId=%d packetSeats=%d localSeats=%d",
                           new Object[]{Integer.valueOf(seatList.entityID_AC), Byte.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
                }
-            } else {
-               MCH_Lib.DbgLog(player.worldObj,
-                       "[MCHeliFullSyncReceiveReject] channel=SEAT_LIST aircraftId=%d packetSeats=%d resolvedEntity=%s reason=AIRCRAFT_ENTITY_NOT_PRESENT",
-                       new Object[]{Integer.valueOf(seatList.entityID_AC), Byte.valueOf(seatList.seatNum), e});
             }
 
          }

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -45,6 +45,7 @@ import net.minecraft.item.crafting.ShapedRecipes;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.play.server.S12PacketEntityVelocity;
 import net.minecraft.network.play.server.S1BPacketEntityAttach;
+import net.minecraft.network.play.server.S1CPacketEntityMetadata;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.tileentity.TileEntity;
@@ -116,7 +117,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    private MCH_SeatInfo[] seatsInfo;
    private String commonUniqueId;
    private int seatSearchCount;
-   private int interactionDebugLoadTicks = -1;
    protected double velocityX;
    protected double velocityY;
    protected double velocityZ;
@@ -1165,9 +1165,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public void writeSpawnData(ByteBuf buffer) {
-      MCH_Lib.DbgLog(super.worldObj,
-              "[MCHeliFullSyncSend] channel=SPAWN_DATA %s",
-              new Object[]{this.getInteractionDebugSnapshot(null)});
       if(this.getAcInfo() != null) {
          buffer.writeFloat(this.getAcInfo().bodyHeight);
          buffer.writeFloat(this.getAcInfo().bodyWidth);
@@ -1194,15 +1191,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          if (len > 0) {
             byte[] dst = new byte[len];
             additionalData.readBytes(dst);
-            String receivedType = new String(dst);
-            changeType(receivedType);
-            MCH_Lib.DbgLog(super.worldObj,
-                    "[MCHeliFullSyncReceive] channel=SPAWN_DATA receivedType=%s acInfoNull=%s %s",
-                    new Object[]{receivedType, Boolean.valueOf(this.getAcInfo() == null), this.getInteractionDebugSnapshot(null)});
-         } else {
-            MCH_Lib.DbgLog(super.worldObj,
-                    "[MCHeliFullSyncReceive] channel=SPAWN_DATA reason=EMPTY_TYPE_NAME %s",
-                    new Object[]{this.getInteractionDebugSnapshot(null)});
+            changeType(new String(dst));
          }
       } catch (Exception var4) {
          MCH_Lib.Log((Entity)this, "readSpawnData error!", new Object[0]);
@@ -1212,7 +1201,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    protected void readEntityFromNBT(NBTTagCompound nbt) {
-      this.interactionDebugLoadTicks = 0;
       MCH_Lib.DbgLog(super.worldObj, "[MCH-STATE][NBT-READ-BEGIN] entity=%s nbtType=%s nbtCommonId=%s rackParent=%s rackSeat=%d",
               new Object[]{this.debugEntity(this), nbt.getString("TypeName"), nbt.getString("AircraftUniqueId"),
                       nbt.getString("MCH_RackParentUniqueId"), Integer.valueOf(nbt.hasKey("MCH_RackSeatId")?nbt.getInteger("MCH_RackSeatId"):-1)});
@@ -1997,6 +1985,12 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public abstract void onUpdateAircraft();
 
    public void onUpdate() {
+      if(super.worldObj.isRemote && this.getAcInfo() == null) {
+         String typeName = this.getTypeName();
+         if(typeName != null && !typeName.isEmpty()) {
+            this.changeType(typeName);
+         }
+      }
       if(this.getCountOnUpdate() < 2) {
          this.prevPosition.clear(Vec3.createVectorHelper(super.posX, super.posY, super.posZ));
       }
@@ -2255,12 +2249,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       if(this.countOnUpdate == 0) {
          this.onFirstUpdate();
-      }
-
-      if(this.interactionDebugLoadTicks >= 0 && this.interactionDebugLoadTicks < 40) {
-         this.debugVehicleState("POST-NBT-LOAD-TICK-" + this.interactionDebugLoadTicks, null);
-         this.debugRackState("POST-NBT-LOAD-TICK-" + this.interactionDebugLoadTicks);
-         ++this.interactionDebugLoadTicks;
       }
 
       ++this.countOnUpdate;
@@ -4888,6 +4876,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public boolean interactFirstSeat(EntityPlayer player) {
+      if(!super.worldObj.isRemote) {
+         this.searchSeat();
+      }
       MCH_EntitySeat[] seatArray = this.getSeats();
       if(seatArray == null || seatArray.length == 0) {
          MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SEARCH-REJECT] reason=no_seat_array vehicle=%s player=%s",
@@ -5074,7 +5065,11 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             if(super.worldObj.isRemote) {
                MCH_PacketSeatListRequest.requestSeatList(this);
             } else {
+               boolean waitedForEntityLoad = this.seatSearchCount > 40;
                this.searchSeat();
+               if(waitedForEntityLoad) {
+                  this.recreateMissingSeatsInLoadedChunks();
+               }
             }
             this.seatSearchCount = 0;
          }
@@ -5126,6 +5121,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
          return;
       }
       this.repairSeatStateAfterLoad();
+      player.playerNetServerHandler.sendPacket(new S1CPacketEntityMetadata(this.getEntityId(), this.getDataWatcher(), true));
       MCH_PacketSeatListResponse.sendSeatList(this, player);
 
       if(super.ridingEntity != null) {
@@ -5140,8 +5136,40 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, seat.riddenByEntity, seat));
          }
       }
-      MCH_Lib.DbgLog(super.worldObj, "[MCHeliFullSyncSend] channel=START_TRACKING_STATE %s",
-              new Object[]{this.getInteractionDebugSnapshot(player)});
+   }
+
+   private void recreateMissingSeatsInLoadedChunks() {
+      if(super.worldObj.isRemote || this.getAcInfo() == null || this.getCommonUniqueId().isEmpty()) {
+         return;
+      }
+
+      for(int i = 0; i < this.seats.length; ++i) {
+         if(this.seats[i] != null) {
+            continue;
+         }
+
+         MCH_SeatInfo seatInfo = this.getSeatInfo(i + 1);
+         if(seatInfo == null) {
+            continue;
+         }
+         Vec3 position = this.getTransformedPosition(seatInfo.pos);
+         if(!super.worldObj.blockExists(MathHelper.floor_double(position.xCoord),
+                 MathHelper.floor_double(position.yCoord), MathHelper.floor_double(position.zCoord))) {
+            continue;
+         }
+
+         MCH_EntitySeat seat = new MCH_EntitySeat(super.worldObj);
+         seat.parentUniqueID = this.getCommonUniqueId();
+         seat.seatID = i;
+         seat.setParent(this);
+         seat.setPosition(position.xCoord, position.yCoord, position.zCoord);
+         seat.prevPosX = position.xCoord;
+         seat.prevPosY = position.yCoord;
+         seat.prevPosZ = position.zCoord;
+         if(super.worldObj.spawnEntityInWorld(seat)) {
+            this.seats[i] = seat;
+         }
+      }
    }
 
    public void searchSeat() {
@@ -6133,47 +6161,14 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
               Integer.valueOf(W_Entity.getEntityId(entity.riddenByEntity)));
    }
 
-   public String getInteractionDebugSnapshot(EntityPlayer player) {
-      String side = super.worldObj != null && super.worldObj.isRemote?"CLIENT":"SERVER";
-      int dimension = super.worldObj != null && super.worldObj.provider != null?super.worldObj.provider.dimensionId:Integer.MIN_VALUE;
-      MCH_AircraftInfo info = this.getAcInfo();
-      MCH_EntitySeat[] seatArray = this.getSeats();
-      int nullSeats = 0;
-      int deadSeats = 0;
-      int wrongParentSeats = 0;
-      int occupiedSeats = 0;
-      for(int i = 0; i < seatArray.length; ++i) {
-         MCH_EntitySeat seat = seatArray[i];
-         if(seat == null) {
-            ++nullSeats;
-         } else {
-            if(seat.isDead) ++deadSeats;
-            if(seat.getParent() != this || !this.getCommonUniqueId().equals(seat.parentUniqueID)) ++wrongParentSeats;
-            if(seat.riddenByEntity != null) ++occupiedSeats;
-         }
-      }
-      return String.format(Locale.ROOT,
-              "side=%s vehicle=%s class=%s name=%s type=%s id=%d uuid=%s dimension=%d pos=%.3f,%.3f,%.3f player=%s playerUuid=%s acInfoNull=%s typeLoaded=%s seatArrayExists=%s seatCount=%d nullSeats=%d deadSeats=%d wrongParentSeats=%d occupiedSeats=%d riddenByEntity=%s ridingEntity=%s isDead=%s isDestroyed=%s damage=%d/%d lockState=NOT_APPLICABLE uav=%s newUav=%s rackMounted=%s commonId=%s dataWatcherType=%s commonStatus=%d",
-              side, this.getClass().getSimpleName(), this.getClass().getName(), this.getEntityName(), this.getTypeName(),
-              Integer.valueOf(this.getEntityId()), this.getUniqueID(), Integer.valueOf(dimension),
-              Double.valueOf(super.posX), Double.valueOf(super.posY), Double.valueOf(super.posZ),
-              player == null?"null":player.getCommandSenderName(), player == null?"null":player.getUniqueID(),
-              Boolean.valueOf(info == null), Boolean.valueOf(info != null && this.getTypeName() != null && !this.getTypeName().isEmpty()),
-              Boolean.valueOf(this.seats != null), Integer.valueOf(seatArray.length), Integer.valueOf(nullSeats),
-              Integer.valueOf(deadSeats), Integer.valueOf(wrongParentSeats), Integer.valueOf(occupiedSeats),
-              this.debugEntity(super.riddenByEntity), this.debugEntity(super.ridingEntity), Boolean.valueOf(super.isDead),
-              Boolean.valueOf(this.isDestroyed()), Integer.valueOf(this.getDamageTaken()), Integer.valueOf(this.getMaxHP()),
-              Boolean.valueOf(this.isUAV()), Boolean.valueOf(this.isNewUAV()), Boolean.valueOf(this.getRackParent() != null || super.ridingEntity instanceof MCH_EntitySeat),
-              this.getCommonUniqueId(), this.getTypeName(), Integer.valueOf(this.commonStatus));
-   }
-
    public void debugVehicleState(String context, EntityPlayer player) {
       if(!MCH_Config.DebugLog) {
          return;
       }
       MCH_Lib.DbgLog(super.worldObj,
-              "[MCH-STATE][%s] %s",
-              new Object[]{context, this.getInteractionDebugSnapshot(player)});
+              "[MCH-STATE][%s] vehicle=%s type=%s commonId=%s player=%s pilot=%s seatCount=%d",
+              new Object[]{context, this.debugEntity(this), this.getTypeName(), this.getCommonUniqueId(),
+                      this.debugEntity(player), this.debugEntity(super.riddenByEntity), Integer.valueOf(this.getSeats().length)});
       for(int i = 0; i < this.getSeats().length; ++i) {
          MCH_EntitySeat seat = this.getSeats()[i];
          MCH_Lib.DbgLog(super.worldObj,
@@ -6268,16 +6263,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    private boolean rejectInteraction(EntityPlayer player, String reason) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractReject] %s reason=%s",
-              new Object[]{this.getInteractionDebugSnapshot(player), reason.toUpperCase(Locale.ROOT)});
-      this.debugVehicleState("INTERACT-REJECT-" + reason, player);
       return false;
    }
 
-   private void acceptInteraction(EntityPlayer player, String result) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractDebug] %s reason=ALLOW_INTERACT result=%s",
-              new Object[]{this.getInteractionDebugSnapshot(player), result});
-   }
+   private void acceptInteraction(EntityPlayer player, String result) {}
 
    public boolean interactFirst(EntityPlayer player, boolean ss) {
       this.switchSeat = ss;
@@ -6287,8 +6276,6 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public boolean interactFirst(EntityPlayer player) {
-      MCH_Lib.DbgLog(super.worldObj, "[MCHeliInteractDebug] %s reason=INTERACT_FIRST_ENTERED",
-              new Object[]{this.getInteractionDebugSnapshot(player)});
       this.repairInvalidOccupantsForInteraction("vehicle_interact");
       if(isDestroyed()) {
          return this.rejectInteraction(player, "destroyed");

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -20,7 +20,6 @@ public class MCH_EntitySeat extends W_Entity {
    public int parentSearchCount;
    protected Entity lastRiddenByEntity;
    public static final float BB_SIZE = 1.0F;
-   private int interactionDebugLoadTicks = -1;
 
    public MCH_EntitySeat(World world) {
       super(world);
@@ -139,12 +138,6 @@ public class MCH_EntitySeat extends W_Entity {
          onUpdate_Server();
       }
 
-      if(this.interactionDebugLoadTicks >= 0 && this.interactionDebugLoadTicks < 40) {
-         MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatLoadTick] tick=%d %s",
-                 new Object[]{Integer.valueOf(this.interactionDebugLoadTicks), this.getInteractionDebugSnapshot(null)});
-         ++this.interactionDebugLoadTicks;
-      }
-
       this.lastRiddenByEntity = this.riddenByEntity;
    }
 
@@ -199,7 +192,6 @@ public class MCH_EntitySeat extends W_Entity {
    }
 
    protected void writeEntityToNBT(NBTTagCompound nbt) {
-      MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatNBTWrite] %s", new Object[]{this.getInteractionDebugSnapshot(null)});
       nbt.setInteger("SeatID", this.seatID);
       nbt.setString("ParentUniqueID", this.parentUniqueID);
    }
@@ -207,8 +199,6 @@ public class MCH_EntitySeat extends W_Entity {
    protected void readEntityFromNBT(NBTTagCompound nbt) {
       this.seatID = nbt.getInteger("SeatID");
       this.parentUniqueID = nbt.getString("ParentUniqueID");
-      this.interactionDebugLoadTicks = 0;
-      MCH_Lib.DbgLog(this.worldObj, "[MCHeliSeatNBTRead] %s", new Object[]{this.getInteractionDebugSnapshot(null)});
    }
 
    @SideOnly(Side.CLIENT)
@@ -224,30 +214,16 @@ public class MCH_EntitySeat extends W_Entity {
       return this.riddenByEntity != null && getParent() != null && getParent().getIsGunnerMode(this.riddenByEntity);
    }
 
-   public String getInteractionDebugSnapshot(EntityPlayer player) {
-      String side = this.worldObj != null && this.worldObj.isRemote?"CLIENT":"SERVER";
-      int dimension = this.worldObj != null && this.worldObj.provider != null?this.worldObj.provider.dimensionId:Integer.MIN_VALUE;
-      MCH_EntityAircraft aircraft = this.getParent();
-      return String.format(java.util.Locale.ROOT,
-              "side=%s seatId=%d id=%d uuid=%s dimension=%d pos=%.3f,%.3f,%.3f player=%s playerUuid=%s parent=%s parentCommonId=%s linkedToExpectedParent=%s occupant=%s occupantDead=%s occupantBackref=%s ridingEntity=%s isDead=%s rack=%s",
-              side, Integer.valueOf(this.seatID), Integer.valueOf(this.getEntityId()), this.getUniqueID(), Integer.valueOf(dimension),
-              Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ),
-              player == null?"null":player.getCommandSenderName(), player == null?"null":player.getUniqueID(),
-              aircraft == null?"null":aircraft.getClass().getSimpleName() + "#" + aircraft.getEntityId(), this.parentUniqueID,
-              Boolean.valueOf(aircraft != null && this.parentUniqueID != null && this.parentUniqueID.equals(aircraft.getCommonUniqueId())),
-              this.riddenByEntity, Boolean.valueOf(this.riddenByEntity != null && this.riddenByEntity.isDead),
-              Boolean.valueOf(this.riddenByEntity != null && this.riddenByEntity.ridingEntity == this), this.ridingEntity,
-              Boolean.valueOf(this.isDead), Boolean.valueOf(aircraft != null && aircraft.getSeatInfo(this.seatID + 1) instanceof MCH_SeatRackInfo));
-   }
-
-   private boolean rejectInteraction(EntityPlayer player, String reason) {
-      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractReject] %s reason=%s",
-              new Object[]{this.getInteractionDebugSnapshot(player), reason});
-      return false;
-   }
-
    public boolean interactFirst(EntityPlayer player) {
-      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractDebug] %s reason=SEAT_INTERACT_FIRST_ENTERED", new Object[]{this.getInteractionDebugSnapshot(player)});
+      if(getParent() == null && this.parentUniqueID != null && !this.parentUniqueID.isEmpty()) {
+         for(Object object : this.worldObj.loadedEntityList) {
+            if(object instanceof MCH_EntityAircraft
+                    && this.parentUniqueID.equals(((MCH_EntityAircraft)object).getCommonUniqueId())) {
+               setParent((MCH_EntityAircraft)object);
+               break;
+            }
+         }
+      }
       MCH_Lib.DbgLog(this.worldObj,
               "[MCH-INTERACT][SEAT-BEGIN] side=%s seatId=%d seatEntity=%d seatUuid=%s parent=%s player=%s playerUuid=%s occupant=%s playerRiding=%s",
               new Object[]{this.worldObj.isRemote?"CLIENT":"SERVER", Integer.valueOf(this.seatID), Integer.valueOf(this.getEntityId()),
@@ -256,11 +232,11 @@ public class MCH_EntitySeat extends W_Entity {
       if(getParent() == null) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=parent_null seatId=%d parentCommonId=%s",
                  new Object[]{Integer.valueOf(this.seatID), this.parentUniqueID});
-         return this.rejectInteraction(player, "SEAT_PARENT_NULL");
+         return false;
       }
       if(getParent().isDestroyed()) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=parent_destroyed seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return this.rejectInteraction(player, "PARENT_DESTROYED");
+         return false;
       }
       ItemStack itemStack = player.getCurrentEquippedItem();
       if(itemStack != null && itemStack.getItem() instanceof mcheli.mob.MCH_ItemSpawnGunner) {
@@ -268,7 +244,7 @@ public class MCH_EntitySeat extends W_Entity {
       }
       if(!getParent().checkTeam(player)) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=team_check_failed seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return this.rejectInteraction(player, "TEAM_CHECK_FAILED");
+         return false;
       }
       if(!this.worldObj.isRemote && this.riddenByEntity != null
               && (this.riddenByEntity.isDead || this.riddenByEntity.ridingEntity != this
@@ -283,19 +259,18 @@ public class MCH_EntitySeat extends W_Entity {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=occupied seatId=%d occupantId=%d occupantUuid=%s dead=%s ridingBackref=%s",
                  new Object[]{Integer.valueOf(this.seatID), Integer.valueOf(this.riddenByEntity.getEntityId()), this.riddenByEntity.getUniqueID(),
                          Boolean.valueOf(this.riddenByEntity.isDead), Boolean.valueOf(this.riddenByEntity.ridingEntity == this)});
-         return this.rejectInteraction(player, this.riddenByEntity.isDead?"SEAT_OCCUPIED_BY_DEAD_ENTITY":"SEAT_OCCUPIED");
+         return false;
       }
       if(player.ridingEntity != null) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=player_already_riding seatId=%d riding=%s",
                  new Object[]{Integer.valueOf(this.seatID), player.ridingEntity});
-         return this.rejectInteraction(player, "PLAYER_ALREADY_RIDING");
+         return false;
       }
       if(!canRideMob(player)) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=seat_is_rack_or_invalid seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
-         return this.rejectInteraction(player, "SEAT_IS_RACK_OR_INVALID");
+         return false;
       }
       player.mountEntity(this);
-      MCH_Lib.DbgLog(this.worldObj, "[MCHeliInteractDebug] %s reason=ALLOW_INTERACT result=SEAT_MOUNT", new Object[]{this.getInteractionDebugSnapshot(player)});
       return true;
    }
 


### PR DESCRIPTION
### Motivation
- Vehicles became un-enterable after their chunks unloaded and later reloaded because seats, rider backreferences, and aircraft type/metadata could be missing or stale on client or server sides after entity join/tracking.
- The goal is a minimal, targeted recovery so vehicles remain enterable after chunk reload without changing physics, weapons, or rack logic.

### Description
- Recover client-side aircraft type when `getAcInfo()` is missing by restoring type from the DataWatcher/spawn metadata during `onUpdate()` so rendering/state is available once metadata arrives. (client-side recovery)
- Harden seat handling: relink valid loaded `MCH_EntitySeat` instances to their parent aircraft, clear invalid/dead references, and only recreate genuinely missing seats after an entity-load grace check and only when the seat's expected chunk/blocks are present to avoid duplicates. (server-side recovery)
- Ensure full per-aircraft re-sync is sent to a player when they start tracking an existing aircraft: resend DataWatcher metadata, the seat list, and attachment (mount) packets so the client has a complete, consistent state to allow interaction. (start-tracking sync)
- Relink seats to parents on entity join so seats that loaded before their parent are attached as soon as possible, and call the seat-repair path after join/load. (entity-join handling)
- Preserve and use existing repair logic that clears stale rider/passenger references when occupants are dead, not loaded, or have invalid riding backreferences so stale occupants do not block seats.
- Remove the previously-added, heavy diagnostic instrumentation that relied on extra logger usage; avoid adding logger-based debug code as requested.
- No changes were made to weapons, aircraft physics, rack launch behavior, carrier collision, or unrelated unmount-position/rack fixes.

### Testing
- Ran repository sanity checks: `git diff --cached --check` and `git diff HEAD^ --check` to validate whitespace and quick diffs (passed where applicable).
- Verified the debug/logging diagnostics added for tracing this issue were removed by scanning for the related diagnostic markers (confirmed removed).
- Attempted a `gradlew compileJava` run to compile the project, but the Gradle wrapper failed to download its distribution due to an environment proxy returning HTTP 403, so a full compile could not be completed in this environment.
- Changes have been committed to the branch and are ready for review; runtime validation (in-game integration tests) should be performed on a server/client setup to confirm seat relinking and tracking resynchronization fix the reproduce steps described.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24e9f20ca483239cb01faac95be43d)