### PR TITLE
Add client-side render-only LOD snapshots for distant MCHeli vehicles

### DIFF
--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -33,6 +33,8 @@ import mcheli.helicopter.MCH_HeliInfoManager;
 import mcheli.helicopter.MCH_RenderHeli;
 import mcheli.hud.MCH_HudManager;
 import mcheli.lweapon.MCH_ItemLightWeaponRender;
+import mcheli.lod.MCH_VehicleLODManager;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.multiplay.MCH_MultiplayClient;
 import mcheli.parachute.MCH_EntityParachute;
 import mcheli.parachute.MCH_RenderParachute;
@@ -88,6 +90,7 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
    }
 
    public void registerRenderer() {
+      MinecraftForge.EVENT_BUS.register(MCH_VehicleLODManager.INSTANCE);
       RenderingRegistry.registerEntityRenderingHandler(MCH_EntitySeat.class, new MCH_RenderTest(0.0F, 0.0F, 0.0F, "seat"));
       RenderingRegistry.registerEntityRenderingHandler(MCH_EntityHeli.class, new MCH_RenderHeli());
       RenderingRegistry.registerEntityRenderingHandler(MCP_EntityPlane.class, new MCP_RenderPlane());
@@ -484,6 +487,14 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       Minecraft mc = Minecraft.getMinecraft();
       MCH_ClientCommonTickHandler.instance = new MCH_ClientCommonTickHandler(mc, MCH_MOD.config);
       W_TickRegistry.registerTickHandler(MCH_ClientCommonTickHandler.instance, Side.CLIENT);
+   }
+
+   public void updateVehicleLODSnapshots(int dimension, java.util.List<PacketVehicleLODSnapshot.Entry> entries) {
+      MCH_VehicleLODManager.INSTANCE.update(dimension, entries);
+   }
+
+   public void clearVehicleLODSnapshots() {
+      MCH_VehicleLODManager.INSTANCE.clear();
    }
 
    public boolean isRemote() {

--- a/src/main/java/mcheli/MCH_CommonProxy.java
+++ b/src/main/java/mcheli/MCH_CommonProxy.java
@@ -6,6 +6,8 @@ import mcheli.MCH_Lib;
 import mcheli.MCH_ServerTickHandler;
 import mcheli.aircraft.MCH_EntityAircraft;
 import mcheli.aircraft.MCH_SoundUpdater;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
+import java.util.List;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.IChatComponent;
@@ -35,6 +37,10 @@ public class MCH_CommonProxy {
    public void registerModelsTank(String name, boolean reload) {}
 
    public void registerClientTick() {}
+
+   public void updateVehicleLODSnapshots(int dimension, List<PacketVehicleLODSnapshot.Entry> entries) {}
+
+   public void clearVehicleLODSnapshots() {}
 
    public void registerServerTick() {
       FMLCommonHandler.instance().bus().register(new MCH_ServerTickHandler());

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -346,11 +346,11 @@ public class MCH_Config {
       DisableItemRender.desc = ";DisableItemRender = 0 ~ 3 (1 = Recommended)";
       RenderDistanceWeight = new MCH_ConfigPrm("RenderDistanceWeight", 1000.0D);
       EnableAircraftLODRender = new MCH_ConfigPrm("EnableAircraftLODRender", true);
-      EnableAircraftLODRender.desc = ";Enable simple far-distance LOD silhouettes for aircraft, tanks, turrets, and ships.";
+      EnableAircraftLODRender.desc = ";Enable client-only far-distance model displays for aircraft, tanks, turrets, and ships.";
       AircraftLODStartDistance = new MCH_ConfigPrm("AircraftLODStartDistance", 256.0D);
-      AircraftLODStartDistance.desc = ";Distance in blocks where aircraft/tank/turret/ship rendering switches to a cheap LOD silhouette.";
+      AircraftLODStartDistance.desc = ";Distance in blocks where tracked aircraft rendering switches to its cheaper model-only pass.";
       AircraftLODFarDistance = new MCH_ConfigPrm("AircraftLODFarDistance", 4096.0D);
-      AircraftLODFarDistance.desc = ";Maximum aircraft/tank/turret/ship LOD render-test distance in blocks. Entity network tracking remains aligned with child seats so chunk reloads respawn the complete vehicle.";
+      AircraftLODFarDistance.desc = ";Maximum distance for client-only vehicle LOD snapshots. Real vehicle entity tracking remains unchanged and aligned with child seats.";
       MobRenderDistanceWeight = new MCH_ConfigPrm("MobRenderDistanceWeight", 10.0D);
       CreativeTabIcon = new MCH_ConfigPrm("CreativeTabIconItem", "fuel");
       CreativeTabIconHeli = new MCH_ConfigPrm("CreativeTabIconHeli", "ah-64");

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -1,161 +1,104 @@
 package mcheli;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.TickEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
-import cpw.mods.fml.common.network.internal.FMLProxyPacket;
-
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import mcheli.aircraft.MCH_EntityAircraft;
-import mcheli.aircraft.MCH_PacketAircraftLocation;
+import mcheli.helicopter.MCH_EntityHeli;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.plane.MCP_EntityPlane;
-import mcheli.weapon.MCH_EntityBaseBullet;
-import mcheli.wrapper.W_Reflection;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.network.NetworkManager;
+import mcheli.ship.MCH_EntityShip;
+import mcheli.tank.MCH_EntityTank;
+import mcheli.vehicle.MCH_EntityVehicle;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.AxisAlignedBB;
-import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 
+/** Sends render-only vehicle snapshots without changing Forge entity tracking. */
 public class MCH_ServerTickHandler {
-
-   HashMap rcvMap = new HashMap();
-   HashMap sndMap = new HashMap();
-   int sndPacketNum = 0;
-   int rcvPacketNum = 0;
-   int tick;
-
+   private static final int UPDATE_INTERVAL_TICKS = 20;
+   private static final int MAX_ENTRIES = 512;
+   private int tick;
 
    @SubscribeEvent
    public void onServerTickEvent(ServerTickEvent event) {
-      if (event.phase != Phase.END) return;
-      //MCH_ESMHandler.getInstance().onTick();
-      MinecraftServer minecraftServer = MinecraftServer.getServer();
+      if(event.phase != Phase.END || ++this.tick < UPDATE_INTERVAL_TICKS) {
+         return;
+      }
+      this.tick = 0;
 
-      for (WorldServer server : MinecraftServer.getServer().worldServers) {
-         for (Object playerObj : server.playerEntities) {
-            EntityPlayer player = (EntityPlayer) playerObj;
-            AxisAlignedBB aabb = player.boundingBox.expand(350, 350, 350);
-            List<MCP_EntityPlane> list = new ArrayList<>();
-            List<Entity> entities = player.worldObj.getEntitiesWithinAABBExcludingEntity(player, aabb);
-            for (Entity e : entities) {
-               if (e instanceof MCP_EntityPlane && !e.onGround) {
-                  MCP_EntityPlane plane = (MCP_EntityPlane) e;
-                  list.add(plane);
-                  //System.out.println("server tick handler");
-                  MCH_PacketAircraftLocation.send(plane, player);
-               }
+      MinecraftServer server = MinecraftServer.getServer();
+      if(server == null || server.worldServers == null) {
+         return;
+      }
+
+      double farDistance = MCH_Config.AircraftLODFarDistance != null
+         ? MCH_Config.AircraftLODFarDistance.prmDouble : 4096.0D;
+      double farDistanceSq = farDistance > 0.0D ? farDistance * farDistance : Double.MAX_VALUE;
+
+      for(WorldServer world : server.worldServers) {
+         for(Object playerObject : world.playerEntities) {
+            if(!(playerObject instanceof EntityPlayerMP)) {
+               continue;
             }
+            EntityPlayerMP player = (EntityPlayerMP)playerObject;
+            List<PacketVehicleLODSnapshot.Entry> entries = collectSnapshots(world, player, farDistanceSq);
+            MCH_MOD.getPacketHandler().sendTo(new PacketVehicleLODSnapshot(world.provider.dimensionId, entries), player);
          }
       }
    }
 
-   double visualDistance = 2500;
-   @SubscribeEvent
-   void onWorldTick(TickEvent.WorldTickEvent evt) {
-      System.out.println("onworldtick works");
-      //inb4 this shit never fires and its more goddamn schizophrenic bullshit from this fuckass mod
-      //it doesn't.
-      World worldObj = evt.world;
-
-      // --- Existing MCH plane syncing logic ---
-      for (Object obj : worldObj.playerEntities) {
-         if (obj instanceof EntityPlayer) {
-            EntityPlayer player = (EntityPlayer) obj;
-            AxisAlignedBB aabb = player.boundingBox.expand(visualDistance, visualDistance, visualDistance);
-            List<MCP_EntityPlane> list = new ArrayList<>();
-            for (Object entityObj : worldObj.getEntitiesWithinAABBExcludingEntity(player, aabb)) {
-               if (entityObj instanceof MCP_EntityPlane) {
-                  MCP_EntityPlane plane = (MCP_EntityPlane) entityObj;
-                  if (!plane.onGround) {
-                     list.add(plane);
-                     MCH_PacketAircraftLocation.send(plane, player);
-                  }
-               }
+   private static List<PacketVehicleLODSnapshot.Entry> collectSnapshots(WorldServer world, final EntityPlayerMP player, double farDistanceSq) {
+      List<MCH_EntityAircraft> aircraft = new ArrayList<MCH_EntityAircraft>();
+      for(Object object : world.loadedEntityList) {
+         if(object instanceof MCH_EntityAircraft) {
+            MCH_EntityAircraft vehicle = (MCH_EntityAircraft)object;
+            if(!vehicle.isDead && vehicle.getAcInfo() != null && categoryOf(vehicle) >= 0
+               && vehicle.getDistanceSqToEntity(player) <= farDistanceSq) {
+               aircraft.add(vehicle);
             }
          }
       }
 
-      // --- NEW: Bullet despawn logic ---
-      //List<Entity> loaded = worldObj.loadedEntityList;
-      //int bulletCount = 0;
-      //List<MCH_EntityBaseBullet> excessBullets = new ArrayList<>();
-//
-      //for (Object obj : loaded) {
-      //   if (obj instanceof MCH_EntityBaseBullet) {
-      //      MCH_EntityBaseBullet bullet = (MCH_EntityBaseBullet) obj;
-      //      bulletCount++;
-//
-      //      if (!bullet.shouldLoadChunks() && bullet.idleStartTime > 0) {
-      //         System.out.println("NOT should load chunks");
-      //         excessBullets.add(bullet);
-      //      }
-      //   }
-      //}
-//
-      //if (bulletCount > 1000) {
-      //   int bulletsToKill = Math.min(200, excessBullets.size());
-      //   for (int i = 0; i < bulletsToKill; i++) {
-      //      excessBullets.get(i).setDead();
-      //   }
-      //   System.out.println("Bullet cleanup triggered: removed " + bulletsToKill + " bullets.");
-      //}
-      //this shit does NOT work. I FUCKING LOVE THIS MOD'S SCHIZOPHRENIA
+      Collections.sort(aircraft, new Comparator<MCH_EntityAircraft>() {
+         @Override
+         public int compare(MCH_EntityAircraft left, MCH_EntityAircraft right) {
+            return Double.compare(left.getDistanceSqToEntity(player), right.getDistanceSqToEntity(player));
+         }
+      });
+
+      int count = Math.min(aircraft.size(), MAX_ENTRIES);
+      List<PacketVehicleLODSnapshot.Entry> entries = new ArrayList<PacketVehicleLODSnapshot.Entry>(count);
+      for(int i = 0; i < count; ++i) {
+         MCH_EntityAircraft vehicle = aircraft.get(i);
+         PacketVehicleLODSnapshot.Entry entry = new PacketVehicleLODSnapshot.Entry();
+         entry.uuid = vehicle.getUniqueID();
+         entry.entityId = vehicle.getEntityId();
+         entry.category = categoryOf(vehicle);
+         entry.typeName = vehicle.getAcInfo().name;
+         entry.textureName = vehicle.getTextureName();
+         entry.x = vehicle.posX;
+         entry.y = vehicle.posY;
+         entry.z = vehicle.posZ;
+         entry.yaw = vehicle.getRotYaw();
+         entry.pitch = vehicle.getRotPitch();
+         entry.roll = vehicle.getRotRoll();
+         entry.scale = 1.0F;
+         entries.add(entry);
+      }
+      return entries;
    }
 
-   private void onServerTickPre() {
-      ++this.tick;
-      List list = W_Reflection.getNetworkManagers();
-      if(list != null) {
-         for(int i = 0; i < list.size(); ++i) {
-            Queue queue = W_Reflection.getReceivedPacketsQueue((NetworkManager)list.get(i));
-            if(queue != null) {
-               this.putMap(this.rcvMap, queue.iterator());
-               this.rcvPacketNum += queue.size();
-            }
-
-            queue = W_Reflection.getSendPacketsQueue((NetworkManager)list.get(i));
-            if(queue != null) {
-               this.putMap(this.sndMap, queue.iterator());
-               this.sndPacketNum += queue.size();
-            }
-         }
-      }
-
-      if(this.tick >= 20) {
-         this.tick = 0;
-         this.rcvPacketNum = this.sndPacketNum = 0;
-         this.rcvMap.clear();
-         this.sndMap.clear();
-      }
-
+   private static byte categoryOf(MCH_EntityAircraft vehicle) {
+      if(vehicle instanceof MCH_EntityHeli) return 0;
+      if(vehicle instanceof MCP_EntityPlane) return 1;
+      if(vehicle instanceof MCH_EntityShip) return 2;
+      if(vehicle instanceof MCH_EntityTank) return 3;
+      if(vehicle instanceof MCH_EntityVehicle) return 4;
+      return -1;
    }
-
-   public void putMap(HashMap map, Iterator iterator) {
-      while(iterator.hasNext()) {
-         Object o = iterator.next();
-         String key = o.getClass().getName().toString();
-         if(key.startsWith("net.minecraft.")) {
-            key = "Minecraft";
-         } else if(o instanceof FMLProxyPacket) {
-            FMLProxyPacket p = (FMLProxyPacket)o;
-            key = p.channel();
-         } else {
-            key = "Unknown!";
-         }
-
-         if(map.containsKey(key)) {
-            map.put(key, Integer.valueOf(1 + ((Integer)map.get(key)).intValue()));
-         } else {
-            map.put(key, Integer.valueOf(1));
-         }
-      }
-
-   }
-
-   private void onServerTickPost() {}
 }

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -1,0 +1,242 @@
+package mcheli.lod;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import mcheli.MCH_Config;
+import mcheli.aircraft.MCH_AircraftInfo;
+import mcheli.aircraft.MCH_EntityAircraft;
+import mcheli.helicopter.MCH_HeliInfoManager;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
+import mcheli.plane.MCP_PlaneInfoManager;
+import mcheli.ship.MCH_ShipInfoManager;
+import mcheli.tank.MCH_TankInfoManager;
+import mcheli.vehicle.MCH_VehicleInfoManager;
+import mcheli.wrapper.W_MOD;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraft.world.World;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import org.lwjgl.opengl.GL11;
+
+/**
+ * Client-only render cache for distant vehicles.  Entries are plain data and are
+ * never added to a World, so they cannot collide, tick, mount, save, or interact.
+ */
+@SideOnly(Side.CLIENT)
+public final class MCH_VehicleLODManager {
+    public static final MCH_VehicleLODManager INSTANCE = new MCH_VehicleLODManager();
+    private static final long STALE_AFTER_MS = 5000L;
+    private final Map<UUID, Display> displays = new HashMap<UUID, Display>();
+    private int dimension = Integer.MIN_VALUE;
+    private World world;
+
+    private MCH_VehicleLODManager() {
+    }
+
+    public synchronized void update(int packetDimension, List<PacketVehicleLODSnapshot.Entry> entries) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.theWorld == null || mc.thePlayer == null || mc.thePlayer.dimension != packetDimension) {
+            return;
+        }
+        if (this.world != mc.theWorld) {
+            this.displays.clear();
+            this.world = mc.theWorld;
+        }
+
+        long now = System.currentTimeMillis();
+        Set<UUID> received = new HashSet<UUID>();
+        for (PacketVehicleLODSnapshot.Entry entry : entries) {
+            if (entry.uuid == null || entry.typeName == null || entry.typeName.length() == 0) {
+                continue;
+            }
+            received.add(entry.uuid);
+            Display display = this.displays.get(entry.uuid);
+            if (display == null) {
+                display = new Display(entry);
+                this.displays.put(entry.uuid, display);
+            } else {
+                display.update(entry);
+            }
+            display.lastUpdateMs = now;
+        }
+
+        this.displays.keySet().retainAll(received);
+        this.dimension = packetDimension;
+    }
+
+    public synchronized void clear() {
+        this.displays.clear();
+        this.dimension = Integer.MIN_VALUE;
+        this.world = null;
+    }
+
+    @SubscribeEvent
+    public synchronized void onRenderWorldLast(RenderWorldLastEvent event) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.theWorld != this.world) {
+            clear();
+            return;
+        }
+        if (mc.theWorld == null || mc.thePlayer == null || this.dimension != mc.thePlayer.dimension
+            || MCH_Config.EnableAircraftLODRender == null || !MCH_Config.EnableAircraftLODRender.prmBool) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        Set<UUID> trackedAircraft = new HashSet<UUID>();
+        Set<Integer> trackedAircraftIds = new HashSet<Integer>();
+        for (Object object : mc.theWorld.loadedEntityList) {
+            if (object instanceof MCH_EntityAircraft) {
+                trackedAircraft.add(((Entity)object).getUniqueID());
+                trackedAircraftIds.add(((Entity)object).getEntityId());
+            }
+        }
+
+        Entity camera = mc.renderViewEntity;
+        if (camera == null) {
+            return;
+        }
+        double cameraX = camera.lastTickPosX + (camera.posX - camera.lastTickPosX) * event.partialTicks;
+        double cameraY = camera.lastTickPosY + (camera.posY - camera.lastTickPosY) * event.partialTicks;
+        double cameraZ = camera.lastTickPosZ + (camera.posZ - camera.lastTickPosZ) * event.partialTicks;
+        double far = MCH_Config.AircraftLODFarDistance != null ? MCH_Config.AircraftLODFarDistance.prmDouble : 4096.0D;
+        double farSq = far > 0.0D ? far * far : Double.MAX_VALUE;
+
+        for (Display display : this.displays.values()) {
+            if (now - display.lastUpdateMs > STALE_AFTER_MS || trackedAircraft.contains(display.uuid)
+                || trackedAircraftIds.contains(display.entityId)) {
+                continue;
+            }
+            float interpolation = Math.min(1.0F, (float)(now - display.previousUpdateMs) / 1000.0F);
+            double worldX = display.previousX + (display.x - display.previousX) * interpolation;
+            double worldY = display.previousY + (display.y - display.previousY) * interpolation;
+            double worldZ = display.previousZ + (display.z - display.previousZ) * interpolation;
+            double x = worldX - cameraX;
+            double y = worldY - cameraY;
+            double z = worldZ - cameraZ;
+            if (x * x + y * y + z * z > farSq) {
+                continue;
+            }
+            render(display, x, y, z, interpolation);
+        }
+    }
+
+    private static void render(Display display, double x, double y, double z, float interpolation) {
+        MCH_AircraftInfo info = getInfo(display.category, display.typeName);
+        String textureFolder = getTextureFolder(display.category);
+        if (info == null || info.model == null || textureFolder == null) {
+            return;
+        }
+
+        GL11.glPushMatrix();
+        GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_CURRENT_BIT | GL11.GL_TEXTURE_BIT);
+        GL11.glDisable(GL11.GL_FOG);
+        GL11.glEnable(GL11.GL_BLEND);
+        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GL11.glColor4f(0.75F, 0.75F, 0.75F, 1.0F);
+        GL11.glTranslated(x, y, z);
+        GL11.glRotatef(interpolateAngle(display.previousYaw, display.yaw, interpolation), 0.0F, -1.0F, 0.0F);
+        GL11.glRotatef(interpolateAngle(display.previousPitch, display.pitch, interpolation), 1.0F, 0.0F, 0.0F);
+        GL11.glRotatef(interpolateAngle(display.previousRoll, display.roll, interpolation), 0.0F, 0.0F, 1.0F);
+        GL11.glScalef(display.scale, display.scale, display.scale);
+        Minecraft.getMinecraft().renderEngine.bindTexture(
+            new ResourceLocation(W_MOD.DOMAIN, "textures/" + textureFolder + "/" + display.textureName + ".png"));
+        info.model.renderAll();
+        GL11.glPopAttrib();
+        GL11.glPopMatrix();
+    }
+
+    private static float interpolateAngle(float previous, float current, float partial) {
+        float delta = current - previous;
+        while (delta < -180.0F) delta += 360.0F;
+        while (delta >= 180.0F) delta -= 360.0F;
+        return previous + delta * partial;
+    }
+
+    private static MCH_AircraftInfo getInfo(byte category, String typeName) {
+        switch (category) {
+            case 0: return MCH_HeliInfoManager.get(typeName);
+            case 1: return MCP_PlaneInfoManager.get(typeName);
+            case 2: return MCH_ShipInfoManager.get(typeName);
+            case 3: return MCH_TankInfoManager.get(typeName);
+            case 4: return MCH_VehicleInfoManager.get(typeName);
+            default: return null;
+        }
+    }
+
+    private static String getTextureFolder(byte category) {
+        switch (category) {
+            case 0: return "helicopters";
+            case 1: return "planes";
+            case 2: return "ships";
+            case 3: return "tanks";
+            case 4: return "vehicles";
+            default: return null;
+        }
+    }
+
+    private static final class Display {
+        private final UUID uuid;
+        private int entityId;
+        private byte category;
+        private String typeName;
+        private String textureName;
+        private double previousX;
+        private double previousY;
+        private double previousZ;
+        private double x;
+        private double y;
+        private double z;
+        private float previousYaw;
+        private float previousPitch;
+        private float previousRoll;
+        private float yaw;
+        private float pitch;
+        private float roll;
+        private float scale;
+        private long previousUpdateMs;
+        private long lastUpdateMs;
+
+        private Display(PacketVehicleLODSnapshot.Entry entry) {
+            this.uuid = entry.uuid;
+            this.previousX = this.x = entry.x;
+            this.previousY = this.y = entry.y;
+            this.previousZ = this.z = entry.z;
+            this.previousYaw = this.yaw = entry.yaw;
+            this.previousPitch = this.pitch = entry.pitch;
+            this.previousRoll = this.roll = entry.roll;
+            update(entry);
+        }
+
+        private void update(PacketVehicleLODSnapshot.Entry entry) {
+            long now = System.currentTimeMillis();
+            float partial = this.previousUpdateMs == 0L ? 1.0F : Math.min(1.0F, (float)(now - this.previousUpdateMs) / 1000.0F);
+            this.previousX = this.previousX + (this.x - this.previousX) * partial;
+            this.previousY = this.previousY + (this.y - this.previousY) * partial;
+            this.previousZ = this.previousZ + (this.z - this.previousZ) * partial;
+            this.previousYaw = interpolateAngle(this.previousYaw, this.yaw, partial);
+            this.previousPitch = interpolateAngle(this.previousPitch, this.pitch, partial);
+            this.previousRoll = interpolateAngle(this.previousRoll, this.roll, partial);
+            this.previousUpdateMs = now;
+            this.entityId = entry.entityId;
+            this.category = entry.category;
+            this.typeName = entry.typeName;
+            this.textureName = entry.textureName;
+            this.x = entry.x;
+            this.y = entry.y;
+            this.z = entry.z;
+            this.yaw = entry.yaw;
+            this.pitch = entry.pitch;
+            this.roll = entry.roll;
+            this.scale = entry.scale > 0.0F ? entry.scale : 1.0F;
+        }
+    }
+}

--- a/src/main/java/mcheli/network/PacketHandler.java
+++ b/src/main/java/mcheli/network/PacketHandler.java
@@ -16,6 +16,7 @@ import mcheli.network.packets.PacketEntityInfoSync;
 import mcheli.network.packets.PacketIronCurtainUse;
 import mcheli.network.packets.PacketLaserGuidanceTargeting;
 import mcheli.network.packets.PacketLockTarget;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -122,6 +123,7 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, PacketB
         registerPacket(PacketIronCurtainUse.class);
         registerPacket(PacketLaserGuidanceTargeting.class);
         registerPacket(PacketLockTarget.class);
+        registerPacket(PacketVehicleLODSnapshot.class);
     }
 
     /**

--- a/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
@@ -1,0 +1,120 @@
+package mcheli.network.packets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import mcheli.MCH_MOD;
+import mcheli.network.PacketBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+
+/**
+ * A lightweight, read-only description of distant vehicles.  These snapshots are
+ * deliberately independent of Forge's entity tracker and never spawn an entity.
+ */
+public class PacketVehicleLODSnapshot extends PacketBase {
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final int MAX_ENTRIES = 512;
+    private static final int MAX_STRING_BYTES = 128;
+
+    public int dimension;
+    public List<Entry> entries = Collections.emptyList();
+
+    public PacketVehicleLODSnapshot() {
+    }
+
+    public PacketVehicleLODSnapshot(int dimension, List<Entry> entries) {
+        this.dimension = dimension;
+        this.entries = entries;
+    }
+
+    @Override
+    public void encodeInto(ChannelHandlerContext ctx, ByteBuf data) {
+        data.writeInt(this.dimension);
+        int count = Math.min(this.entries.size(), MAX_ENTRIES);
+        data.writeShort(count);
+        for (int i = 0; i < count; ++i) {
+            Entry entry = this.entries.get(i);
+            data.writeLong(entry.uuid.getMostSignificantBits());
+            data.writeLong(entry.uuid.getLeastSignificantBits());
+            data.writeInt(entry.entityId);
+            data.writeByte(entry.category);
+            writeString(data, entry.typeName);
+            writeString(data, entry.textureName);
+            data.writeDouble(entry.x);
+            data.writeDouble(entry.y);
+            data.writeDouble(entry.z);
+            data.writeFloat(entry.yaw);
+            data.writeFloat(entry.pitch);
+            data.writeFloat(entry.roll);
+            data.writeFloat(entry.scale);
+        }
+    }
+
+    @Override
+    public void decodeInto(ChannelHandlerContext ctx, ByteBuf data) {
+        this.dimension = data.readInt();
+        int count = Math.min(data.readUnsignedShort(), MAX_ENTRIES);
+        List<Entry> decoded = new ArrayList<Entry>(count);
+        for (int i = 0; i < count; ++i) {
+            Entry entry = new Entry();
+            entry.uuid = new UUID(data.readLong(), data.readLong());
+            entry.entityId = data.readInt();
+            entry.category = data.readByte();
+            entry.typeName = readString(data);
+            entry.textureName = readString(data);
+            entry.x = data.readDouble();
+            entry.y = data.readDouble();
+            entry.z = data.readDouble();
+            entry.yaw = data.readFloat();
+            entry.pitch = data.readFloat();
+            entry.roll = data.readFloat();
+            entry.scale = data.readFloat();
+            decoded.add(entry);
+        }
+        this.entries = decoded;
+    }
+
+    @Override
+    public void handleClientSide(EntityPlayer player) {
+        MCH_MOD.proxy.updateVehicleLODSnapshots(this.dimension, this.entries);
+    }
+
+    @Override
+    public void handleServerSide(EntityPlayerMP player) {
+        // Server-to-client only.
+    }
+
+    private static void writeString(ByteBuf data, String value) {
+        byte[] bytes = (value == null ? "" : value).getBytes(UTF_8);
+        int length = Math.min(bytes.length, MAX_STRING_BYTES);
+        data.writeByte(length);
+        data.writeBytes(bytes, 0, length);
+    }
+
+    private static String readString(ByteBuf data) {
+        int length = data.readUnsignedByte();
+        byte[] bytes = new byte[length];
+        data.readBytes(bytes);
+        return new String(bytes, UTF_8);
+    }
+
+    public static class Entry {
+        public UUID uuid;
+        public int entityId;
+        public byte category;
+        public String typeName;
+        public String textureName;
+        public double x;
+        public double y;
+        public double z;
+        public float yaw;
+        public float pitch;
+        public float roll;
+        public float scale = 1.0F;
+    }
+}


### PR DESCRIPTION
### Motivation
- Distant MCHeli vehicles currently have broken or non-functional LOD behavior and the previous attempts to "fix" LODs by increasing entity tracking ranges caused desync, missing parent entities, stale seats, and other severe issues. 
- The goal is to display distant vehicles visually without touching real vehicle `EntityRegistry.registerModEntity` tracking settings or vehicle interaction/physics logic. 
- Implement a separate render-only client path so distant vehicles are visible while the real entities retain safe/server-side tracking and behavior.

### Description
- Add a bounded server-to-client snapshot packet `PacketVehicleLODSnapshot` that carries compact, render-only entries (UUID, entityId, category, type, texture, pos, rot, scale) and register it in `PacketHandler` (`src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java`, `src/main/java/mcheli/network/PacketHandler.java`).
- Replace the unfinished per-tick plane location sender with a once-per-second batched snapshot sender in `MCH_ServerTickHandler`, collecting up to a bounded set of nearby aircraft per player without modifying entity tracking (`src/main/java/mcheli/MCH_ServerTickHandler.java`).
- Implement a client-only, non-world, render cache/manager `MCH_VehicleLODManager` that receives snapshots via the proxy, interpolates and renders models on `RenderWorldLastEvent`, expires stale entries, and suppresses LODs whenever the real aircraft UUID or entityId is present on the client (`src/main/java/mcheli/lod/MCH_VehicleLODManager.java`, `src/main/java/mcheli/MCH_ClientProxy.java`, `src/main/java/mcheli/MCH_CommonProxy.java`).
- Keep real vehicle/seat tracking configuration unchanged (shared `aircraftTrackingRange = 200` remains in `MCH_MOD`), and update config descriptions to clarify that LOD displays are client-only (`src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/MCH_MOD.java`).

### Testing
- Ran repository/automation checks: `git diff --check` and `git diff --exit-code -- src/main/java/mcheli/MCH_MOD.java` and they succeeded. 
- Performed source-level safety assertions and static checks ensuring `aircraftTrackingRange = 200` remains, the five vehicle categories are covered, and the client LOD manager does not spawn or insert real entities; these assertions passed. 
- Verified changed Java brace/tab formatting and basic parse-safety checks which passed. 
- Attempted to run `./gradlew compileJava` and `gradle compileJava --no-daemon` to build the project, but dependency/Gradle downloads were blocked by the environment proxy (HTTP 403) so full compilation could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2503d35da483239aa20883a0c01027)