### PR TITLE
Prevent destroyed new UAVs from respawning via Continue

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -239,6 +239,9 @@ public class MCH_EntityUavStation
          }
 
       public boolean hasContinuableUavLink() {
+           if(this.storedUavWasDestroyed) {
+                return false;
+           }
            return getLastControlAircraftEntityId().intValue() != 0 ||
                   (this.assignedUav != null && !this.assignedUav.isDead) ||
                   this.assignedUavId > 0 ||
@@ -354,22 +357,23 @@ public class MCH_EntityUavStation
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
           this.storedUavWasDestroyed = nbt.getBoolean("StoredUavWasDestroyed");
+          this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
 
           if(this.storedUavWasDestroyed) {
               this.lastUavItemStack = null;
               this.hasStoredUavRespawnPosition = false;
               this.respawnStoredUavAtSavedPosition = false;
           }
-          this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
           if(this.linkedUavEntityUUID == null) {
               this.linkedUavEntityUUID = parseUavUUID(this.assignedUavUUID);
           }
-          boolean hasLinkedUavIdentity = this.linkedUavEntityUUID != null ||
+          boolean hasLinkedUavIdentity = !this.storedUavWasDestroyed &&
+                  (this.linkedUavEntityUUID != null ||
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
                   this.assignedUavId > 0 ||
                   (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty()) ||
                   (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
-                  this.lastUavItemStack != null;
+                  this.lastUavItemStack != null);
           if(this.lastUavItemStack != null && !this.hasStoredUavRespawnPosition) {
               this.hasStoredUavRespawnPosition = this.linkedUavY != 0.0D || this.linkedUavX != 0.0D || this.linkedUavZ != 0.0D;
           }
@@ -813,7 +817,11 @@ public class MCH_EntityUavStation
            if(this.worldObj.isRemote || ac == null) {
                 return;
            }
-          this.storedUavWasDestroyed = false;
+           if(ac.isDestroyed()) {
+                markLinkedNewUavDestroyed(ac);
+                return;
+           }
+           this.storedUavWasDestroyed = false;
            updateLinkedUavPosition(ac);
            this.hasStoredUavRespawnPosition = true;
            MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; deleting drone entity and keeping station launch state for Continue", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
@@ -890,7 +898,6 @@ public class MCH_EntityUavStation
 
            ItemStack stack = this.lastUavItemStack.copy();
            stack.stackSize = 1;
-          //problem: this still runs after the UAV has been destroyed. Allowing infinite spawning of UAVs this is not the intended behavior
            MCH_Lib.Log((Entity)this, "Continue requested after shifted-out new UAV; relaunching stored UAV item %s", new Object[] { stack.getItem() == null ? "null" : stack.getItem().getUnlocalizedName() });
            this.respawnStoredUavAtSavedPosition = true;
            try {
@@ -1097,7 +1104,7 @@ public class MCH_EntityUavStation
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);
-                 } else if (continueWithStoredUavItem(user)) { //we need to track if the drone has been destroyed here and if so do not allow continue to attempt to link until a new drone item is used again
+                 } else if (continueWithStoredUavItem(user)) {
                      this.pendingContinueTicks = 0;
                  } else if (this.storedUavWasDestroyed) {
                      this.pendingContinueTicks = 0;


### PR DESCRIPTION
### Motivation
- Fix a bug where a destroyed "newUAV" could still be relaunched by repeatedly pressing the station "Continue" button because destruction-state was being overwritten by the shift-exit flow and stale item/link data could be restored on load.

### Description
- Do not advertise a continuable UAV when the station has recorded a destroyed stored UAV by returning false from `hasContinuableUavLink()` if `storedUavWasDestroyed` is set. (changed in `MCH_EntityUavStation.java`).
- Make NBT load order authoritative so `StoredUavWasDestroyed` clears any cached `lastUavItemStack` and prevents the station from reconstituting a stored link on load. (reordered handling in `readEntityFromNBT`).
- Harden the shift-exit path so `prepareNewUavShiftExit(...)` calls `markLinkedNewUavDestroyed(...)` and returns immediately when the UAV passed in is destroyed, preventing the normal shift-exit cleanup from undoing the destroyed marker. (changed in `MCH_EntityUavStation.java`).
- Minor cleanup: remove a stale comment and tighten the continue-path branching to keep the destroyed-check authoritative (single modified Java source file: `src/main/java/mcheli/uav/MCH_EntityUavStation.java`).

### Testing
- Ran `git diff --check` and static diff checks to ensure no whitespace/format issues, which succeeded. 
- Executed a set of Python assertions that verify the new destruction guard is present in the source, NBT load ordering was adjusted, and the shift-exit path now short-circuits for destroyed UAVs, which all passed. 
- Verified repository status and diff summary to ensure only the intended file was changed. 
- Attempted to run `./gradlew compileJava` but the environment could not download the Gradle distribution due to a proxy returning HTTP 403, so a full JVM compile was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2671179fec8323be5739f2847de4df)