### PR TITLE
Restore legacy mobility as the default vehicle path

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -134,6 +134,13 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public float flightCeiling;
    /** Vertical distance over which lift fades when approaching the flight ceiling. */
    public float flightCeilingRange;
+   /**
+    * Explicit opt-in for the post-legacy mobility/flight-model helpers.
+    *
+    * <p>Legacy MCHeli packs predate these keys, so absence must keep the original
+    * movement, rotation, throttle, and damping paths intact.</p>
+    */
+   public boolean useNewMobilitySystem;
     private List textureNameList;
    public int textureCount;
    public float particlesScale;
@@ -344,6 +351,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
       this.throttleUpDownOnEntity = 2.0F;
       this.flightCeiling = 9100.0F;
       this.flightCeilingRange = 24.0F;
+      this.useNewMobilitySystem = false;
       this.pivotTurnThrottle = 0.0F;
       this.trackRollerRot = 30.0F;
       this.partWheelRot = 30.0F;
@@ -857,6 +865,11 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                                     this.flightCeiling = this.toFloat(data, 32.0F, 37650.0F);
                                  } else if(item.equalsIgnoreCase("FlightCeilingRange")) {
                                     this.flightCeilingRange = this.toFloat(data, 1.0F, 128.0F);
+                                 } else if(item.equalsIgnoreCase("UseNewMobilitySystem")
+                                       || item.equalsIgnoreCase("EnableNewMobilitySystem")
+                                       || item.equalsIgnoreCase("UseNewFlightModel")
+                                       || item.equalsIgnoreCase("EnableNewFlightModel")) {
+                                    this.useNewMobilitySystem = this.toBool(data);
                                  } else if(item.equalsIgnoreCase("Stealth")) {
                                     this.stealth = this.toFloat(data, 0.0F, 1.0F);
                                  } else if(item.equalsIgnoreCase("EntityWidth")) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1817,7 +1817,173 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    protected void updateVehicleStress() {
    }
 
