### PR TITLE
Improve New UAV shift-exit handling and persist respawn coordinates for stations

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -5298,12 +5298,41 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    }
 
 
+   private MCH_EntityUavStation resolveUavStationForShiftExit() {
+      if(this.uavStation != null && !this.uavStation.isDead) {
+         return this.uavStation;
+      }
+      if(this.linkedUavStationUUID == null || this.linkedUavStationDimension != this.dimension) {
+         return null;
+      }
+
+      // Integrated runClient usually retains the direct object reference. A dedicated server
+      // may unload that station reference while preserving its UUID and coordinates in NBT.
+      super.worldObj.getChunkFromBlockCoords(MathHelper.floor_double(this.linkedUavStationX), MathHelper.floor_double(this.linkedUavStationZ));
+      for(Object obj : super.worldObj.loadedEntityList) {
+         if(obj instanceof MCH_EntityUavStation) {
+            MCH_EntityUavStation station = (MCH_EntityUavStation)obj;
+            if(!station.isDead && this.linkedUavStationUUID.equals(station.getUniqueID())) {
+               this.setUavStation(station);
+               return station;
+            }
+         }
+      }
+      return null;
+   }
+
    private void deleteNewUavAfterShiftExit() {
       if(super.worldObj.isRemote || !this.isNewUAV()) {
          return;
       }
-      if(this.uavStation != null && !this.uavStation.isDead) {
-         this.uavStation.prepareNewUavShiftExit(this);
+      MCH_EntityUavStation station = resolveUavStationForShiftExit();
+      if(station != null) {
+         if(!station.prepareNewUavShiftExit(this)) {
+            return;
+         }
+      } else {
+         MCH_Lib.Log((Entity)this, "Unable to resolve the New UAV station during shift-exit; preserving the aircraft instead of losing its position", new Object[0]);
+         return;
       }
       MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
       this.setDead(false);
@@ -5336,13 +5365,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       setCommonStatus(1, false);
            if (rByEntity != null) {
-                if (isUAV()) {
-                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
-                          rByEntity.mountEntity((Entity)null);
-                        }
-                   } else if (isNewUAV()) {
+                // NewUAV/NewSmallUAV must use the direct-control shift exit even when a
+                // content definition also includes the legacy UAV/SmallUAV flag.
+                if (isNewUAV()) {
                      newuavvariable = true;
-                     //here
                      if(!this.worldObj.isRemote) {
                       rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
                       rByEntity.mountEntity((Entity) null);
@@ -5351,6 +5377,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
                       }
                       deleteNewUavAfterShiftExit();
                      }
+                   } else if (isUAV()) {
+                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
+                          rByEntity.mountEntity((Entity)null);
+                        }
                    } else {
                      setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
                    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -80,6 +80,9 @@ public class MCH_EntityUavStation
       private boolean hasStoredUavLink;
       private ItemStack lastUavItemStack;
       private boolean hasStoredUavRespawnPosition;
+      private double storedUavRespawnX;
+      private double storedUavRespawnY;
+      private double storedUavRespawnZ;
       private boolean respawnStoredUavAtSavedPosition;
       private boolean awaitingLoadedUav;
       private int pendingContinueTicks;
@@ -311,6 +314,11 @@ public class MCH_EntityUavStation
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
            nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
            nbt.setBoolean("HasStoredUavRespawnPosition", this.hasStoredUavRespawnPosition);
+           if(this.hasStoredUavRespawnPosition) {
+                nbt.setDouble("StoredUavRespawnX", this.storedUavRespawnX);
+                nbt.setDouble("StoredUavRespawnY", this.storedUavRespawnY);
+                nbt.setDouble("StoredUavRespawnZ", this.storedUavRespawnZ);
+           }
            nbt.setDouble("LinkedUavX", this.linkedUavX);
            nbt.setDouble("LinkedUavY", this.linkedUavY);
            nbt.setDouble("LinkedUavZ", this.linkedUavZ);
@@ -356,6 +364,25 @@ public class MCH_EntityUavStation
           this.linkedUavX = nbt.getDouble("LinkedUavX");
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
+          if(this.hasStoredUavRespawnPosition && nbt.hasKey("StoredUavRespawnX") && nbt.hasKey("StoredUavRespawnY") && nbt.hasKey("StoredUavRespawnZ")) {
+              this.storedUavRespawnX = nbt.getDouble("StoredUavRespawnX");
+              this.storedUavRespawnY = nbt.getDouble("StoredUavRespawnY");
+              this.storedUavRespawnZ = nbt.getDouble("StoredUavRespawnZ");
+          } else {
+              // Older saves used the live-link coordinates as the shifted-out respawn position.
+              this.storedUavRespawnX = this.linkedUavX;
+              this.storedUavRespawnY = this.linkedUavY;
+              this.storedUavRespawnZ = this.linkedUavZ;
+          }
+          if(this.hasStoredUavRespawnPosition && !isUsableUavPosition(this.storedUavRespawnX, this.storedUavRespawnY, this.storedUavRespawnZ)) {
+              if(isUsableUavPosition(this.linkedUavX, this.linkedUavY, this.linkedUavZ)) {
+                  this.storedUavRespawnX = this.linkedUavX;
+                  this.storedUavRespawnY = this.linkedUavY;
+                  this.storedUavRespawnZ = this.linkedUavZ;
+              } else {
+                  this.hasStoredUavRespawnPosition = false;
+              }
+          }
           this.storedUavWasDestroyed = nbt.getBoolean("StoredUavWasDestroyed");
           this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
 
@@ -813,18 +840,62 @@ public class MCH_EntityUavStation
          }
 
 
-      public void prepareNewUavShiftExit(MCH_EntityAircraft ac) {
+      private boolean isUsableUavPosition(double x, double y, double z) {
+           return !Double.isNaN(x) && !Double.isInfinite(x) &&
+                  !Double.isNaN(y) && !Double.isInfinite(y) &&
+                  !Double.isNaN(z) && !Double.isInfinite(z) &&
+                  (x != 0.0D || y != 0.0D || z != 0.0D);
+         }
+
+      public boolean prepareNewUavShiftExit(MCH_EntityAircraft ac) {
            if(this.worldObj.isRemote || ac == null) {
-                return;
+                return false;
            }
            if(ac.isDestroyed()) {
                 markLinkedNewUavDestroyed(ac);
-                return;
+                return true;
            }
            this.storedUavWasDestroyed = false;
-           updateLinkedUavPosition(ac);
-           this.hasStoredUavRespawnPosition = true;
-           MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; deleting drone entity and keeping station launch state for Continue", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(this.linkedUavX), Double.valueOf(this.linkedUavY), Double.valueOf(this.linkedUavZ) });
+           double previousLinkedX = this.linkedUavX;
+           double previousLinkedY = this.linkedUavY;
+           double previousLinkedZ = this.linkedUavZ;
+           double shiftX = ac.posX;
+           double shiftY = ac.posY;
+           double shiftZ = ac.posZ;
+
+           // On a dedicated server the dismount can be processed after the entity has briefly
+           // received an uninitialized zero position. Keep the last authoritative server-tick
+           // position instead of replacing a valid snapshot with 0,0,0.
+           if(!isUsableUavPosition(shiftX, shiftY, shiftZ)) {
+                if(isUsableUavPosition(ac.lastTickPosX, ac.lastTickPosY, ac.lastTickPosZ)) {
+                     shiftX = ac.lastTickPosX;
+                     shiftY = ac.lastTickPosY;
+                     shiftZ = ac.lastTickPosZ;
+                } else if(isUsableUavPosition(ac.prevPosX, ac.prevPosY, ac.prevPosZ)) {
+                     shiftX = ac.prevPosX;
+                     shiftY = ac.prevPosY;
+                     shiftZ = ac.prevPosZ;
+                } else if(isUsableUavPosition(previousLinkedX, previousLinkedY, previousLinkedZ)) {
+                     shiftX = previousLinkedX;
+                     shiftY = previousLinkedY;
+                     shiftZ = previousLinkedZ;
+                }
+           }
+
+           if(isUsableUavPosition(shiftX, shiftY, shiftZ)) {
+                this.linkedUavDimension = ac.dimension;
+                this.linkedUavX = shiftX;
+                this.linkedUavY = shiftY;
+                this.linkedUavZ = shiftZ;
+                this.storedUavRespawnX = shiftX;
+                this.storedUavRespawnY = shiftY;
+                this.storedUavRespawnZ = shiftZ;
+                this.hasStoredUavRespawnPosition = true;
+                MCH_Lib.Log((Entity)this, "New UAV %d shifted out at %.2f, %.2f, %.2f; replacing the saved Continue position", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Double.valueOf(shiftX), Double.valueOf(shiftY), Double.valueOf(shiftZ) });
+           } else {
+                MCH_Lib.Log((Entity)this, "New UAV %d shifted out with an invalid server position; cancelling deletion so Continue cannot use stale coordinates", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)) });
+                return false;
+           }
            this.assignedUav = null;
            this.assignedUavId = -1;
            this.assignedUavUUID = "";
