### PR TITLE
Persist shifted New UAV positions in world JSON

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -25,6 +25,7 @@ import mcheli.ship.MCH_EntityShip;
 import mcheli.tank.MCH_EntityTank;
 import mcheli.uav.MCH_EntityUavStation;
 import mcheli.uav.MCH_UavInventory;
+import mcheli.uav.MCH_UavJsonStore;
 import mcheli.uav.MCH_UavRegistry;
 import mcheli.weapon.*;
 import mcheli.wrapper.*;
@@ -877,6 +878,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       if(!super.worldObj.isRemote && this.isNewUAV()) {
+         if(this.linkedUavStationUUID != null) {
+            MCH_UavJsonStore.remove(super.worldObj, this.linkedUavStationDimension, this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
+         }
          MCH_EntityUavStation station = this.getUavStation();
          if(station != null && !station.isDead) {
             station.markLinkedNewUavDestroyed(this);

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -252,7 +252,8 @@ public class MCH_EntityUavStation
                   this.linkedUavEntityUUID != null ||
                   (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
                   (this.loadedLastControlAircraftGuid != null && !this.loadedLastControlAircraftGuid.isEmpty()) ||
-                  this.lastUavItemStack != null;
+                  this.lastUavItemStack != null ||
+                  (!this.worldObj.isRemote && MCH_UavJsonStore.load(this.worldObj, this) != null);
          }
 
       public void unlinkInvalidUav() {
@@ -313,21 +314,10 @@ public class MCH_EntityUavStation
            nbt.setString("LinkedUavCommonId", this.linkedUavCommonId == null ? "" : this.linkedUavCommonId);
            nbt.setInteger("LinkedUavDimension", this.linkedUavDimension);
            nbt.setBoolean("HasStoredUavLink", this.hasStoredUavLink);
-           nbt.setBoolean("HasStoredUavRespawnPosition", this.hasStoredUavRespawnPosition);
-           if(this.hasStoredUavRespawnPosition) {
-                nbt.setDouble("StoredUavRespawnX", this.storedUavRespawnX);
-                nbt.setDouble("StoredUavRespawnY", this.storedUavRespawnY);
-                nbt.setDouble("StoredUavRespawnZ", this.storedUavRespawnZ);
-           }
            nbt.setDouble("LinkedUavX", this.linkedUavX);
            nbt.setDouble("LinkedUavY", this.linkedUavY);
            nbt.setDouble("LinkedUavZ", this.linkedUavZ);
            nbt.setBoolean("StoredUavWasDestroyed", this.storedUavWasDestroyed);
-           if(this.lastUavItemStack != null) {
-                NBTTagCompound itemTag = new NBTTagCompound();
-                this.lastUavItemStack.writeToNBT(itemTag);
-                nbt.setTag("LastUavItem", itemTag);
-              }
 
           if (this.assignedUav != null && !this.assignedUav.isDead) {
               nbt.setInteger("AssignedUavId", this.assignedUav.getEntityId());
@@ -360,31 +350,12 @@ public class MCH_EntityUavStation
           this.linkedUavCommonId = nbt.getString("LinkedUavCommonId");
           this.linkedUavDimension = nbt.getInteger("LinkedUavDimension");
           this.hasStoredUavLink = nbt.getBoolean("HasStoredUavLink");
-          this.hasStoredUavRespawnPosition = nbt.getBoolean("HasStoredUavRespawnPosition");
+          this.hasStoredUavRespawnPosition = false;
           this.linkedUavX = nbt.getDouble("LinkedUavX");
           this.linkedUavY = nbt.getDouble("LinkedUavY");
           this.linkedUavZ = nbt.getDouble("LinkedUavZ");
-          if(this.hasStoredUavRespawnPosition && nbt.hasKey("StoredUavRespawnX") && nbt.hasKey("StoredUavRespawnY") && nbt.hasKey("StoredUavRespawnZ")) {
-              this.storedUavRespawnX = nbt.getDouble("StoredUavRespawnX");
-              this.storedUavRespawnY = nbt.getDouble("StoredUavRespawnY");
-              this.storedUavRespawnZ = nbt.getDouble("StoredUavRespawnZ");
-          } else {
-              // Older saves used the live-link coordinates as the shifted-out respawn position.
-              this.storedUavRespawnX = this.linkedUavX;
-              this.storedUavRespawnY = this.linkedUavY;
-              this.storedUavRespawnZ = this.linkedUavZ;
-          }
-          if(this.hasStoredUavRespawnPosition && !isUsableUavPosition(this.storedUavRespawnX, this.storedUavRespawnY, this.storedUavRespawnZ)) {
-              if(isUsableUavPosition(this.linkedUavX, this.linkedUavY, this.linkedUavZ)) {
-                  this.storedUavRespawnX = this.linkedUavX;
-                  this.storedUavRespawnY = this.linkedUavY;
-                  this.storedUavRespawnZ = this.linkedUavZ;
-              } else {
-                  this.hasStoredUavRespawnPosition = false;
-              }
-          }
+          this.lastUavItemStack = null;
           this.storedUavWasDestroyed = nbt.getBoolean("StoredUavWasDestroyed");
-          this.lastUavItemStack = nbt.hasKey("LastUavItem") ? ItemStack.loadItemStackFromNBT(nbt.getCompoundTag("LastUavItem")) : null;
 
           if(this.storedUavWasDestroyed) {
               this.lastUavItemStack = null;
@@ -883,6 +854,10 @@ public class MCH_EntityUavStation
            }
 
            if(isUsableUavPosition(shiftX, shiftY, shiftZ)) {
+                if(this.lastUavItemStack == null || !MCH_UavJsonStore.save(this.worldObj, this, ac, this.lastUavItemStack, shiftX, shiftY, shiftZ)) {
+                     MCH_Lib.Log((Entity)this, "New UAV %d shift-exit JSON save failed; preserving the aircraft", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)ac)) });
+                     return false;
+                }
                 this.linkedUavDimension = ac.dimension;
                 this.linkedUavX = shiftX;
                 this.linkedUavY = shiftY;
@@ -925,6 +900,7 @@ public class MCH_EntityUavStation
                  }
 
                  this.storedUavWasDestroyed = true;
+                 MCH_UavJsonStore.remove(this.worldObj, this);
 
                  // This is the important part: kill the fake respawn token.
                  this.lastUavItemStack = null;
@@ -964,9 +940,20 @@ public class MCH_EntityUavStation
               return false;
           }
 