+   protected void setAnglesLegacy(Entity player, boolean fixRot, float fixYaw, float fixPitch, float deltaX, float deltaY, float x, float y, float partialTicks) {
+      //System.out.println("set angles");
+      if(partialTicks < 0.03F) {
+         partialTicks = 0.4F;
+         //System.out.println("partial ticks = 0.4");
+      }
+
+      if(partialTicks > 0.9F) {
+         partialTicks = 0.6F;
+         //System.out.println("Partial ticks = 0.6");
+      }
+
+      this.lowPassPartialTicks.put(partialTicks);
+      partialTicks = this.lowPassPartialTicks.getAvg();
+      float ac_pitch = this.getRotPitch();
+      float ac_yaw = this.getRotYaw();
+      float ac_roll = this.getRotRoll();
+      if(this.isFreeLookMode()) {
+         y = 0.0F;
+         x = 0.0F;
+      }
+
+      float yaw = 0.0F;
+      float pitch = 0.0F;
+      float roll = 0.0F;
+      double m_add;
+      if(this.canUpdateYaw(player)) {
+         m_add = this.getAddRotationYawLimit();
+         yaw = this.getControlRotYaw(x, y, partialTicks);
+         if((double)yaw < -m_add) {
+            yaw = (float)(-m_add);
+         }
+
+         if((double)yaw > m_add) {
+            yaw = (float)m_add;
+         }
+
+         yaw = (float)((double)(yaw * this.getYawFactor()) * 0.06D * (double)partialTicks);
+      }
+
+      if(this.canUpdatePitch(player)) {
+         m_add = this.getAddRotationPitchLimit();
+         pitch = this.getControlRotPitch(x, y, partialTicks);
+         if((double)pitch < -m_add) {
+            pitch = (float)(-m_add);
+         }
+
+         if((double)pitch > m_add) {
+            pitch = (float)m_add;
+         }
+
+         pitch = (float)((double)(-pitch * this.getPitchFactor()) * 0.06D * (double)partialTicks);
+      }
+
+      if(this.canUpdateRoll(player)) {
+         m_add = this.getAddRotationRollLimit();
+         roll = this.getControlRotRoll(x, y, partialTicks);
+         if((double)roll < -m_add) {
+            roll = (float)(-m_add);
+         }
+
+         if((double)roll > m_add) {
+            roll = (float)m_add;
+         }
+
+         roll = roll * this.getRollFactor() * 0.06F * partialTicks;
+      }
+
+      MCH_Math.FMatrix m_add1 = MCH_Math.newMatrix();
+      MCH_Math.MatTurnZ(m_add1, roll / 180.0F * 3.1415927F);
+      MCH_Math.MatTurnX(m_add1, pitch / 180.0F * 3.1415927F);
+      MCH_Math.MatTurnY(m_add1, yaw / 180.0F * 3.1415927F);
+      MCH_Math.MatTurnZ(m_add1, (float)((double)(this.getRotRoll() / 180.0F) * 3.141592653589793D));
+      MCH_Math.MatTurnX(m_add1, (float)((double)(this.getRotPitch() / 180.0F) * 3.141592653589793D));
+      MCH_Math.MatTurnY(m_add1, (float)((double)(this.getRotYaw() / 180.0F) * 3.141592653589793D));
+      MCH_Math.FVector3D v = MCH_Math.MatrixToEuler(m_add1);
+      if(this.getAcInfo().limitRotation) {
+         v.x = MCH_Lib.RNG(v.x, this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
+         v.z = MCH_Lib.RNG(v.z, this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);
+      }
+
+      if(v.z > 180.0F) {
+         v.z -= 360.0F;
+      }
+
+      if(v.z < -180.0F) {
+         v.z += 360.0F;
+      }
+
+      this.setRotYaw(v.y);
+      this.setRotPitch(v.x);
+      this.setRotRoll(v.z);
+      this.onUpdateAngles(partialTicks);
+      if(this.getAcInfo().limitRotation) {
+         v.x = MCH_Lib.RNG(this.getRotPitch(), this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
+         v.z = MCH_Lib.RNG(this.getRotRoll(), this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);
+         this.setRotPitch(v.x);
+         this.setRotRoll(v.z);
+      }
+
+      float RV = 180.0F;
+      if(MathHelper.abs(this.getRotPitch()) > 90.0F) {
+         MCH_Lib.DbgLog(true, "MCH_EntityBaseVehicle.setAngles Error:Pitch=%.1f", new Object[]{Float.valueOf(this.getRotPitch())});
+      }
+
+      if(this.getRotRoll() > 180.0F) {
+         this.setRotRoll(this.getRotRoll() - 360.0F);
+      }
+
+      if(this.getRotRoll() < -180.0F) {
+         this.setRotRoll(this.getRotRoll() + 360.0F);
+      }
+
+      this.prevRotationRoll = this.getRotRoll();
+      super.prevRotationPitch = this.getRotPitch();
+      if(this.getRidingEntity() == null) {
+         super.prevRotationYaw = this.getRotYaw();
+      }
+
+      if(!this.isOverridePlayerYaw() && !fixRot) {
+         player.setAngles(deltaX, 0.0F);
+      } else {
+         if(this.getRidingEntity() == null) {
+            player.prevRotationYaw = this.getRotYaw() + (fixRot?fixYaw:0.0F);
+         } else {
+            if(this.getRotYaw() - player.rotationYaw > 180.0F) {
+               player.prevRotationYaw += 360.0F;
+            }
+
+            if(this.getRotYaw() - player.rotationYaw < -180.0F) {
+               player.prevRotationYaw -= 360.0F;
+            }
+         }
+
+         player.rotationYaw = this.getRotYaw() + (fixRot?fixYaw:0.0F);
+      }
+
+      if(!this.isOverridePlayerPitch() && !fixRot) {
+         //System.out.println("this is when the helicopter is hovering");
+         player.setAngles(0.0F, deltaY);
+      } else {
+         //System.out.println("God's unholy retribution");
+         player.prevRotationPitch = this.getRotPitch() + (fixRot?fixPitch:0.0F);
+         player.rotationPitch = this.getRotPitch() + (fixRot?fixPitch:0.0F);
+      }
+
+      if(this.getRidingEntity() == null && ac_yaw != this.getRotYaw() || ac_pitch != this.getRotPitch() || ac_roll != this.getRotRoll()) {
+         this.aircraftRotChanged = true;
+         //System.out.println("aircraft rot changed");
+      }
+
+   }
+
+   protected boolean useNewMobilitySystem() {
+      return this.getAcInfo() != null && this.getAcInfo().useNewMobilitySystem;
+   }
+
+   protected float decayMobilityValue(float value, float factor, float partialTicks) {
+      return this.useNewMobilitySystem() ? MCH_FlightModel.decayPerTick(value, factor, partialTicks) : value * factor;
+   }
+
    public void setAngles(Entity player, boolean fixRot, float fixYaw, float fixPitch, float deltaX, float deltaY, float x, float y, float partialTicks) {
+      if(!this.useNewMobilitySystem()) {
+         this.setAnglesLegacy(player, fixRot, fixYaw, fixPitch, deltaX, deltaY, x, y, partialTicks);
+         return;
+      }
+
       // Render tick callbacks pass a fraction of a Minecraft tick. Treat that
       // value only as elapsed simulation time; never clamp tiny high-FPS frames
       // to a large fixed value or smooth it with previous render frames.

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -342,7 +342,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          super.prevPosY = super.posY;
          super.prevPosZ = super.posZ;
          if(!this.isDestroyed() && this.isHovering() && MathHelper.abs(this.getRotPitch()) < 70.0F) {
-            this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, 1.0F));
+            this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
          }
 
          if(this.isDestroyed() && this.getCurrentThrottle() > 0.0D) {
@@ -410,15 +410,17 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    public void onUpdateAngles(float partialTicks) {
-      partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      if(this.useNewMobilitySystem()) {
+         partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      }
       if(!this.isDestroyed()) {
          float rotRoll = !this.isHovering()?0.96F:0.93F;
          if((double)this.getRotRoll() > 0.1D && this.getRotRoll() < 65.0F) {
-            this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), rotRoll, partialTicks));
+            this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), rotRoll, partialTicks));
          }
 
          if((double)this.getRotRoll() < -0.1D && this.getRotRoll() > -65.0F) {
-            this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), rotRoll, partialTicks));
+            this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), rotRoll, partialTicks));
          }
 
          if(MCH_Lib.getBlockIdY(this, 3, -3) == 0) {
@@ -824,18 +826,21 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             }
 
             double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
