### PR TITLE
Fix destruct weapons for NewUAV/NewSmallUAV

### DIFF
--- a/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
@@ -29,7 +29,7 @@ public class MCH_WeaponBomb extends MCH_WeaponBase {
       if(this.getInfo() != null && this.getInfo().destruct) {
          if(prm.entity instanceof MCH_EntityAircraft) {
             MCH_EntityAircraft e1 = (MCH_EntityAircraft)prm.entity;
-            if(e1.isUAV() && e1.getSeatNum() == 0) {
+            if((e1.isUAV() || e1.isNewUAV()) && e1.getSeatNum() == 0) {
                if(!super.worldObj.isRemote) {
                   MCH_Explosion.newExplosion(super.worldObj, (Entity)null, prm.user, e1.posX, e1.posY, e1.posZ, (float)this.getInfo().explosion, (float)this.getInfo().explosionBlock, true, true, this.getInfo().flaming, true, 0);
                   this.playSound(prm.entity);


### PR DESCRIPTION
### Motivation
- The `Destruct = true` path only matched legacy UAVs so bombs intended to self-destruct FPV drones using `NewUAV`/`NewSmallUAV` did not explode or destroy the aircraft.

### Description
- Update the destruct check in `src/main/java/mcheli/weapon/MCH_WeaponBomb.java` to `if ((e1.isUAV() || e1.isNewUAV()) && e1.getSeatNum() == 0)` so new UAV variants are recognized while preserving the single-seat restriction and existing explosion/destruct behavior.

### Testing
- Ran `git diff --check` to validate whitespace/patch consistency and it passed.
- Verified the change with `rg`/searches to ensure `isNewUAV` is now considered and the modified file is staged in the commit.
- Attempted `./gradlew compileJava` but the Gradle wrapper failed to download (proxy returned HTTP 403), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276cf86d1483239762b36d82806c13)