### PR TITLE
docs: modernize README and add comprehensive docs/ (getting-started, configuration, commands, server, audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Documentation
+
+- Rewrote `README.md` with a modern project overview, feature list, installation steps, compatibility/client-server requirements, configuration overview, command examples, troubleshooting, FAQ, and confirmed resource links.
+- Added `docs/getting-started.md` for new-player installation, asset layout, creative tabs, basic controls, and first configuration changes.
+- Added `docs/configuration.md` with source-verified configuration defaults, keybind defaults, damage/ignore-list behavior, and hidden/advanced config notes.
+- Added `docs/commands.md` with source-verified `/mcheli` command syntax, permission model, examples, and safety notes.
+- Added `docs/server-administration.md` with server installation, safe survival defaults, permission guidance, runtime reloads, diagnostics, and performance notes.
+- Added `docs/documentation-audit.md` listing discovered undocumented systems and remaining documentation gaps.

--- a/README.md
+++ b/README.md
@@ -1,96 +1,167 @@
-# MCH-mocmaster
+# MC Helicopter Overdrive+
 
+MC Helicopter Overdrive+ is a Minecraft Forge 1.7.10 vehicle-combat mod based on the original MC Helicopter codebase. It expands MCHeli with a larger vehicle ecosystem, modernized rendering work, ships, tanks, drones/UAV support, man-portable weapons, deployable equipment, and extensive server-side configuration.
 
-NEW! (experimental):
+The mod is intended for players, modpack authors, and server administrators who want military-style vehicles and combined-arms gameplay in legacy Minecraft 1.7.10 packs.
 
-# How do I use this with assets?:
+> **Project status:** active fork/overhaul of the original MCHeli lineage. The codebase targets Minecraft **1.7.10** and Forge **10.13.4.1614** for builds, while declaring compatibility with Forge **10.13.2.1230 or newer**.
 
-A. Find the repo's directory build\run\mods
+## What the mod adds
 
-B. Put your assets into the mod folder exactly how they would be in a normal instance of minecraft
+- **Aircraft and vehicles:** helicopters, fixed-wing planes, tanks, ships, and ground vehicles loaded from MCHeli-style asset/config packs.
+- **Combat systems:** bullets, rockets, bombs, torpedoes, anti-air/anti-surface/anti-tank missiles, target markers, flares, chaff, APS/maintenance hooks, and damage multipliers.
+- **Portable equipment:** GLTD target designator, FIM-92 Stinger, FGM-148 Javelin, RPG-7, wrench, rangefinder, parachute, tow chain, containers, UAV stations, and gunner spawn items.
+- **Drafting table workflow:** a dedicated Drafting Table block for vehicle/item crafting recipes.
+- **Multiplayer tools:** team/scoreboard UI hooks, entity markers, server reconfiguration, mod-list/screenshot requests, and administrative entity utilities.
+- **Client rendering options:** long-distance vehicle LOD snapshots, shader toggle, smooth shading, render-distance weighting, configurable HUD behavior, and optional multi-threaded model loading.
+- **Server controls:** block-destruction rules, collision damage, recipe toggles, item/block IDs, command permissions, creative-tab icons, global speed multipliers, and keybind defaults.
 
-C. It *ideally* just works. Still testing.
+## Requirements and compatibility
 
+| Requirement | Details |
+| --- | --- |
+| Minecraft | 1.7.10 only |
+| Mod loader | Minecraft Forge 1.7.10; build script uses `1.7.10-10.13.4.1614-1.7.10` |
+| Java | Java 8 recommended/required for development and runtime compatibility with ForgeGradle 1.x |
+| Client | Required for players connecting to servers that use the mod |
+| Server | Install on dedicated servers that need MCHeli entities, recipes, commands, and configuration |
+| Asset pack | Required for actual vehicles/weapons/content beyond the registered core items; assets are read from `assets/mcheli/...` in the mod jar or from `mods/mcheli/` in the development run directory |
 
+The Forge metadata marks the mod as client-required and server-optional, but multiplayer worlds that spawn or simulate MCHeli vehicles should run the mod on the server and all participating clients.
 
+## Installation
 
+### Single-player or client
 
-# This repository is meant to enhance the mcheli minecraft mod far beyond what it is capable of. Any and all help would be resourceful. This is a derivative of the source code found [[here](https://github.com/RagexPrince683/MCH-defaultmaster)] 
+1. Install Minecraft Forge for Minecraft 1.7.10.
+2. Place the built MC Helicopter Overdrive+ jar in `.minecraft/mods/`.
+3. Install the matching MCHeli asset/content pack so the folder structure includes `assets/mcheli/` content such as `helicopters`, `planes`, `ships`, `tanks`, `vehicles`, `weapons`, `hud`, `models`, `textures`, `sounds`, `item`, and `throwable` where applicable.
+4. Start the game once to generate `.minecraft/config/mcheli.cfg`.
+5. Adjust configuration options as needed, then restart or use `/mcheli reconfig` for server-side config reloads.
 
+### Dedicated server
 
+1. Install Forge 1.7.10 on the server.
+2. Place the mod jar and matching asset/content pack in the server `mods/` directory.
+3. Start the server once to generate `config/mcheli.cfg`.
+4. Stop the server, edit the configuration, then restart. Some server settings can be reloaded with `/mcheli reconfig`.
+5. Ensure every joining client has the same mod and compatible content/assets.
 
+### Development builds
 
+This repository uses ForgeGradle 1.x through the Gradle wrapper.
 
-# FAQ:
-# 1. Why is it called mocmaster if it's for mcheli overdrive?
-This repository was originally called mocmaster after Moc the guy who showed me the original mcheli backend code, since then I've broken a few repos and have resorted to this being my main Mcheli-Overdrive repository.
-# 2. How to use?
-   
-I use and set this up with intellij
+```bash
+./gradlew setupDecompWorkspace
+./gradlew build
+```
 
-you need jdk-8u361-windows and if your on 64x 64x 32 for 32.
+Build output is written under `build/libs/`. The Gradle build increments `version.properties` as part of `build`, so avoid running a release build casually if you do not intend to bump the patch version.
 
-JDK 8u361
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-linux-i586.rpm
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-linux-i586.tar.gz
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-linux-x64.rpm
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-linux-x64.tar.gz
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-macosx-x64.dmg
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-solaris-sparcv9.tar.gz
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-windows-i586.exe
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-windows-i586.zip
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-windows-x64.exe
-https://cfdownload.adobe.com/pub/adobe/coldfusion/java/java8/java8u361/jdk/jdk-8u361-windows-x64.zip
+For development asset testing, the build/run setup expects assets in `build/run/mods/mcheli/` with the same structure used by normal MCHeli installations.
 
-open gradle console you should see gradle and then a bunch of things, then you want to type
+## Basic usage
 
-build
+1. Open the MCHeli creative tabs (`MCHeliO Item`, `MCHeliO Helicopters`, `MCHeliO Planes`, `MCHeliO Ships`, `MCHeliO Tanks`, `MCHeliO Vehicles`, and `MCHeliO Recipe Items`).
+2. Place or craft a **Drafting Table** to access recipes when recipes are enabled.
+3. Use vehicle item icons to place vehicles. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
+4. Enter vehicles, use the configured movement/weapon keys, and refuel/repair according to the content pack's vehicle definitions.
+5. Server operators can use `/mcheli list` to discover available administrative subcommands.
 
-then if all goes well go to build/libs and a java file will be there. If you have made edits to the src you want to open the jar file with a archiver tool such as winrar. You can put this compiled class code into mcheli/mcheli in a actual mcheli instance/folder/the yknow mod and test things out yourself. If you want to make sure there are no errors just copy and paste over the mcheli/mcheli with this stuff.
-   
-# 3. Why so many branches?
+See the extended documentation for step-by-step guides:
 
-I am bad at coding/this project has taken my soul
+- [Getting Started Guide](docs/getting-started.md)
+- [Configuration Reference](docs/configuration.md)
+- [Command and Permission Reference](docs/commands.md)
+- [Server Administration Guide](docs/server-administration.md)
+- [Documentation Audit Notes](docs/documentation-audit.md)
 
+## Configuration overview
 
-# What to do if something breaks?:
+The mod writes `config/mcheli.cfg` on startup. Important options include:
 
-1. Close IntelliJ and delete the garbage cache
-   Close IntelliJ completely.
+- `EnableCommand` - enables or disables `/mcheli` subcommands.
+- `PlaceableOnSpongeOnly` - restricts vehicle placement to sponge blocks.
+- `Explosion_DestroyBlock`, `Explosion_FlamingBlock`, and `Collision_DestroyBlock` - control world damage behavior.
+- `InfinityAmmo` and `InfinityFuel` - enable unlimited ammunition/fuel globally.
+- `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed` - global speed multipliers/clamps.
+- `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` - control long-distance vehicle model rendering.
+- `MultiThreadedModelLoading` - toggles threaded model loading on the client.
+- `CommandPermission` entries - grant specific `/mcheli` subcommands to named non-operator players.
+- `Key*` entries - default key and mouse bindings for MCHeli controls.
 
-In your McheliO project folder, delete:
+For every documented option and default value found in source, see [docs/configuration.md](docs/configuration.md).
 
-.gradle/
-build/
-out/ (if exists)
+## Commands
 
-2. Re-open the project as a Gradle project
-   Open IntelliJ.
+All commands use the `/mcheli` root command and can be disabled globally with `EnableCommand = false`.
 
-Do NOT use “New Project” or “Import from existing sources.”
+Common examples:
 
-Use File → Open… → select your McheliO root folder (where build.gradle lives).
+```text
+/mcheli list
+/mcheli reconfig
+/mcheli status entity 5
+/mcheli showboundingbox true
+/mcheli title 5 2 {"text":"Mission start"}
+```
 
-When prompted, import as a Gradle project.
+Operators can use all subcommands. Non-operators need matching `CommandPermission` entries in `mcheli.cfg`. See [docs/commands.md](docs/commands.md) for syntax, examples, and permission configuration.
 
-3. Make sure SDK is Java 8
-   File → Project Structure → Project SDK → Set to Java 1.8.
+## Troubleshooting
 
-Also set Project language level to 8 - Lambdas, type annotations, etc.
+### Vehicles, models, textures, or sounds are missing
 
-4. Force Gradle to rebuild MCP
-   Open the terminal in IntelliJ (or system terminal in the project root) and run:
+Verify that the MCHeli asset/content pack is installed with the expected `assets/mcheli/` structure. The code loads definitions from folders such as `assets/mcheli/helicopters`, `assets/mcheli/planes`, `assets/mcheli/ships`, `assets/mcheli/tanks`, `assets/mcheli/vehicles`, `assets/mcheli/weapons`, `assets/mcheli/hud`, `assets/mcheli/item`, and `assets/mcheli/throwable`.
 
-gradlew clean
-gradlew setupDecompWorkspace --refresh-dependencies
-gradlew genIntellijRuns
+### The config did not change in-game
 
-5. Re-sync Gradle
-   In IntelliJ, click the little elephant icon (Gradle tool window) → “Reload All Gradle Projects.”
+Restart the game/server after editing `mcheli.cfg`, or use `/mcheli reconfig` for server-side reloadable settings. Client keybind changes may require reopening the game or reloading the client-side config.
 
-Wait for indexing to finish (top-right progress bar).
+### Commands say I do not have permission
 
-6. Check sources
-   Right-click src/main/java → Mark Directory As → Sources Root
+Use an operator account or add `CommandPermission = commandName:PlayerName` entries to `mcheli.cfg`, then reload/restart. Permissions are per subcommand, not for the whole `/mcheli` tree.
 
-Right-click src/main/resources → Mark Directory As → Resources Root
+### A build fails in a clean environment
+
+This is an old ForgeGradle 1.x Minecraft 1.7.10 project. Use Java 8, run `./gradlew setupDecompWorkspace`, and ensure legacy dependency repositories are reachable.
+
+## Resources
+
+- CurseForge/update page from mod metadata: <https://www.curseforge.com/minecraft/mc-mods/mcheli-overdrive-loader-mod>
+- Project website from mod metadata: <https://ragexprince.wordpress.com/>
+- Original derivative source noted by the previous README: <https://github.com/RagexPrince683/MCH-defaultmaster>
+- Current repository: this checkout (`MCH-mocmaster`)
+
+If this project has an official Discord, Modrinth page, wiki, or current GitHub remote, add those URLs here once confirmed.
+
+## Screenshots
+
+Screenshots are not currently stored in this repository. Suggested placeholders for future documentation:
+
+- Vehicle selection in creative tabs
+- Drafting Table recipe screen
+- Aircraft HUD in flight
+- Server/admin command examples
+
+## FAQ
+
+### Is this the original MC Helicopter mod?
+
+No. It is a fork/overhaul derived from the MCHeli code lineage, with additional systems and compatibility work.
+
+### Does it work on modern Minecraft versions?
+
+No. The current codebase targets Minecraft 1.7.10.
+
+### Do clients need the mod on multiplayer servers?
+
+Yes. Players need the mod and compatible assets to render and control vehicles correctly. Dedicated servers should also install it to simulate entities, recipes, commands, and config behavior.
+
+### Can I disable terrain damage?
+
+Yes. Start with `Explosion_DestroyBlock = false`, `Collision_DestroyBlock = false`, and related collision/breakable-block options in `config/mcheli.cfg`.
+
+### Where are vehicles defined?
+
+Vehicle and weapon content is data-driven through MCHeli asset folders under `assets/mcheli/`. This repository contains the Java implementation; a matching asset/content pack supplies most vehicle definitions, models, textures, HUDs, and sounds.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,94 @@
+# Command and Permission Reference
+
+All commands use the root command:
+
+```text
+/mcheli <subcommand> ...
+```
+
+Commands only run when `EnableCommand = true` in `config/mcheli.cfg`.
+
+## Permission model
+
+The command class allows the root command for everyone, then checks each subcommand before execution. Operators/players who can use vanilla `/gamemode` pass automatically. Non-operators need `CommandPermission` entries in `mcheli.cfg`.
+
+Format:
+
+```text
+CommandPermission = commandName:PlayerName1, PlayerName2
+```
+
+Examples:
+
+```text
+CommandPermission = modlist:Alice, Bob
+CommandPermission = status:ServerMod
+CommandPermission = reconfig:AdminHelper
+```
+
+Permissions are per subcommand. Granting `status` does not grant `fill` or `killentity`.
+
+## Subcommands
+
+| Command | Syntax | Purpose |
+| --- | --- | --- |
+| `list` | `/mcheli list` | Prints the available MCHeli subcommands. |
+| `reconfig` | `/mcheli reconfig` | Reloads `mcheli.cfg`; on servers, broadcasts updated server settings to clients. |
+| `sendss` | `/mcheli sendss <playerName>` | Sends a client packet requesting/triggering screenshot-related client handling for the named player. |
+| `modlist` | `/mcheli modlist <playerName>` | Requests mod-list information from the named player. |
+| `title` | `/mcheli title <timeSeconds> <position> <jsonMessage>` | Sends a JSON chat title/message packet to clients. Time is clamped to 1-180 seconds; position is clamped by code to 0-5. |
+| `fill` | `/mcheli fill <x1> <y1> <z1> <x2> <y2> <z2> <block> [metadata] [oldBlockHandling] [dataTag]` | MCHeli copy of a fill/setblock-style admin utility. `oldBlockHandling` supports `replace`, `destroy`, `keep`, and `override` in tab completion. |
+| `status` | `/mcheli status <entity|tile> [minNum]` | Counts loaded entity or tile-entity classes in the sender's world and prints classes with at least `minNum` instances. |
+| `killentity` | `/mcheli killentity <entityClassNameFragment>` | Calls `setDead()` on matching loaded non-player entities. |
+| `removeentity` | `/mcheli removeentity <entityClassNameFragment>` | Marks matching loaded non-player entities dead by setting `isDead = true`. |
+| `attackentity` | `/mcheli attackentity <entityClassNameFragment> <damage> [damageSource]` | Damages matching loaded non-player entities. |
+| `showboundingbox` | `/mcheli showboundingbox <true|false>` | Toggles MCHeli debug bounding boxes and broadcasts server settings. This does not save the config file. |
+
+## `attackentity` damage sources
+
+Recognized names include:
+
+```text
+player, anvil, cactus, drown, fall, fallingBlock, generic,
+inFire, inWall, lava, magic, onFire, starve, wither
+```
+
+Tab completion also advertises `outOfWorld`, but the implementation does not assign a special `DamageSource` for it; unrecognized values fall back to generic damage.
+
+## Examples
+
+Reload server config:
+
+```text
+/mcheli reconfig
+```
+
+Show classes for loaded entities with at least 10 instances:
+
+```text
+/mcheli status entity 10
+```
+
+Remove all loaded entities whose class name contains `EntityBullet`:
+
+```text
+/mcheli removeentity EntityBullet
+```
+
+Display a JSON title for 5 seconds at position 2:
+
+```text
+/mcheli title 5 2 {"text":"Objective updated","color":"gold"}
+```
+
+Enable debug bounding boxes for connected clients:
+
+```text
+/mcheli showboundingbox true
+```
+
+## Safety notes
+
+- `fill`, `killentity`, `removeentity`, and `attackentity` are destructive admin tools. Grant them only to trusted users.
+- Entity matching uses case-insensitive substring matching against Java class names. A broad fragment can affect more entities than intended.
+- `showboundingbox` changes the in-memory setting but the save call is commented out in source, so restart/reload behavior depends on `EnableDebugBoundingBox` in `mcheli.cfg`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,199 @@
+# Configuration Reference
+
+MC Helicopter Overdrive+ writes `config/mcheli.cfg` during startup. The file is generated from source-defined defaults, then rewritten after loading so missing options are restored.
+
+## Editing workflow
+
+1. Start the game/server once.
+2. Stop the game/server.
+3. Edit `config/mcheli.cfg`.
+4. Restart, or use `/mcheli reconfig` for server-side reloadable settings.
+
+Client keybinds and rendering settings are safest to change while the client is closed.
+
+## Value formats
+
+- Booleans use `true` or `false`.
+- Numeric keybinds use LWJGL key/mouse codes. Negative values are mouse buttons (`-100` = left click, `-99` = right click, `-98` = middle click).
+- Block/material lists are comma-separated names.
+- `HitMarkColor` uses `Alpha, Red, Green, Blue`, each clamped to 0-255.
+- `CommandPermission` uses `commandName:Player1, Player2`.
+- Damage factors use either a plain multiplier such as `1.0` or a multiplier with an entity-class filter, depending on the existing config format.
+
+## General options
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `TestMode` | `false` | Development/test toggle. |
+| `EnableCommand` | `true` | Enables `/mcheli` subcommands. |
+| `PlaceableOnSpongeOnly` | `false` | Restricts vehicle placement to sponge blocks. |
+| `ItemDamage` | `true` | Enables item damage behavior for applicable MCHeli items. |
+| `ItemFuel` | `true` | Enables fuel item behavior. |
+| `AutoRepairHP` | `0.0` | Global auto-repair HP value/threshold. |
+| `AutoRepairEnabled` | `false` | Auto-repair feature toggle. The source contains a commented older initialization and an active generated-config entry. |
+| `Explosion_DestroyBlock` | `true` | Allows explosions to destroy blocks. |
+| `Explosion_FlamingBlock` | `true` | Allows explosions to create flaming blocks. |
+| `BulletBreakableBlocks` | `glass_pane, stained_glass_pane, tallgrass, double_plant, yellow_flower, red_flower, vine, wheat, reeds, waterlily` | Blocks bullets can break. |
+| `Collision_DestroyBlock` | `true` | Allows collision block destruction. |
+| `Collision_Car_BreakableBlock` | `double_plant, glass_pane,stained_glass_pane` | Car/vehicle collision breakable block list. |
+| `Collision_Car_BreakableMaterial` | `cactus, cake, gourd, leaves, vine, plants` | Car/vehicle collision breakable material list. |
+| `Collision_Tank_BreakableBlock` | `nether_brick_fence` | Tank collision breakable block list. |
+| `Collision_Tank_BreakableMaterial` | `cactus, cake, carpet, circuits, glass, gourd, leaves, vine, wood, plants` | Tank collision breakable material list. |
+| `Collision_EntityDamage` | `true` | Enables entity damage from collisions. |
+| `Collision_EntityTankDamage` | `false` | Enables tank collision entity damage. |
+| `InfinityAmmo` | `false` | Unlimited ammunition. |
+| `InfinityFuel` | `false` | Unlimited fuel. |
+| `DismountAll` | `false` | Dismount behavior toggle. |
+| `MountMinecartHeli` | `true` | Allows helicopters to mount/interact with minecarts where supported. |
+| `MountMinecartPlane` | `true` | Allows planes to mount/interact with minecarts where supported. |
+| `MountMinecartShip` | `false` | Allows ships to mount/interact with minecarts where supported. |
+| `MountMinecartVehicle` | `false` | Allows vehicles to mount/interact with minecarts where supported. |
+| `MountMinecartTank` | `true` | Allows tanks to mount/interact with minecarts where supported. |
+| `PreventingBroken` | `false` | Prevents breakage behavior where implemented. |
+| `DropItemInCreativeMode` | `false` | Allows item drops in creative mode for applicable actions. |
+| `BreakableOnlyPickaxe` | `false` | Restricts breakability to pickaxe behavior where implemented. |
+| `AllHeliSpeed` | `1.5` | Global helicopter speed scalar; clamped between 0 and 1000. |
+| `AllPlaneSpeed` | `1000.0` | Global plane speed scalar/clamp value; clamped between 0 and 1000. |
+| `AllShipSpeed` | `2.0` | Global ship speed scalar; clamped between 0 and 1000. |
+| `AllTankSpeed` | `1.0` | Global tank speed scalar; clamped between 0 and 1000. |
+| `HurtResistantTime` | `0.0` | Hurt resistance timing; clamped from 0 to 10000. |
+| `StingerLockRange` | `4988.0` | Lock range for Stinger-style light weapons. |
+| `delayrangeloader` | `5` | Advanced loader timing option. Exact gameplay effect needs code-level tracing. |
+| `bombletloader` | `10` | Advanced bomblet loader option. Exact gameplay effect needs code-level tracing. |
+| `wrenchdropitem` | `false` | Wrench drop-item behavior toggle. |
+| `placetimer` | `60` | Placement timer value. |
+| `RangeFinderSpotDist` | `400` | Rangefinder spot distance. |
+| `RangeFinderSpotTime` | `15` | Rangefinder spot duration. |
+| `RangeFinderConsume` | `true` | Rangefinder consumes required item/ammo when spotting. |
+| `EnablePutRackInFlying` | `true` | Allows rack operations during flight. |
+| `EnableDebugBoundingBox` | `false` | Enables debug bounding boxes. Can be toggled in memory with `/mcheli showboundingbox`. |
+| `InvertMouse` | `false` | Inverts aircraft mouse controls. |
+| `MouseSensitivity` | `30.0` | MCHeli mouse sensitivity. |
+| `MouseControlStickModeHeli` | `false` | Enables stick-style mouse mode for helicopters. |
+| `MouseControlStickModePlane` | `false` | Enables stick-style mouse mode for planes. |
+| `MouseControlFlightSimMode` | `true` | Flight-sim mouse mode (`Yaw:key, Roll=mouse` per source comment). |
+| `AutoThrottleDownHeli` | `true` | Auto-throttle-down behavior for helicopters. |
+| `AutoThrottleDownPlane` | `false` | Auto-throttle-down behavior for planes. |
+| `AutoThrottleDownShip` | `false` | Auto-throttle-down behavior for ships. |
+| `AutoThrottleDownTank` | `false` | Auto-throttle-down behavior for tanks. |
+| `SwitchWeaponWithMouseWheel` | `true` | Allows mouse-wheel weapon switching. |
+| `LWeaponAutoFire` | `false` | Auto-fire behavior for light weapons. |
+| `DisableItemRender` | `1` | Valid range noted in source: `0 ~ 3`; `1` recommended. |
+| `HideKeybind` | `false` | Hides keybind display/help where implemented. |
+| `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
+| `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |
+| `AircraftLODStartDistance` | `256.0` | Distance where tracked vehicles switch to cheaper model-only rendering. |
+| `AircraftLODFarDistance` | `4096.0` | Maximum distance for client-only LOD snapshots. If positive and below start distance, it is corrected upward. |
+| `MobRenderDistanceWeight` | `10.0` | Mob render-distance weight; clamped to 0.1-100. |
+| `CreativeTabIconItem` | `fuel` | Icon item for general tab. |
+| `CreativeTabIconHeli` | `ah-64` | Icon item for helicopter tab. |
+| `CreativeTabIconPlane` | `f22a` | Icon item for plane tab. |
+| `CreativeTabIconShip` | `project1204` | Icon item for ship tab. |
+| `CreativeTabIconTank` | `merkava_mk4` | Icon item for tank tab. |
+| `CreativeTabIconVehicle` | `mk15` | Icon item for vehicle tab. |
+| `DisableShader` | `false` | Disables shader usage where implemented. |
+| `DefaultExplosionParticle` | `false` | Uses default explosion particles where implemented. |
+| `AliveTimeOfCartridge` | `200` | Cartridge casing lifetime. |
+| `HitMarkColor` | `255, 255, 0, 0` | ARGB hit marker color. |
+| `SmoothShading` | `true` | Smooth model shading toggle. |
+| `EnableModEntityRender` | `true` | Enables mod entity rendering. |
+| `DisableRenderLivingSpecials` | `true` | Disables living-special rendering such as nameplate-related render hooks. |
+| `DisplayHUDThirdPerson` | `false` | Shows HUD in third person where supported. |
+| `DisableThirdPersonCameraDistChange` | `false` | Prevents MCHeli third-person camera-distance changes. |
+| `EnableReplaceTextureManager` | `true` | Texture manager replacement hook. |
+| `DisplayEntityMarker` | `true` | Shows entity markers. |
+| `EntityMarkerSize` | `10.0` | Entity marker size; minimum corrected to 0. |
+| `BlockMarkerSize` | `10.0` | Block marker size; minimum corrected to 0. |
+| `ReplaceRenderViewEntity` | `true` | Replaces render-view entity for MCHeli camera behavior. |
+| `ItemRecipe_*` | See generated config/source defaults | Recipe strings for core MCHeli items. |
+| `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
+
+## Hidden/advanced options initialized in source
+
+These are initialized but not all are written through the active `General` array in the inspected source:
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `Collision_Car_NoBreakBlock` | `torch` | Car collision no-break block list. Initialized and used by correction logic, but not written in the current `General` array. |
+| `Collision_Tank_NoBreakBlock` | `torch, glowstone` | Tank collision no-break block list. Initialized and used by correction logic, but not written in the current `General` array. |
+| `DespawnCount` | `25` | Initialized but not written in the current `General` array. |
+| `HitBoxDelayTick` | `0` | Initialized but not written in the current `General` array. |
+| `EnableRotationLimit` | `false` | Initialized but not written in the current `General` array. |
+| `PitchLimitMax` | `10` | Initialized but not written in the current `General` array. |
+| `PitchLimitMin` | `-10` | Initialized but not written in the current `General` array. |
+| `RollLimit` | `35` | Initialized but not written in the current `General` array. |
+| `RangeOfGunner_VsMonster_Horizontal` | `80` | Initialized but not written in the current `General` array. |
+| `RangeOfGunner_VsMonster_Vertical` | `160` | Initialized but not written in the current `General` array. |
+| `RangeOfGunner_VsPlayer_Horizontal` | `200` | Initialized but not written in the current `General` array. |
+| `RangeOfGunner_VsPlayer_Vertical` | `300` | Initialized but not written in the current `General` array. |
+| `FixVehicleAtPlacedPoint` | `true` | Initialized but not written in the current `General` array. |
+| `KillPassengersWhenDestroyed` | `false` | Initialized but not written in the current `General` array. |
+
+## Damage and ignored projectile entries
+
+The generated config includes damage factor entries for:
+
+```text
+DamageVsEntity
+DamageVsLiving
+DamageVsPlayer
+DamageVsMCHeliAircraft
+DamageVsMCHeliTank
+DamageVsMCHeliVehicle
+DamageVsMCHeliOther
+DamageMCHeliAircraftByExternal
+DamageMCHeliTankByExternal
+DamageMCHeliVehicleByExternal
+DamageMCHeliOtherByExternal
+```
+
+If no entries are present, the code adds default `1.0` multipliers.
+
+`IgnoreBulletHit` defaults are added when the list is empty:
+
+```text
+IgnoreBulletHit = flansmod.common.guns.EntityBullet
+IgnoreBulletHit = flansmod.common.guns.EntityGrenade
+```
+
+## Key config defaults
+
+| Option | Default code | Default input |
+| --- | --- | --- |
+| `KeyUp` | `17` | W |
+| `KeyDown` | `31` | S |
+| `KeySubmarineAscend` | `200` | Up Arrow |
+| `KeySubmarineDescend` | `208` | Down Arrow |
+| `KeyRight` | `32` | D |
+| `KeyLeft` | `30` | A |
+| `KeySwitchGunner` | `35` | H |
+| `KeySwitchHovering` | `57` | Space |
+| `KeySwitchWeapon1` | `-98` | Middle Click |
+| `KeySwitchWeapon2` | `34` | G |
+| `KeySwitchWeaponMode` | `45` | X |
+| `KeyZoom` | `44` | Z |
+| `KeyCameraMode` | `46` | C |
+| `KeyUnmountMob` | `21` | Y |
+| `KeyFlare` | `47` | V |
+| `KeyExtra` | `33` | F |
+| `KeyCameraDistanceUp` | `201` | Page Up |
+| `KeyCameraDistanceDown` | `209` | Page Down |
+| `KeyFreeLook` | `29` | Left Control |
+| `KeyGUI` | `19` | R |
+| `KeyGearUpDown` | `48` | B |
+| `KeyPutToRack` | `36` | J |
+| `KeyDownFromRack` | `22` | U |
+| `KeyScoreboard` | `38` | L |
+| `KeyMultiplayManager` | `50` | M |
+| `KeyChaff` | `47` | V |
+| `KeyMaintenance` | `47` | V |
+| `KeyAPS` | `47` | V |
+| `KeyUseWeapon` | `-99` | Right Click |
+| `KeyAttack` | `-100` | Left Click |
+| `KeyCurrentWeaponLock` | `-100` | Left Click |
+
+`KeyEjectHeli` is initialized with `54` (Right Shift), but it is not included in the current `KeyConfig` array and therefore is not written with the generated key config.
+
+## Item and block IDs
+
+The source still initializes legacy numeric IDs for core items/blocks, including fuel, GLTD, chain, parachute, container, UAV stations, drafting table, wrench, rangefinder, Stinger/Javelin/RPG shared IDs, and Drafting Table block IDs. In modern Forge 1.7.10 modpacks, prefer resolving conflicts through generated config and registry names rather than hand-editing unless you know your pack's ID map.

--- a/docs/documentation-audit.md
+++ b/docs/documentation-audit.md
@@ -1,0 +1,33 @@
+# Documentation Audit Notes
+
+This file records features/configuration discovered during the documentation pass and gaps that could not be completed confidently from the available source and repository contents.
+
+## Undocumented features, commands, configs, or systems discovered
+
+- Ships are a first-class vehicle category with loading, item registration, entity registration, renderer registration, and creative tab support.
+- Client-only long-distance vehicle LOD rendering is configurable through `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance`.
+- Multi-threaded model loading is enabled by default through `MultiThreadedModelLoading`.
+- The mod registers a custom light block named `mcheli_lightblock` in addition to Drafting Table blocks.
+- Three light weapons are registered from the same base light-weapon class: FIM-92 Stinger, FGM-148 Javelin, and RPG-7.
+- Gunner spawn eggs/items include vs-monster, vs-player, and evil variants.
+- `/mcheli showboundingbox` toggles `EnableDebugBoundingBox` in memory and broadcasts settings, but the save call is commented out.
+- `/mcheli fill` includes an `override` mode in addition to `replace`, `destroy`, and `keep` tab-completion values.
+- `IgnoreBulletHit` defaults include Flan's Mod bullet and grenade entity classes when the config list is empty.
+- Several initialized config options are not written through the active generated config arrays, including rotation limits, gunner ranges, and no-break collision lists.
+
+## Documentation gaps and limitations
+
+- No current Git remote, official Discord, Modrinth page, wiki URL, or screenshot assets were present in the checkout, so the README only links confirmed URLs from existing metadata/README text.
+- The repository does not include the full `assets/mcheli/` content pack, so individual vehicle names, stats, recipes, HUD layouts, sounds, and screenshots could not be documented comprehensively.
+- Some advanced options (`delayrangeloader`, `bombletloader`, `placetimer`, `wrenchdropitem`, several rotation/gunner options) need deeper feature tracing or maintainer confirmation for user-facing explanations.
+- The exact behavior of `sendss` and `modlist` depends on client packet handlers and UI flow; this pass documented their source-visible purpose without promising file upload/storage behavior.
+- Numeric legacy item/block ID behavior can vary by Forge 1.7.10 pack state and ID map; users should validate in their own modpacks.
+- Build verification may depend on legacy ForgeGradle/Maven repositories and bundled local jars.
+
+## Source areas inspected
+
+- Mod metadata and Forge declaration: `src/main/resources/mcmod.info`, `src/main/java/mcheli/MCH_MOD.java`
+- Configuration defaults/read/write logic: `src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/MCH_ConfigPrm.java`
+- Commands and permissions: `src/main/java/mcheli/command/MCH_Command.java`
+- Client/server config loading and rendering hooks: `src/main/java/mcheli/MCH_CommonProxy.java`, `src/main/java/mcheli/MCH_ClientProxy.java`
+- Build/development setup: `build.gradle`, `gradle/wrapper/gradle-wrapper.properties`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,119 @@
+# Getting Started with MC Helicopter Overdrive+
+
+This guide explains the basic workflow for installing, finding, placing, and operating the mod's content.
+
+## 1. Install the mod and assets
+
+MC Helicopter Overdrive+ is code plus MCHeli-style content assets. The Java mod registers systems, items, commands, entities, and rendering; the content pack provides most vehicle definitions, models, textures, HUD files, sounds, and recipes.
+
+Expected content folders include:
+
+```text
+assets/mcheli/hud
+assets/mcheli/weapons
+assets/mcheli/helicopters
+assets/mcheli/planes
+assets/mcheli/ships
+assets/mcheli/tanks
+assets/mcheli/vehicles
+assets/mcheli/item
+assets/mcheli/throwable
+assets/mcheli/models
+assets/mcheli/textures
+assets/mcheli/sounds
+assets/mcheli/sounds.json
+```
+
+In a normal Minecraft install, put the mod jar and matching content in `mods/`. In the development run directory, the code expects assets under `build/run/mods/mcheli/`.
+
+## 2. Start the game once
+
+The first launch creates `config/mcheli.cfg`. The mod writes the file back out with current defaults, command permission examples, damage multipliers, ignored projectile classes, and key configuration values.
+
+## 3. Find content in creative mode
+
+The mod creates several creative tabs:
+
+- `MCHeliO Item`
+- `MCHeliO Recipe Items`
+- `MCHeliO Helicopters`
+- `MCHeliO Planes`
+- `MCHeliO Ships`
+- `MCHeliO Tanks`
+- `MCHeliO Vehicles`
+
+If a tab is empty or an expected vehicle is missing, verify that the matching asset folder is installed and that the content definition loaded without errors.
+
+## 4. Craft or place the Drafting Table
+
+The mod registers a **Drafting Table** and a lit Drafting Table variant. The Drafting Table is the main recipe interface for MCHeli content when recipes are enabled.
+
+Default Drafting Table recipe:
+
+```text
+"R  ", "PCP", "F F", R, redstone, C, crafting_table, P, planks, F, fence
+```
+
+Set `ItemRecipe_DraftingTable` in `mcheli.cfg` to change or disable the recipe according to the recipe parser behavior used by your pack.
+
+## 5. Place and use vehicles
+
+- Vehicle placement is controlled by item definitions and global settings.
+- If `PlaceableOnSpongeOnly = true`, vehicle placement is restricted to sponge blocks.
+- Global speed scalars are controlled by `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed`.
+- Fuel and ammunition requirements are controlled by content definitions and global `InfinityFuel`/`InfinityAmmo` settings.
+
+## 6. Default controls
+
+The config stores key codes rather than names. Common defaults:
+
+| Action | Config key | Default |
+| --- | --- | --- |
+| Forward/up | `KeyUp` | W |
+| Back/down | `KeyDown` | S |
+| Right | `KeyRight` | D |
+| Left | `KeyLeft` | A |
+| Switch gunner/mode | `KeySwitchGunner` | H |
+| Switch hovering | `KeySwitchHovering` | Space |
+| Use weapon | `KeyUseWeapon` | Right Click |
+| Attack/current lock | `KeyAttack`, `KeyCurrentWeaponLock` | Left Click |
+| Switch weapon 1 | `KeySwitchWeapon1` | Middle Click |
+| Switch weapon 2 | `KeySwitchWeapon2` | G |
+| Switch weapon mode | `KeySwitchWeaponMode` | X |
+| Zoom | `KeyZoom` | Z |
+| Camera mode | `KeyCameraMode` | C |
+| Dismount mob/seat action | `KeyUnmountMob` | Y |
+| Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
+| Extra function | `KeyExtra` | F |
+| Free look | `KeyFreeLook` | Left Control |
+| Open MCHeli GUI | `KeyGUI` | R |
+| Gear | `KeyGearUpDown` | B |
+| Rack up/down | `KeyPutToRack`, `KeyDownFromRack` | J / U |
+| Scoreboard | `KeyScoreboard` | L |
+| Multiplayer manager | `KeyMultiplayManager` | M |
+
+## 7. Useful first configuration changes
+
+For survival-friendly servers:
+
+```text
+Explosion_DestroyBlock = false
+Collision_DestroyBlock = false
+InfinityAmmo = false
+InfinityFuel = false
+PlaceableOnSpongeOnly = true
+```
+
+For creative testing:
+
+```text
+InfinityAmmo = true
+InfinityFuel = true
+EnableDebugBoundingBox = true
+```
+
+## 8. Next steps
+
+- Read [Configuration Reference](configuration.md) for defaults and server/client impact.
+- Read [Command and Permission Reference](commands.md) before granting admin tools.
+- Read [Server Administration Guide](server-administration.md) for safe server defaults.

--- a/docs/server-administration.md
+++ b/docs/server-administration.md
@@ -1,0 +1,84 @@
+# Server Administration Guide
+
+This guide focuses on safe defaults and operational practices for multiplayer servers.
+
+## Installation checklist
+
+- Install Forge 1.7.10 on the server.
+- Put the MC Helicopter Overdrive+ jar in `mods/`.
+- Install the same MCHeli asset/content pack expected by your clients.
+- Start once to generate `config/mcheli.cfg`.
+- Stop the server and review world-damage, command, and permission settings.
+- Require clients to use the same mod and compatible assets.
+
+## Recommended survival-server baseline
+
+```text
+EnableCommand = true
+PlaceableOnSpongeOnly = true
+Explosion_DestroyBlock = false
+Explosion_FlamingBlock = false
+Collision_DestroyBlock = false
+Collision_EntityDamage = true
+Collision_EntityTankDamage = false
+InfinityAmmo = false
+InfinityFuel = false
+DropItemInCreativeMode = false
+EnableDebugBoundingBox = false
+```
+
+This limits accidental terrain damage while preserving vehicle combat and admin tooling.
+
+## Command permissions
+
+Operators can use all MCHeli commands. For non-operators, grant only the exact subcommands required:
+
+```text
+CommandPermission = status:Moderator1
+CommandPermission = modlist:Moderator1, Moderator2
+CommandPermission = reconfig:AdminHelper
+```
+
+Avoid granting destructive commands (`fill`, `killentity`, `removeentity`, `attackentity`) to normal users.
+
+## Runtime reloads
+
+Use:
+
+```text
+/mcheli reconfig
+```
+
+This reloads the server config and sends updated server settings to clients. Some client-only rendering/keybind changes still require client restart or local config reload.
+
+## Entity cleanup and diagnostics
+
+Useful diagnostics:
+
+```text
+/mcheli status entity 5
+/mcheli status tile 5
+```
+
+Emergency cleanup examples:
+
+```text
+/mcheli removeentity EntityBullet
+/mcheli killentity EntityParachute
+```
+
+Be careful: matching is a case-insensitive substring search against full Java class names and excludes players only.
+
+## Performance notes
+
+- `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` are client-side rendering aids for far vehicle snapshots.
+- `MultiThreadedModelLoading = true` enables threaded model loading and is on by default.
+- Large asset packs can increase startup time and memory use.
+- `RenderDistanceWeight` and `MobRenderDistanceWeight` can affect how far mod entities render.
+
+## Pack policy recommendations
+
+- Publish the exact asset pack version with your server pack.
+- Keep a known-good copy of `mcheli.cfg` under version control outside the live server.
+- Disable terrain damage before public events unless vehicle griefing is intended.
+- Test every added vehicle definition in a staging world before deployment.


### PR DESCRIPTION
### Motivation

- Make the project approachable for new users by replacing the old README with a concise modern overview, installation steps, compatibility details and quickstart instructions. 
- Provide source-verified reference material so players and server operators can configure and run the mod without external help. 
- Capture discovered, undocumented behaviors and remaining gaps so future documentation work or maintainers can follow up.

### Description

- Rewrote `README.md` with a project overview, feature list, requirements, installation (client/server/development), basic usage, configuration overview, commands, troubleshooting, resources and FAQ. 
- Added a new `docs/` folder containing: `getting-started.md`, `configuration.md`, `commands.md`, `server-administration.md`, and `documentation-audit.md` with source-verified defaults, command syntax, permission model, recommended server defaults, and a list of undocumented features/gaps discovered during the pass. 
- Added `CHANGELOG.md` with an Unreleased entry summarizing the documentation work and produced a short documentation audit listing hidden/advanced options, command behaviors, and asset requirements. 
- Ensured the README links into the new docs and includes guidance for development builds (ForgeGradle 1.x / Java 8) and asset layout expectations (`assets/mcheli/...`).

### Testing

- Performed repository consistency checks and whitespace/diff checks; no issues were reported and documentation files were added cleanly. 
- Manually inspected source locations referenced by the docs (notably `MCH_Config.java`, `MCH_Command.java`, `MCH_MOD.java`, and `mcmod.info`) to verify defaults, command syntax, and config keys used in the new documentation. 
- Verified the README links to the new `docs/` pages and that the added Markdown files render as standard documentation (basic smoke check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28be19396883298c20adbb20c1f336)