-            double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
-            double rotorEfficiency = ceilingLift;
+            double rotorEfficiency = 1.0D;
+            double translationalLift = 0.0D;
+            if(this.useNewMobilitySystem()) {
+               rotorEfficiency = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
 
-            // Fast forward flight gives the rotor cleaner airflow (translational lift).
-            double translationalLift = MCH_FlightModel.clamp(horizontalSpeed / Math.max(0.1D, (double)this.getAcInfo().speed), 0.0D, 1.0D) * 0.004D;
+               // Fast forward flight gives the rotor cleaner airflow (translational lift).
+               translationalLift = MCH_FlightModel.clamp(horizontalSpeed / Math.max(0.1D, (double)this.getAcInfo().speed), 0.0D, 1.0D) * 0.004D;
 
-            // A powered, near-vertical descent can enter a vortex-ring state. Forward
-            // motion or lowering collective lets the helicopter recover naturally.
-            boolean vortexRing = super.motionY < -0.12D && horizontalSpeed < 0.15D && throttle > 0.45D;
-            if(vortexRing) {
-               rotorEfficiency *= 0.55D;
-               super.motionY -= 0.006D;
+               // A powered, near-vertical descent can enter a vortex-ring state. Forward
+               // motion or lowering collective lets the helicopter recover naturally.
+               boolean vortexRing = super.motionY < -0.12D && horizontalSpeed < 0.15D && throttle > 0.45D;
+               if(vortexRing) {
+                  rotorEfficiency *= 0.55D;
+                  super.motionY -= 0.006D;
+               }
             }
 
             super.motionY += ((y * 0.025D + 0.03D) * throttle + translationalLift * throttle) * rotorEfficiency;
@@ -877,12 +882,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
       }
 
