### PR TITLE
Introduce quadratic aerodynamic drag + air density and apply to plane horizontal damping

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -29,6 +29,50 @@ public final class MCH_FlightModel {
       return clamp((stallSpeed - horizontalSpeed) / stallSpeed, 0.0D, 1.0D);
    }
 
+   /**
+    * Approximates the standard atmosphere's density change with altitude.
+    * The returned value is relative to sea-level density and is bounded so
+    * unusual world heights cannot remove aerodynamic control entirely.
+    */
+   public static double getAirDensityFactor(double altitude) {
+      double heightAboveSeaLevel = altitude - 64.0D;
+      return clamp(Math.exp(-heightAboveSeaLevel / 8500.0D), 0.25D, 1.1D);
+   }
+
+   /**
+    * Calculates speed lost to aerodynamic drag during one tick.
+    *
+    * Parasitic drag follows the physical v^2 relationship. motionFactor is
+    * used as the aircraft's drag calibration: at referenceSpeed and sea-level
+    * density this produces the same loss as the old linear damping. Banking
+    * adds induced drag from the increased lift/load requirement, while
+    * sideslip exposes more of the airframe to the airflow during a turn.
+    */
+   public static double getAerodynamicDragLoss(double speed, float referenceSpeed, float motionFactor, double airDensityFactor, float bankAngle, double sideslip) {
+      if(speed <= 0.0D || referenceSpeed <= 0.0F) {
+         return 0.0D;
+      }
+
+      double baseDrag = clamp(1.0D - (double)motionFactor, 0.0D, 1.0D);
+      double density = clamp(airDensityFactor, 0.25D, 1.1D);
+      double quadraticDrag = baseDrag * density * speed * speed / (double)referenceSpeed;
+
+      // Limit the load-factor calculation to a 60-degree coordinated turn. Steeper
+      // visual banks must not make drag approach infinity as cos(bank) approaches 0.
+      double bankRadians = Math.toRadians(clamp(Math.abs((double)bankAngle), 0.0D, 60.0D));
+      double loadFactor = 1.0D / Math.max(0.5D, Math.cos(bankRadians));
+      double inducedDragPenalty = Math.min(0.24D, (loadFactor * loadFactor - 1.0D) * 0.08D);
+
+      // Heading naturally leads the velocity vector while an aircraft starts turning.
+      // Ignore that small lag and only penalize substantial uncoordinated sideslip.
+      double sideslipExcess = clamp((Math.abs(sideslip) - 0.2D) / 0.8D, 0.0D, 1.0D);
+      double sideslipDragPenalty = sideslipExcess * 0.16D;
+      double turnDragMultiplier = 1.0D + Math.min(0.4D, inducedDragPenalty + sideslipDragPenalty);
+
+      // Keep drag gradual even for low-drag aircraft after collisions or abrupt rotations.
+      return Math.min(speed * 0.05D, quadraticDrag * turnDragMultiplier);
+   }
+
    /** Diving raises the speed cap gradually, rather than creating an abrupt second limit. */
    public static double getDiveSpeedLimit(float topSpeed, float pitch, double verticalSpeed, float multiplier) {
       double noseDown = clamp((double)pitch / 60.0D, 0.0D, 1.0D);

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -850,16 +850,38 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
          super.motionZ += Math.cos(yaw) * diveAcceleration;
       }
 
-      // 对垂直速度进行衰减
+      // Preserve the existing vertical flight damping; horizontal resistance below
+      // uses quadratic aerodynamic drag instead of a constant per-tick multiplier.
       super.motionY *= 0.95D;
-      // 根据飞行器的运动系数衰减水平速度
-      super.motionX *= this.getAcInfo().motionFactor;
-      super.motionZ *= this.getAcInfo().motionFactor;
 
-      // 计算当前水平速度的大小
+      // Calculate current horizontal speed and the configured cruise-speed reference.
       double motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
-      // 获取最大速度限制
       float baseSpeedLimit = this.getMaxSpeed();
+      boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
+
+      // In free flight, drag rises with v^2. Banking increases the load factor and
+      // therefore induced drag, while sideslip exposes more airframe area during a
+      // turn. The lost energy remains lost after leveling out, so sustained or hard
+      // turns produce a noticeable reduction in speed.
+      if(!nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && motion1 > 1.0E-4D) {
+         double yaw = Math.toRadians((double)this.getRotYaw());
+         double forwardX = -Math.sin(yaw);
+         double forwardZ = Math.cos(yaw);
+         double sideslip = Math.abs(forwardX * super.motionZ - forwardZ * super.motionX) / motion1;
+         double airDensity = MCH_FlightModel.getAirDensityFactor(super.posY);
+         double dragLoss = MCH_FlightModel.getAerodynamicDragLoss(motion1, baseSpeedLimit, this.getAcInfo().motionFactor, airDensity, this.getRotRoll(), sideslip);
+         double dragScale = Math.max(0.0D, (motion1 - dragLoss) / motion1);
+         super.motionX *= dragScale;
+         super.motionZ *= dragScale;
+         motion1 -= dragLoss;
+      } else {
+         // Retain legacy damping for taxiing, water contact, and VTOL operation.
+         super.motionX *= this.getAcInfo().motionFactor;
+         super.motionZ *= this.getAcInfo().motionFactor;
+         motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      }
+
+      // 获取最大速度限制
       float speedLimit = (float)MCH_FlightModel.getDiveSpeedLimit(baseSpeedLimit, this.getRotPitch(), super.motionY, this.getAcInfo().diveSpeedMultiplier);
       // 如果当前速度超过最大速度限制，按最大速度比例缩小水平速度
       if(motion1 > (double)speedLimit) {
@@ -884,7 +906,6 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
 
       // Keep ground effect for several blocks so the stall model cannot cancel
       // normal rotation and lift immediately after the wheels leave the runway.
-      boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
       if(!nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff) {
          double bank = MCH_FlightModel.clamp(MathHelper.abs(this.getRotRoll()) / 90.0D, 0.0D, 1.0D);
          float effectiveStallFactor = this.getAcInfo().stallSpeedFactor * (float)(1.0D + bank * 0.35D);


### PR DESCRIPTION
### Motivation
- Replace the previous constant per-tick horizontal damping with a more physically-plausible aerodynamic model that scales with speed and altitude. 
- Account for increased drag from banking (induced drag) and uncoordinated turns (sideslip) so sustained or hard turns lose speed more realistically. 
- Preserve legacy damping for taxiing, VTOL/water contact and near-ground behavior to avoid breaking existing ground handling.

### Description
- Added `getAirDensityFactor(double altitude)` to `MCH_FlightModel` to approximate atmospheric density as an exponential function of altitude and clamp the result. 
- Added `getAerodynamicDragLoss(double speed, float referenceSpeed, float motionFactor, double airDensityFactor, float bankAngle, double sideslip)` to `MCH_FlightModel` implementing a quadratic `v^2` drag term with density scaling, induced-drag from bank, a sideslip penalty, and caps to keep losses reasonable. 
- Reworked horizontal damping in `MCP_EntityPlane` to use the new aerodynamic model when airborne and under normal flight conditions by computing `sideslip`, `airDensity` from `posY`, and applying a `dragLoss` scale to `motionX`/`motionZ`, while falling back to the original `motionFactor` multiplier for near-ground, VTOL or water contact cases. 
- Kept existing vertical damping and dive-speed logic intact and moved `nearGround` detection earlier to ensure correct branch selection.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a276d9da5e883238d77caf6d1bfdc8f)