### PR TITLE
Add high-load, compressibility and overspeed penalties to aircraft

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftInfo.java
@@ -158,6 +158,20 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
    public float stallStrength;
    /** Maximum extra horizontal speed available while a plane is diving. */
    public float diveSpeedMultiplier;
+   /** Load factor where high-G control authority begins to fade. */
+   public float maxComfortableG;
+   /** Load factor treated as the structural limit. */
+   public float maxStructuralG;
+   /** Maximum fraction of control authority removed by excessive G. */
+   public float gControlPenalty;
+   /** Airspeed where pitch compressibility begins. Zero derives 90% of configured speed. */
+   public float compressibilitySpeed;
+   /** Maximum fraction of pitch authority removed by compressibility. */
+   public float compressibilityPitchPenalty;
+   /** Airspeed where overspeed warnings and damage begin. Zero derives 110% of configured speed. */
+   public float maxSafeSpeed;
+   /** Damage points per tick at 100% overspeed; zero leaves the damage hook disabled. */
+   public float overspeedDamageRate;
     private List textureNameList;
    public int textureCount;
    public float particlesScale;
@@ -388,6 +402,13 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
       this.stallSpeedFactor = 0.22F;
       this.stallStrength = 0.6F;
       this.diveSpeedMultiplier = 1.25F;
+      this.maxComfortableG = 4.0F;
+      this.maxStructuralG = 8.0F;
+      this.gControlPenalty = 0.7F;
+      this.compressibilitySpeed = 0.0F;
+      this.compressibilityPitchPenalty = 0.65F;
+      this.maxSafeSpeed = 0.0F;
+      this.overspeedDamageRate = 0.2F;
       this.pivotTurnThrottle = 0.0F;
       this.trackRollerRot = 30.0F;
       this.partWheelRot = 30.0F;
@@ -937,6 +958,20 @@ public abstract class MCH_AircraftInfo extends MCH_BaseInfo {
                                     this.stallStrength = this.toFloat(data, 0.0F, 4.0F);
                                  } else if(item.equalsIgnoreCase("DiveSpeedMultiplier")) {
                                     this.diveSpeedMultiplier = this.toFloat(data, 1.0F, 2.0F);
+                                 } else if(item.equalsIgnoreCase("MaxComfortableG")) {
+                                    this.maxComfortableG = this.toFloat(data, 1.0F, 30.0F);
+                                 } else if(item.equalsIgnoreCase("MaxStructuralG")) {
+                                    this.maxStructuralG = this.toFloat(data, 1.0F, 50.0F);
+                                 } else if(item.equalsIgnoreCase("GControlPenalty")) {
+                                    this.gControlPenalty = this.toFloat(data, 0.0F, 1.0F);
+                                 } else if(item.equalsIgnoreCase("CompressibilitySpeed")) {
+                                    this.compressibilitySpeed = this.toFloat(data, 0.0F, 10.0F);
+                                 } else if(item.equalsIgnoreCase("CompressibilityPitchPenalty")) {
+                                    this.compressibilityPitchPenalty = this.toFloat(data, 0.0F, 1.0F);
+                                 } else if(item.equalsIgnoreCase("MaxSafeSpeed")) {
+                                    this.maxSafeSpeed = this.toFloat(data, 0.0F, 10.0F);
+                                 } else if(item.equalsIgnoreCase("OverspeedDamageRate")) {
+                                    this.overspeedDamageRate = this.toFloat(data, 0.0F, 100.0F);
                                  } else if(item.equalsIgnoreCase("Stealth")) {
                                     this.stealth = this.toFloat(data, 0.0F, 1.0F);
                                  } else if(item.equalsIgnoreCase("EntityWidth")) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityAircraft.java
@@ -137,6 +137,10 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
    protected float pitchAngularVelocity;
    protected float rollAngularVelocity;
    protected float yawAngularVelocity;
+   /** Latest approximate load factor, shared by controls and client feedback. */
+   protected double currentGForce = 1.0D;
+   /** Fractional overspeed damage retained between ticks. */
+   private double overspeedDamageAccumulator;
    private double currentThrottle;
    private double prevCurrentThrottle;
    public double currentSpeed;