@@ -836,6 +907,7 @@ public class MCH_EntityUavStation
            this.controlAircraft = null;
            setLastControlAircraft((MCH_EntityAircraft)null);
            setLastControlAircraftEntityId(0);
+           return true;
          }
 
 
@@ -1132,10 +1204,11 @@ public class MCH_EntityUavStation
                 double x = this.posX + this.posUavX;
                 double y = this.posY + this.posUavY;
                 double z = this.posZ + this.posUavZ;
-                if(this.respawnStoredUavAtSavedPosition && this.hasStoredUavRespawnPosition) {
-                     x = this.linkedUavX;
-                     y = this.linkedUavY;
-                     z = this.linkedUavZ;
+                if(this.respawnStoredUavAtSavedPosition && this.hasStoredUavRespawnPosition &&
+                   isUsableUavPosition(this.storedUavRespawnX, this.storedUavRespawnY, this.storedUavRespawnZ)) {
+                     x = this.storedUavRespawnX;
+                     y = this.storedUavRespawnY;
+                     z = this.storedUavRespawnZ;
                      MCH_Lib.Log((Entity)this, "Respawning shifted-out UAV at saved delete position %.2f, %.2f, %.2f", new Object[] { Double.valueOf(x), Double.valueOf(y), Double.valueOf(z) });
                    }
                 if (y <= 1.0D) {


### PR DESCRIPTION
### Motivation
- Prevent loss of UAV station linkage and invalid respawn coordinates when a NewUAV is shift-exited on dedicated servers or across chunk/unload boundaries.
- Ensure NewUAVs use a robust direct-control dismount path (shift-exit) even when legacy UAV flags are present in content data.
- Preserve and validate saved respawn/delete coordinates so Continue/respawn does not reuse invalid or zeroed positions from server-side timing issues.

### Description
- Added `resolveUavStationForShiftExit()` to `MCH_EntityAircraft` to re-resolve a station by UUID and loaded entities when the direct reference is missing, and used it from `deleteNewUavAfterShiftExit()` to avoid deleting the aircraft when the station cannot be found.
- Reworked `unmountEntity()` logic to prefer the NewUAV direct-control dismount path first, restoring pilot inventory and calling `deleteNewUavAfterShiftExit()` only for `isNewUAV()`, while preserving legacy `isUAV()` behavior for station dismounts.
- In `MCH_EntityUavStation` added saved respawn coordinates (`storedUavRespawnX/Y/Z`), NBT read/write of those coordinates, and validation/fallback for older saves so saved positions are recovered or discarded safely.
- Introduced `isUsableUavPosition()` and made `prepareNewUavShiftExit()` return a boolean and choose the best available server-side position (current, `lastTickPos`, `prevPos`, or previous linked position), rejecting invalid positions and logging the outcome; updated callers accordingly.
- Updated `handleItem()` to respawn shifted-out UAVs at the validated stored respawn position only when present and usable.

### Testing
- Performed an automated project build using `./gradlew build`, which completed successfully.
- Executed the existing automated test task with `./gradlew test`; no failing tests were reported (project has no mod-specific unit tests to exercise these code paths).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2744cb98408323bbd2069af6540eea)