### PR TITLE
Introduce damped angular-velocity rotation and throttle spool for heavier, more physical aircraft feel

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
@@ -115,6 +115,20 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
    public float mobilityPitch;
    public float mobilityRoll;
    public float mobilityYawOnGround;
+   /** Control torque applied around each local aircraft axis. */
+   public float pitchTorque;
+   public float rollTorque;
+   public float yawTorque;
+   /** Angular drag applied to each local aircraft axis. */
+   public float pitchDamping;
+   public float rollDamping;
+   public float yawDamping;
+   /** Scales resistance to angular acceleration without changing eventual control authority. */
+   public float inertiaMultiplier;
+   /** Maximum engine-output increase per tick. */
+   public float throttleAcceleration;
+   /** Maximum engine-output decrease per tick. */
+   public float engineDrag;
    public float minRotationPitch;
    public float maxRotationPitch;
    public float minRotationRoll;
@@ -333,6 +347,17 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
       this.mobilityPitch = 1.0F;
       this.mobilityRoll = 1.0F;
       this.mobilityYawOnGround = 1.0F;
+      // Matching torque and damping preserves the old mobility values as the eventual
+      // turn rate while adding a short, weighty acceleration into that rate.
+      this.pitchTorque = 0.35F;
+      this.rollTorque = 0.35F;
+      this.yawTorque = 0.35F;
+      this.pitchDamping = 0.35F;
+      this.rollDamping = 0.35F;
+      this.yawDamping = 0.35F;
+      this.inertiaMultiplier = 1.0F;
+      this.throttleAcceleration = 0.02F;
+      this.engineDrag = 0.015F;
       this.minRotationPitch = this.getMinRotationPitch();
       this.maxRotationPitch = this.getMaxRotationPitch();
       this.minRotationRoll = this.getMinRotationPitch();
@@ -838,6 +863,24 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
                                     this.mobilityPitch = this.toFloat(data, 0.0F, 100.0F);
                                  } else if(item.equalsIgnoreCase("MobilityRoll")) {
                                     this.mobilityRoll = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("PitchTorque")) {
+                                    this.pitchTorque = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("RollTorque")) {
+                                    this.rollTorque = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("YawTorque")) {
+                                    this.yawTorque = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("PitchDamping")) {
+                                    this.pitchDamping = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("RollDamping")) {
+                                    this.rollDamping = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("YawDamping")) {
+                                    this.yawDamping = this.toFloat(data, 0.0F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("Mass") || item.equalsIgnoreCase("InertiaMultiplier")) {
+                                    this.inertiaMultiplier = this.toFloat(data, 0.05F, 100.0F);
+                                 } else if(item.equalsIgnoreCase("ThrottleAcceleration")) {
+                                    this.throttleAcceleration = this.toFloat(data, 0.0F, 1.0F);
+                                 } else if(item.equalsIgnoreCase("EngineDrag")) {
+                                    this.engineDrag = this.toFloat(data, 0.0F, 1.0F);
                                  } else if(item.equalsIgnoreCase("MinRotationPitch")) {
                                     this.limitRotation = true;
                                     this.minRotationPitch = this.toFloat(data, this.getMinRotationPitch(), 0.0F);

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -133,6 +133,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    public boolean aircraftRotChanged;
    public float rotationRoll;
    public float prevRotationRoll;
+   /** Local-axis body rates used to turn control input into weighted aircraft rotation. */
+   protected float pitchAngularVelocity;
+   protected float rollAngularVelocity;
+   protected float yawAngularVelocity;
    private double currentThrottle;
    private double prevCurrentThrottle;
    public double currentSpeed;
@@ -1801,7 +1805,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             yaw = (float)m_add;
          }
 
-         yaw = (float)((double)(yaw * this.getYawFactor()) * 0.06D * (double)partialTicks);
+         yaw = (float)((double)(yaw * this.getYawFactor()) * 0.06D);
       }
 
       if(this.canUpdatePitch(player)) {
@@ -1815,7 +1819,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             pitch = (float)m_add;
          }
 
-         pitch = (float)((double)(-pitch * this.getPitchFactor()) * 0.06D * (double)partialTicks);
+         pitch = (float)((double)(-pitch * this.getPitchFactor()) * 0.06D);
       }
 
       if(this.canUpdateRoll(player)) {
@@ -1829,8 +1833,22 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
             roll = (float)m_add;
          }
 
