### PR TITLE
Authoritative newUAV support for helicopters/small UAVs and station hardening

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -890,17 +890,13 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
 
       if (getRiddenByEntity() != null) {
-         if (isUAV()) {
-            // For normal UAVs, perform the standard dismount.
-            Entity rider = getRiddenByEntity();
-            if (rider != null) {
-               rider.mountEntity(null);
-            }
-         } else if (isNewUAV()) {
+         if (isNewUAV()) {
             Entity rider = getRiddenByEntity();
             if (rider instanceof EntityPlayer) {
                EntityPlayer player = (EntityPlayer) rider;
-                  this.unmountEntity(); // ← this triggers the correct logic and teleport
+               if(!super.worldObj.isRemote) {
+                  dismountNewUavPilot(rider, "uav_destroyed");
+               }
 
                //System.out.println("uavposxyz" + MCH_EntityUavStation.posUavX + ", " +
                //        super.posY + ", " +
@@ -914,6 +910,11 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
                player.addPotionEffect(new PotionEffect(12, 20, 0)); // Fire Resistance
 
+            }
+         } else if (isUAV()) {
+            Entity rider = getRiddenByEntity();
+            if (rider != null) {
+               rider.mountEntity(null);
             }
          }
       }
@@ -5298,6 +5299,21 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
 
+   private void dismountNewUavPilot(Entity rider, String inventoryReason) {
+      if(super.worldObj.isRemote || rider == null) {
+         return;
+      }
+      if(rider instanceof EntityPlayerMP) {
+         EntityPlayerMP player = (EntityPlayerMP)rider;
+         player.mountEntity((Entity)null);
+         player.setPositionAndUpdate(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
+         MCH_UavInventory.restorePilotInventory(player, inventoryReason);
+      } else {
+         rider.mountEntity((Entity)null);
+         rider.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
+      }
+   }
+
    private void deleteNewUavAfterShiftExit() {
       if(super.worldObj.isRemote || !this.isNewUAV()) {
          return;
@@ -5336,21 +5352,17 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       setCommonStatus(1, false);
            if (rByEntity != null) {
-                if (isUAV()) {
-                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
-                          rByEntity.mountEntity((Entity)null);
-                        }
-                   } else if (isNewUAV()) {
+                if (isNewUAV()) {
                      newuavvariable = true;
                      //here
                      if(!this.worldObj.isRemote) {
-                      rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-                      rByEntity.mountEntity((Entity) null);
-                      if(rByEntity instanceof EntityPlayerMP) {
-                         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
-                      }
+                      dismountNewUavPilot(rByEntity, "uav_exit");
                       deleteNewUavAfterShiftExit();
                      }
+                   } else if (isUAV()) {
+                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
+                          rByEntity.mountEntity((Entity)null);
+                        }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
                    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -267,14 +267,24 @@ public class MCH_EntityUavStation
          }
 
 
+      public void handleStatusRequest(EntityPlayer player, int x, int y, int z, boolean continueControl) {
+           if(this.worldObj.isRemote || player == null || player.isDead || this.isDead || this.riddenByEntity != player || player.ridingEntity != this) {
+                return;
+           }
+           setUavPosition(x, y, z);
+           if(continueControl) {
+                controlLastAircraft(player);
+           }
+         }
+
       public void setUavPosition(int x, int y, int z) {
            if (!this.worldObj.isRemote) {
-                this.posUavX = x;
-                this.posUavY = y;
-                this.posUavZ = z;
-                getDataWatcher().updateObject(29, Integer.valueOf(x));
-                getDataWatcher().updateObject(30, Integer.valueOf(y));
-                getDataWatcher().updateObject(31, Integer.valueOf(z));
+                this.posUavX = MathHelper.clamp_int(x, -50, 50);
+                this.posUavY = MathHelper.clamp_int(y, -50, 50);
+                this.posUavZ = MathHelper.clamp_int(z, -50, 50);
+                getDataWatcher().updateObject(29, Integer.valueOf(this.posUavX));
+                getDataWatcher().updateObject(30, Integer.valueOf(this.posUavY));
+                getDataWatcher().updateObject(31, Integer.valueOf(this.posUavZ));
               }
          }
 
@@ -1053,6 +1063,9 @@ public class MCH_EntityUavStation
 
              private void controlLastAircraft(Entity user, boolean notify) {
 
+                 if(this.worldObj.isRemote || user == null || user.isDead || this.isDead || this.riddenByEntity != user || user.ridingEntity != this) {
+                     return;
+                 }
                  if(!hasContinuableUavLink()) {
                      if(notify && user instanceof EntityPlayer) {
                          W_EntityPlayer.addChatMessage((EntityPlayer)user, "No linked UAV is stored in this station.");
@@ -1119,8 +1132,8 @@ public class MCH_EntityUavStation
 
 
      public void handleItem(Entity user, ItemStack itemStack) {
-           if (user != null && !user.isDead && itemStack != null && itemStack.stackSize == 1 &&
-                     !this.worldObj.isRemote) {
+           if (user != null && !user.isDead && user == this.riddenByEntity && user.ridingEntity == this &&
+                     itemStack != null && itemStack.stackSize == 1 && !this.worldObj.isRemote) {
                 Object ac = null;
                 double x = this.posX + this.posUavX;
                 double y = this.posY + this.posUavY;
@@ -1160,7 +1173,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemHeli) {
                      MCH_HeliInfo hi1 = MCH_HeliInfoManager.getFromItem(item);
-                     if (hi1 != null && hi1.isUAV) {
+                     if (hi1 != null && (hi1.isUAV || hi1.isNewUAV)) {
                          if (!hi1.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -1171,7 +1184,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemTank) {
                      MCH_TankInfo hi2 = MCH_TankInfoManager.getFromItem(item);
-                     if (hi2 != null && hi2.isUAV) {
+                     if (hi2 != null && (hi2.isUAV || hi2.isNewUAV)) {
                           if (!hi2.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {

--- a/src/main/java/mcheli/uav/MCH_GuiUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_GuiUavStation.java
@@ -58,7 +58,7 @@ public class MCH_GuiUavStation
                      info = MCH_TankInfoManager.getFromItem(item.getItem());
                    }
 
-                if (item != null && (item == null || info == null || !((MCH_AircraftInfo)info).isUAV || !((MCH_AircraftInfo)info).isNewUAV)) {
+                if (item != null && (item == null || info == null || (!((MCH_AircraftInfo)info).isUAV && !((MCH_AircraftInfo)info).isNewUAV))) {
                      if (item != null) {
                           drawString("Not UAV", 8, 6, 16711680);
                         }

--- a/src/main/java/mcheli/uav/MCH_UavPacketHandler.java
+++ b/src/main/java/mcheli/uav/MCH_UavPacketHandler.java
@@ -12,10 +12,8 @@ public class MCH_UavPacketHandler {
             MCH_UavPacketStatus status = new MCH_UavPacketStatus();
             status.readData(data);
             if(player.ridingEntity instanceof MCH_EntityUavStation) {
-                ((MCH_EntityUavStation)player.ridingEntity).setUavPosition(status.posUavX, status.posUavY, status.posUavZ);
-                if(status.continueControl) {
-                    ((MCH_EntityUavStation)player.ridingEntity).controlLastAircraft(player);
-                }
+                ((MCH_EntityUavStation)player.ridingEntity).handleStatusRequest(
+                        player, status.posUavX, status.posUavY, status.posUavZ, status.continueControl);
             }
         }
 


### PR DESCRIPTION
### Motivation
- The `newUAV` mechanic did not behave correctly for helicopter and small UAV types and client packets could alter station state without server validation. 
- The station Continue/respawn flow could relaunch destroyed drones or be triggered by non-riders, so the station needs server-side authoritative checks and bounded spawn offsets to prevent abuse.

### Description
- Added a server-authoritative request handler `handleStatusRequest(EntityPlayer, int x, int y, int z, boolean continueControl)` and routed the incoming packet processing in `MCH_UavPacketHandler` through it so the server validates the rider before applying updates.  
- Bounds the station launch offsets in `setUavPosition` with `MathHelper.clamp_int(..., -50, 50)` and updated the datawatcher writes to use the clamped values.  
- Restricted spawn/continue actions so `handleItem` and control flows only accept requests from the player actually riding the station (`user == this.riddenByEntity && user.ridingEntity == this`) and added early-return guards in `controlLastAircraft`.  
- Enabled `isNewUAV` acceptance for helicopter and tank item flows (previously only `isUAV` was checked) while preserving `isSmallUAV` controller restrictions, and fixed the station GUI check so items flagged as either `isUAV` or `isNewUAV` are recognized.  
- Prioritized `isNewUAV` behavior vs `isUAV` in aircraft dismount/destruction paths and added `dismountNewUavPilot` to perform server-side teleport + `MCH_UavInventory.restorePilotInventory` for new-UAV exits/destroy events.

### Testing
- Ran focused source assertions (automated Python checks) that verified helicopter/tank `isNewUAV` acceptance, GUI classification, packet routing to `handleStatusRequest`, coordinate clamping, and new-UAV branch precedence, and all assertions passed.  
- Ran whitespace/format checks with `git diff --check` and repository diff checks which reported no remaining whitespace errors.  
- Attempted to run `./gradlew compileJava` but the build failed because the environment proxy blocked downloading the legacy Gradle distribution (HTTP 403), and an offline compile also failed because the required ForgeGradle artifact was not present in the local cache.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263ff7650c832399d12ece89d568b1)