### PR TITLE
Add stall, dive and soft-ceiling flight-model improvements for planes and helicopters

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
@@ -122,6 +122,16 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
    public boolean limitRotation;
    public float throttleUpDown;
    public float throttleUpDownOnEntity;
+   /** Soft altitude limit. Lift fades before this height and excess altitude adds sink. */
+   public float flightCeiling;
+   /** Vertical distance over which lift fades when approaching the flight ceiling. */
+   public float flightCeilingRange;
+   /** Fraction of configured top speed below which fixed-wing lift begins to stall. */
+   public float stallSpeedFactor;
+   /** Strength of the fixed-wing stall sink and nose-drop response. */
+   public float stallStrength;
+   /** Maximum extra horizontal speed available while a plane is diving. */
+   public float diveSpeedMultiplier;
     private List textureNameList;
    public int textureCount;
    public float particlesScale;
@@ -330,6 +340,11 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
       this.limitRotation = false;
       this.throttleUpDown = 1.0F;
       this.throttleUpDownOnEntity = 2.0F;
+      this.flightCeiling = 220.0F;
+      this.flightCeilingRange = 40.0F;
+      this.stallSpeedFactor = 0.35F;
+      this.stallStrength = 1.0F;
+      this.diveSpeedMultiplier = 1.25F;
       this.pivotTurnThrottle = 0.0F;
       this.trackRollerRot = 30.0F;
       this.partWheelRot = 30.0F;
@@ -839,6 +854,16 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
                                     this.throttleUpDown = this.toFloat(data, 0.0F, 3.0F);
                                  } else if(item.equalsIgnoreCase("ThrottleUpDownOnEntity")) {
                                     this.throttleUpDownOnEntity = this.toFloat(data, 0.0F, 100000.0F);
+                                 } else if(item.equalsIgnoreCase("FlightCeiling")) {
+                                    this.flightCeiling = this.toFloat(data, 32.0F, 255.0F);
+                                 } else if(item.equalsIgnoreCase("FlightCeilingRange")) {
+                                    this.flightCeilingRange = this.toFloat(data, 1.0F, 128.0F);
+                                 } else if(item.equalsIgnoreCase("StallSpeedFactor")) {
+                                    this.stallSpeedFactor = this.toFloat(data, 0.0F, 0.95F);
+                                 } else if(item.equalsIgnoreCase("StallStrength")) {
+                                    this.stallStrength = this.toFloat(data, 0.0F, 4.0F);
+                                 } else if(item.equalsIgnoreCase("DiveSpeedMultiplier")) {
+                                    this.diveSpeedMultiplier = this.toFloat(data, 1.0F, 2.0F);
                                  } else if(item.equalsIgnoreCase("Stealth")) {
                                     this.stealth = this.toFloat(data, 0.0F, 1.0F);
                                  } else if(item.equalsIgnoreCase("EntityWidth")) {

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -1,0 +1,39 @@
+package mcheli.aircraft;
+
+/**
+ * Small, stateless helpers shared by fixed-wing and rotorcraft physics.
+ * Keeping these calculations here makes the server flight loops easier to tune.
+ */
+public final class MCH_FlightModel {
+
+   private MCH_FlightModel() {
+   }
+
+   public static double clamp(double value, double min, double max) {
+      return value < min ? min : (value > max ? max : value);
+   }
+
+   /** Returns 1 below the ceiling fade band and 0 at or above the ceiling. */
+   public static double getCeilingLiftFactor(double altitude, float ceiling, float fadeRange) {
+      if(ceiling <= 0.0F) {
+         return 1.0D;
+      }
+
+      double range = Math.max(1.0D, (double)fadeRange);
+      return clamp((ceiling - altitude) / range, 0.0D, 1.0D);
+   }
+
+   /** Returns a 0..1 severity value as airspeed falls below the stall threshold. */
+   public static double getStallSeverity(double horizontalSpeed, float topSpeed, float stallSpeedFactor) {
+      double stallSpeed = Math.max(0.05D, (double)topSpeed * (double)stallSpeedFactor);
+      return clamp((stallSpeed - horizontalSpeed) / stallSpeed, 0.0D, 1.0D);
+   }
+
+   /** Diving raises the speed cap gradually, rather than creating an abrupt second limit. */
+   public static double getDiveSpeedLimit(float topSpeed, float pitch, double verticalSpeed, float multiplier) {
+      double noseDown = clamp((double)pitch / 60.0D, 0.0D, 1.0D);
+      double descending = clamp(-verticalSpeed / 0.35D, 0.0D, 1.0D);
+      double dive = Math.max(noseDown, descending);
+      return (double)topSpeed * (1.0D + ((double)multiplier - 1.0D) * dive);
+   }
+}

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -822,7 +822,22 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
                throttle *= 0.65D;
             }
 
-            super.motionY += (y * 0.025D + 0.03D) * throttle;
+            double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+            double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
+            double rotorEfficiency = ceilingLift;
+
+            // Fast forward flight gives the rotor cleaner airflow (translational lift).
+            double translationalLift = MCH_FlightModel.clamp(horizontalSpeed / Math.max(0.1D, (double)this.getAcInfo().speed), 0.0D, 1.0D) * 0.004D;
+
+            // A powered, near-vertical descent can enter a vortex-ring state. Forward
+            // motion or lowering collective lets the helicopter recover naturally.
+            boolean vortexRing = super.motionY < -0.12D && horizontalSpeed < 0.15D && throttle > 0.45D;
+            if(vortexRing) {
+               rotorEfficiency *= 0.55D;
+               super.motionY -= 0.006D;
+            }
+
+            super.motionY += ((y * 0.025D + 0.03D) * throttle + translationalLift * throttle) * rotorEfficiency;
          } else {
             if(MathHelper.abs(this.getRotPitch()) < 40.0F) {
                speedLimit = this.getRotPitch();
@@ -859,6 +874,14 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
          if(super.rand.nextInt(50) == 0) {
             super.motionZ += (super.rand.nextDouble() - 0.5D) / 30.0D;
          }
+      }
+
+      double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
+      if(!super.onGround && ceilingLift < 1.0D) {
+         if(super.motionY > 0.0D) {
+            super.motionY *= 0.88D + ceilingLift * 0.12D;
+         }
+         super.motionY -= (1.0D - ceilingLift) * 0.014D;
       }
 
       motion = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -840,6 +840,16 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
          }
       }
 
