### PR TITLE
Fix NewUAV pilot return: detach-before-teleport and persist station coordinates

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -64,7 +64,6 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.oredict.OreDictionary;
 
 import static mcheli.hud.MCH_HudItem.player;
-import static mcheli.uav.MCH_EntityUavStation.*;
 //import static net.minecraft.command.CommandBase.getCommandSenderAsPlayer;
 //import static net.minecraft.command.CommandBase.getPlayer;
 
@@ -257,10 +256,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public float thirdPersonDist = 4.0F;
    public Entity lastAttackedEntity = null;
    private static final MCH_EntitySeat[] seatsDummy = new MCH_EntitySeat[0];
-   public static boolean newuavvariable = false;
-   public EntityPlayer storedRider;
-
-   public String newUavPlayerUUID;
    private int delayedUavInventoryTicks;
    private UUID uavPersistentUUID;
    private UUID uavOwnerUUID;
@@ -285,9 +280,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public float ironCurtainCurrentFactor = 0.5f;
    public int ironCurtainWaveTimer = 0;
 
-   public int UavStationPosX;
-   public int UavStationPosY;
-   public int UavStationPosZ;
+   private boolean hasLinkedUavStationPosition;
+   private boolean newUavShiftExitInProgress;
 
    private final Set<ChunkCoordinates> activeLights = new HashSet<>();
 
@@ -363,6 +357,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.linkedUavStationX = 0.0D;
       this.linkedUavStationY = 0.0D;
       this.linkedUavStationZ = 0.0D;
+      this.hasLinkedUavStationPosition = false;
+      this.newUavShiftExitInProgress = false;
       this.modeSwitchCooldown = 0;
       this.partHatch = null;
       this.partCanopy = null;
@@ -575,15 +571,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public boolean isNewUAV() {
-           return (getAcInfo() != null && (getAcInfo()).isNewUAV);
-         }
-
-  // if (isNewUAV() = true) {
-  //    System.out.println("isNewUAV() is true");
-//
-  // } else {
-  //    System.out.println("isNewUAV() is false");
-  // }
+      return this.getAcInfo() != null && this.getAcInfo().isNewUAV;
+   }
 
    public boolean isSmallUAV() {
       return this.getAcInfo() != null && this.getAcInfo().isSmallUAV;
@@ -593,17 +582,19 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return this.getAcInfo() != null && this.getAcInfo().alwaysCameraView;
    }
 
