### PR TITLE
Stabilize walking on floating ship decks

### DIFF
--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -1034,12 +1034,14 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         public final Entity entity;
         public final int surfaceIndex;
         public final double surfaceCenterX;
+        public final double surfaceTopY;
         public final double surfaceCenterZ;
 
         private DeckContact(Entity entity, int surfaceIndex, AxisAlignedBB surface) {
             this.entity = entity;
             this.surfaceIndex = surfaceIndex;
             this.surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
+            this.surfaceTopY = surface.maxY;
             this.surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
         }
     }
@@ -1119,8 +1121,15 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
                 Vec3 rotated = MCH_Lib.RotVec3(relativeX, 0.0D, relativeZ, -yawChange, 0.0F);
                 double surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
                 double surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
-                double correctedY = entity.posY + surface.maxY - entity.boundingBox.minY;
-                entity.setPosition(surfaceCenterX + rotated.xCoord, correctedY, surfaceCenterZ + rotated.zCoord);
+                double deckDeltaY = surface.maxY - contact.surfaceTopY;
+
+                // Carry the entity by the deck's actual vertical delta instead of
+                // snapping its feet to the new surface. Float ships continuously
+                // cross the player's bounding box while bobbing; preserving the
+                // relative height prevents that correction from consuming the
+                // player's horizontal movement.
+                entity.setPosition(surfaceCenterX + rotated.xCoord, entity.posY + deckDeltaY,
+                        surfaceCenterZ + rotated.zCoord);
                 entity.motionY = 0.0D;
                 entity.onGround = true;
                 entity.isCollidedVertically = true;


### PR DESCRIPTION
### Motivation
- Float=true ships visually bob on the water and the previous deck-support logic repeatedly snapped player bounding boxes to the bobbing surface, which caused vertical collision correction to consume horizontal movement and produce felt slowdown when walking on decks.

### Description
- Record the deck surface top height for each standing contact by adding `surfaceTopY` to `DeckContact` in `src/main/java/mcheli/ship/MCH_EntityShip.java` so we know the pre-move deck Y used when the player was detected.
- In `finishDeckMovement` compute `deckDeltaY = surface.maxY - contact.surfaceTopY` and translate standing entities by that delta (adjusting `entity.posY`) instead of snapping their feet to the newly bobbed surface, preserving the ship bob visually while stabilizing player vertical position.
- Preserve existing yaw rotation handling and post-transport stabilization (clearing `motionY`, setting `onGround`, `isCollidedVertically`, and `fallDistance`) to avoid reintroducing jitter and to keep water/boat physics unchanged.

### Testing
- Ran `git diff --check` which returned clean results.
- Created a commit for the change using `git commit` which succeeded.
- Attempted to run a full compile with the project wrapper (`./gradlew compileJava` / `bash gradlew compileJava`) but compilation could not be completed because the Gradle wrapper was not executable and the wrapper distribution download was blocked by an environment proxy (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2513dfc2a48323ba5d2ce961e2392a)