-      double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
-      if(!super.onGround && ceilingLift < 1.0D) {
-         if(super.motionY > 0.0D) {
-            super.motionY *= 0.88D + ceilingLift * 0.12D;
+      if(this.useNewMobilitySystem()) {
+         double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
+         if(!super.onGround && ceilingLift < 1.0D) {
+            if(super.motionY > 0.0D) {
+               super.motionY *= 0.88D + ceilingLift * 0.12D;
+            }
+            super.motionY -= (1.0D - ceilingLift) * 0.014D;
          }
-         super.motionY -= (1.0D - ceilingLift) * 0.014D;
       }
 
       motion = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -261,17 +261,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    public float getYawFactor() {
       float yaw = this.getVtolMode() > 0?this.getPlaneInfo().vtolYaw:super.getYawFactor();
-      return yaw * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
+      return yaw * 0.8F * (this.useNewMobilitySystem() ? PLANE_MANEUVERABILITY_FACTOR : 1.0F);
    }
 
    public float getPitchFactor() {
       float pitch = this.getVtolMode() > 0?this.getPlaneInfo().vtolPitch:super.getPitchFactor();
-      return pitch * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
+      return pitch * 0.8F * (this.useNewMobilitySystem() ? PLANE_MANEUVERABILITY_FACTOR : 1.0F);
    }
 
    public float getRollFactor() {
       float roll = this.getVtolMode() > 0?this.getPlaneInfo().vtolYaw:super.getRollFactor();
-      return roll * 0.8F * PLANE_MANEUVERABILITY_FACTOR;
+      return roll * 0.8F * (this.useNewMobilitySystem() ? PLANE_MANEUVERABILITY_FACTOR : 1.0F);
    }
 
    public boolean isOverridePlayerPitch() {
@@ -319,6 +319,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected float getControlAuthorityFactor() {
+      if(!this.useNewMobilitySystem()) {
+         return 1.0F;
+      }
+
       if(this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
          return 1.0F;
       }
@@ -408,6 +412,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
 
    public void setAngles(Entity player, boolean fixRot, float fixYaw, float fixPitch, float deltaX, float deltaY, float x, float y, float partialTicks) {
+      if(!this.useNewMobilitySystem()) {
+         super.setAngles(player, fixRot, fixYaw, fixPitch, deltaX, deltaY, x, y, partialTicks);
+         return;
+      }
+
       MCP_PlaneInfo planeInfo = this.getPlaneInfo();
       if(planeInfo == null) {
          super.setAngles(player, fixRot, fixYaw, fixPitch, deltaX, deltaY, x, y, partialTicks);
@@ -621,6 +630,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected void updateVehicleStress() {
+      if(!this.useNewMobilitySystem()) {
+         this.currentGForce = 1.0D;
+         this.overspeedDamageAccumulator = 0.0D;
+         return;
+      }
+
       MCP_PlaneInfo info = this.getPlaneInfo();
       if(info == null) {
          this.currentGForce = 1.0D;
@@ -647,13 +662,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    public void onUpdateAngles(float partialTicks) {
-      partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      if(this.useNewMobilitySystem()) {
+         partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      }
       if(!this.isDestroyed()) {
          if(super.isGunnerMode) {
-            this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, partialTicks));
+            this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
             this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
             if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
-               this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), 0.95F, partialTicks));
+               this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
             }
          }
 
@@ -664,8 +681,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                MCH_Config var10000 = MCH_MOD.config;
                if(!MCH_Config.MouseControlFlightSimMode.prmBool) {
                   this.rotationByKey(partialTicks);
+                  float maneuverabilityFactor = this.useNewMobilitySystem()
+                        ? PLANE_MANEUVERABILITY_FACTOR * this.getControlAuthorityFactor() : 1.0F;
                   this.setRotRoll(this.getRotRoll() + this.addkeyRotValue * 0.5F * this.getAcInfo().mobilityRoll
-                        * PLANE_MANEUVERABILITY_FACTOR * this.getControlAuthorityFactor());
+                        * maneuverabilityFactor);
                }
             }
          } else {
@@ -689,14 +708,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             }
          }
 
