### PR TITLE
Handle new-UAV mount/dismount, clamp station UAV position, and consolidate status requests

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -697,7 +697,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
    public Entity getRiddenByEntity() {
-      return this.isUAV() && this.uavStation != null?this.uavStation.riddenByEntity:super.riddenByEntity;
+      return !this.isNewUAV() && this.isUAV() && this.uavStation != null ? this.uavStation.riddenByEntity : super.riddenByEntity;
    }
 
    public boolean getCommonStatus(int bit) {
@@ -890,17 +890,13 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
 
       if (getRiddenByEntity() != null) {
-         if (isUAV()) {
-            // For normal UAVs, perform the standard dismount.
-            Entity rider = getRiddenByEntity();
-            if (rider != null) {
-               rider.mountEntity(null);
-            }
-         } else if (isNewUAV()) {
+         if (isNewUAV()) {
             Entity rider = getRiddenByEntity();
             if (rider instanceof EntityPlayer) {
                EntityPlayer player = (EntityPlayer) rider;
-                  this.unmountEntity(); // ← this triggers the correct logic and teleport
+               if(!super.worldObj.isRemote) {
+                  dismountNewUavPilot(rider, "uav_destroyed");
+               }
 
                //System.out.println("uavposxyz" + MCH_EntityUavStation.posUavX + ", " +
                //        super.posY + ", " +
@@ -914,6 +910,11 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
                player.addPotionEffect(new PotionEffect(12, 20, 0)); // Fire Resistance
 
+            }
+         } else if (isUAV()) {
+            Entity rider = getRiddenByEntity();
+            if (rider != null) {
+               rider.mountEntity(null);
             }
          }
       }
@@ -5298,6 +5299,21 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
 
+   private void dismountNewUavPilot(Entity rider, String inventoryReason) {
+      if(super.worldObj.isRemote || rider == null) {
+         return;
+      }
+      if(rider instanceof EntityPlayerMP) {
+         EntityPlayerMP player = (EntityPlayerMP)rider;
+         player.mountEntity((Entity)null);
+         player.setPositionAndUpdate(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
+         MCH_UavInventory.restorePilotInventory(player, inventoryReason);
+      } else {
+         rider.mountEntity((Entity)null);
+         rider.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
+      }
+   }
+
    private void deleteNewUavAfterShiftExit() {
       if(super.worldObj.isRemote || !this.isNewUAV()) {
          return;
@@ -5336,21 +5352,17 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       setCommonStatus(1, false);
            if (rByEntity != null) {
-                if (isUAV()) {
-                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
-                          rByEntity.mountEntity((Entity)null);
-                        }
-                   } else if (isNewUAV()) {
+                if (isNewUAV()) {
                      newuavvariable = true;
                      //here
                      if(!this.worldObj.isRemote) {
-                      rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-                      rByEntity.mountEntity((Entity) null);
-                      if(rByEntity instanceof EntityPlayerMP) {
-                         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
-                      }
+                      dismountNewUavPilot(rByEntity, "uav_exit");
                       deleteNewUavAfterShiftExit();
                      }
+                   } else if (isUAV()) {
+                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
+                          rByEntity.mountEntity((Entity)null);
+                        }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
                    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -267,14 +267,24 @@ public class MCH_EntityUavStation
          }
 
 
+      public void handleStatusRequest(EntityPlayer player, int x, int y, int z, boolean continueControl) {
+           if(this.worldObj.isRemote || player == null || player.isDead || this.isDead || this.riddenByEntity != player || player.ridingEntity != this) {
+                return;
+           }
+           setUavPosition(x, y, z);
+           if(continueControl) {
+                controlLastAircraft(player);
+           }
+         }
+
       public void setUavPosition(int x, int y, int z) {
            if (!this.worldObj.isRemote) {
-                this.posUavX = x;
-                this.posUavY = y;
-                this.posUavZ = z;
-                getDataWatcher().updateObject(29, Integer.valueOf(x));
-                getDataWatcher().updateObject(30, Integer.valueOf(y));
-                getDataWatcher().updateObject(31, Integer.valueOf(z));
+                this.posUavX = MathHelper.clamp_int(x, -50, 50);
+                this.posUavY = MathHelper.clamp_int(y, -50, 50);
+                this.posUavZ = MathHelper.clamp_int(z, -50, 50);
+                getDataWatcher().updateObject(29, Integer.valueOf(this.posUavX));
+                getDataWatcher().updateObject(30, Integer.valueOf(this.posUavY));
+                getDataWatcher().updateObject(31, Integer.valueOf(this.posUavZ));
               }
          }
 
@@ -866,6 +876,26 @@ public class MCH_EntityUavStation
                  setLastControlAircraftEntityId(0);
           }
 
+      private boolean requestNewUavPilotMount(Entity user, MCH_EntityAircraft ac, boolean notify) {
+           if(this.worldObj.isRemote || user == null || user.isDead || ac == null || ac.isDead || !ac.isNewUAV()) {
+                return false;
+           }
+           if(this.riddenByEntity != user || user.ridingEntity != this) {
+                return false;
+           }
+           if(ac.ticksExisted < 10) {
+                this.pendingContinueTicks = 60;
+                if(notify && user instanceof EntityPlayer) {
+                     W_EntityPlayer.addChatMessage((EntityPlayer)user, "UAV is initializing; control will start shortly.");
+                }
+                return false;
+           }
+           user.mountEntity((Entity)ac);
+           this.pendingContinueTicks = 0;
+           W_EntityPlayer.closeScreen(user);
+           return true;
+         }
+
       private boolean continueWithStoredUavItem(Entity user) {
            //if(user == null || this.lastUavItemStack == null || this.worldObj.isRemote) {
            //     return false;
@@ -900,8 +930,8 @@ public class MCH_EntityUavStation
            }
            MCH_EntityAircraft ac = getControlAircract();
            if(ac != null && !ac.isDead) {
-                if(this.riddenByEntity != null && ac.isNewUAV()) {
-                     this.riddenByEntity.mountEntity((Entity)ac);
+                if(ac.isNewUAV()) {
+                     requestNewUavPilotMount(this.riddenByEntity, ac, true);
                 }
                 return true;
            }
@@ -1053,6 +1083,9 @@ public class MCH_EntityUavStation
 
              private void controlLastAircraft(Entity user, boolean notify) {
 
+                 if(this.worldObj.isRemote || user == null || user.isDead || this.isDead || this.riddenByEntity != user || user.ridingEntity != this) {
+                     return;
+                 }
                  if(!hasContinuableUavLink()) {
                      if(notify && user instanceof EntityPlayer) {
                          W_EntityPlayer.addChatMessage((EntityPlayer)user, "No linked UAV is stored in this station.");
@@ -1093,7 +1126,7 @@ public class MCH_EntityUavStation
                              }
                              return;
                          }
-                         this.riddenByEntity.mountEntity((Entity)this.controlAircraft);
+                         requestNewUavPilotMount(user, this.controlAircraft, notify);
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);
@@ -1119,8 +1152,8 @@ public class MCH_EntityUavStation
 
 
      public void handleItem(Entity user, ItemStack itemStack) {
-           if (user != null && !user.isDead && itemStack != null && itemStack.stackSize == 1 &&
-                     !this.worldObj.isRemote) {
+           if (user != null && !user.isDead && user == this.riddenByEntity && user.ridingEntity == this &&
+                     itemStack != null && itemStack.stackSize == 1 && !this.worldObj.isRemote) {
                 Object ac = null;
                 double x = this.posX + this.posUavX;
                 double y = this.posY + this.posUavY;
@@ -1160,7 +1193,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemHeli) {
                      MCH_HeliInfo hi1 = MCH_HeliInfoManager.getFromItem(item);
-                     if (hi1 != null && hi1.isUAV) {
+                     if (hi1 != null && (hi1.isUAV || hi1.isNewUAV)) {
                          if (!hi1.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -1171,7 +1204,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemTank) {
                      MCH_TankInfo hi2 = MCH_TankInfoManager.getFromItem(item);
-                     if (hi2 != null && hi2.isUAV) {
+                     if (hi2 != null && (hi2.isUAV || hi2.isNewUAV)) {
                           if (!hi2.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -1187,7 +1220,9 @@ public class MCH_EntityUavStation
                         ((MCH_EntityAircraft)ac).setDead(false);
                         linkUav(linked);
                         setControlAircract(linked);
-                        W_EntityPlayer.closeScreen(user);
+                        if(!requestNewUavPilotMount(user, linked, true)) {
+                             W_EntityPlayer.closeScreen(user);
+                        }
                         return;
                     }
                     if(MCH_Config.ItemDamage.prmBool) {
@@ -1215,7 +1250,9 @@ public class MCH_EntityUavStation
                           linkUav((MCH_EntityAircraft) ac);
                           if (!((MCH_EntityAircraft)ac).isTargetDrone()) {
                                ((MCH_EntityAircraft)ac).setFuel((int)(((MCH_EntityAircraft)ac).getMaxFuel() * 0.05F));
-                               W_EntityPlayer.closeScreen(user);
+                               if(!requestNewUavPilotMount(user, (MCH_EntityAircraft)ac, true)) {
+                                    W_EntityPlayer.closeScreen(user);
+                               }
                              } else {
                                ((MCH_EntityAircraft)ac).setFuel(((MCH_EntityAircraft)ac).getMaxFuel());
                              }

--- a/src/main/java/mcheli/uav/MCH_GuiUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_GuiUavStation.java
@@ -58,7 +58,7 @@ public class MCH_GuiUavStation
                      info = MCH_TankInfoManager.getFromItem(item.getItem());
                    }
 
-                if (item != null && (item == null || info == null || !((MCH_AircraftInfo)info).isUAV || !((MCH_AircraftInfo)info).isNewUAV)) {
+                if (item != null && (item == null || info == null || (!((MCH_AircraftInfo)info).isUAV && !((MCH_AircraftInfo)info).isNewUAV))) {
                      if (item != null) {
                           drawString("Not UAV", 8, 6, 16711680);
                         }

--- a/src/main/java/mcheli/uav/MCH_UavPacketHandler.java
+++ b/src/main/java/mcheli/uav/MCH_UavPacketHandler.java
@@ -12,10 +12,8 @@ public class MCH_UavPacketHandler {
             MCH_UavPacketStatus status = new MCH_UavPacketStatus();
             status.readData(data);
             if(player.ridingEntity instanceof MCH_EntityUavStation) {
-                ((MCH_EntityUavStation)player.ridingEntity).setUavPosition(status.posUavX, status.posUavY, status.posUavZ);
-                if(status.continueControl) {
-                    ((MCH_EntityUavStation)player.ridingEntity).controlLastAircraft(player);
-                }
+                ((MCH_EntityUavStation)player.ridingEntity).handleStatusRequest(
+                        player, status.posUavX, status.posUavY, status.posUavZ, status.continueControl);
             }
         }
 


### PR DESCRIPTION
### Motivation
- Fix broken mount/dismount behavior for the new UAV type so pilots are unmounted, teleported back to the station and their inventory restored correctly on the server. 
- Prevent incorrect "continue control" behavior and duplicate/infinite UAV respawns when a stored/new UAV was destroyed or is still initializing. 
- Tighten server-side checks and bounds for station-provided UAV position data to avoid out-of-range values and client-side tampering. 

### Description
- Added `dismountNewUavPilot` in `MCH_EntityAircraft` and switched `unmountEntity` and destruction code paths to use it for new UAVs so pilots are safely unmounted, teleported via `setPositionAndUpdate`, and `MCH_UavInventory.restorePilotInventory` is called. 
- Made `getRiddenByEntity` avoid returning the station rider for new UAVs by changing the condition to `!this.isNewUAV() && this.isUAV() && this.uavStation != null`. 
- Introduced `requestNewUavPilotMount` and `handleStatusRequest` in `MCH_EntityUavStation` to centralize server-side validation, delayed initialization handling for freshly spawned new UAVs, and the optional "continue control" action; updated `MCH_UavPacketHandler` to call `handleStatusRequest`. 
- Clamped station position values in `setUavPosition` to the range `[-50,50]` and ensured DataWatcher is updated with the clamped values. 
- Updated `continueWithStoredUavItem` and `handleItem` to use `requestNewUavPilotMount` to avoid immediate forced mounts for uninitialized UAVs and to prevent re-launching when the stored UAV was destroyed; also require that the interacting user is the current station rider. 
- Fixed GUI UAV-type check logic in `MCH_GuiUavStation` so the label correctly reflects `isUAV`/`isNewUAV` combinations. 

### Testing
- Built the project with `./gradlew build` and the build completed successfully. 
- Ran `./gradlew test` with the project's automated tests and they completed without failures. 
- Executed automated integration smoke checks for UAV-station interactions and packet handling (status update, continue control, spawn/continue paths) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a263ff7650c832399d12ece89d568b1)