### PR TITLE
Optimize particle effects and add VBO model rendering

### DIFF
--- a/src/main/java/mcheli/particles/MCH_EntityParticleBase.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleBase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import mcheli.wrapper.W_EntityFX;
 import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.crash.CrashReportCategory;
 import net.minecraft.entity.Entity;
@@ -49,6 +50,18 @@ public abstract class MCH_EntityParticleBase extends W_EntityFX {
 
    public int getFXLayer() {
       return 2;
+   }
+
+   protected boolean isInRenderRange(double maxDistance) {
+      Minecraft mc = Minecraft.getMinecraft();
+      if(mc == null || mc.renderViewEntity == null) {
+         return false;
+      }
+
+      double dx = super.posX - mc.renderViewEntity.posX;
+      double dy = super.posY - mc.renderViewEntity.posY;
+      double dz = super.posZ - mc.renderViewEntity.posZ;
+      return dx * dx + dy * dy + dz * dz <= maxDistance * maxDistance;
    }
 
    public void moveEntity(double par1, double par3, double par5) {

--- a/src/main/java/mcheli/particles/MCH_EntityParticleExplode.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleExplode.java
@@ -27,6 +27,10 @@ public class MCH_EntityParticleExplode extends MCH_EntityParticleBase {
    }
 
    public void renderParticle(Tessellator tessellator, float p_70539_2_, float p_70539_3_, float p_70539_4_, float p_70539_5_, float p_70539_6_, float p_70539_7_) {
+      if(!this.isInRenderRange(256.0D)) {
+         return;
+      }
+
       int i = (int)(((float)this.nowCount + p_70539_2_) * 15.0F / (float)this.endCount);
       if(i <= 15) {
          GL11.glEnable(3042);

--- a/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
@@ -18,6 +18,7 @@ public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
       super.particleRed = super.particleGreen = super.particleBlue = super.rand.nextFloat() * 0.3F + 0.7F;
       this.setParticleScale(super.rand.nextFloat() * 0.5F + 5.0F);
       this.setParticleMaxAge((int)(16.0D / ((double)super.rand.nextFloat() * 0.8D + 0.2D)) + 2);
+      super.noClip = true;
    }
 
    public void onUpdate() {
@@ -81,7 +82,7 @@ public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
    }
 
    public void effectWind() {
-      if(super.isEffectedWind) {
+      if(super.isEffectedWind && (super.particleAge & 3) == 0) {
          boolean range = true;
          List list = super.worldObj.getEntitiesWithinAABB(MCH_EntityAircraft.class, this.getBoundingBox().expand(15.0D, 15.0D, 15.0D));
 
@@ -114,6 +115,10 @@ public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
    }
 
    public void renderParticle(Tessellator par1Tessellator, float par2, float par3, float par4, float par5, float par6, float par7) {
+      if(!this.isInRenderRange(256.0D)) {
+         return;
+      }
+
       W_McClient.MOD_bindTexture("textures/particles/smoke.png");
       GL11.glEnable(3042);
       int srcBlend = GL11.glGetInteger(3041);

--- a/src/main/java/mcheli/particles/MCH_EntityParticleSplash.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleSplash.java
@@ -51,6 +51,10 @@ public class MCH_EntityParticleSplash extends MCH_EntityParticleBase {
    }
 
    public void renderParticle(Tessellator par1Tessellator, float par2, float par3, float par4, float par5, float par6, float par7) {
+      if(!this.isInRenderRange(256.0D)) {
+         return;
+      }
+
       W_McClient.MOD_bindTexture("textures/particles/smoke.png");
       float f6 = (float)super.particleTextureIndexX / 8.0F;
       float f7 = f6 + 0.125F;

--- a/src/main/java/mcheli/particles/MCH_ParticlesUtil.java
+++ b/src/main/java/mcheli/particles/MCH_ParticlesUtil.java
@@ -47,9 +47,55 @@ import net.minecraft.world.World;
 public class MCH_ParticlesUtil {
 
    public static MCH_EntityParticleMarkPoint markPoint = null;
+   private static World particleBudgetWorld;
+   private static long particleBudgetTick = Long.MIN_VALUE;
+   private static int particlesSpawnedThisTick;
 
+   private static boolean canSpawnParticle(World world, double x, double y, double z, boolean important) {
+      Minecraft mc = Minecraft.getMinecraft();
+      if(world == null || mc == null || mc.renderViewEntity == null || mc.effectRenderer == null) {
+         return false;
+      }
+
+      int particleSetting = mc.gameSettings.particleSetting;
+      if(!important) {
+         if(particleSetting >= 2 && world.rand.nextInt(4) != 0) {
+            return false;
+         }
+         if(particleSetting == 1 && world.rand.nextInt(2) != 0) {
+            return false;
+         }
+      }
+
+      double dx = mc.renderViewEntity.posX - x;
+      double dy = mc.renderViewEntity.posY - y;
+      double dz = mc.renderViewEntity.posZ - z;
+      double maxDistance = Math.max(96.0D, Math.min(256.0D, (double)(mc.gameSettings.renderDistanceChunks * 16 + 32)));
+      if(dx * dx + dy * dy + dz * dz > maxDistance * maxDistance) {
+         return false;
+      }
+
+      long tick = world.getTotalWorldTime();
+      if(world != particleBudgetWorld || tick != particleBudgetTick) {
+         particleBudgetWorld = world;
+         particleBudgetTick = tick;
+         particlesSpawnedThisTick = 0;
+      }
+
+      int budget = particleSetting >= 2 ? 64 : (particleSetting == 1 ? 192 : 384);
+      if(particlesSpawnedThisTick >= budget) {
+         return false;
+      }
+
+      ++particlesSpawnedThisTick;
+      return true;
+   }
 
    public static void spawnParticleExplode(World w, double x, double y, double z, float size, float r, float g, float b, float a, int age) {
+      if(!canSpawnParticle(w, x, y, z, true)) {
+         return;
+      }
+
       MCH_EntityParticleExplode epe = new MCH_EntityParticleExplode(w, x, y, z, (double)size, (double)age, 0.0D);
       epe.setParticleMaxAge(age);
       epe.setRBGColorF(r, g, b);
@@ -242,7 +288,7 @@ public class MCH_ParticlesUtil {
    }
 
    public static void spawnParticle(MCH_ParticleParam p) {
-      if(p.world.isRemote) {
+      if(p.world.isRemote && canSpawnParticle(p.world, p.posX, p.posY, p.posZ, false)) {
          Object entityFX = null;
          if(p.name.equalsIgnoreCase("Splash")) {
             entityFX = new MCH_EntityParticleSplash(p.world, p.posX, p.posY, p.posZ, p.motionX, p.motionY, p.motionZ);

--- a/src/main/java/mcheli/wrapper/modelloader/W_Face.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_Face.java
@@ -2,6 +2,7 @@ package mcheli.wrapper.modelloader;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.nio.FloatBuffer;
 import net.minecraft.client.renderer.Tessellator;
 
 @SideOnly(Side.CLIENT)
@@ -95,6 +96,32 @@ public class W_Face {
 
    public float getVertexZ(int index) {
       return this.packedData != null ? this.packedData[index * this.packedStride + 2] : this.vertices[index].z;
+   }
+
+   /**
+    * Writes this face in the fixed-function T2F_N3F_V3F layout used by model VBOs.
+    */
+   public void appendInterleaved(FloatBuffer buffer) {
+      if(!this.hasPackedFaceNormal) {
+         W_Vertex normal = this.faceNormal != null ? this.faceNormal : this.calculateFaceNormal();
+         this.faceNormalX = normal.x;
+         this.faceNormalY = normal.y;
+         this.faceNormalZ = normal.z;
+         this.hasPackedFaceNormal = true;
+      }
+
+      int vertexCount = this.getVertexCount();
+      int textureCount = this.getTextureCoordinateCount();
+      for(int i = 0; i < vertexCount; ++i) {
+         buffer.put(textureCount > i ? this.getTextureU(i) : 0.0F);
+         buffer.put(textureCount > i ? this.getTextureV(i) : 0.0F);
+         buffer.put(this.hasVertexNormal(i) ? this.getNormalX(i) : this.faceNormalX);
+         buffer.put(this.hasVertexNormal(i) ? this.getNormalY(i) : this.faceNormalY);
+         buffer.put(this.hasVertexNormal(i) ? this.getNormalZ(i) : this.faceNormalZ);
+         buffer.put(this.getVertexX(i));
+         buffer.put(this.getVertexY(i));
+         buffer.put(this.getVertexZ(i));
+      }
    }
 
    public void addFaceForRender(Tessellator tessellator) {

--- a/src/main/java/mcheli/wrapper/modelloader/W_GroupObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_GroupObject.java
@@ -2,18 +2,25 @@ package mcheli.wrapper.modelloader;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
-import mcheli.wrapper.modelloader.W_Face;
 import net.minecraft.client.renderer.Tessellator;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GLContext;
 
 @SideOnly(Side.CLIENT)
 public class W_GroupObject {
 
+   private static final int VBO_FLOATS_PER_VERTEX = 8;
    public String name;
    public ArrayList faces;
    public int glDrawingMode;
-
+   private int vertexBufferId;
+   private int vertexCount;
+   private boolean vboUnavailable;
 
    public W_GroupObject() {
       this("");
@@ -31,12 +38,71 @@ public class W_GroupObject {
 
    public void render() {
       if(this.faces.size() > 0) {
+         if(this.renderVbo()) {
+            return;
+         }
+
          Tessellator tessellator = Tessellator.instance;
          tessellator.startDrawing(this.glDrawingMode);
          this.render(tessellator);
          tessellator.draw();
       }
+   }
 
+   private boolean renderVbo() {
+      if(this.vboUnavailable || !GLContext.getCapabilities().OpenGL15) {
+         return false;
+      }
+
+      try {
+         if(this.vertexBufferId == 0) {
+            this.createVbo();
+         }
+
+         if(this.vertexBufferId == 0 || this.vertexCount == 0) {
+            return false;
+         }
+
+         GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, this.vertexBufferId);
+         GL11.glInterleavedArrays(GL11.GL_T2F_N3F_V3F, 0, 0L);
+         GL11.glDrawArrays(this.glDrawingMode, 0, this.vertexCount);
+         GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+         GL11.glDisableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+         GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY);
+         GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY);
+         return true;
+      } catch (RuntimeException ignored) {
+         GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
+         GL11.glDisableClientState(GL11.GL_TEXTURE_COORD_ARRAY);
+         GL11.glDisableClientState(GL11.GL_NORMAL_ARRAY);
+         GL11.glDisableClientState(GL11.GL_VERTEX_ARRAY);
+         this.vboUnavailable = true;
+         return false;
+      }
+   }
+
+   private void createVbo() {
+      this.vertexCount = 0;
+      Iterator i$ = this.faces.iterator();
+      while(i$.hasNext()) {
+         this.vertexCount += ((W_Face)i$.next()).getVertexCount();
+      }
+
+      if(this.vertexCount <= 0) {
+         return;
+      }
+
+      FloatBuffer data = BufferUtils.createFloatBuffer(this.vertexCount * VBO_FLOATS_PER_VERTEX);
+      i$ = this.faces.iterator();
+      while(i$.hasNext()) {
+         ((W_Face)i$.next()).appendInterleaved(data);
+      }
+
+      data.flip();
+      this.vertexBufferId = GL15.glGenBuffers();
+      GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, this.vertexBufferId);
+      GL15.glBufferData(GL15.GL_ARRAY_BUFFER, data, GL15.GL_STATIC_DRAW);
+      GL15.glBindBuffer(GL15.GL_ARRAY_BUFFER, 0);
    }
 
    public void render(Tessellator tessellator) {
@@ -48,6 +114,5 @@ public class W_GroupObject {
             face.addFaceForRender(tessellator);
          }
       }
-
    }
 }

--- a/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
@@ -269,15 +269,13 @@ public class W_MetasequoiaObject extends W_ModelCustom {
    }
 
    public void renderAll() {
-      Tessellator tessellator = Tessellator.instance;
-      if(this.currentGroupObject != null) {
-         tessellator.startDrawing(this.currentGroupObject.glDrawingMode);
-      } else {
-         tessellator.startDrawing(4);
+      Iterator i$ = this.groupObjects.iterator();
+      while(i$.hasNext()) {
+         W_GroupObject groupObject = (W_GroupObject)i$.next();
+         if(groupObject != null) {
+            groupObject.render();
+         }
       }
-
-      this.tessellateAll(tessellator);
-      tessellator.draw();
    }
 
    public void tessellateAll(Tessellator tessellator) {

--- a/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
@@ -171,15 +171,13 @@ public class W_WavefrontObject extends W_ModelCustom {
    }
 
    public void renderAll() {
-      Tessellator tessellator = Tessellator.instance;
-      if(this.currentGroupObject != null) {
-         tessellator.startDrawing(this.currentGroupObject.glDrawingMode);
-      } else {
-         tessellator.startDrawing(4);
+      Iterator i$ = this.groupObjects.iterator();
+      while(i$.hasNext()) {
+         W_GroupObject groupObject = (W_GroupObject)i$.next();
+         if(groupObject != null) {
+            groupObject.render();
+         }
       }
-
-      this.tessellateAll(tessellator);
-      tessellator.draw();
    }
 
    private void compactFaces() {


### PR DESCRIPTION
### Motivation
- Reduce client-side lag caused by many custom particles by culling and throttling spawn rates and by making smoke updates cheaper. 
- Improve model rendering throughput by uploading per-group geometry to GPU VBOs while keeping the existing Tessellator path as a compatibility fallback.

### Description
- Added centralized particle spawn gating `canSpawnParticle(...)` that respects camera distance, `gameSettings.particleSetting`, and enforces a per-tick particle budget; integrated this into `spawnParticle(...)` and `spawnParticleExplode(...)` in `MCH_ParticlesUtil.java`.
- Added runtime distance culling helper `isInRenderRange(...)` and early-return checks in particle renderers (`MCH_EntityParticleSmoke.java`, `MCH_EntityParticleSplash.java`, `MCH_EntityParticleExplode.java`) plus cheaper smoke behavior by setting `noClip = true` and throttling aircraft wind queries to every 4 ticks.
- Implemented an interleaved vertex writer `appendInterleaved(FloatBuffer)` in `W_Face.java` and a lazy VBO uploader/renderer in `W_GroupObject.java` that uses `GL15` when available and falls back to the original Tessellator path when VBOs are unavailable or initialization fails.
- Updated whole-model render paths to render via group objects (`renderAll()` in `W_WavefrontObject.java` and `W_MetasequoiaObject.java`) so group VBOs are used automatically while preserving existing functionality.
- Files changed: `MCH_ParticlesUtil.java`, `MCH_EntityParticleBase.java`, `MCH_EntityParticleSmoke.java`, `MCH_EntityParticleSplash.java`, `MCH_EntityParticleExplode.java`, `W_Face.java`, `W_GroupObject.java`, `W_WavefrontObject.java`, `W_MetasequoiaObject.java`.

### Testing
- Ran `git diff --check` and addressed no problems, which succeeded.
- Performed a lightweight syntax/delimiter balance validation across edited Java files, which succeeded.
- Attempted to compile with `gradle compileJava` / `./gradlew compileJava`, but dependency resolution and Gradle wrapper download were blocked by the environment (HTTP 403 while fetching ForgeGradle/Gradle), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25f3cbb2248323b4c5db37f91eeb50)