### PR TITLE
Preserve entity support during floating-deck vertical transitions and carry entities by deck delta

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -74,6 +74,14 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
       return offset;
    }
 
+   private boolean isDeckSupportContact(AxisAlignedBB deck, AxisAlignedBB other) {
+      final double supportTolerance = 0.6D;
+      return other.maxX > deck.minX && other.minX < deck.maxX
+              && other.maxZ > deck.minZ && other.minZ < deck.maxZ
+              && other.minY >= deck.maxY - supportTolerance
+              && other.minY <= deck.maxY + supportTolerance;
+   }
+
    @Override
    public double calculateYOffset(AxisAlignedBB other, double offset) {
       if(!this.hasDeckCollision()) {
@@ -82,7 +90,18 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
 
       offset = super.calculateYOffset(other, offset);
       for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
-         offset = bb.boundingBox.calculateYOffset(other, offset);
+         AxisAlignedBB deck = bb.boundingBox;
+         AxisAlignedBB previousDeck = bb.backupBoundingBox;
+         offset = deck.calculateYOffset(other, offset);
+
+         // When a floating deck rises into an entity, vanilla's Y resolver sees
+         // overlapping boxes and no longer treats the deck as floor support. Use
+         // the previous top for that one transition; finishDeckMovement then
+         // carries the entity by the matching surface delta.
+         if(this.ac.canFloatWater() && deck.maxY > previousDeck.maxY
+                 && this.isDeckSupportContact(previousDeck, other)) {
+            offset = previousDeck.calculateYOffset(other, offset);
+         }
       }
       return offset;
    }

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -1034,12 +1034,14 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
         public final Entity entity;
         public final int surfaceIndex;
         public final double surfaceCenterX;
+        public final double surfaceTopY;
         public final double surfaceCenterZ;
 
         private DeckContact(Entity entity, int surfaceIndex, AxisAlignedBB surface) {
             this.entity = entity;
             this.surfaceIndex = surfaceIndex;
             this.surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
+            this.surfaceTopY = surface.maxY;
             this.surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
         }
     }
@@ -1119,8 +1121,15 @@ public class MCH_EntityShip extends MCH_EntityAircraft {
                 Vec3 rotated = MCH_Lib.RotVec3(relativeX, 0.0D, relativeZ, -yawChange, 0.0F);
                 double surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
                 double surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
-                double correctedY = entity.posY + surface.maxY - entity.boundingBox.minY;
-                entity.setPosition(surfaceCenterX + rotated.xCoord, correctedY, surfaceCenterZ + rotated.zCoord);
+                double deckDeltaY = surface.maxY - contact.surfaceTopY;
+
+                // Carry the entity by the deck's actual vertical delta instead of
+                // snapping its feet to the new surface. Float ships continuously
+                // cross the player's bounding box while bobbing; preserving the
+                // relative height prevents that correction from consuming the
+                // player's horizontal movement.
+                entity.setPosition(surfaceCenterX + rotated.xCoord, entity.posY + deckDeltaY,
+                        surfaceCenterZ + rotated.zCoord);
                 entity.motionY = 0.0D;
                 entity.onGround = true;
                 entity.isCollidedVertically = true;


### PR DESCRIPTION
### Motivation

- Prevent floating ship decks from losing floor support for entities during a single-tick upward movement which causes vanilla collision resolution to snap players and consume horizontal motion.  
- Ensure entities standing on extra deck boxes are translated smoothly by the deck's actual vertical delta instead of snapping feet to the new top surface.

### Description

- Added `isDeckSupportContact` to `MCH_AircraftBoundingBox` to detect when an entity was supported by the previous deck top using a `supportTolerance` of `0.6D`.  
- In `calculateYOffset` the code now applies `previousDeck.calculateYOffset` when a floating deck rises into an entity to preserve floor support for that transition.  
- Extended `DeckContact` in `MCH_EntityShip` to store `surfaceTopY` (previous surface top) so finish-step movement can compute the deck vertical delta.  
- Reworked `finishDeckMovement` to move entities by the computed `deckDeltaY` instead of snapping their feet to the new deck top, and kept other collision state resets intact.

### Testing

- Project was built with `./gradlew build` and the build completed successfully.  
- Automated test suite was executed with `./gradlew test` and completed without failures.  
- Verified in a runtime smoke scenario that entities standing on floating decks are carried vertically with preserved horizontal motion (no automated failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2513dfc2a48323ba5d2ce961e2392a)