-         roll = roll * this.getRollFactor() * 0.06F * partialTicks;
+         roll = roll * this.getRollFactor() * 0.06F;
       }
+
+      // The legacy controls above still define the requested angular rate.
+      // Integrating that request as a damped body rate retains existing mobility
+      // tuning while preventing the airframe from snapping to every mouse movement.
+      MCH_AircraftInfo info = this.getAcInfo();
+      this.pitchAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.pitchAngularVelocity, pitch,
+            info.pitchTorque, info.pitchDamping, info.inertiaMultiplier, partialTicks);
+      this.rollAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.rollAngularVelocity, roll,
+            info.rollTorque, info.rollDamping, info.inertiaMultiplier, partialTicks);
+      this.yawAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.yawAngularVelocity, yaw,
+            info.yawTorque, info.yawDamping, info.inertiaMultiplier, partialTicks);
+      pitch = this.pitchAngularVelocity * partialTicks;
+      roll = this.rollAngularVelocity * partialTicks;
+      yaw = this.yawAngularVelocity * partialTicks;
 
       MCH_Math.FMatrix m_add1 = MCH_Math.newMatrix();
       MCH_Math.MatTurnZ(m_add1, roll / 180.0F * 3.1415927F);

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -13,6 +13,35 @@ public final class MCH_FlightModel {
       return value < min ? min : (value > max ? max : value);
    }
 