@@ -1770,7 +1774,83 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
    /** Aircraft types can reduce all three pilot control axes under degraded airflow. */
    protected float getControlAuthorityFactor() {
-      return 1.0F;
+      MCH_AircraftInfo info = this.getAcInfo();
+      return info != null ? (float)MCH_FlightModel.getHighGControlAuthority(this.currentGForce,
+            info.maxComfortableG, info.maxStructuralG, info.gControlPenalty) : 1.0F;
+   }
+
+   /** Current simplified load factor, useful to HUDs and aircraft-specific extensions. */
+   public double getCurrentGForce() {
+      return this.currentGForce;
+   }
+
+   protected double getAirspeed() {
+      return Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY
+            + super.motionZ * super.motionZ);
+   }
+
+   protected double getCompressibilitySpeed() {
+      MCH_AircraftInfo info = this.getAcInfo();
+      return info == null ? 0.0D : (info.compressibilitySpeed > 0.0F
+            ? (double)info.compressibilitySpeed : (double)info.speed * 0.9D);
+   }
+
+   protected double getMaxSafeSpeed() {
+      MCH_AircraftInfo info = this.getAcInfo();
+      return info == null ? 0.0D : (info.maxSafeSpeed > 0.0F
+            ? (double)info.maxSafeSpeed : (double)info.speed * 1.1D);
+   }
+
+   /** Override to customize how an aircraft reacts above its structural load limit. */
+   protected void onStructuralOverload(double severity) {
+   }
+
+   /** Override to customize how airframe damage is applied during an overspeed. */
+   protected void applyOverspeedDamage(double severity) {
+      MCH_AircraftInfo info = this.getAcInfo();
+      if(info == null || info.overspeedDamageRate <= 0.0F || severity <= 0.0D || this.isDestroyed()) {
+         return;
+      }
+
+      this.overspeedDamageAccumulator += severity * (double)info.overspeedDamageRate;
+      int damage = (int)this.overspeedDamageAccumulator;
+      if(damage > 0) {
+         this.overspeedDamageAccumulator -= (double)damage;
+         this.setDamageTaken(this.getDamageTaken() + damage);
+      }
+   }
+
+   private void updateFlightStress() {
+      MCH_AircraftInfo info = this.getAcInfo();
+      if(info == null) {
+         this.currentGForce = 1.0D;
+         return;
+      }
+
+      double pitchRate = Math.max(Math.abs((double)this.pitchAngularVelocity),
+            Math.abs((double)MathHelper.wrapAngleTo180_float(this.getRotPitch() - this.prevRotationPitch)));
+      double yawRate = Math.max(Math.abs((double)this.yawAngularVelocity),
+            Math.abs((double)MathHelper.wrapAngleTo180_float(this.getRotYaw() - this.prevRotationYaw)));
+      double turnRate = Math.sqrt(pitchRate * pitchRate + yawRate * yawRate);
+      double speed = this.getAirspeed();
+      this.currentGForce = MCH_FlightModel.getApproximateGForce(speed, turnRate);
+
+      double structuralOverload = Math.max(0.0D, this.currentGForce / Math.max(1.0D,
+            (double)info.maxStructuralG) - 1.0D);
+      double overspeed = MCH_FlightModel.getOverspeedSeverity(speed, this.getMaxSafeSpeed());
+      if(!super.worldObj.isRemote) {
+         if(structuralOverload > 0.0D) {
+            this.onStructuralOverload(structuralOverload);
+         }
+         this.applyOverspeedDamage(overspeed);
+      } else if(info.hasalert && super.ticksExisted % 20 == 0
+            && W_Entity.isEqual(MCH_MOD.proxy.getClientPlayer(), this.getRiddenByEntity())) {
+         boolean highLoad = this.currentGForce > (double)info.maxComfortableG;
+         boolean compressing = speed > this.getCompressibilitySpeed();
+         if(highLoad || compressing || overspeed > 0.0D) {
+            W_McClient.DEF_playSoundFX("random.click", 0.8F, overspeed > 0.0D ? 0.6F : 1.4F);
+         }
+      }
    }
 
    public void setAngles(Entity player, boolean fixRot, float fixYaw, float fixPitch, float deltaX, float deltaY, float x, float y, float partialTicks) {
@@ -1842,7 +1922,9 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
       }
 
       float controlAuthority = this.getControlAuthorityFactor();
-      pitch *= controlAuthority;
+      double pitchAuthority = MCH_FlightModel.getCompressibilityPitchAuthority(this.getAirspeed(),
+            this.getCompressibilitySpeed(), this.getMaxSafeSpeed(), this.getAcInfo().compressibilityPitchPenalty);
+      pitch *= controlAuthority * (float)pitchAuthority;
       roll *= controlAuthority;
       yaw *= controlAuthority;
 
@@ -2077,6 +2159,7 @@ public abstract class MCH_EntityAircraft extends W_EntityContainer implements MC
 
       this.prevCurrentThrottle = this.getCurrentThrottle();
       this.lastBBDamageFactor = 1.0F;
+      this.updateFlightStress();
       this.updateControl();
       this.checkServerNoMove();
       this.onUpdate_RidingEntity();

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -128,6 +128,42 @@ public final class MCH_FlightModel {
       return clamp(drag, 0.0D, 0.5D);
    }
 
