### PR TITLE
Recognize NewSmallUAV aircraft in UAV stations

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
@@ -1418,7 +1418,7 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
    }
 
    public static String[] getCannotReloadItem() {
-      return new String[]{"DisplayName", "AddDisplayName", "ItemID", "AddRecipe", "AddShapelessRecipe", "InventorySize", "Sound", "UAV", "SmallUAV", "TargetDrone", "Category"};
+      return new String[]{"DisplayName", "AddDisplayName", "ItemID", "AddRecipe", "AddShapelessRecipe", "InventorySize", "Sound", "UAV", "SmallUAV", "NewUAV", "NewSmallUAV", "TargetDrone", "Category"};
    }
 
    public boolean canReloadItem(String item) {

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -1160,7 +1160,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemHeli) {
                      MCH_HeliInfo hi1 = MCH_HeliInfoManager.getFromItem(item);
-                     if (hi1 != null && hi1.isUAV) {
+                     if (hi1 != null && (hi1.isUAV || hi1.isNewUAV)) {
                          if (!hi1.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {
@@ -1171,7 +1171,7 @@ public class MCH_EntityUavStation
 
                 if (item instanceof MCH_ItemTank) {
                      MCH_TankInfo hi2 = MCH_TankInfoManager.getFromItem(item);
-                     if (hi2 != null && hi2.isUAV) {
+                     if (hi2 != null && (hi2.isUAV || hi2.isNewUAV)) {
                           if (!hi2.isSmallUAV && getKind() == 2) {
                                ac = null;
                              } else {

--- a/src/main/java/mcheli/uav/MCH_GuiUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_GuiUavStation.java
@@ -58,10 +58,8 @@ public class MCH_GuiUavStation
                      info = MCH_TankInfoManager.getFromItem(item.getItem());
                    }
 
-                if (item != null && (item == null || info == null || !((MCH_AircraftInfo)info).isUAV || !((MCH_AircraftInfo)info).isNewUAV)) {
-                     if (item != null) {
-                          drawString("Not UAV", 8, 6, 16711680);
-                        }
+                if (item != null && (info == null || (!((MCH_AircraftInfo)info).isUAV && !((MCH_AircraftInfo)info).isNewUAV))) {
+                     drawString("Not UAV", 8, 6, 16711680);
                    } else if (this.uavStation.getKind() <= 1) {
                      drawString("UAV Station", 8, 6, 16777215);
                    } else if (item != null && !((MCH_AircraftInfo)info).isSmallUAV) {


### PR DESCRIPTION
### Motivation
- NewSmallUAV-marked aircraft were being treated as "Not UAV" by the UAV station GUI and some station spawn paths, preventing intended behavior for new small drones. 
- The new-UAV mechanic (`NewUAV`) is already supported in many places but heli/tank station paths and the GUI required both `isUAV` and `isNewUAV`, which is incorrect. 
- Keep the original small-UAV semantics while making the NewSmallUAV flag follow the same NewUAV logic so new small drones behave like legacy small UAVs.

### Description
- Adjusted the UAV station GUI validation to accept an aircraft when either `isUAV` or `isNewUAV` is true instead of requiring both flags. 
- Modified helicopter and tank spawn-path checks in the UAV station to accept `hi.isUAV || hi.isNewUAV`, matching existing plane/ship behavior. 
- Added `NewUAV` and `NewSmallUAV` to the `getCannotReloadItem()` keys so those flags are treated consistently during reload/ignore checks. 
- Preserved the existing `NewSmallUAV` parsing which sets `isNewUAV = true` and `isSmallUAV = true`, maintaining the intended small-UAV behavior.

### Testing
- Ran static/search checks to verify modified conditions are present and no remaining instances of the old incorrect pattern were found; the searches succeeded. 
- Ran a whitespace / diff consistency check which passed with no check failures. 
- Attempted to compile with the project Gradle wrapper and a local Gradle, but network access to external Maven/Forge metadata was blocked (HTTP 403), so a full build could not complete. 
- Attempted a targeted `javac` compile of the three modified sources which ran but failed because Minecraft/Forge runtime classes are unavailable without a successful dependency-resolved build, so bytecode-level verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265c23776c83238ac85a68575a05fc)