+   /**
+    * Integrates one local-axis body rate. Torque and damping are divided by inertia,
+    * so heavier aircraft take longer to reach the same configured control authority.
+    */
+   public static float updateAngularVelocity(float velocity, float control, float torque, float damping,
+                                             float inertiaMultiplier, float delta) {
+      float inertia = Math.max(0.05F, inertiaMultiplier);
+      float step = Math.max(0.0F, delta);
+      float drag = Math.max(0.0F, damping);
+      float force = control * Math.max(0.0F, torque);
+      if(drag <= 1.0E-4F) {
+         return velocity + force / inertia * step;
+      }
+
+      float targetVelocity = force / drag;
+      float response = 1.0F - (float)Math.exp((double)(-drag * step / inertia));
+      return velocity + (targetVelocity - velocity) * response;
+   }
+
+   /** Moves engine output toward commanded throttle without an instantaneous thrust step. */
+   public static double approachEngineOutput(double output, double target, float acceleration, float drag) {
+      double difference = clamp(target, 0.0D, 1.0D) - clamp(output, 0.0D, 1.0D);
+      double limit = difference >= 0.0D ? Math.max(0.0D, (double)acceleration) : Math.max(0.0D, (double)drag);
+      if(Math.abs(difference) <= limit) {
+         return clamp(target, 0.0D, 1.0D);
+      }
+      return clamp(output + (difference > 0.0D ? limit : -limit), 0.0D, 1.0D);
+   }
+
    /** Returns 1 below the ceiling fade band and 0 at or above the ceiling. */
    public static double getCeilingLiftFactor(double altitude, float ceiling, float fadeRange) {
       if(ceiling <= 0.0F) {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -46,6 +46,8 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
    public float rotationRotor;
    public float prevRotationRotor;
    public float addkeyRotValue;
+   /** Smoothed engine output; commanded throttle remains unchanged for controls and networking. */
+   private double engineThrottle;
 
 
    public MCP_EntityPlane(World world) {
@@ -64,6 +66,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
       super.stepHeight = 0.6F;
       this.rotationRotor = 0.0F;
       this.prevRotationRotor = 0.0F;
+      this.engineThrottle = 0.0D;
    }
 
    public String getKindName() {
@@ -382,6 +385,12 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
          this.setThrottle(this.getCurrentThrottle());
       }
 
+      this.engineThrottle = MCH_FlightModel.approachEngineOutput(this.engineThrottle, this.getCurrentThrottle(),
+            this.getAcInfo().throttleAcceleration, this.getAcInfo().engineDrag);
+   }
+
+   protected double getEngineThrottle() {
+      return this.engineThrottle;
    }
 
    protected void onUpdate_ControlNotHovering() {
@@ -764,7 +773,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
 
          if(!levelOff) {
             super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
-            super.motionY += -0.047D * (1.0D - this.getCurrentThrottle());
+            super.motionY += -0.047D * (1.0D - this.getEngineThrottle());
          } else {
             super.motionY *= 0.8D;
          }
@@ -776,7 +785,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
 
          if(dp < 1.0D) {
             super.motionY -= 1.0E-4D;
-            super.motionY += 0.007D * this.getCurrentThrottle();
+            super.motionY += 0.007D * this.getEngineThrottle();
          } else {
             if(super.motionY < 0.0D) {
                super.motionY /= 2.0D;
@@ -787,7 +796,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
       }
 
       // 计算油门1的值，当前油门除以10
-      float throttle1 = (float)(this.getCurrentThrottle() / 10.0D);
+      float throttle1 = (float)(this.getEngineThrottle() / 10.0D);
       Vec3 v;
 
       // 如果喷嘴的旋转角度大于0.001F
@@ -893,7 +902,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
          // Full power and an established climb greatly reduce the initial sink. A
          // low-speed aircraft can therefore take off, while power-off and turning
          // stalls remain considerably stronger once clear of the runway.
-         double poweredLift = MCH_FlightModel.clamp(this.getCurrentThrottle(), 0.0D, 1.0D);
+         double poweredLift = MCH_FlightModel.clamp(this.getEngineThrottle(), 0.0D, 1.0D);
          double takeoffRelief = super.motionY >= 0.0D ? poweredLift * 0.8D : poweredLift * 0.45D;
          stall *= 1.0D - takeoffRelief;
          if(stall > 0.0D) {


### PR DESCRIPTION
### Motivation
- Replace instantaneous, camera-like application of pitch/roll/yaw with a short-lived, torque-driven body-rate so aircraft feel weighty and retain momentum. 
- Prevent abrupt velocity/thrust jumps by smoothing engine output so throttle changes spool rather than instantly changing lift/forward acceleration. 
- Expose per-aircraft tuning for torque, damping, inertia and engine spool so fighters remain responsive while heavy aircraft feel less twitchy. 

### Description
- Added per-aircraft tunables to `MCH_AircraftInfo`: `pitchTorque`, `rollTorque`, `yawTorque`, `pitchDamping`, `rollDamping`, `yawDamping`, `inertiaMultiplier` (alias `Mass`/`InertiaMultiplier`), `throttleAcceleration`, and `engineDrag`, with conservative defaults that preserve prior steady-state mobility. (file: `MCH_AircraftInfo.java`) 
- Implemented two stable helpers in `MCH_FlightModel.java`: `updateAngularVelocity(...)` to integrate damped body rates (torque/damping/inertia) and `approachEngineOutput(...)` to clamp per-tick engine spool-up/spool-down. 
- Replaced the direct application of control deltas with persistent local-axis angular velocities in `MCH_EntityAircraft` so input → requested angular rate is integrated through torque/damping/inertia before modifying the orientation matrix, preserving existing mobility as the eventual authority. (file: `MCH_EntityAircraft.java`) 
- Introduced a smoothed engine-output state in `MCP_EntityPlane` (`engineThrottle`) and switched movement/lift/stall calculations to use that smoothed value while leaving the commanded/networked throttle API unchanged, preserving compatibility. (file: `MCP_EntityPlane.java`) 
- Kept changes incremental and backwards-compatible: defaults reproduce prior behaviour as steady-state limits, and config parsing accepts existing fields plus the new tunables. 

### Testing
- Ran static checks (`diff --check`) and lint-style review of the modifications; no whitespace or obvious diff-check issues were found. 
- Compiled `MCH_FlightModel` and executed a small Java harness that asserts: heavier `inertiaMultiplier` slows angular acceleration, balanced torque+damping preserves steady-state authority, damping reduces velocity when controls are released, and `approachEngineOutput` respects configured acceleration/drag; all assertions passed. 
- Attempted full project compilation with Gradle, but the environment could not download legacy Gradle/ForgeGradle artifacts (HTTP 403 from external Maven endpoints), so a complete `compileJava` of the full mod could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a277e8fce648323b2a437d5ceb999f9)