-         this.addkeyRotValue = MCH_FlightModel.decayPerTick(this.addkeyRotValue, 0.9F, partialTicks);
+         this.addkeyRotValue = this.decayMobilityValue(this.addkeyRotValue, 0.9F, partialTicks);
          if(!isFly && MathHelper.abs(this.getRotPitch()) < 40.0F) {
             this.applyOnGroundPitch(0.97F);
          }
 
          if(this.getNozzleRotation() > 0.001F) {
-            this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.97F, partialTicks));
-            this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), 0.9F, partialTicks));
+            this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.97F, partialTicks));
+            this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.9F, partialTicks));
          }
 
       }
@@ -738,12 +757,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.setThrottle(this.getCurrentThrottle());
       }
 
-      this.engineThrottle = MCH_FlightModel.approachEngineOutput(this.engineThrottle, this.getCurrentThrottle(),
-            this.getPlaneInfo().throttleAcceleration, this.getPlaneInfo().engineDrag);
+      if(this.useNewMobilitySystem()) {
+         this.engineThrottle = MCH_FlightModel.approachEngineOutput(this.engineThrottle, this.getCurrentThrottle(),
+               this.getPlaneInfo().throttleAcceleration, this.getPlaneInfo().engineDrag);
+      } else {
+         this.engineThrottle = this.getCurrentThrottle();
+      }
    }
 
    protected double getEngineThrottle() {
-      return this.engineThrottle;
+      return this.useNewMobilitySystem() ? this.engineThrottle : this.getCurrentThrottle();
    }
 
    protected void onUpdate_ControlNotHovering() {
@@ -1080,7 +1103,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if(this.canFloatWater()) {
          dp = this.getWaterDepth();
       }
-      this.updateAerodynamicState();
+      if(this.useNewMobilitySystem()) {
+         this.updateAerodynamicState();
+      } else {
+         this.angleOfAttack = 0.0D;
+         this.stallSeverity = 0.0D;
+         this.lastAerodynamicDrag = 0.0D;
+         this.lastLiftLoss = 0.0D;
+         this.stalling = false;
+      }
 
       boolean levelOff = super.isGunnerMode;
       if(dp == 0.0D) {
@@ -1112,7 +1143,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
 
                // 自动调整俯仰角度，使其逐渐减小
-               this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, 1.0F));
+               this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
 
                // 如果可以收起起落架，则执行收起起落架的操作
                if (this.canFoldLandingGear()) {
@@ -1156,7 +1187,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // 如果喷嘴的旋转角度大于0.001F
       if(this.getNozzleRotation() > 0.001F) {
          // 根据喷嘴旋转角度调整飞机俯仰角度
-         this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, 1.0F));
+         this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
          // 根据航向角和俯仰角计算方向向量
          v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch() - this.getNozzleRotation());
          // 如果喷嘴旋转角度大于等于90度，缩小x和z方向的速度
@@ -1210,13 +1241,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       super.motionZ *= this.getAcInfo().motionFactor;
 
       float baseSpeedLimit = this.getMaxSpeed();
-      float levelSpeed = this.getPlaneInfo().maxLevelSpeed > 0.0F ? this.getPlaneInfo().maxLevelSpeed : baseSpeedLimit;
+      float levelSpeed = this.useNewMobilitySystem() && this.getPlaneInfo().maxLevelSpeed > 0.0F ? this.getPlaneInfo().maxLevelSpeed : baseSpeedLimit;
 
       // Apply a deliberately simple energy model only to conventional airborne flight.
       // Velocity direction carries the gained/lost energy, while bank and body rates
       // cheaply approximate induced and control-surface drag during hard manoeuvres.
       this.lastAerodynamicDrag = 0.0D;
