### PR TITLE
Save the latest NewUAV position on every shift exit

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -5336,13 +5336,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       setCommonStatus(1, false);
            if (rByEntity != null) {
-                if (isUAV()) {
-                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
-                          rByEntity.mountEntity((Entity)null);
-                        }
-                   } else if (isNewUAV()) {
+                // NewUAV/NewSmallUAV must use the direct-control shift exit even when a
+                // content definition also includes the legacy UAV/SmallUAV flag.
+                if (isNewUAV()) {
                      newuavvariable = true;
-                     //here
                      if(!this.worldObj.isRemote) {
                       rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                       rByEntity.mountEntity((Entity) null);
@@ -5351,6 +5348,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                       }
                       deleteNewUavAfterShiftExit();
                      }
+                   } else if (isUAV()) {
+                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
+                          rByEntity.mountEntity((Entity)null);
+                        }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
                    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -80,6 +80,9 @@ public class MCH_EntityUavStation
       private boolean hasStoredUavLink;
       private ItemStack lastUavItemStack;
       private boolean hasStoredUavRespawnPosition;
+      private double storedUavRespawnX;
+      private double storedUavRespawnY;
+      private double storedUavRespawnZ;
       private boolean respawnStoredUavAtSavedPosition;
       private boolean awaitingLoadedUav;
       private int pendingContinueTicks;
@@ -311,6 +314,9 @@ public class MCH_EntityUavStation
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
            nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
            nbt.setBoolean("HasStoredUavRespawnPosition", this.hasStoredUavRespawnPosition);
+           nbt.setDouble("StoredUavRespawnX", this.storedUavRespawnX);
+           nbt.setDouble("StoredUavRespawnY", this.storedUavRespawnY);
+           nbt.setDouble("StoredUavRespawnZ", this.storedUavRespawnZ);
            nbt.setDouble("LinkedUavX", this.linkedUavX);
            nbt.setDouble("LinkedUavY", this.linkedUavY);
            nbt.setDouble("LinkedUavZ", this.linkedUavZ);
@@ -356,6 +362,16 @@ public class MCH_EntityUavStation
           this.linkedUavX = nbt.getDouble("LinkedUavX");
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
+          if(nbt.hasKey("StoredUavRespawnX") || nbt.hasKey("StoredUavRespawnY") || nbt.hasKey("StoredUavRespawnZ")) {
+              this.storedUavRespawnX = nbt.getDouble("StoredUavRespawnX");
+              this.storedUavRespawnY = nbt.getDouble("StoredUavRespawnY");
+              this.storedUavRespawnZ = nbt.getDouble("StoredUavRespawnZ");
+          } else {
+              // Older saves used the live-link coordinates as the shifted-out respawn position.
+              this.storedUavRespawnX = this.linkedUavX;
+              this.storedUavRespawnY = this.linkedUavY;
+              this.storedUavRespawnZ = this.linkedUavZ;
+          }
           this.storedUavWasDestroyed = nbt.getBoolean("StoredUavWasDestroyed");
           this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
 
@@ -823,8 +839,11 @@ public class MCH_EntityUavStation
            }
            this.storedUavWasDestroyed = false;
            updateLinkedUavPosition(ac);
+           this.storedUavRespawnX = ac.posX;
+           this.storedUavRespawnY = ac.posY;
+           this.storedUavRespawnZ = ac.posZ;
            this.hasStoredUavRespawnPosition = true;
-           MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; deleting drone entity and keeping station launch state for Continue", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
+           MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; replacing the saved Continue position", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.storedUavRespawnX), Double.valueOf(this.storedUavRespawnY), Double.valueOf(this.storedUavRespawnZ) });
            this.assignedUav = null;
            this.assignedUavId = -1;
            this.assignedUavUUID = "";
@@ -1133,9 +1152,9 @@ public class MCH_EntityUavStation
                 double y = this.posY + this.posUavY;
                 double z = this.posZ + this.posUavZ;
                 if(this.respawnStoredUavAtSavedPosition && this.hasStoredUavRespawnPosition) {
-                     x = this.linkedUavX;
-                     y = this.linkedUavY;
-                     z = this.linkedUavZ;
+                     x = this.storedUavRespawnX;
+                     y = this.storedUavRespawnY;
+                     z = this.storedUavRespawnZ;
                      MCH_Lib.Log((Entity)this, "Respawning shifted-out UAV at saved delete position %.2f, %.2f, %.2f", new Object[] { Double.valueOf(x), Double.valueOf(y), Double.valueOf(z) });
                    }
                 if (y <= 1.0D) {


### PR DESCRIPTION
### Motivation
- NewUAV/NewSmallUAV pilots observed that when they shifted out multiple times the station always returned the drone to the first-shifted coordinates instead of the most recent shift snapshot. 
- The intent is to snapshot the drone position on each shift exit and use that per-shift snapshot for Continue/respawn, rather than relying on a mutable live-link coordinate that may change after the initial shift.

### Description
- Add dedicated per-shift respawn coordinates (`storedUavRespawnX`, `storedUavRespawnY`, `storedUavRespawnZ`) to `MCH_EntityUavStation` and persist them in station NBT. 
- Update `prepareNewUavShiftExit` to overwrite the stored respawn snapshot with the aircraft's current `posX/posY/posZ` on every shift exit and log the replacement. 
- Change `handleItem` Continue/respawn logic to spawn at the stored per-shift snapshot when `respawnStoredUavAtSavedPosition` is set, instead of using the live `linkedUavX/Y/Z`. 
- Maintain backward compatibility when reading NBT by falling back to the legacy live-link coordinates if the new stored respawn keys are not present. 
- Prioritize NewUAV/NewSmallUAV direct-control dismount behavior in `MCH_EntityAircraft.unmountEntity` so new UAV content uses the correct teleport/unmount flow even if legacy UAV flags are also present.

### Testing
- Ran `git diff --check` and repository status checks to validate the change set and found no whitespace errors. 
- Attempted `bash gradlew compileJava` and `gradle compileJava` to compile the project, but both builds were blocked by external repository access (ForgeGradle/maven metadata) returning HTTP 403 in this environment, causing dependency resolution to fail and the build to abort. 
- No automated unit tests were executed in this environment due to the dependency resolution / network restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2744cb98408323bbd2069af6540eea)