### PR TITLE
Support rotating/oriented vehicle bounding boxes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,8 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `RangeFinderConsume` | `true` | Rangefinder consumes required item/ammo when spotting. |
 | `EnablePutRackInFlying` | `true` | Allows rack operations during flight. |
 | `EnableDebugBoundingBox` | `false` | Enables debug bounding boxes. Can be toggled in memory with `/mcheli showboundingbox`. |
+| `enableRotatingVehicleBounds` | `true` | Rotates MCHeli vehicle sub-bounding boxes with aircraft/tank/vehicle yaw, pitch, and roll while keeping Minecraft-required enclosing AABBs for broad-phase collision. Set to `false` for legacy static world-axis behavior. |
+| `debugRotatingVehicleBounds` | `false` | When debug rendering is active, renders the oriented local boxes and their enclosing AABBs for collision diagnostics. |
 | `InvertMouse` | `false` | Inverts aircraft mouse controls. |
 | `MouseSensitivity` | `30.0` | MCHeli mouse sensitivity. |
 | `MouseControlStickModeHeli` | `false` | Enables stick-style mouse mode for helicopters. |

--- a/src/main/java/mcheli/MCH_CommonPacketHandler.java
+++ b/src/main/java/mcheli/MCH_CommonPacketHandler.java
@@ -72,6 +72,10 @@ public class MCH_CommonPacketHandler {
          MCH_ServerSettings.enablePVP = pkt.enablePVP;
          MCH_ServerSettings.stingerLockRange = pkt.stingerLockRange;
          MCH_ServerSettings.enableDebugBoundingBox = pkt.enableDebugBoundingBox;
+         MCH_ServerSettings.enableRotatingVehicleBounds = pkt.enableRotatingVehicleBounds;
+         MCH_ServerSettings.debugRotatingVehicleBounds = pkt.debugRotatingVehicleBounds;
+         MCH_Config.EnableRotatingVehicleBounds.prmBool = pkt.enableRotatingVehicleBounds;
+         MCH_Config.DebugRotatingVehicleBounds.prmBool = pkt.debugRotatingVehicleBounds;
          MCH_ClientLightWeaponTickHandler.lockRange = MCH_ServerSettings.stingerLockRange;
       }
    }

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -170,6 +170,8 @@ public class MCH_Config {
    public static MCH_ConfigPrm RangeFinderConsume;
    public static MCH_ConfigPrm EnablePutRackInFlying;
    public static MCH_ConfigPrm EnableDebugBoundingBox;
+   public static MCH_ConfigPrm EnableRotatingVehicleBounds;
+   public static MCH_ConfigPrm DebugRotatingVehicleBounds;
 
    //TODOne mch1.0.5 -> mchr?
    public static MCH_ConfigPrm DespawnCount;
@@ -412,6 +414,10 @@ public class MCH_Config {
       RangeFinderConsume = new MCH_ConfigPrm("RangeFinderConsume", true);
       EnablePutRackInFlying = new MCH_ConfigPrm("EnablePutRackInFlying", true);
       EnableDebugBoundingBox = new MCH_ConfigPrm("EnableDebugBoundingBox", false);
+      EnableRotatingVehicleBounds = new MCH_ConfigPrm("enableRotatingVehicleBounds", true);
+      EnableRotatingVehicleBounds.desc = ";Rotate MCHeli vehicle sub-bounding boxes with vehicle yaw/pitch/roll. Disable to restore legacy static AABB behavior.";
+      DebugRotatingVehicleBounds = new MCH_ConfigPrm("debugRotatingVehicleBounds", false);
+      DebugRotatingVehicleBounds.desc = ";Client debug: render local/rotated vehicle collision boxes and their Minecraft-required enclosing AABBs when TestMode debug rendering is active.";
       DespawnCount = new MCH_ConfigPrm("DespawnCount", 25);
       HitBoxDelayTick = new MCH_ConfigPrm("HitBoxDelayTick", 0);
       EnableRotationLimit = new MCH_ConfigPrm("EnableRotationLimit", false);
@@ -500,6 +506,8 @@ public class MCH_Config {
               RangeFinderConsume,
               EnablePutRackInFlying,
               EnableDebugBoundingBox,
+              EnableRotatingVehicleBounds,
+              DebugRotatingVehicleBounds,
               null,
               InvertMouse,
               MouseSensitivity,

--- a/src/main/java/mcheli/MCH_PacketNotifyServerSettings.java
+++ b/src/main/java/mcheli/MCH_PacketNotifyServerSettings.java
@@ -18,6 +18,8 @@ public class MCH_PacketNotifyServerSettings extends MCH_Packet {
    public double stingerLockRange = 120.0D;
    //todo change bullshit
    public boolean enableDebugBoundingBox = false;
+   public boolean enableRotatingVehicleBounds = true;
+   public boolean debugRotatingVehicleBounds = false;
 
 
    public int getMessageID() {
@@ -32,6 +34,8 @@ public class MCH_PacketNotifyServerSettings extends MCH_Packet {
          this.enablePVP = this.getBit(e, 2);
          this.stingerLockRange = (double)data.readFloat();
          this.enableDebugBoundingBox = this.getBit(e, 3);
+         this.enableRotatingVehicleBounds = this.getBit(e, 4);
+         this.debugRotatingVehicleBounds = this.getBit(e, 5);
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -45,6 +49,8 @@ public class MCH_PacketNotifyServerSettings extends MCH_Packet {
          e1 = this.setBit(e1, 1, this.enableEntityMarker);
          e1 = this.setBit(e1, 2, this.enablePVP);
          e1 = this.setBit(e1, 3, this.enableDebugBoundingBox);
+         e1 = this.setBit(e1, 4, this.enableRotatingVehicleBounds);
+         e1 = this.setBit(e1, 5, this.debugRotatingVehicleBounds);
          dos.writeByte(e1);
          dos.writeFloat((float)this.stingerLockRange);
       } catch (IOException var3) {
@@ -64,6 +70,8 @@ public class MCH_PacketNotifyServerSettings extends MCH_Packet {
       s.stingerLockRange = MCH_Config.StingerLockRange.prmDouble;
       var10001 = MCH_MOD.config;
       s.enableDebugBoundingBox = MCH_Config.EnableDebugBoundingBox.prmBool;
+      s.enableRotatingVehicleBounds = MCH_Config.EnableRotatingVehicleBounds.prmBool;
+      s.debugRotatingVehicleBounds = MCH_Config.DebugRotatingVehicleBounds.prmBool;
       if(player != null) {
          W_Network.sendToPlayer(s, player);
       } else {

--- a/src/main/java/mcheli/MCH_ServerSettings.java
+++ b/src/main/java/mcheli/MCH_ServerSettings.java
@@ -12,6 +12,8 @@ public class MCH_ServerSettings {
    public static boolean enablePVP = true;
    public static double stingerLockRange = 120.0D;
    public static boolean enableDebugBoundingBox = true;
+   public static boolean enableRotatingVehicleBounds = true;
+   public static boolean debugRotatingVehicleBounds = false;
 
 
 }

--- a/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_AircraftBoundingBox.java
@@ -140,8 +140,8 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
          MCH_BoundingBox bb = arr$[i$];
          //wheelBoundingBox wb = arr$[i$];
 
-         if(bb.boundingBox.intersectsWith(aabb)) {
-            double dist2 = this.getDistSq(aabb, this);
+         if(bb.intersectsRotated(aabb, this.ac.posX, this.ac.posY, this.ac.posZ, this.ac.getRotYaw(), this.ac.getRotPitch(), this.ac.getRotRoll())) {
+            double dist2 = this.getDistSq(aabb, bb.boundingBox);
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;
@@ -266,7 +266,7 @@ public class MCH_AircraftBoundingBox extends AxisAlignedBB {
 
       for(int i$ = 0; i$ < len$; ++i$) {
          MCH_BoundingBox bb = arr$[i$];
-         MovingObjectPosition mop2 = bb.boundingBox.calculateIntercept(v1, v2);
+         MovingObjectPosition mop2 = bb.calculateRotatedIntercept(v1, v2, this.ac.posX, this.ac.posY, this.ac.posZ, this.ac.getRotYaw(), this.ac.getRotPitch(), this.ac.getRotRoll());
          if(mop2 != null) {
             double dist2 = v1.distanceTo(mop2.hitVec);
             if(dist2 < dist) {

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -2,6 +2,7 @@ package mcheli.aircraft;
 
 import mcheli.MCH_Lib;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 
 public class MCH_BoundingBox {
@@ -35,6 +36,115 @@ public class MCH_BoundingBox {
    }
 
 
+   private boolean rotatingBoundsDisabled() {
+      return mcheli.MCH_Config.EnableRotatingVehicleBounds == null || !mcheli.MCH_Config.EnableRotatingVehicleBounds.prmBool;
+   }
+
+   public AxisAlignedBB getLocalBox() {
+      double hw = (double)this.width / 2.0D;
+      double hh = (double)this.height / 2.0D;
+      return AxisAlignedBB.getBoundingBox(this.offsetX - hw, this.offsetY - hh, this.offsetZ - hw, this.offsetX + hw, this.offsetY + hh, this.offsetZ + hw);
+   }
+
+   public Vec3 toWorld(double localX, double localY, double localZ, double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      Vec3 v = MCH_Lib.RotVec3(localX, localY, localZ, -yaw, -pitch, -roll);
+      return Vec3.createVectorHelper(posX + v.xCoord, posY + v.yCoord, posZ + v.zCoord);
+   }
+
+   public Vec3 toLocal(Vec3 world, double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      double x = world.xCoord - posX;
+      double y = world.yCoord - posY;
+      double z = world.zCoord - posZ;
+      Vec3 v = Vec3.createVectorHelper(x, y, z);
+      v.rotateAroundY(yaw / 180.0F * 3.1415927F);
+      v.rotateAroundX(pitch / 180.0F * 3.1415927F);
+      mcheli.wrapper.W_Vec3.rotateAroundZ(roll / 180.0F * 3.1415927F, v);
+      return v;
+   }
+
+   public AxisAlignedBB createRotatedEnclosingAABB(double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      AxisAlignedBB local = this.getLocalBox();
+      double minX = Double.MAX_VALUE;
+      double minY = Double.MAX_VALUE;
+      double minZ = Double.MAX_VALUE;
+      double maxX = -Double.MAX_VALUE;
+      double maxY = -Double.MAX_VALUE;
+      double maxZ = -Double.MAX_VALUE;
+
+      for(int ix = 0; ix < 2; ++ix) {
+         double x = ix == 0?local.minX:local.maxX;
+         for(int iy = 0; iy < 2; ++iy) {
+            double y = iy == 0?local.minY:local.maxY;
+            for(int iz = 0; iz < 2; ++iz) {
+               double z = iz == 0?local.minZ:local.maxZ;
+               Vec3 w = this.toWorld(x, y, z, posX, posY, posZ, yaw, pitch, roll);
+               minX = Math.min(minX, w.xCoord);
+               minY = Math.min(minY, w.yCoord);
+               minZ = Math.min(minZ, w.zCoord);
+               maxX = Math.max(maxX, w.xCoord);
+               maxY = Math.max(maxY, w.yCoord);
+               maxZ = Math.max(maxZ, w.zCoord);
+            }
+         }
+      }
+
+      // Minecraft 1.7.10 stores and queries only AxisAlignedBB values.  The
+      // actual vehicle box is oriented, so this AABB is only the safe broad-phase
+      // envelope used by the engine; precise tests transform probes back into
+      // vehicle-local space and compare against the unrotated local box.
+      return AxisAlignedBB.getBoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+   }
+
+   public boolean intersectsRotated(AxisAlignedBB aabb, double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      if(this.rotatingBoundsDisabled()) {
+         return this.boundingBox.intersectsWith(aabb);
+      }
+
+      AxisAlignedBB local = this.getLocalBox();
+      double minX = Double.MAX_VALUE;
+      double minY = Double.MAX_VALUE;
+      double minZ = Double.MAX_VALUE;
+      double maxX = -Double.MAX_VALUE;
+      double maxY = -Double.MAX_VALUE;
+      double maxZ = -Double.MAX_VALUE;
+
+      for(int ix = 0; ix < 2; ++ix) {
+         double x = ix == 0?aabb.minX:aabb.maxX;
+         for(int iy = 0; iy < 2; ++iy) {
+            double y = iy == 0?aabb.minY:aabb.maxY;
+            for(int iz = 0; iz < 2; ++iz) {
+               double z = iz == 0?aabb.minZ:aabb.maxZ;
+               Vec3 localPoint = this.toLocal(Vec3.createVectorHelper(x, y, z), posX, posY, posZ, yaw, pitch, roll);
+               minX = Math.min(minX, localPoint.xCoord);
+               minY = Math.min(minY, localPoint.yCoord);
+               minZ = Math.min(minZ, localPoint.zCoord);
+               maxX = Math.max(maxX, localPoint.xCoord);
+               maxY = Math.max(maxY, localPoint.yCoord);
+               maxZ = Math.max(maxZ, localPoint.zCoord);
+            }
+         }
+      }
+
+      return maxX > local.minX && minX < local.maxX && maxY > local.minY && minY < local.maxY && maxZ > local.minZ && minZ < local.maxZ;
+   }
+
+   public MovingObjectPosition calculateRotatedIntercept(Vec3 start, Vec3 end, double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      if(this.rotatingBoundsDisabled()) {
+         return this.boundingBox.calculateIntercept(start, end);
+      }
+
+      Vec3 localStart = this.toLocal(start, posX, posY, posZ, yaw, pitch, roll);
+      Vec3 localEnd = this.toLocal(end, posX, posY, posZ, yaw, pitch, roll);
+      MovingObjectPosition localHit = this.getLocalBox().calculateIntercept(localStart, localEnd);
+      if(localHit == null) {
+         return null;
+      }
+
+      Vec3 worldHit = this.toWorld(localHit.hitVec.xCoord, localHit.hitVec.yCoord, localHit.hitVec.zCoord, posX, posY, posZ, yaw, pitch, roll);
+      return new MovingObjectPosition(0, 0, 0, localHit.sideHit, worldHit);
+   }
+
+
    public MCH_BoundingBox copy() {
       return new MCH_BoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
    }
@@ -58,6 +168,16 @@ public class MCH_BoundingBox {
       this.nowPos.yCoord = y;
       this.nowPos.zCoord = z;
       this.backupBoundingBox.setBB(this.boundingBox);
-      this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+      if(this.rotatingBoundsDisabled()) {
+         this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+      } else {
+         try {
+            this.boundingBox.setBB(this.createRotatedEnclosingAABB(posX, posY, posZ, yaw, pitch, roll));
+         } catch(Throwable t) {
+            // Safety fallback: any math/config problem restores the legacy
+            // static world-axis sub-box instead of risking client/server desync.
+            this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+         }
+      }
    }
 }

--- a/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderAircraft.java
@@ -440,6 +440,12 @@ public abstract class MCH_RenderAircraft extends W_Render {
             MCH_BoundingBox bb = arr$[i$];
             GL11.glPushMatrix();
             GL11.glTranslated(bb.rotatedOffset.xCoord, bb.rotatedOffset.yCoord, bb.rotatedOffset.zCoord);
+            if(MCH_Config.EnableRotatingVehicleBounds.prmBool && MCH_Config.DebugRotatingVehicleBounds.prmBool) {
+               // Draw the local-space OBB in the same yaw/pitch/roll frame used by collision.
+               GL11.glRotatef(-yaw, 0.0F, 1.0F, 0.0F);
+               GL11.glRotatef(-pitch, 1.0F, 0.0F, 0.0F);
+               GL11.glRotatef(-e.getRotRoll(), 0.0F, 0.0F, 1.0F);
+            }
             GL11.glPushMatrix();
             GL11.glScalef(bb.width, bb.height, bb.width);
             this.bindTexture("textures/bounding_box.png");
@@ -447,6 +453,18 @@ public abstract class MCH_RenderAircraft extends W_Render {
             GL11.glPopMatrix();
             this.drawHitBoxDetail(bb);
             GL11.glPopMatrix();
+
+            if(MCH_Config.EnableRotatingVehicleBounds.prmBool && MCH_Config.DebugRotatingVehicleBounds.prmBool) {
+               GL11.glPushMatrix();
+               double cx = (bb.boundingBox.minX + bb.boundingBox.maxX) / 2.0D - e.posX;
+               double cy = (bb.boundingBox.minY + bb.boundingBox.maxY) / 2.0D - e.posY;
+               double cz = (bb.boundingBox.minZ + bb.boundingBox.maxZ) / 2.0D - e.posZ;
+               GL11.glTranslated(cx, cy, cz);
+               GL11.glScalef((float)(bb.boundingBox.maxX - bb.boundingBox.minX), (float)(bb.boundingBox.maxY - bb.boundingBox.minY), (float)(bb.boundingBox.maxZ - bb.boundingBox.minZ));
+               this.bindTexture("textures/hit_box.png");
+               debugModel.renderAll();
+               GL11.glPopMatrix();
+            }
          }
 
          GL11.glPopMatrix();


### PR DESCRIPTION
### Motivation
- Vehicle sub-boxes were treated as static world-axis AABBs, causing collisions and raycasts to not follow vehicle yaw/pitch/roll.\
- The change introduces oriented local-space bounding behavior while preserving Minecraft 1.7.10 compatibility by producing safe enclosing AABBs for engine use.\
- Make the feature configurable and add debug rendering so operators can toggle/inspect oriented boxes without breaking existing configs.\

### Description
- Added local-space OBB utilities to `MCH_BoundingBox`: `getLocalBox`, `toWorld`, `toLocal`, `createRotatedEnclosingAABB`, `intersectsRotated`, and `calculateRotatedIntercept` to compute rotated corners and the safe enclosing `AxisAlignedBB`.\
- Swap composite checks in `MCH_AircraftBoundingBox` to use `intersectsRotated` and `calculateRotatedIntercept` for extra sub-boxes so raycasts and intersection tests follow vehicle yaw/pitch/roll.\
- Updated `MCH_BoundingBox.updatePosition` to transform sub-box offsets by `RotVec3` and to set the enclosing `AxisAlignedBB` from the rotated box when `enableRotatingVehicleBounds` is enabled, with a try/catch fallback to the legacy static AABB on error.\
- Added config parameters `enableRotatingVehicleBounds` and `debugRotatingVehicleBounds` to `MCH_Config` (default `true`/`false`), synchronized them via `MCH_PacketNotifyServerSettings`/`MCH_CommonPacketHandler`/`MCH_ServerSettings`, and added client debug rendering in `MCH_RenderAircraft` to visualize local OBBs and their enclosing AABBs when debug is enabled.\
- Documented the new config options in `docs/configuration.md` and preserved existing config layout and defaults.\

### Testing
- Ran `git diff --check` to validate diffs and spacing; it reported no check failures.\
- Attempted `gradle compileJava` and `./gradlew compileJava` to compile the modified code, but builds were blocked by network/proxy access to external Gradle/Maven artifacts (HTTP 403), so compilation could not be completed in this environment.\
- Runtime/functional tests described in the change request (multi-angle aircraft/tank collision, pitched/rolled aircraft, ray/projectile accuracy, client/server sync, and config fallback) should be executed in a full dev environment; the code includes safe fallbacks to legacy behavior if the feature is disabled or an exception occurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28cfa3348c8329a1683bcf7919a38c)