+   /**
+    * Approximates felt load from airspeed and aircraft turn rate. Minecraft motion is
+    * measured per tick, so centripetal acceleration is compared with vanilla gravity.
+    */
+   public static double getApproximateGForce(double speed, double turnRateDegreesPerTick) {
+      double turnRate = Math.toRadians(Math.abs(turnRateDegreesPerTick));
+      double lateralAcceleration = Math.max(0.0D, speed) * turnRate;
+      return Math.sqrt(1.0D + lateralAcceleration * lateralAcceleration / (0.08D * 0.08D));
+   }
+
+   /** Progressive control loss between the comfortable and structural load limits. */
+   public static double getHighGControlAuthority(double gForce, float comfortableG, float structuralG,
+                                                  float controlPenalty) {
+      double comfortable = Math.max(1.0D, (double)comfortableG);
+      double structural = Math.max(comfortable + 0.01D, (double)structuralG);
+      double severity = clamp((gForce - comfortable) / (structural - comfortable), 0.0D, 1.0D);
+      return clamp(1.0D - severity * clamp((double)controlPenalty, 0.0D, 1.0D), 0.05D, 1.0D);
+   }
+
+   /** Pitch authority fades progressively above the compressibility threshold. */
+   public static double getCompressibilityPitchAuthority(double speed, double compressibilitySpeed,
+                                                           double maxSafeSpeed, float pitchPenalty) {
+      if(compressibilitySpeed <= 0.0D || speed <= compressibilitySpeed) {
+         return 1.0D;
+      }
+
+      double range = Math.max(0.05D, maxSafeSpeed - compressibilitySpeed);
+      double severity = clamp((speed - compressibilitySpeed) / range, 0.0D, 1.0D);
+      return clamp(1.0D - severity * clamp((double)pitchPenalty, 0.0D, 1.0D), 0.05D, 1.0D);
+   }
+
+   /** Relative overspeed above the safe limit; 1 means twice the safe speed. */
+   public static double getOverspeedSeverity(double speed, double maxSafeSpeed) {
+      return maxSafeSpeed > 0.0D ? Math.max(0.0D, speed / maxSafeSpeed - 1.0D) : 0.0D;
+   }
+
    /** Positive values gain horizontal speed in a dive; negative values lose it in a climb. */
    public static double getVerticalEnergyChange(double verticalSpeed, float climbEnergyLoss, float diveEnergyGain) {
       double climb = clamp(verticalSpeed / 0.35D, 0.0D, 1.0D);

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -422,12 +422,13 @@ public class MCH_EntityHeli extends MCH_EntityAircraft {
          }
 
          if(MCH_Lib.getBlockIdY(this, 3, -3) == 0) {
+            float controlAuthority = this.getControlAuthorityFactor();
             if(super.moveLeft && !super.moveRight) {
-               this.setRotRoll(this.getRotRoll() - 1.2F * partialTicks);
+               this.setRotRoll(this.getRotRoll() - 1.2F * partialTicks * controlAuthority);
             }
 
             if(super.moveRight && !super.moveLeft) {
-               this.setRotRoll(this.getRotRoll() + 1.2F * partialTicks);
+               this.setRotRoll(this.getRotRoll() + 1.2F * partialTicks * controlAuthority);
             }
          } else {
             if(MathHelper.abs(this.getRotPitch()) < 40.0F) {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -307,7 +307,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
       }
 
       double severity = Math.max(this.stallSeverity, this.getInstantStallSeverity());
-      return (float)MCH_FlightModel.getControlAuthority(severity);
+      return super.getControlAuthorityFactor() * (float)MCH_FlightModel.getControlAuthority(severity);
    }
 
    private double getInstantStallSeverity() {


### PR DESCRIPTION
### Motivation
- Prevent instantaneous, risk-free maximum-elevator inputs at extreme speed by introducing penalties for high-G manoeuvres, compressibility (very high speed pitch loss), and overspeed damage. 
- Provide tunables and overridable hooks so aircraft packs and types can customize comfortable/structural G, control loss, compressibility, safe speed, and overspeed damage behavior.

### Description
- Add new aircraft tunables to `MCH_AircraftInfo` with sensible defaults: `MaxComfortableG`, `MaxStructuralG`, `GControlPenalty`, `CompressibilitySpeed`, `CompressibilityPitchPenalty`, `MaxSafeSpeed`, and `OverspeedDamageRate`.
- Implement shared helpers in `MCH_FlightModel`: `getApproximateGForce`, `getHighGControlAuthority`, `getCompressibilityPitchAuthority`, and `getOverspeedSeverity` for G, control-authority, compressibility and overspeed math.
- Integrate flight-stress update in `MCH_EntityAircraft`: compute an approximate G from airspeed and pitch/yaw turn rate, apply progressive control-authority loss, reduce pitch authority above compressibility, provide client warning tones, accumulate fractional overspeed damage server-side, and expose overridable `onStructuralOverload` and `applyOverspeedDamage` hooks.
- Compose the new high-G penalty with the existing fixed-wing stall authority in `MCP_EntityPlane` so stall and G penalties multiply rather than conflict, and apply control-authority scaling to helicopter keyboard roll in `MCH_EntityHeli`.
- Keep changes backward-compatible by deriving compressibility and safe-speed defaults from existing `speed` where explicit values are not set.

### Testing
- Ran `git diff --check` to validate whitespace and simple issues (no errors reported). ✅
- Built and executed a standalone Java assertion harness (compiled with `javac`) that exercised `MCH_FlightModel` helpers covering G-force scaling, high-G control authority, compressibility pitch loss, and overspeed severity; all assertions passed. ✅
- Attempted project compile with `bash ./gradlew compileJava --no-daemon` but Gradle wrapper download failed due to the environment proxy returning HTTP 403, so full project build could not be completed in this environment. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a278b3222708323b79d447634caf1af)