+      // A dive converts altitude into speed even at reduced throttle. This also makes
+      // a nose-down recovery the natural way to fly out of a stall.
+      if(dp == 0.0D && !super.onGround && this.getNozzleRotation() <= 0.01F) {
+         double dive = MCH_FlightModel.clamp((double)this.getRotPitch() / 60.0D, 0.0D, 1.0D);
+         double yaw = Math.toRadians((double)this.getRotYaw());
+         double diveAcceleration = dive * 0.012D;
+         super.motionX += -Math.sin(yaw) * diveAcceleration;
+         super.motionZ += Math.cos(yaw) * diveAcceleration;
+      }
+
       // 对垂直速度进行衰减
       super.motionY *= 0.95D;
       // 根据飞行器的运动系数衰减水平速度
@@ -849,7 +859,8 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
       // 计算当前水平速度的大小
       double motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
       // 获取最大速度限制
-      float speedLimit = this.getMaxSpeed();
+      float baseSpeedLimit = this.getMaxSpeed();
+      float speedLimit = (float)MCH_FlightModel.getDiveSpeedLimit(baseSpeedLimit, this.getRotPitch(), super.motionY, this.getAcInfo().diveSpeedMultiplier);
       // 如果当前速度超过最大速度限制，按最大速度比例缩小水平速度
       if(motion1 > (double)speedLimit) {
          super.motionX *= (double)speedLimit / motion1;
@@ -871,8 +882,30 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
          }
       }
 
+      boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 1, -2) > 0;
+      if(!nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff) {
+         double stall = MCH_FlightModel.getStallSeverity(motion1, baseSpeedLimit, this.getAcInfo().stallSpeedFactor);
+         double bankLoss = MCH_FlightModel.clamp(MathHelper.abs(this.getRotRoll()) / 90.0D, 0.0D, 1.0D) * 0.35D;
+         stall = MCH_FlightModel.clamp(stall + bankLoss, 0.0D, 1.0D);
+         if(stall > 0.0D) {
+            super.motionY -= 0.028D * stall * (double)this.getAcInfo().stallStrength;
+            if(this.getRotPitch() < 35.0F) {
+               this.setRotPitch(this.getRotPitch() + (float)(0.22D * stall * (double)this.getAcInfo().stallStrength));
+            }
+         }
+      }
+
+      // Lift fades through a band below the configured ceiling instead of hitting an invisible wall.
+      double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
+      if(!nearGround && ceilingLift < 1.0D) {
+         if(super.motionY > 0.0D) {
+            super.motionY *= 0.9D + ceilingLift * 0.1D;
+         }
+         super.motionY -= (1.0D - ceilingLift) * 0.012D;
+      }
+
       // 如果飞行器在地面或距离地面较近，则缩减水平速度，应用地面俯仰角度
-      if(super.onGround || MCH_Lib.getBlockIdY(this, 1, -2) > 0) {
+      if(nearGround) {
          super.motionX *= this.getAcInfo().motionFactor;
          super.motionZ *= this.getAcInfo().motionFactor;
          // 如果俯仰角度小于40度，则根据地面状态调整俯仰角度


### PR DESCRIPTION
### Motivation
- Add realistic, low-risk flight behaviours requested for planes/helicopters: stalling, diving energy, and altitude ceilings. 
- Provide quick, configurable knobs so aircraft designers can tune stalls, dive gains and soft ceilings per vehicle type.

### Description
- Added new configurable fields to `MCH_AircraftInfo`: `flightCeiling`, `flightCeilingRange`, `stallSpeedFactor`, `stallStrength`, and `diveSpeedMultiplier` to expose ceiling/stall/dive tuning. 
- Introduced `MCH_FlightModel` helper with `getCeilingLiftFactor`, `getStallSeverity`, `getDiveSpeedLimit` and `clamp` to centralize the new formulas. 
- Enhanced plane server physics in `MCP_EntityPlane` to apply dive acceleration, a dive-adjusted speed cap, stall severity (sink + nose-drop recovery) and bank-induced lift loss, and to fade lift through a soft flight ceiling band. 
- Enhanced helicopter server physics in `MCH_EntityHeli` to add translational lift in fast forward flight, a simple vortex-ring-state penalty during powered low-speed vertical descents, and altitude-dependent rotor efficiency with the same soft ceiling fade.
- Modified files: `MCH_AircraftInfo.java`, `MCH_FlightModel.java` (new), `MCP_EntityPlane.java`, `MCH_EntityHeli.java`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and found no check failures. 
- Compiled and ran a standalone assertion test for the shared helper by `javac` + running `TestFlightModel`, which passed basic unit assertions for ceiling, stall and dive formulas. 
- Attempted full project `./gradlew compileJava` / `gradle compileJava` but full compilation was blocked because the environment could not download Gradle/ForgeGradle metadata (HTTP 403 from the network/proxy), so an end-to-end build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25481649a48323afa3cccb661ad615)