-      if(dp == 0.0D && !super.onGround && this.getNozzleRotation() <= 0.01F && !levelOff) {
+      if(this.useNewMobilitySystem() && dp == 0.0D && !super.onGround && this.getNozzleRotation() <= 0.01F && !levelOff) {
          double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
          double bankLoad = MCH_FlightModel.clamp(MathHelper.abs(this.getRotRoll()) / 75.0D, 0.0D, 1.0D);
          double bodyRate = (MathHelper.abs(this.pitchAngularVelocity) + MathHelper.abs(this.rollAngularVelocity)
@@ -1247,8 +1278,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       // 计算当前水平速度的大小
       double motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
-      // Diving permits an overspeed, but level flight settles toward maxLevelSpeed.
-      float speedLimit = (float)MCH_FlightModel.getDiveSpeedLimit(levelSpeed, this.getRotPitch(), super.motionY, this.getPlaneInfo().diveSpeedMultiplier);
+      // Diving permits an overspeed only for vehicles explicitly using the new mobility system.
+      float speedLimit = this.useNewMobilitySystem()
+            ? (float)MCH_FlightModel.getDiveSpeedLimit(levelSpeed, this.getRotPitch(), super.motionY, this.getPlaneInfo().diveSpeedMultiplier)
+            : baseSpeedLimit;
       // 如果当前速度超过最大速度限制，按最大速度比例缩小水平速度
       if(motion1 > (double)speedLimit) {
          super.motionX *= (double)speedLimit / motion1;
@@ -1275,7 +1308,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // buffet/wing drop. Lowering the nose reduces AoA and lets speed build to recovery.
       boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
       this.lastLiftLoss = 0.0D;
-      if(!nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff && this.stallSeverity > 0.0D) {
+      if(this.useNewMobilitySystem() && !nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff && this.stallSeverity > 0.0D) {
          double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)this.getPlaneInfo().stallLiftLoss, 0.0D, 1.0D);
          this.lastLiftLoss = liftLoss;
          if(super.motionY > 0.0D) {
@@ -1294,12 +1327,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       // Lift fades through a band below the configured ceiling instead of hitting an invisible wall.
-      double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
-      if(!nearGround && ceilingLift < 1.0D) {
-         if(super.motionY > 0.0D) {
-            super.motionY *= 0.9D + ceilingLift * 0.1D;
+      if(this.useNewMobilitySystem()) {
+         double ceilingLift = MCH_FlightModel.getCeilingLiftFactor(super.posY, this.getAcInfo().flightCeiling, this.getAcInfo().flightCeilingRange);
+         if(!nearGround && ceilingLift < 1.0D) {
+            if(super.motionY > 0.0D) {
+               super.motionY *= 0.9D + ceilingLift * 0.1D;
+            }
+            super.motionY -= (1.0D - ceilingLift) * 0.012D;
          }
-         super.motionY -= (1.0D - ceilingLift) * 0.012D;
       }
 
       // 如果飞行器在地面或距离地面较近，则缩减水平速度，应用地面俯仰角度

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -379,13 +379,15 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
     }
 
     public void onUpdateAngles(float partialTicks) {
-        partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+        if(this.useNewMobilitySystem()) {
+            partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+        }
         if(!this.isDestroyed()) {
             if(super.isGunnerMode) {
-                this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, partialTicks));
+                this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
                 this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
                 if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
-                    this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), 0.95F, partialTicks));
+                    this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
                 }
             }
 
@@ -423,14 +425,14 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 }
             }
 
-            this.addkeyRotValue = MCH_FlightModel.decayPerTick(this.addkeyRotValue, 0.9F, partialTicks);
+            this.addkeyRotValue = this.decayMobilityValue(this.addkeyRotValue, 0.9F, partialTicks);
             if(!isFly && MathHelper.abs(this.getRotPitch()) < 40.0F) {
                 this.applyOnGroundPitch(0.97F);
             }
 
             if(this.getNozzleRotation() > 0.001F) {
-                this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.97F, partialTicks));
-                this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), 0.9F, partialTicks));
+                this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.97F, partialTicks));
+                this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.9F, partialTicks));
             }
 
         }
@@ -804,7 +806,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                     }
                 } else {
                     this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
-                    this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, 1.0F));
+                    this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
                     if(this.canFoldLandingGear()) {
                         this.foldLandingGear();
                     }