-          if(this.lastUavItemStack == null) {
+          MCH_UavJsonStore.StoredUav stored = MCH_UavJsonStore.load(this.worldObj, this);
+          if(stored == null) {
               return false;
           }
+          ItemStack storedStack = stored.createItemStack();
+          if(storedStack == null || stored.uavDimension != this.dimension || !isUsableUavPosition(stored.exitX, stored.exitY, stored.exitZ)) {
+              MCH_Lib.Log((Entity)this, "Stored New UAV JSON entry is invalid for station %d", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+              return false;
+          }
+          this.lastUavItemStack = storedStack;
+          this.storedUavRespawnX = stored.exitX;
+          this.storedUavRespawnY = stored.exitY;
+          this.storedUavRespawnZ = stored.exitZ;
+          this.hasStoredUavRespawnPosition = true;
 
            ItemStack stack = this.lastUavItemStack.copy();
            stack.stackSize = 1;
@@ -979,7 +966,9 @@ public class MCH_EntityUavStation
            }
            MCH_EntityAircraft ac = getControlAircract();
            if(ac != null && !ac.isDead) {
+                ac.setLocationAndAngles(stored.exitX, stored.exitY, stored.exitZ, stored.exitYaw, stored.exitPitch);
                 if(this.riddenByEntity != null && ac.isNewUAV()) {
+                     teleportPlayerToUav(this.riddenByEntity, ac);
                      this.riddenByEntity.mountEntity((Entity)ac);
                 }
                 return true;
@@ -987,6 +976,13 @@ public class MCH_EntityUavStation
            return false;
          }
 
+
+
+      private void teleportPlayerToUav(Entity user, MCH_EntityAircraft ac) {
+           if(user instanceof EntityPlayerMP && ac != null) {
+                ((EntityPlayerMP)user).setPositionAndUpdate(ac.posX, ac.posY + ac.getMountedYOffset(), ac.posZ);
+           }
+         }
 
 
       private void notifyInitialUavStateOnce(EntityPlayerMP player, MCH_EntityAircraft ac) {
@@ -1172,6 +1168,7 @@ public class MCH_EntityUavStation
                              }
                              return;
                          }
+                         teleportPlayerToUav(this.riddenByEntity, this.controlAircraft);
                          this.riddenByEntity.mountEntity((Entity)this.controlAircraft);
                      }
                      this.pendingContinueTicks = 0;

