### PR TITLE
Disable RWR by default

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -119,7 +119,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `regeneration` | All | boolean | false | self-repair/regen flag |
 | `Stealth` | All | float | 0.0 | radar/targeting visibility modifier |
 | `RadarType` | All | enum `EARLY_AA`, `MODERN_AA`, etc. | `EARLY_AA`; invalid -> `MODERN_AA` | radar classification |
-| `RWRType` | All | enum | `DIGITAL`; invalid -> `DIGITAL` | radar-warning receiver |
+| `RWRType` | All | enum | `NONE`; invalid -> `NONE` | radar-warning receiver; set `DIGITAL` to enable the current RWR display |
 | `NameOnModernAARadar` | All | string | `?` | radar label |
 | `NameOnEarlyAARadar` | All | string | `?` | radar label |
 | `NameOnModernASRadar` | All | string | `?` | radar label |

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -95,7 +95,7 @@ Planes use a sink of `0.012 * (1 - ceilingLift)` away from the runway; helicopte
 | Key | Type | Default | Notes |
 |---|---|---:|---|
 | `RadarType` | enum | `EARLY_AA` | Invalid values fall back to `MODERN_AA`. |
-| `RWRType` | enum | `DIGITAL` | Invalid values fall back to `DIGITAL`. |
+| `RWRType` | enum | `NONE` | Invalid values fall back to `NONE`; set `DIGITAL` to enable the current RWR display. |
 | `NameOnModernAARadar`, `NameOnEarlyAARadar`, `NameOnModernASRadar`, `NameOnEarlyASRadar` | string | `?` | Radar labels. |
 | `Stealth` | float[0..1] | 0 | Visibility modifier. |
 | `UAV`, `SmallUAV`, `NewUAV`, `NewSmallUAV`, `TargetDrone` | boolean | false | UAV/NewUAV force camera view and add a hidden seat when needed. `TargetDrone` also sets `UAV`. |

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -1,6 +1,7 @@
 package mcheli;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import mcheli.aircraft.EnumRWRType;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.helicopter.MCH_EntityHeli;
@@ -54,6 +55,7 @@ public class MCH_RenderRWR {
             ac = ((MCH_EntityUavStation)player.ridingEntity).getControlAircract();
         }
         if(!(ac instanceof MCP_EntityPlane || ac instanceof MCH_EntityHeli)) return;
+        if(ac.getAcInfo().rwrType == null || ac.getAcInfo().rwrType == EnumRWRType.NONE) return;
 
         //开始渲染
         GL11.glPushMatrix();

--- a/src/main/java/mcheli/aircraft/EnumRWRType.java
+++ b/src/main/java/mcheli/aircraft/EnumRWRType.java
@@ -1,6 +1,5 @@
 package mcheli.aircraft;
 
 public enum EnumRWRType {
-    FOUR_WAY, ALL_WAY_EARLY, DIGITAL
-    //TODO clean this horrific spaghetti up and have it off by default. BF-109 shouldn't have a fucking RWR.
+    NONE, FOUR_WAY, ALL_WAY_EARLY, DIGITAL
 }

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -169,7 +169,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    /**
     * RWR种类
     */
-   public EnumRWRType rwrType = EnumRWRType.DIGITAL;
+   public EnumRWRType rwrType = EnumRWRType.NONE;
 
    /**
     * 当前载具在现代对空雷达中显示的名字
@@ -631,7 +631,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
             try {
                this.rwrType = EnumRWRType.valueOf(data);
             } catch (Exception e) {
-               this.rwrType = EnumRWRType.DIGITAL;
+               this.rwrType = EnumRWRType.NONE;
             }
          }
          else if(item.equalsIgnoreCase("NameOnModernAARadar")) {


### PR DESCRIPTION
### Motivation
- RWR currently appears for every vehicle by default, which is undesirable for vehicles without a receiver. 
- Make the absence of an RWR explicit so the overlay only appears for vehicles that opt in. 
- Keep existing `DIGITAL` behavior available as an opt-in for vehicles that should show RWR. 

### Description
- Add `NONE` to `EnumRWRType` to represent no RWR (`src/main/java/mcheli/aircraft/EnumRWRType.java`).
- Change the default/fallback `rwrType` in `MCH_BaseVehicleInfo` from `DIGITAL` to `NONE` and use `NONE` for invalid `RWRType` parser fallbacks (`src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java`).
- Short-circuit the RWR overlay renderer to return early when a vehicle's `rwrType` is `NONE` or null (`src/main/java/mcheli/MCH_RenderRWR.java`).
- Update docs to show the new default and note that `DIGITAL` must be set to enable the existing RWR display (`docs/vehicle-config-reference.md`, `docs/vehicle-config/base.md`).

### Testing
- `git diff --check` was run and reported no whitespace/error problems (success).
- `bash ./gradlew test` was attempted but blocked by a proxy (HTTP 403) while downloading the Gradle distribution and dependencies (failure due to network/proxy, not code).
- `gradle test` was attempted and failed resolving ForgeGradle/Maven metadata due to proxy 403 responses (dependency resolution failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a3038018483298360ab47c7ff1ff9)