@@ -842,7 +844,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         if(submarineInWater) {
             v = MCH_Lib.Rot2Vec3(this.getRotYaw(), 0.0F);
         } else if(this.getNozzleRotation() > 0.001F) {
-            this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, 1.0F));
+            this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
             v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch() - this.getNozzleRotation());
             if(this.getNozzleRotation() >= 90.0F) {
                 v.xCoord *= 0.800000011920929D;

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -388,13 +388,15 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    }
 
    public void onUpdateAngles(float partialTicks) {
-      partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      if(this.useNewMobilitySystem()) {
+         partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      }
       if(!this.isDestroyed()) {
          if(super.isGunnerMode) {
-            this.setRotPitch(MCH_FlightModel.decayPerTick(this.getRotPitch(), 0.95F, partialTicks));
+            this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
             this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
             if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
-               this.setRotRoll(MCH_FlightModel.decayPerTick(this.getRotRoll(), 0.95F, partialTicks));
+               this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
             }
          }
 
@@ -440,7 +442,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
             }
          }
 
-         this.addkeyRotValue = MCH_FlightModel.decayPerTick(this.addkeyRotValue, 0.9F, partialTicks);
+         this.addkeyRotValue = this.decayMobilityValue(this.addkeyRotValue, 0.9F, partialTicks);
       }
    }
 
@@ -1296,8 +1298,21 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
    //set angles is le turret (1.12.2)
    public void setAngles(Entity player, boolean fixRot, float fixYaw, float fixPitch, float deltaX, float deltaY, float x, float y, float partialTicks) {
-      // Keep turret/camera limits tied to elapsed tick time instead of render FPS.
-      partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      // Keep turret/camera limits tied to elapsed tick time instead of render FPS only for the opt-in mobility path.
+      if(this.useNewMobilitySystem()) {
+         partialTicks = MCH_FlightModel.getBoundedTickDelta(partialTicks);
+      } else {
+         if(partialTicks < 0.03F) {
+            partialTicks = 0.4F;
+         }
+
+         if(partialTicks > 0.9F) {
+            partialTicks = 0.6F;
+         }
+
+         this.lowPassPartialTicks.put(partialTicks);
+         partialTicks = this.lowPassPartialTicks.getAvg();
+      }
       float ac_pitch = this.getRotPitch();
       float ac_yaw = this.getRotYaw();
       float ac_roll = this.getRotRoll();


### PR DESCRIPTION
### Motivation
- Preserve compatibility by ensuring existing vehicle packs keep legacy MCHeli handling unless they explicitly opt into the new mobility/flight model.
- Avoid unintended changes to handling, throttle, damping, stall, drag and rotation for aircraft, helicopters, tanks, ships, turrets and other vehicles when new mobility helpers are present.

### Description
- Add an explicit opt-in flag `useNewMobilitySystem` (config keys accepted: `UseNewMobilitySystem`, `EnableNewMobilitySystem`, `UseNewFlightModel`, `EnableNewFlightModel`) to `MCH_BaseVehicleInfo` that defaults to `false`, so absence preserves legacy behavior.
- Reintroduce the legacy angle/partial-tick integration path from `OLD_MCH_EntityAircraft` as `setAnglesLegacy` inside `MCH_EntityBaseVehicle` and dispatch to it for non-opt-in vehicles.
- Introduce `useNewMobilitySystem()` and `decayMobilityValue()` helpers on `MCH_EntityBaseVehicle` and gate new-flight-model calculations (engine smoothing, aerodynamic state, energy-drag, stall/overspeed, dive-speed, maneuverability multipliers, ceiling/translational lift, vortex-ring logic) behind the opt-in flag in `MCP_EntityPlane`, `MCH_EntityHeli`, `MCH_EntityTank`, `MCH_EntityShip` and related places.
- Keep legacy config parsing and numeric meanings unchanged for the legacy path and add `useNewMobilitySystem` parsing in `MCH_BaseVehicleInfo.loadItemData` so legacy files load without modification.

### Testing
- Ran `git diff --check` and code style/basic diff checks with no immediate whitespace conflicts detected (success).
- Attempted Java compilation with `bash ./gradlew compileJava`, but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so a full compile could not be completed.
- Ran `gradle compileJava` and `gradle --offline compileJava` which failed to resolve `com.anatawa12.forge:ForgeGradle` due to remote repository access being blocked or missing cached metadata (dependency resolution failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a360a64ac8329b2803f2deb03873e)