### PR TITLE
Increase plane maneuverability 1.5x and scale plane speed thresholds with AllPlaneSpeed

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -39,6 +39,8 @@ import net.minecraft.world.World;
 
 public class MCP_EntityPlane extends MCH_EntityAircraft {
 
+   private static final float PLANE_MANEUVERABILITY_FACTOR = 1.5F;
+
    private MCP_PlaneInfo planeInfo = null;
    public float soundVolume;
    public MCH_Parts partNozzle;
@@ -244,17 +246,17 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
 
    public float getYawFactor() {
       float yaw = this.getVtolMode() > 0?this.getPlaneInfo().vtolYaw:super.getYawFactor();
-      return yaw * 0.8F;
+      return yaw * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
    }
 
    public float getPitchFactor() {
       float pitch = this.getVtolMode() > 0?this.getPlaneInfo().vtolPitch:super.getPitchFactor();
-      return pitch * 0.8F;
+      return pitch * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
    }
 
    public float getRollFactor() {
       float roll = this.getVtolMode() > 0?this.getPlaneInfo().vtolYaw:super.getRollFactor();
-      return roll * 0.8F;
+      return roll * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
    }
 
    public boolean isOverridePlayerPitch() {
@@ -308,6 +310,27 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
 
       double severity = Math.max(this.stallSeverity, this.getInstantStallSeverity());
       return super.getControlAuthorityFactor() * (float)MCH_FlightModel.getControlAuthority(severity);
+   }
+
+
+   protected double getCompressibilitySpeed() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null) {
+         return 0.0D;
+      }
+
+      float levelSpeed = info.maxLevelSpeed > 0.0F ? info.maxLevelSpeed : this.getMaxSpeed();
+      return info.compressibilitySpeed > 0.0F ? (double)info.compressibilitySpeed : (double)levelSpeed * 0.9D;
+   }
+
+   protected double getMaxSafeSpeed() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null) {
+         return 0.0D;
+      }
+
+      float levelSpeed = info.maxLevelSpeed > 0.0F ? info.maxLevelSpeed : this.getMaxSpeed();
+      return info.maxSafeSpeed > 0.0F ? (double)info.maxSafeSpeed : (double)levelSpeed * 1.1D;
    }
 
    private double getInstantStallSeverity() {
@@ -372,7 +395,7 @@ public class MCP_EntityPlane extends MCH_EntityAircraft {
                if(!MCH_Config.MouseControlFlightSimMode.prmBool) {
                   this.rotationByKey(partialTicks);
                   this.setRotRoll(this.getRotRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll
-                        * this.getControlAuthorityFactor());
+                        * PLANE_MANEUVERABILITY_FACTOR * this.getControlAuthorityFactor());
                }
             }
          } else {

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -94,7 +94,24 @@ public class MCP_PlaneInfo extends MCH_AircraftInfo {
       if(this.maxLevelSpeed > 0.0F) {
          this.maxLevelSpeed = (float)((double)this.maxLevelSpeed * MCH_Config.AllPlaneSpeed.prmDouble);
       }
+      this.scaleSpeedThresholds(MCH_Config.AllPlaneSpeed.prmDouble);
       return super.isValidData();
+   }
+
+
+   private void scaleSpeedThresholds(double speedScale) {
+      if(this.stallSpeed > 0.0F) {
+         this.stallSpeed = (float)((double)this.stallSpeed * speedScale);
+      }
+      if(this.stallRecoverySpeed > 0.0F) {
+         this.stallRecoverySpeed = (float)((double)this.stallRecoverySpeed * speedScale);
+      }
+      if(this.compressibilitySpeed > 0.0F) {
+         this.compressibilitySpeed = (float)((double)this.compressibilitySpeed * speedScale);
+      }
+      if(this.maxSafeSpeed > 0.0F) {
+         this.maxSafeSpeed = (float)((double)this.maxSafeSpeed * speedScale);
+      }
    }
 
    public void loadItemData(String item, String data) {


### PR DESCRIPTION
### Motivation
- Increase all plane control authority (yaw, pitch, roll) by 1.5x so fixed-wing handling is more responsive.
- Ensure global plane speed scaling (`AllPlaneSpeed`) also adjusts thresholds used for stall/compressibility/overspeed so safety limits remain consistent when speeds are multiplied.

### Description
- Added `PLANE_MANEUVERABILITY_FACTOR = 1.5F` to `MCP_EntityPlane` and applied it to `getYawFactor`, `getPitchFactor`, `getRollFactor`, and key-roll handling so all plane controls are 1.5x more maneuverable.
- Added `getCompressibilitySpeed` and `getMaxSafeSpeed` overrides in `MCP_EntityPlane` to derive defaults from the active level speed (`maxLevelSpeed` or `getMaxSpeed()`), making compressibility/overspeed calculations respect plane-level speed settings.
- Added `scaleSpeedThresholds(double)` to `MCP_PlaneInfo` and call it from `isValidData` to multiply explicit thresholds (`stallSpeed`, `stallRecoverySpeed`, `compressibilitySpeed`, `maxSafeSpeed`) by `MCH_Config.AllPlaneSpeed.prmDouble`.
- Kept legacy behavior for aircraft that do not define explicit thresholds while making explicit values scale correctly with `AllPlaneSpeed`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which completed successfully.
- Attempted `./gradlew build` to run a full build, but the Gradle wrapper download failed due to a network/proxy error (`HTTP 403`), so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2895d94d208329b9f4b6d6907ff456)