--- a/src/main/java/mcheli/uav/MCH_UavJsonStore.java
+++ b/src/main/java/mcheli/uav/MCH_UavJsonStore.java
@@ -1,0 +1,218 @@
+package mcheli.uav;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_EntityAircraft;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+
+/** Server-side JSON persistence for NewUAV/NewSmallUAV shift-exit locations. */
+public final class MCH_UavJsonStore {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private static final String FILE_NAME = "mcheli_new_uavs.json";
+
+    private MCH_UavJsonStore() {}
+
+    public static final class StoredUav {
+        public int stationDimension;
+        public int stationX;
+        public int stationY;
+        public int stationZ;
+        public int uavDimension;
+        public double exitX;
+        public double exitY;
+        public double exitZ;
+        public float exitYaw;
+        public float exitPitch;
+        public String droneType;
+        public String uavCategory;
+        public boolean smallUav;
+        public String itemId;
+        public int itemDamage;
+
+        public ItemStack createItemStack() {
+            if(itemId == null || itemId.isEmpty()) {
+                return null;
+            }
+            Object registered = Item.itemRegistry.getObject(itemId);
+            return registered instanceof Item ? new ItemStack((Item)registered, 1, itemDamage) : null;
+        }
+    }
+
+    private static final class StoreFile {
+        int version = 1;
+        List<StoredUav> drones = new ArrayList<StoredUav>();
+    }
+
+    public static synchronized boolean save(World world, MCH_EntityUavStation station, MCH_EntityAircraft aircraft, ItemStack itemStack,
+                                            double exitX, double exitY, double exitZ) {
+        if(world == null || world.isRemote || station == null || aircraft == null || itemStack == null || itemStack.getItem() == null) {
+            return false;
+        }
+        File file = getFile();
+        if(file == null) {
+            return false;
+        }
+        StoreFile data = read(file);
+        if(data == null) {
+            return false;
+        }
+        removeMatching(data, station.dimension, station.posX, station.posY, station.posZ);
+
+        StoredUav stored = new StoredUav();
+        stored.stationDimension = station.dimension;
+        stored.stationX = MathHelper.floor_double(station.posX);
+        stored.stationY = MathHelper.floor_double(station.posY);
+        stored.stationZ = MathHelper.floor_double(station.posZ);
+        stored.uavDimension = aircraft.dimension;
+        stored.exitX = exitX;
+        stored.exitY = exitY;
+        stored.exitZ = exitZ;
+        stored.exitYaw = aircraft.rotationYaw;
+        stored.exitPitch = aircraft.rotationPitch;
+        stored.droneType = aircraft.getAcInfo() == null ? "" : aircraft.getAcInfo().name;
+        stored.smallUav = aircraft.isSmallUAV();
+        stored.uavCategory = stored.smallUav ? "newsmallUAVS" : "newUAVs";
+        Object itemName = Item.itemRegistry.getNameForObject(itemStack.getItem());
+        stored.itemId = itemName == null ? "" : itemName.toString();
+        stored.itemDamage = itemStack.getItemDamage();
+        data.drones.add(stored);
+        return write(file, data);
+    }
+
+    public static synchronized StoredUav load(World world, MCH_EntityUavStation station) {
+        if(world == null || world.isRemote || station == null) {
+            return null;
+        }
+        File file = getFile();
+        if(file == null || !file.isFile()) {
+            return null;
+        }
+        StoreFile data = read(file);
+        if(data == null) {
+            return null;
+        }
+        int x = MathHelper.floor_double(station.posX);
+        int y = MathHelper.floor_double(station.posY);
+        int z = MathHelper.floor_double(station.posZ);
+        for(StoredUav stored : data.drones) {
+            if(stored != null && stored.stationDimension == station.dimension && stored.stationX == x && stored.stationY == y && stored.stationZ == z) {
+                return stored;
+            }
+        }
+        return null;
+    }
+
+    public static synchronized void remove(World world, MCH_EntityUavStation station) {
+        if(station != null) {
+            remove(world, station.dimension, station.posX, station.posY, station.posZ);
+        }
+    }
+
+    public static synchronized void remove(World world, int stationDimension, double stationX, double stationY, double stationZ) {
+        if(world == null || world.isRemote) {
+            return;
+        }
+        File file = getFile();
+        if(file == null || !file.isFile()) {
+            return;
+        }
+        StoreFile data = read(file);
+        if(data != null && removeMatching(data, stationDimension, stationX, stationY, stationZ)) {
+            write(file, data);
+        }
+    }
+
+    private static boolean removeMatching(StoreFile data, int dimension, double x, double y, double z) {
+        int blockX = MathHelper.floor_double(x);
+        int blockY = MathHelper.floor_double(y);
+        int blockZ = MathHelper.floor_double(z);
+        boolean removed = false;
+        Iterator<StoredUav> iterator = data.drones.iterator();
+        while(iterator.hasNext()) {
+            StoredUav stored = iterator.next();
+            if(stored != null && stored.stationDimension == dimension && stored.stationX == blockX && stored.stationY == blockY && stored.stationZ == blockZ) {
+                iterator.remove();
+                removed = true;
+            }
+        }
+        return removed;
+    }
+
+    private static File getFile() {
+        File saveRoot = DimensionManager.getCurrentSaveRootDirectory();
+        if(saveRoot == null) {
+            MCH_Lib.Log("Unable to access the current world directory for New UAV JSON persistence.", new Object[0]);
+            return null;
+        }
+        File dataDirectory = new File(saveRoot, "data");
+        if(!dataDirectory.isDirectory() && !dataDirectory.mkdirs()) {
+            MCH_Lib.Log("Unable to create New UAV JSON data directory: %s", new Object[] { dataDirectory.getAbsolutePath() });
+            return null;
+        }
+        return new File(dataDirectory, FILE_NAME);
+    }
+
+    private static StoreFile read(File file) {
+        if(!file.isFile()) {
+            return new StoreFile();
+        }
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(file));
+            try {
+                StoreFile data = GSON.fromJson(reader, StoreFile.class);
+                if(data == null) {
+                    data = new StoreFile();
+                }
+                if(data.drones == null) {
+                    data.drones = new ArrayList<StoredUav>();
+                }
+                return data;
+            } finally {
+                reader.close();
+            }
+        } catch(Exception e) {
+            MCH_Lib.Log("Failed to read New UAV JSON store %s: %s", new Object[] { file.getAbsolutePath(), e.toString() });
+            return null;
+        }
+    }
+
+    private static boolean write(File file, StoreFile data) {
+        File temporary = new File(file.getParentFile(), file.getName() + ".tmp");
+        try {
+            BufferedWriter writer = new BufferedWriter(new FileWriter(temporary));
+            try {
+                GSON.toJson(data, writer);
+            } finally {
+                writer.close();
+            }
+            try {
+                Files.move(temporary.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch(IOException atomicMoveFailure) {
+                Files.move(temporary.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            return true;
+        } catch(IOException e) {
+            MCH_Lib.Log("Failed to write New UAV JSON store %s: %s", new Object[] { file.getAbsolutePath(), e.toString() });
+            if(temporary.exists()) {
+                temporary.delete();
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace unreliable station NBT persistence for `newUAVs`/`newsmallUAVS` shift-exit positions with a stable, server-side world store because the NBT-based values were getting corrupted/stale and caused teleport/dismount bugs. 
- Ensure players are teleported to the actual saved exit position and that stations retain ownership metadata across unloads/reloads. 
- Prevent lost drones by failing-safe preservation of the live aircraft if persistence fails. 

### Description
- Add a new server-side JSON registry `MCH_UavJsonStore` that writes `data/mcheli_new_uavs.json` and stores station coordinates, UAV category (`newUAVs` / `newsmallUAVS`), item identity, exit XYZ and orientation. 
- Stop writing shifted-exit coordinates and stored UAV item to station NBT and instead write the authoritative shift-exit record to JSON during `prepareNewUavShiftExit`; if the JSON write fails, preserve the aircraft. 
- Load the JSON entry in `continueWithStoredUavItem`, recreate/relaunch at the saved coordinates and orientation, teleport the player to the UAV, and mount them. 
- Remove JSON entries when a stored/linked UAV is destroyed, with cleanup performed both from the station path and from the aircraft destruction path. 

### Testing
- Ran targeted source assertions (small Python checks) that verified NBT keys are no longer written, JSON save/load hooks exist, station coordinate keys are recorded, destruction triggers JSON removal, and that the continue path teleports the player; those checks passed. 
- `git diff --check` and local static checks passed with no whitespace/compile-time text issues. 
- Attempted `./gradlew compileJava` / `gradle compileJava` to perform a full compile, but the environment blocked dependency/Gradle downloads (ForgeGradle/maven metadata) with HTTP 403 so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2754e8fd2c8323bc9747b7e76af155)