+   private void saveUavStationPosition(MCH_EntityUavStation station) {
+      this.linkedUavStationUUID = station.getUniqueID();
+      this.linkedUavStationDimension = station.dimension;
+      this.linkedUavStationX = station.posX;
+      this.linkedUavStationY = station.posY;
+      this.linkedUavStationZ = station.posZ;
+      this.hasLinkedUavStationPosition = true;
+   }
+
    public void setUavStation(MCH_EntityUavStation uavSt) {
       this.uavStation = uavSt;
       if(uavSt != null) {
-         this.linkedUavStationUUID = uavSt.getUniqueID();
-         this.linkedUavStationDimension = uavSt.dimension;
-         this.linkedUavStationX = uavSt.posX;
-         this.linkedUavStationY = uavSt.posY;
-         this.linkedUavStationZ = uavSt.posZ;
-         this.UavStationPosX = MathHelper.floor_double(uavSt.posX);
-         this.UavStationPosY = MathHelper.floor_double(uavSt.posY);
-         this.UavStationPosZ = MathHelper.floor_double(uavSt.posZ);
+         saveUavStationPosition(uavSt);
          if(uavSt.getOwnerUUID() != null) {
             this.setOwnerUUID(uavSt.getOwnerUUID());
          }
@@ -897,34 +888,24 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
 
 
-      if (getRiddenByEntity() != null) {
-         if (isUAV()) {
-            // For normal UAVs, perform the standard dismount.
-            Entity rider = getRiddenByEntity();
-            if (rider != null) {
-               rider.mountEntity(null);
+      Entity rider = this.getRiddenByEntity();
+      if(rider != null) {
+         // NewUAV may also carry the legacy UAV flag, so always handle it first.
+         if(this.isNewUAV()) {
+            if(!super.worldObj.isRemote) {
+               this.returnNewUavPilotToStation(rider, "uav_destroyed");
             }
-         } else if (isNewUAV()) {
-            Entity rider = getRiddenByEntity();
-            if (rider instanceof EntityPlayer) {
-               EntityPlayer player = (EntityPlayer) rider;
-                  this.unmountEntity(); // ← this triggers the correct logic and teleport
-
-               //System.out.println("uavposxyz" + MCH_EntityUavStation.posUavX + ", " +
-               //        super.posY + ", " +
-               //        super.posZ + ", " +
-               //        "riderposxyz" + rider.posX + ", " +
-               //        rider.posY + ", " +
-               //        rider.posZ + ", ");
-
+            if(rider instanceof EntityPlayer) {
+               EntityPlayer player = (EntityPlayer)rider;
                player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Drone destroyed!"));
                player.addPotionEffect(new PotionEffect(11, 20, 50));
-
-               player.addPotionEffect(new PotionEffect(12, 20, 0)); // Fire Resistance
-
+               player.addPotionEffect(new PotionEffect(12, 20, 0));
             }
+         } else if(this.isUAV()) {
+            rider.mountEntity((Entity)null);
          }
       }
+
 
       if(!super.worldObj.isRemote) {
          this.ejectSeat(this.getRiddenByEntity());
@@ -933,40 +914,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             this.ejectSeat(var3);
          }
 
-         //if (isNewUAV()) {
-         //   System.out.println("New UAV detected, performing special dismount logic. IS REMOTE");
-         //   player.mountEntity(null);
-         //   player.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-//
-         //   System.out.println("Setting position to: " +
-         //           this.UavStationPosX + ", " +
-         //           this.UavStationPosY + ", " +
-         //           this.UavStationPosZ);
-//
-         //   player.setPositionAndUpdate(
-         //           this.UavStationPosX,
-         //           this.UavStationPosY,
-         //           this.UavStationPosZ
-         //   );
-         //   System.out.println("Setting position to: " +
-         //           getUavStation().getStoredStationX() + ", " +
-         //           getUavStation().getStoredStationY() + ", " +
-         //           getUavStation().getStoredStationZ());
-//
-         //   getRiddenByEntity().setPosition(
-         //           getUavStation().getStoredStationX(),
-         //           getUavStation().getStoredStationY(),
-         //           getUavStation().getStoredStationZ());
-//
-         //   //player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Drone destroyed!"));
-         //   player.addPotionEffect(new PotionEffect(11, 20, 50));
-//
-//
-         //   //player.addPotionEffect(new PotionEffect(11, 20, 4)); // Resistance IV
-         //   //already applied
-         //   player.addPotionEffect(new PotionEffect(12, 20, 0)); // Fire Resistance
-         //}
-         //so basically this crashed the game or something
 
          //float dmg = MCH_Config.KillPassengersWhenDestroyed.prmBool ? 100000.0F : 0.001F;
          //DamageSource damageSource = DamageSource.generic; // 默认的伤害来源为generic
@@ -1263,9 +1210,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.linkedUavStationX = nbt.getDouble("MCH_UavStationX");
       this.linkedUavStationY = nbt.getDouble("MCH_UavStationY");
       this.linkedUavStationZ = nbt.getDouble("MCH_UavStationZ");
-      this.UavStationPosX = MathHelper.floor_double(this.linkedUavStationX);
-      this.UavStationPosY = MathHelper.floor_double(this.linkedUavStationY);
-      this.UavStationPosZ = MathHelper.floor_double(this.linkedUavStationZ);
+      this.hasLinkedUavStationPosition = nbt.hasKey("MCH_HasUavStationPosition")
+              ? nbt.getBoolean("MCH_HasUavStationPosition")
+              : this.linkedUavStationUUID != null;
       if(!super.worldObj.isRemote && (this.isUAV() || this.isNewUAV())) {
          MCH_UavRegistry.register(this);
          if(this.uavStation != null && !this.uavStation.isDead) {
@@ -1335,6 +1282,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       nbt.setDouble("MCH_UavStationX", this.linkedUavStationX);
       nbt.setDouble("MCH_UavStationY", this.linkedUavStationY);
       nbt.setDouble("MCH_UavStationZ", this.linkedUavStationZ);
+      nbt.setBoolean("MCH_HasUavStationPosition", this.hasLinkedUavStationPosition);
    }
 
    public boolean attackEntityFrom(DamageSource damageSource, float org_damage) {
@@ -1591,11 +1539,14 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void destruct() {
-      if(this.getRiddenByEntity() != null) {
-         this.getRiddenByEntity().mountEntity((Entity)null);
+      Entity pilot = this.getRiddenByEntity();
+      if(pilot != null) {
+         if(this.isNewUAV() && !super.worldObj.isRemote) {
+            this.returnNewUavPilotToStation(pilot, "uav_destructed");
+         } else {
+            pilot.mountEntity((Entity)null);
+         }
       }
-
-      //this.clearSearchlightBlocks();
       this.setDead(true);
    }
 
@@ -2765,18 +2716,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(!super.worldObj.isRemote) {
          updateDelayedUavInventoryStore();
 
-         if (this.uavStation != null) {
-            //this fires before we have successfully binded to UAV.
-            UavStationPosX = (int) this.uavStation.posX;
-            UavStationPosY = (int) this.uavStation.posY;
-            UavStationPosZ = (int) this.uavStation.posZ;
+         if(this.uavStation != null && !this.uavStation.isDead) {
+            this.saveUavStationPosition(this.uavStation);
             if(this.isNewUAV()) {
                this.uavStation.updateLinkedUavPosition(this);
             }
          }
-         //don't do that in updatecontrol, uav station might be unloaded during update control
-         //actually wait, let's see what it's printing
-         //grab and set uav station position
 
          this.setCommonStatus(7, this.moveLeft);
          this.setCommonStatus(8, this.moveRight);
@@ -5239,13 +5184,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void onUnmountPlayerSeat(MCH_EntitySeat seat, Entity entity) {
 
-      if (this.isNewUAV()) {
-         //teleport player to UAV station.
-         //doesn't working
-            if (entity instanceof EntityPlayer) {
-                ((EntityPlayer) entity).setPositionAndUpdate(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-                //entity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-            }
+      if(this.isNewUAV() && !super.worldObj.isRemote) {
+         this.returnNewUavPilotToStation(entity, "uav_seat_exit");
       }
 
       MCH_Lib.DbgLog(super.worldObj, "onUnmountPlayerSeat:%d", new Object[]{Integer.valueOf(W_Entity.getEntityId(entity))});
@@ -5475,8 +5415,13 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setDead(boolean dropItems) {
-      if(!super.worldObj.isRemote && this.isNewUAV()) {
-         restoreStoredPilot("uav_destroyed");
+      if(!super.worldObj.isRemote && this.isNewUAV() && !this.newUavShiftExitInProgress) {
+         Entity pilot = super.riddenByEntity != null ? super.riddenByEntity : this.lastRiddenByEntity;
+         if(pilot != null) {
+            this.returnNewUavPilotToStation(pilot, "uav_destroyed");
+         } else {
+            restoreStoredPilot("uav_destroyed");
+         }
       }
       MCH_UavRegistry.unregister(this);
       super.dropContentsWhenDead = dropItems;
@@ -5556,6 +5501,62 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return null;
    }
 
+   private boolean hasNewUavReturnPosition() {
+      return this.hasLinkedUavStationPosition && this.linkedUavStationDimension == this.dimension;
+   }
+
+   private void updateNewUavReturnPositionFromStation() {
+      MCH_EntityUavStation station = resolveLinkedUavStation();
+      if(station != null) {
+         this.setUavStation(station);
+      }
+   }
+
+   /**
+    * Detaches a NewUAV pilot before moving them. Vanilla's unmount placement runs during
+    * mountEntity(null), so teleporting first can be overwritten with the aircraft position.
+    */
+   public boolean returnNewUavPilotToStation(Entity pilot, String inventoryReason) {
+      if(pilot == null || pilot instanceof MCH_EntitySeat || super.worldObj.isRemote || !this.isNewUAV()) {
+         return false;
+      }
+
+      updateNewUavReturnPositionFromStation();
+      if(!hasNewUavReturnPosition()) {
+         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: no saved station position", new Object[0]);
+         return false;
+      }
+
+      if(pilot.ridingEntity != null) {
+         pilot.mountEntity((Entity)null);
+      }
+      pilot.motionX = 0.0D;
+      pilot.motionY = 0.0D;
+      pilot.motionZ = 0.0D;
+      pilot.fallDistance = 0.0F;
+      if(pilot instanceof EntityPlayerMP) {
+         ((EntityPlayerMP)pilot).setPositionAndUpdate(this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
+         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)pilot, inventoryReason);
+      } else {
+         pilot.setPosition(this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
+      }
+      return true;
+   }
+
+   /** Called by every concrete vehicle subclass when its pilot entity dies. */
+   protected void handleDeadPilot() {
+      Entity pilot = this.getRiddenByEntity();
+      if(pilot == null || !pilot.isDead) {
+         return;
+      }
+      if(this.isNewUAV() && !super.worldObj.isRemote) {
+         this.returnNewUavPilotToStation(pilot, "uav_pilot_death");
+      } else {
+         this.unmountEntity();
+      }
+      super.riddenByEntity = null;
+   }
+
    private void deleteNewUavAfterShiftExit() {
       if(super.worldObj.isRemote || !this.isNewUAV()) {
          return;
@@ -5570,7 +5571,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return;
       }
       MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
-      this.setDead(false);
+      this.newUavShiftExitInProgress = true;
+      try {
+         this.setDead(false);
+      } finally {
+         this.newUavShiftExitInProgress = false;
+      }
    }
 
    public void unmountEntity() {
@@ -5599,27 +5605,20 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       setCommonStatus(1, false);
-           if (rByEntity != null) {
-                // NewUAV/NewSmallUAV must use the direct-control shift exit even when a
-                // content definition also includes the legacy UAV/SmallUAV flag.
-                if (isNewUAV()) {
-                     newuavvariable = true;
-                     if(!this.worldObj.isRemote) {
-                      rByEntity.setPosition(this.UavStationPosX, this.UavStationPosY, this.UavStationPosZ);
-                      rByEntity.mountEntity((Entity) null);
-                      if(rByEntity instanceof EntityPlayerMP) {
-                         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)rByEntity, "uav_exit");
-                      }
-                      deleteNewUavAfterShiftExit();
-                     }
-                   } else if (isUAV()) {
-                     if (rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
-                          rByEntity.mountEntity((Entity)null);
-                        }
-                   } else {
-                     setUnmountPosition(rByEntity, (getSeatsInfo()[0]).pos);
-                   }
-              }
+      if(rByEntity != null) {
+         // NewUAV takes precedence over the legacy UAV flag used by some content packs.
+         if(this.isNewUAV()) {
+            if(!super.worldObj.isRemote && this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+               deleteNewUavAfterShiftExit();
+            }
+         } else if(this.isUAV()) {
+            if(rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
+               rByEntity.mountEntity((Entity)null);
+            }
+         } else {
+            setUnmountPosition(rByEntity, this.getSeatsInfo()[0].pos);
+         }
+      }
 
       super.riddenByEntity = null;
       this.lastRiddenByEntity = null;
@@ -5770,70 +5769,27 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             this.listUnmountReserve.add(new MCH_EntityBaseVehicle.UnmountReserve(rByEntity, v.xCoord, v.yCoord, v.zCoord));
          }
 
-      } else {
-         //new uav only
-            if (rByEntity != null) {
-                MCH_BaseVehicleInfo info = this.getAcInfo();
-                if (info != null && info.unmountPosition != null) {
-                    rByEntity.setPosition(info.unmountPosition.xCoord, info.unmountPosition.yCoord, info.unmountPosition.zCoord);
-                   rByEntity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
-                }
-
-                rByEntity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
-            }
+      } else if(rByEntity != null && !super.worldObj.isRemote) {
+         this.returnNewUavPilotToStation(rByEntity, "uav_unmount_position");
       }
 
    }
 
    public boolean unmountEntityFromSeat(Entity entity) {
+      if(entity == null || this.seats == null) {
+         return false;
+      }
 
-      if (!this.isNewUAV()) {
-
-         if (entity != null && this.seats != null && this.seats.length != 0) {
-            MCH_EntitySeat[] arr$ = this.seats;
-            int len$ = arr$.length;
-
-            for (int i$ = 0; i$ < len$; ++i$) {
-               MCH_EntitySeat seat = arr$[i$];
-               if (seat != null && seat.riddenByEntity != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
-                  entity.mountEntity((Entity) null);
-               }
-            }
-
-            return false;
-         } else {
-            return false;
+      for(MCH_EntitySeat seat : this.seats) {
+         if(seat != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
+            entity.mountEntity((Entity)null);
+            break;
          }
-      } else {
-         if (entity != null) {
-            MCH_BaseVehicleInfo info = this.getAcInfo();
-            if (info != null && info.unmountPosition != null) {
-               MCH_EntitySeat[] arr$ = this.seats;
-               int len$ = arr$.length;
+      }
 
-               for (int i$ = 0; i$ < len$; ++i$) {
-                  MCH_EntitySeat seat = arr$[i$];
-                  if (seat != null && seat.riddenByEntity != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
-                     entity.mountEntity((Entity) null);
-                  }
-               }
-               entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
-               deleteNewUavAfterShiftExit();
-               return false;
-            }
-            MCH_EntitySeat[] arr$ = this.seats;
-            int len$ = arr$.length;
-
-            for (int i$ = 0; i$ < len$; ++i$) {
-               MCH_EntitySeat seat = arr$[i$];
-               if (seat != null && seat.riddenByEntity != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
-                  entity.mountEntity((Entity) null);
-               }
-            }
-            entity.setPosition(UavStationPosX, UavStationPosY, UavStationPosZ);
-            deleteNewUavAfterShiftExit();
-            return false;
-         }
+      if(this.isNewUAV() && !super.worldObj.isRemote
+              && this.returnNewUavPilotToStation(entity, "uav_seat_exit")) {
+         deleteNewUavAfterShiftExit();
       }
       return false;
    }

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -934,10 +934,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       super.motionZ *= 0.99D;
       this.setRotation(this.getRotYaw(), this.getRotPitch());
       this.onUpdate_updateBlock();
-      if(this.getRiddenByEntity() != null && this.getRiddenByEntity().isDead) {
-         this.unmountEntity();
-         super.riddenByEntity = null;
-      }
+      this.handleDeadPilot();
 
    }
 

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1355,11 +1355,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // 更新方块信息
       this.onUpdate_updateBlock();
 
-      // 如果骑乘的实体存在并且已经死亡，则解除骑乘
-      if(this.getRiddenByEntity() != null && this.getRiddenByEntity().isDead) {
-         this.unmountEntity();
-         super.riddenByEntity = null;
-      }
+      this.handleDeadPilot();
 
 
    }

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -954,10 +954,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         }
         this.setRotation(this.getRotYaw(), this.getRotPitch());
         this.onUpdate_updateBlock();
-        if(this.getRiddenByEntity() != null && this.getRiddenByEntity().isDead) {
-            this.unmountEntity();
-            super.riddenByEntity = null;
-        }
+        this.handleDeadPilot();
 
     }
 

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -1048,10 +1048,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.onUpdate_updateBlock();
       this.updateCollisionBox();
 
-      if (this.getRiddenByEntity() != null && this.getRiddenByEntity().isDead) {
-         this.unmountEntity();
-         super.riddenByEntity = null;
-      }
+      this.handleDeadPilot();
    }
 
 

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -63,13 +63,7 @@ public class MCH_EntityUavStation
       protected int aircraftPosRotInc;
       protected double aircraftX;
 
-      public static double storedStationX;
-      public static double storedStationY;
-      public static double storedStationZ;
-
       private boolean continuePressed = false;
-      public boolean isridingnewuav = false;
-      public String newUavPlayerUUID;
       public MCH_EntityBaseVehicle assignedUav = null;
 
       public int assignedUavId = -1; // fallback tracking
@@ -101,12 +95,6 @@ public class MCH_EntityUavStation
 
              public boolean isContinuePressed() {
                  return this.continuePressed;
-             }
-
-             public void storeStationPosition() {
-                 storedStationX = this.posX;
-                 storedStationY = this.posY;
-                 storedStationZ = this.posZ;
              }
 
       public MCH_EntityUavStation(World world) {
@@ -423,38 +411,6 @@ public class MCH_EntityUavStation
          }
 
              @Override
-             public void setDead() {
-                 if (this.worldObj.isRemote) {
-                     System.out.println("setDead fired in UAV Station (client)");
-                 } else {
-                     System.out.println("setDead fired in UAV Station (server)");
-
-                     // If this is a new UAV, we would handle dismount logic here
-                     // (currently commented out)
-        /*
-        if (this.riddenByEntity instanceof EntityPlayer && this.controlAircraft != null && this.controlAircraft.getAcInfo().isNewUAV) {
-            EntityPlayer player = (EntityPlayer)this.riddenByEntity;
-            if (player != null) {
-                System.out.println("Unmounting player: " + player.getDisplayName());
-                unmountEntity(true);
-                // player.mountEntity(null);
-                // player.setPositionAndUpdate(storedStationX, storedStationY, storedStationZ);
-            }
-        }
-        */
-                 }
-
-                 // Notes:
-                 // - setDead clientside: no longer chunk loaded, should init a chunk loader
-                 // - setDead serverside: entity attacked, force dismount linked player
-                 // - This isn’t strictly “dead” — just unloaded or broken
-                 // - Current conclusion: handle actual logic in attackEntityFrom()
-
-                 super.setDead();
-             }
-
-
-             @Override
              public boolean attackEntityFrom(DamageSource damageSource, float damage) {
                  if (isEntityInvulnerable()) return false;
                  if (this.isDead) return true;
@@ -487,63 +443,22 @@ public class MCH_EntityUavStation
                  setBeenAttacked();
 
                  if (damage > 0.0F) {
-                     EntityPlayer assignedPlayer = null;
-
-                     //kill UAV if station is fucked HOPEFULLY
-                     if (this.assignedUav != null && !this.assignedUav.isDead) {
-                         Entity rider = this.assignedUav.riddenByEntity;
-                         if (rider instanceof EntityPlayer) {
-                             EntityPlayer player = (EntityPlayer) rider;
-                             player.mountEntity(null); // force unmount
-                             player.setPositionAndUpdate(storedStationX, storedStationY, storedStationZ);
-                             System.out.println("Teleported " + player.getCommandSenderName() + " back to station.");
-                         }
-                         this.assignedUav.setDead();
-                         //todone?? now teleport the player to the station again because for some fucking reason
-                         // they dont get teleported back when the station is destroyed
-                         // I fucking hate this goddamn mod
-                         System.out.println("Killed assigned UAV: " + this.assignedUav.getEntityId());
-                     } else {
-                         System.out.println("No assigned UAV linked to this station.");
+                     MCH_EntityBaseVehicle linkedUav = this.assignedUav;
+                     if(linkedUav == null || linkedUav.isDead) {
+                         linkedUav = this.controlAircraft;
                      }
-
-                     //WARNING: REDUNDANT BULLSHIT:
-
-                     // DOES NOT --- Resolve assigned player ---
-                     if (this.riddenByEntity instanceof EntityPlayer) {
-                         assignedPlayer = (EntityPlayer) this.riddenByEntity;
-                         this.newUavPlayerUUID = assignedPlayer.getUniqueID().toString();
-                     } else if (this.newUavPlayerUUID != null) {
-                         for (Object obj : worldObj.playerEntities) {
-                             if (obj instanceof EntityPlayer) {
-                                 EntityPlayer p = (EntityPlayer) obj;
-                                 if (p.getUniqueID().toString().equals(this.newUavPlayerUUID)) {
-                                     assignedPlayer = p;
-                                     break;
-                                 }
-                             }
-                         }
+                     if(linkedUav == null || linkedUav.isDead) {
+                         linkedUav = findLinkedUavEntity(this.worldObj);
                      }
-
-                     // DOES NOT --- Kill the UAV the assigned player is riding ---
-                     if (assignedPlayer != null && assignedPlayer.ridingEntity instanceof MCH_EntityBaseVehicle) {
-                         MCH_EntityBaseVehicle uav = (MCH_EntityBaseVehicle) assignedPlayer.ridingEntity;
-                         uav.setDead(); // will automatically dismount player
-                         System.out.println("Killed UAV for player: " + assignedPlayer.getCommandSenderName());
-                     } else {
-                         System.out.println("No UAV found to kill for assigned player.");
+                     if(linkedUav != null && !linkedUav.isDead) {
+                         // The aircraft owns the exact persisted return coordinates and always
+                         // detaches before teleporting, including when this station is destroyed.
+                         linkedUav.setUavStation(this);
+                         linkedUav.setDead();
                      }
-
-                     //WARNING: END OF REDUNDANT BULLSHIT
 
                      // Handle station death
                      this.dropContentsWhenDead = true;
-
-                     System.out.println(
-                             MCH_EntityUavStation.storedStationX + " " +
-                                     MCH_EntityUavStation.storedStationY + " " +
-                                     MCH_EntityUavStation.storedStationZ + " station pos"
-                     );
 
                      setDead();
 
@@ -668,17 +583,10 @@ public class MCH_EntityUavStation
                 this.rotCover = 0.0F;
               }
 
-          if (this.riddenByEntity instanceof EntityPlayer && this.controlAircraft != null && this.controlAircraft.getAcInfo().isNewUAV) {
-
-              if(!this.worldObj.isRemote) {
-                  isridingnewuav = true;
-                  this.storeStationPosition();
-
-              }
-              //this is our first bugged state. do nothing here.
-
+          if(!this.worldObj.isRemote && this.riddenByEntity instanceof EntityPlayer
+                  && this.controlAircraft != null && this.controlAircraft.isNewUAV()) {
+              this.controlAircraft.setUavStation(this);
           }
-
 
 
 
@@ -1204,7 +1112,6 @@ public class MCH_EntityUavStation
                      //this.assignedUav = uav;
 
                      if(this.riddenByEntity instanceof EntityPlayer) {
-                         lastAc.storedRider = (EntityPlayer)this.riddenByEntity;
                          setOwnerUUID(((EntityPlayer)this.riddenByEntity).getUniqueID());
                          if(this.riddenByEntity instanceof EntityPlayerMP) {
                              EntityPlayerMP player = (EntityPlayerMP)this.riddenByEntity;
@@ -1212,9 +1119,6 @@ public class MCH_EntityUavStation
                              notifyInitialUavStateOnce(player, lastAc);
                          }
                      }
-
-                     // Store the current station position
-                     storeStationPosition();
 
                      if (this.controlAircraft != null &&
                              this.controlAircraft.getAcInfo() != null &&
@@ -1370,7 +1274,6 @@ public class MCH_EntityUavStation
       public boolean interactFirst(EntityPlayer player) {
 
           if(player != null) {
-              this.newUavPlayerUUID = player.getUniqueID().toString();
               this.setOwnerUUID(player.getUniqueID());
           }
 

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -437,10 +437,7 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
       super.motionX *= 0.99D;
       super.motionZ *= 0.99D;
       this.onUpdate_updateBlock();
-      if(super.riddenByEntity != null && super.riddenByEntity.isDead) {
-         this.unmountEntity();
-         super.riddenByEntity = null;
-      }
+      this.handleDeadPilot();
 
    }
 


### PR DESCRIPTION
### Motivation
- Eliminate a rare race where dismount/kill paths sometimes leave players positioned at the UAV entity instead of the UAV station by ensuring every NewUAV exit/death path detaches the pilot first and then teleports them to an authoritative station coordinate. 
- Replace duplicated/stale station-position storage and multiple special-case code paths with a single, robust implementation that survives station unloads and server-only flows.

### Description
- Centralized NewUAV return logic into a single server-side routine `returnNewUavPilotToStation(Entity,String)` that always unmounts the pilot first, zeroes motion/fall distance, then teleports and restores inventory if the pilot is `EntityPlayerMP`. (core: `MCH_EntityBaseVehicle`)
- Persisted exact station coordinates (UUID, dimension, X/Y/Z) plus an explicit `hasLinkedUavStationPosition` flag in vehicle NBT to avoid relying on truncated integer fields; removed obsolete integer station fields. (NBT: `MCH_HasUavStationPosition`) 
- Added `handleDeadPilot()` on the base vehicle and routed all concrete vehicle subclasses (plane, heli, tank, ship, turret) to call that shared handler for pilot-death handling, removing per-subclass duplication and edge cases. 
- Reworked NewUAV shift-exit deletion and destruction flows so shift-exit deletion is separate from destruction/pilot-death handling, and added a guard (`newUavShiftExitInProgress`) to avoid reentrancy during station-driven shift-exit deletes. 
- Simplified UAV station code to use the aircraft’s authoritative persisted coordinates and removed the static station-position/debug duplication in the station class; station now resolves linked aircraft and relies on the aircraft-side routine for safe pilot return. 
- Cleanup and readability improvements: removed commented/duplicated teleport patterns, added small helper `saveUavStationPosition`, and consolidated unmount/unseat/seat-eject paths to call the new centralized routine.

### Testing
- Ran `git diff --check` and code-sanity checks (no whitespace/check failures); these passed. 
- Executed targeted Python-driven source invariants that verified detach-before-teleport ordering, presence of persisted exact station coordinates and NBT flag, that destruct/setDead/unmount/seat-exit paths call the centralized routine, and that every concrete subclass uses the shared dead-pilot handler; these validation scripts passed. 
- Performed a lightweight Java delimiter/braces sanity check across all modified files; this passed. 
- Attempted Java compilation with Gradle wrapper and with `gradle compileJava --offline`; both builds were blocked by environment constraints: the Gradle wrapper distribution download failed due to an external proxy (HTTP 403), and offline mode failed because ForgeGradle artifacts are not cached in the environment; compilation could not be completed here. 

Files changed (high level): updated base vehicle logic and NBT handling (`MCH_EntityBaseVehicle`), streamlined UAV station (`MCH_EntityUavStation`), and routed subclasses (`MCP_EntityPlane`, `MCH_EntityHeli`, `MCH_EntityTank`, `MCH_EntityShip`, `MCH_EntityTurret`) to use the shared dead-pilot handler. Automated unit/regression tests are not present in the repo; the change was validated with the described static and scripted checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b43cb8f4483238b021bcf4f1801b4)