### PR TITLE
Add new-flight throttle controls, HUD percent, and combat-flaps (new-flight gated)

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -223,6 +223,19 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `InertiaMultiplier` | Plane | float[0.05..100] | 1.0 | angular inertia |
 | `ThrottleAcceleration` | Plane | float[0..1] | 0.02 | engine-output spool-up/tick |
 | `EngineDrag` | Plane | float[0..1] | 0.015 | engine-output spool-down/tick |
+| `NewFlightThrottleResponse` | Plane | float[0.1..4] | 1.0 | new-flight-only throttle curve |
+| `NewFlightThrottleChangeRateUp` | Plane | float[0..0.1] | 0.006 | new-flight-only pilot throttle-up rate/tick |
+| `NewFlightThrottleChangeRateDown` | Plane | float[0..0.1] | 0.008 | new-flight-only pilot throttle-down rate/tick |
+| `NewFlightIdleThrottle` | Plane | float[0..0.35] | 0.08 | new-flight-only effective idle power |
+| `NewFlightEngineBrakeDrag` | Plane | float[0..0.25] | 0.0035 | new-flight-only low-power drag |
+| `NewFlightLowThrottleLiftRetention` | Plane | float[0..1] | 0.82 | new-flight-only lift/support retained at idle |
+| `NewFlightThrottleControlAuthorityScale` | Plane | float[0..1] | 0.18 | new-flight-only idle control-authority penalty |
+| `NewFlightThrottleHudDisplay` | Plane | boolean | true | show `THR 0-100%` for new-flight pilots |
+| `NewFlightCombatFlaps` | Plane | boolean | false | enables new-flight-only combat flaps |
+| `NewFlightCombatFlapLift` | Plane | float[0..1] | 0.16 | flap lift/support contribution |
+| `NewFlightCombatFlapDrag` | Plane | float[0..0.25] | 0.009 | flap drag penalty |
+| `NewFlightCombatFlapControl` | Plane | float[0..1] | 0.14 | flap control-authority boost |
+| `NewFlightCombatFlapOverspeed` | Plane | float[0.1..1] | 0.82 | flap safe-speed multiplier |
 | `StallSpeed` | Plane | float[0..10] | 0 = derive from `Speed*StallSpeedFactor` | fixed-wing stall entry |
 | `CriticalAoA` | Plane | float[1..90] | 18 | stall/AoA threshold degrees |
 | `StallLiftLoss` | Plane | float[0..1] | 0.65 | lift removed at full stall |

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -36,8 +36,21 @@ All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpee
 | `PitchDamping`, `RollDamping`, `YawDamping` | float[0..100] | 0.35 | Angular damping. Higher values lower steady body rate for the same torque. |
 | `InertiaMultiplier` | float[0.05..100] | 1 | Resistance to angular acceleration. Higher values make controls feel heavier. |
 | `Mass` | float[0.05..100] | alias of `InertiaMultiplier` | Legacy/compatibility alias; no separate weight simulation exists. |
-| `ThrottleAcceleration` | float[0..1] | 0.02 | Max engine-output increase per tick toward pilot throttle. |
-| `EngineDrag` | float[0..1] | 0.015 | Max engine-output decrease per tick. |
+| `ThrottleAcceleration` | float[0..1] | 0.02 | Legacy engine-output spool-up. New-flight planes still use it only to smooth commanded throttle into engine output; pilot input rate is controlled by `NewFlightThrottleChangeRateUp`. |
+| `EngineDrag` | float[0..1] | 0.015 | Legacy engine-output spool-down. New-flight planes still use it only to smooth commanded throttle into engine output; pilot input rate is controlled by `NewFlightThrottleChangeRateDown`. |
+| `NewFlightThrottleResponse` | float[0.1..4] | 1.0 | **New flight model only.** Curves smoothed engine output before thrust. `1` is linear, `<1` gives more low-throttle thrust, `>1` softens the low end. |
+| `NewFlightThrottleChangeRateUp` | float[0..0.1] | 0.006 | **New flight model only.** Pilot-commanded throttle increase per tick. Full idle-to-max travel is about `1 / value` ticks. |
+| `NewFlightThrottleChangeRateDown` | float[0..0.1] | 0.008 | **New flight model only.** Pilot-commanded throttle decrease per tick. Usually slightly faster than increase for approach and dogfight energy control. |
+| `NewFlightIdleThrottle` | float[0..0.35] | 0.08 | **New flight model only.** Minimum effective engine power at 0% commanded throttle; keeps idle physically plausible without making idle accelerate like cruise. |
+| `NewFlightEngineBrakeDrag` | float[0..0.25] | 0.0035 | **New flight model only.** Closed-throttle/low-power drag used by the energy model. Replaces `IdleDrag` for opted-in planes. |
+| `NewFlightLowThrottleLiftRetention` | float[0..1] | 0.82 | **New flight model only.** Retains this fraction of the legacy throttle-coupled vertical support at idle so lift does not vanish immediately when throttle is chopped. Stall is still driven by airspeed/AoA. |
+| `NewFlightThrottleControlAuthorityScale` | float[0..1] | 0.18 | **New flight model only.** Maximum control-authority penalty at idle. Keep low so glide/landing controls remain useful. |
+| `NewFlightThrottleHudDisplay` | boolean | true | **New flight model only.** Shows pilot HUD text like `THR 85%`. Legacy HUDs are unchanged for planes that do not opt in. |
+| `NewFlightCombatFlaps` | boolean | false | **New flight model only.** Enables the combat-flap toggle on the Extra key. Inactive on legacy planes even if present. |
+| `NewFlightCombatFlapLift` | float[0..1] | 0.16 | **New flight model only.** Added low-speed lift/support and induced-load contribution while combat flaps are deployed. |
+| `NewFlightCombatFlapDrag` | float[0..0.25] | 0.009 | **New flight model only.** Extra drag while combat flaps are deployed. |
+| `NewFlightCombatFlapControl` | float[0..1] | 0.14 | **New flight model only.** Control-authority boost while combat flaps are deployed. |
+| `NewFlightCombatFlapOverspeed` | float[0.1..1] | 0.82 | **New flight model only.** Multiplier applied to `MaxSafeSpeed` while flaps are deployed; lower values punish high-speed flap use earlier. |
 | `StallSpeed` | float[0..10] | 0 | Absolute stall threshold; if 0, uses `max(0.05, topSpeed * StallSpeedFactor)`. |
 | `CriticalAoA` | float[1..90] | 18 | AoA in degrees where stall demand begins. |
 | `StallLiftLoss` | float[0..1] | 0.65 | Fraction of lift removed at full stall. |
@@ -59,7 +72,17 @@ All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpee
 
 ### Engine output and throttle
 
-Pilot throttle still changes through shared `throttleupdown`. Planes then smooth engine output:
+Legacy planes still change pilot throttle through shared `throttleupdown` and keep the old HUD behavior. Planes with `useNewMobilitySystem = true` use a normalized pilot throttle (`0.0` to `1.0`) for input and display it to the pilot as `THR 0%` through `THR 100%` when `NewFlightThrottleHudDisplay = true`.
+
+New-flight pilot input rates are independent of legacy `throttleupdown`:
+
+```text
+if throttle-up key:   currentThrottle += NewFlightThrottleChangeRateUp
+if throttle-down key: currentThrottle -= NewFlightThrottleChangeRateDown
+currentThrottle = clamp(currentThrottle, 0, 1)
+```
+
+Planes then smooth engine output:
 
 ```text
 engineThrottle = approach(engineThrottle, currentThrottle,
@@ -67,7 +90,21 @@ engineThrottle = approach(engineThrottle, currentThrottle,
                          EngineDrag when decreasing)
 ```
 
-`engineThrottle`, not raw pilot throttle, drives idle drag and sustainable speed.
+New-flight thrust uses an additional curve and idle floor:
+
+```text
+effectiveThrottle = NewFlightIdleThrottle
+                  + (1 - NewFlightIdleThrottle)
+                  * pow(engineThrottle, NewFlightThrottleResponse)
+```
+
+`effectiveThrottle`, not raw pilot throttle, drives new-flight thrust and sustainable speed. This makes 30-70% useful for cruise/formation/approach instead of forcing pilots to live near 100%. Cutting throttle reduces acceleration and adds engine-brake drag; it no longer directly deletes lift.
+
+Recommended starting ranges:
+
+- WW2 props / dogfighters: response `0.85-1.2`, up `0.004-0.008`, down `0.006-0.012`, idle `0.06-0.12`, brake drag `0.003-0.008`, lift retention `0.78-0.9`, authority scale `0.10-0.25`.
+- Jets: response `1.1-1.6`, up `0.003-0.006`, down `0.004-0.008`, idle `0.08-0.15`, brake drag `0.002-0.006`, lift retention `0.82-0.94`, authority scale `0.05-0.18`.
+- Heavy aircraft: response `1.0-1.4`, up `0.002-0.005`, down `0.003-0.007`, idle `0.08-0.16`, brake drag `0.002-0.005`, lift retention `0.85-0.95`, authority scale `0.05-0.15`.
 
 ### Angular response and input smoothing
 
@@ -228,3 +265,11 @@ FlightCeilingRange = 48
 ## Safe-to-omit legacy notes
 
 Old plane packs can omit every new aerodynamic key. Defaults are applied and `StallSpeedFactor` preserves derived low-speed stall behavior. Use `Mass` only for compatibility with packs that already chose that name; prefer `InertiaMultiplier` for new configs.
+
+### Combat flaps and throttle interaction
+
+Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy packs are unaffected unless they opt in. With `NewFlightCombatFlaps = true`, the pilot toggles flaps with the Extra key, the HUD appends `FLP`, and the new flight model applies lift/control help plus extra drag and a lower safe overspeed threshold.
+
+Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
+
+Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, AoA, lift loss, drag, control authority, stall, and overspeed state for new-flight tuning.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -331,7 +331,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(speed=%.3f,aoa=%.2f,stall=%.2f,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f)",
               simDelta,
               mouseX,
               mouseY,
@@ -343,9 +343,12 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getRotPitch(),
               ac.getRotYaw(),
               ac.getRotRoll(),
+              Double.valueOf(ac.getNormalizedThrottle() * 100.0D),
+              Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
               ac.getAngleOfAttackDegrees(),
               ac.getStallSeverity(),
+              Boolean.valueOf(ac.isOverspeeding()),
               ac.getCurrentGForce(),
               ac.getLastAerodynamicDrag(),
               ac.getLastLiftLoss(),

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1764,6 +1764,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return this.getControlAuthorityFactor();
    }
 
+   /** Normalized pilot throttle for debug/HUD text. */
+   public double getNormalizedThrottle() {
+      return this.getCurrentThrottle();
+   }
+
+   /** New-flight combat flap state for debug/HUD text. */
+   public boolean isCombatFlapsDeployed() {
+      return false;
+   }
+
+   /** True when the vehicle is currently beyond its new-flight safe speed. */
+   public boolean isOverspeeding() {
+      return false;
+   }
+
    /** Hook for vehicle-family-specific stress or aerodynamic updates. */
    protected void updateVehicleStress() {
    }

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -166,6 +166,10 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
 
                plane.swithVtolMode(!isUav);
                send = true;
+            } else if(plane.canUseCombatFlaps()) {
+               plane.toggleCombatFlaps();
+               pc.switchCombatFlaps = (byte)(plane.isCombatFlapsDeployed()?1:0);
+               send = true;
             } else {
                playSoundNG();
             }

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -68,6 +68,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    /** Smoothed stall state used by lift loss, controls, and instability. */
    private double stallSeverity;
    private boolean stalling;
+   private boolean combatFlapsDeployed;
 
 
    public MCP_EntityPlane(World world) {
@@ -92,6 +93,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
       this.stalling = false;
+      this.combatFlapsDeployed = false;
    }
 
    public String getKindName() {
@@ -331,7 +333,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double highGAuthority = MCH_FlightModel.getHighGControlAuthority(this.currentGForce,
             info.maxComfortableG, info.maxStructuralG, info.gControlPenalty);
       double severity = Math.max(this.stallSeverity, this.getInstantStallSeverity());
-      return (float)(highGAuthority * MCH_FlightModel.getControlAuthority(severity));
+      double throttleAuthority = 1.0D - (1.0D - this.getEffectiveEngineThrottle())
+            * (double)info.newFlightThrottleControlAuthorityScale;
+      double flapAuthority = this.isCombatFlapsDeployed() ? 1.0D + (double)info.newFlightCombatFlapControl : 1.0D;
+      return (float)MCH_FlightModel.clamp(highGAuthority * MCH_FlightModel.getControlAuthority(severity)
+            * throttleAuthority * flapAuthority, 0.05D, 1.35D);
    }
 
    public double getCurrentGForce() {
@@ -370,9 +376,42 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return this.getControlAuthorityFactor();
    }
 
-   private double getAirspeed() {
+   public double getAirspeed() {
       return Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY
             + super.motionZ * super.motionZ);
+   }
+
+   public boolean isNewFlightModelEnabled() {
+      return this.useNewMobilitySystem();
+   }
+
+   public double getNormalizedThrottle() {
+      return MCH_FlightModel.clamp(this.getCurrentThrottle(), 0.0D, 1.0D);
+   }
+
+   public int getThrottlePercent() {
+      return (int)Math.round(this.getNormalizedThrottle() * 100.0D);
+   }
+
+   public boolean canUseCombatFlaps() {
+      return this.useNewMobilitySystem() && this.getPlaneInfo() != null && this.getPlaneInfo().newFlightCombatFlaps
+            && this.getNozzleRotation() <= 0.01F;
+   }
+
+   public boolean isCombatFlapsDeployed() {
+      return this.canUseCombatFlaps() && this.combatFlapsDeployed;
+   }
+
+   public void setCombatFlapsDeployed(boolean deployed) {
+      this.combatFlapsDeployed = deployed && this.canUseCombatFlaps();
+   }
+
+   public void toggleCombatFlaps() {
+      this.setCombatFlapsDeployed(!this.combatFlapsDeployed);
+   }
+
+   public boolean isOverspeeding() {
+      return this.useNewMobilitySystem() && MCH_FlightModel.getOverspeedSeverity(this.getAirspeed(), this.getMaxSafeSpeed()) > 0.0D;
    }
 
    protected double getCompressibilitySpeed() {
@@ -392,7 +431,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       float levelSpeed = info.maxLevelSpeed > 0.0F ? info.maxLevelSpeed : this.getMaxSpeed();
-      return info.maxSafeSpeed > 0.0F ? (double)info.maxSafeSpeed : (double)levelSpeed * 1.1D;
+      double safeSpeed = info.maxSafeSpeed > 0.0F ? (double)info.maxSafeSpeed : (double)levelSpeed * 1.1D;
+      if(this.isCombatFlapsDeployed()) {
+         safeSpeed *= (double)info.newFlightCombatFlapOverspeed;
+      }
+      return safeSpeed;
    }
 
    private double getInstantStallSeverity() {
@@ -742,6 +785,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.setCurrentThrottle(0.0D);
       }
 
+      if(this.useNewMobilitySystem() && this.getCurrentThrottle() > 1.0D) {
+         this.setCurrentThrottle(1.0D);
+      }
+
       if(super.worldObj.isRemote) {
          if(!W_Lib.isClientPlayer(this.getRiddenByEntity())) {
             double ct = this.getThrottle();
@@ -763,10 +810,27 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       } else {
          this.engineThrottle = this.getCurrentThrottle();
       }
+
+      if(!this.canUseCombatFlaps()) {
+         this.combatFlapsDeployed = false;
+      }
    }
 
    protected double getEngineThrottle() {
       return this.useNewMobilitySystem() ? this.engineThrottle : this.getCurrentThrottle();
+   }
+
+   protected double getEffectiveEngineThrottle() {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null) {
+         return this.getEngineThrottle();
+      }
+
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      double smoothed = MCH_FlightModel.clamp(this.getEngineThrottle(), 0.0D, 1.0D);
+      double response = Math.max(0.1D, (double)info.newFlightThrottleResponse);
+      double curved = Math.pow(smoothed, response);
+      return MCH_FlightModel.clamp((double)info.newFlightIdleThrottle
+            + (1.0D - (double)info.newFlightIdleThrottle) * curved, 0.0D, 1.0D);
    }
 
    protected void onUpdate_ControlNotHovering() {
@@ -774,6 +838,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if (!super.isGunnerMode) {
          // 获取油门上下状态
          float throttleUpDown = this.getAcInfo().throttleUpDown;
+         double throttleRateUp = 0.01D * (double)throttleUpDown;
+         double throttleRateDown = 0.01D * (double)throttleUpDown;
+         if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
+            throttleRateUp = (double)this.getPlaneInfo().newFlightThrottleChangeRateUp;
+            throttleRateDown = (double)this.getPlaneInfo().newFlightThrottleChangeRateDown;
+         }
 
          // 判断是否是转向状态（只左转或只右转）
          boolean turn = super.moveLeft && !super.moveRight || !super.moveLeft && super.moveRight;
@@ -813,7 +883,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                super.throttleBack = 0.0F;
                // 如果当前油门小于1，则增加油门
                if (this.getCurrentThrottle() < 1.0D) {
-                  this.addCurrentThrottle(0.01D * (double) f);
+                  this.addCurrentThrottle(this.useNewMobilitySystem() && this.getPlaneInfo() != null ? throttleRateUp : 0.01D * (double) f);
                } else {
                   // 否则，设置油门为最大值1
                   this.setCurrentThrottle(1.0D);
@@ -824,7 +894,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          else if (super.throttleDown) {
             // 如果当前油门大于0，则递减油门
             if (this.getCurrentThrottle() > 0.0D) {
-               this.addCurrentThrottle(-0.01D * (double) throttleUpDown);
+               this.addCurrentThrottle(-throttleRateDown);
             } else {
                // 否则，设置油门为0
                this.setCurrentThrottle(0.0D);
@@ -840,7 +910,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
          // 如果启用了自动油门降低，并且当前油门大于0，则逐步降低油门
          else if (super.cs_planeAutoThrottleDown && this.getCurrentThrottle() > 0.0D) {
-            this.addCurrentThrottle(-0.005D * (double) throttleUpDown);
+            this.addCurrentThrottle(-(this.useNewMobilitySystem() && this.getPlaneInfo() != null ? throttleRateDown * 0.5D : 0.005D * (double) throttleUpDown));
             // 如果油门低于0，则设置为0
             if (this.getCurrentThrottle() <= 0.0D) {
                this.setCurrentThrottle(0.0D);
@@ -1158,7 +1228,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
          if(!levelOff) {
             super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
-            super.motionY += -0.047D * (1.0D - this.getEngineThrottle());
+            if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
+               double liftPower = (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention
+                     + (1.0D - (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
+               if(this.isCombatFlapsDeployed()) {
+                  liftPower += (double)this.getPlaneInfo().newFlightCombatFlapLift;
+               }
+               super.motionY += -0.047D * (1.0D - MCH_FlightModel.clamp(liftPower, 0.0D, 1.0D));
+            } else {
+               super.motionY += -0.047D * (1.0D - this.getEngineThrottle());
+            }
          } else {
             super.motionY *= 0.8D;
          }
@@ -1181,7 +1260,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       // 计算油门1的值，当前油门除以10
-      float throttle1 = (float)(this.getEngineThrottle() / 10.0D);
+      float throttle1 = (float)((this.useNewMobilitySystem() ? this.getEffectiveEngineThrottle() : this.getEngineThrottle()) / 10.0D);
       Vec3 v;
 
       // 如果喷嘴的旋转角度大于0.001F
@@ -1254,9 +1333,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                + MathHelper.abs(this.yawAngularVelocity)) / 6.0D;
          double controlLoad = MCH_FlightModel.clamp(bodyRate, 0.0D, 1.0D);
          double turnLoad = Math.max(bankLoad, controlLoad);
-         double drag = MCH_FlightModel.getEnergyDrag(horizontalSpeed, (double)levelSpeed, this.getEngineThrottle(),
+         double engineBrakeDrag = this.getPlaneInfo().newFlightEngineBrakeDrag;
+         if(this.isCombatFlapsDeployed()) {
+            engineBrakeDrag += this.getPlaneInfo().newFlightCombatFlapDrag;
+            turnLoad = MCH_FlightModel.clamp(turnLoad + (double)this.getPlaneInfo().newFlightCombatFlapLift, 0.0D, 1.0D);
+         }
+         double drag = MCH_FlightModel.getEnergyDrag(horizontalSpeed, (double)levelSpeed, this.getEffectiveEngineThrottle(),
                turnLoad, controlLoad, this.getPlaneInfo().baseDrag, this.getPlaneInfo().inducedDrag,
-               this.getPlaneInfo().controlSurfaceDrag, this.getPlaneInfo().idleDrag);
+               this.getPlaneInfo().controlSurfaceDrag, (float)engineBrakeDrag);
          drag += MCH_FlightModel.getAngleOfAttackDrag(this.angleOfAttack, this.getPlaneInfo().criticalAoA,
                this.getPlaneInfo().baseDrag, this.getPlaneInfo().aoaDragMultiplier);
          drag = MCH_FlightModel.clamp(drag, 0.0D, 0.5D);

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -61,6 +61,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                }
             }
 
+            if(seatID == 0) {
+               this.drawNewFlightThrottleHud(plane);
+            }
+
             if(plane.getTVMissile() != null && (plane.getIsGunnerMode(player) || plane.isUAV())) {
                this.drawTvMissileNoise(plane, plane.getTVMissile());
             } else {
@@ -70,6 +74,18 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
          this.drawHitBullet(plane, -14101432, seatID);
       }
+   }
+
+   private void drawNewFlightThrottleHud(MCP_EntityPlane plane) {
+      MCP_PlaneInfo info = plane.getPlaneInfo();
+      if(info == null || !plane.isNewFlightModelEnabled() || !info.newFlightThrottleHudDisplay) {
+         return;
+      }
+
+      int color = plane.isOverspeeding() ? -65536 : -1;
+      String flap = plane.canUseCombatFlaps() ? (plane.isCombatFlapsDeployed() ? " FLP" : "") : "";
+      this.drawString(String.format("THR %3d%%%s", new Object[]{Integer.valueOf(plane.getThrottlePercent()), flap}),
+            super.centerX - 35, super.centerY + 42, color);
    }
 
    public void drawKeybind(MCP_EntityPlane plane, EntityPlayer player, int seatID) {
@@ -101,6 +117,16 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                var10001 = MCH_MOD.config;
                msg = var12.append(MCH_KeyName.getDescOrName(MCH_Config.KeySwitchMode.prmInt)).toString();
                this.drawString(msg, RX, super.centerY - 40, colorActive);
+            }
+
+            if(seatID == 0 && plane.canUseCombatFlaps() && !info.isEnableVtol) {
+               var10000 = MCH_MOD.config;
+               if(!Keyboard.isKeyDown(MCH_Config.KeyFreeLook.prmInt)) {
+                  var12 = (new StringBuilder()).append(plane.isCombatFlapsDeployed()?"Flaps Up : ":"Combat Flaps : ");
+                  var10001 = MCH_MOD.config;
+                  msg = var12.append(MCH_KeyName.getDescOrName(MCH_Config.KeyExtra.prmInt)).toString();
+                  this.drawString(msg, RX, super.centerY - 60, colorActive);
+               }
             }
 
             if(seatID == 0 && info.isEnableVtol) {

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -48,10 +48,31 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float yawDamping = 0.35F;
    /** Scales resistance to angular acceleration without changing eventual control authority. */
    public float inertiaMultiplier = 1.0F;
-   /** Maximum engine-output increase per tick. */
+   /** Legacy maximum engine-output increase per tick. */
    public float throttleAcceleration = 0.02F;
-   /** Maximum engine-output decrease per tick. */
+   /** Legacy maximum engine-output decrease per tick. */
    public float engineDrag = 0.015F;
+   /** Non-linear pilot-throttle to thrust curve used by the new flight model. */
+   public float newFlightThrottleResponse = 1.0F;
+   /** Pilot throttle increase/decrease rates used only by the new flight model. */
+   public float newFlightThrottleChangeRateUp = 0.006F;
+   public float newFlightThrottleChangeRateDown = 0.008F;
+   /** Minimum effective engine power at zero commanded throttle. */
+   public float newFlightIdleThrottle = 0.08F;
+   /** Closed-throttle aerodynamic braking used by the new flight model. */
+   public float newFlightEngineBrakeDrag = 0.0035F;
+   /** Fraction of legacy throttle-coupled lift retained at idle. */
+   public float newFlightLowThrottleLiftRetention = 0.82F;
+   /** Maximum fraction of control authority lost at idle throttle. */
+   public float newFlightThrottleControlAuthorityScale = 0.18F;
+   /** Show the normalized 0-100% throttle readout to pilots using the new flight model. */
+   public boolean newFlightThrottleHudDisplay = true;
+   /** Enables the new-flight-only combat-flap toggle. */
+   public boolean newFlightCombatFlaps = false;
+   public float newFlightCombatFlapLift = 0.16F;
+   public float newFlightCombatFlapDrag = 0.009F;
+   public float newFlightCombatFlapControl = 0.14F;
+   public float newFlightCombatFlapOverspeed = 0.82F;
    /** Absolute airspeed below which a fixed-wing plane can enter a stall. Zero derives it from StallSpeedFactor. */
    public float stallSpeed = 0.0F;
    /** Angle between the plane forward vector and velocity vector at which airflow separates. */
@@ -271,6 +292,32 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.throttleAcceleration = this.toFloat(data, 0.0F, 1.0F);
          } else if(item.equalsIgnoreCase("EngineDrag")) {
             this.engineDrag = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightThrottleResponse")) {
+            this.newFlightThrottleResponse = this.toFloat(data, 0.1F, 4.0F);
+         } else if(item.equalsIgnoreCase("NewFlightThrottleChangeRateUp")) {
+            this.newFlightThrottleChangeRateUp = this.toFloat(data, 0.0F, 0.1F);
+         } else if(item.equalsIgnoreCase("NewFlightThrottleChangeRateDown")) {
+            this.newFlightThrottleChangeRateDown = this.toFloat(data, 0.0F, 0.1F);
+         } else if(item.equalsIgnoreCase("NewFlightIdleThrottle")) {
+            this.newFlightIdleThrottle = this.toFloat(data, 0.0F, 0.35F);
+         } else if(item.equalsIgnoreCase("NewFlightEngineBrakeDrag")) {
+            this.newFlightEngineBrakeDrag = this.toFloat(data, 0.0F, 0.25F);
+         } else if(item.equalsIgnoreCase("NewFlightLowThrottleLiftRetention")) {
+            this.newFlightLowThrottleLiftRetention = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightThrottleControlAuthorityScale")) {
+            this.newFlightThrottleControlAuthorityScale = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightThrottleHudDisplay")) {
+            this.newFlightThrottleHudDisplay = this.toBool(data);
+         } else if(item.equalsIgnoreCase("NewFlightCombatFlaps")) {
+            this.newFlightCombatFlaps = this.toBool(data);
+         } else if(item.equalsIgnoreCase("NewFlightCombatFlapLift")) {
+            this.newFlightCombatFlapLift = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightCombatFlapDrag")) {
+            this.newFlightCombatFlapDrag = this.toFloat(data, 0.0F, 0.25F);
+         } else if(item.equalsIgnoreCase("NewFlightCombatFlapControl")) {
+            this.newFlightCombatFlapControl = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightCombatFlapOverspeed")) {
+            this.newFlightCombatFlapOverspeed = this.toFloat(data, 0.1F, 1.0F);
          } else if(item.equalsIgnoreCase("StallSpeed")) {
             this.stallSpeed = this.toFloat(data, 0.0F, 10.0F);
          } else if(item.equalsIgnoreCase("CriticalAoA")) {

--- a/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
+++ b/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
@@ -45,6 +45,14 @@ public class MCP_PlanePacketHandler {
                   plane.swithVtolMode(true);
                }
 
+               if(pc.switchCombatFlaps == 0) {
+                  plane.setCombatFlapsDeployed(false);
+               }
+
+               if(pc.switchCombatFlaps == 1) {
+                  plane.setCombatFlapsDeployed(true);
+               }
+
                if(pc.switchMode == 0) {
                   plane.switchGunnerMode(false);
                }

--- a/src/main/java/mcheli/plane/MCP_PlanePacketPlayerControl.java
+++ b/src/main/java/mcheli/plane/MCP_PlanePacketPlayerControl.java
@@ -8,6 +8,7 @@ import mcheli.aircraft.MCH_PacketPlayerControlBase;
 public class MCP_PlanePacketPlayerControl extends MCH_PacketPlayerControlBase {
 
    public byte switchVtol = -1;
+   public byte switchCombatFlaps = -1;
 
 
    public int getMessageID() {
@@ -19,6 +20,7 @@ public class MCP_PlanePacketPlayerControl extends MCH_PacketPlayerControlBase {
 
       try {
          this.switchVtol = data.readByte();
+         this.switchCombatFlaps = data.readByte();
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -30,6 +32,7 @@ public class MCP_PlanePacketPlayerControl extends MCH_PacketPlayerControlBase {
 
       try {
          dos.writeByte(this.switchVtol);
+         dos.writeByte(this.switchCombatFlaps);
       } catch (IOException var3) {
          var3.printStackTrace();
       }


### PR DESCRIPTION
### Motivation

- Provide deeper, usable throttle control and a pilot-visible 0–100% throttle readout for aircraft using the new flight model while preserving legacy behavior for non-opted-in planes. 
- Prevent instant lift collapse when chopping throttle by making lift remain primarily airspeed/AoA dependent and letting engine output affect acceleration/recovery instead of acting as the only thing keeping aircraft aloft. 
- Add a combat-flap toggle that improves low-speed lift/control and increases drag/overspeed penalty for short-term maneuver benefit, and ensure both flaps and throttle changes are only active for new-flight-model aircraft. 

### Description

- Added new per-plane config fields to `MCP_PlaneInfo` with parser support: `NewFlightThrottleResponse`, `NewFlightThrottleChangeRateUp`, `NewFlightThrottleChangeRateDown`, `NewFlightIdleThrottle`, `NewFlightEngineBrakeDrag`, `NewFlightLowThrottleLiftRetention`, `NewFlightThrottleControlAuthorityScale`, `NewFlightThrottleHudDisplay`, and combat-flap keys (`NewFlightCombatFlaps`, `NewFlightCombatFlapLift`, `NewFlightCombatFlapDrag`, `NewFlightCombatFlapControl`, `NewFlightCombatFlapOverspeed`).
- Introduced normalized pilot throttle semantics for new-flight planes where pilot throttle is 0.0–1.0, with new per-tick input rates applied in `onUpdate_ControlNotHovering` and `engineThrottle` smoothed by `MCH_FlightModel.approachEngineOutput`, then mapped to an `effectiveThrottle` via an idle floor and response curve (`getEffectiveEngineThrottle`) used by the energy/drag model; legacy behavior remains unchanged unless `useNewMobilitySystem = true`.
- Prevented abrupt lift loss by retaining `NewFlightLowThrottleLiftRetention` fraction of throttle-coupled vertical support and applied lift addition from deployed combat flaps; energy/drag uses `effectiveThrottle` and `NewFlightEngineBrakeDrag` (plus extra flap drag) so cutting throttle reduces acceleration/energy without instantly removing lift.
- Added combat-flap state to `MCP_EntityPlane` with client toggle/packet sync (`MCP_PlanePacketPlayerControl`, `MCP_PlanePacketHandler`, client key handling in `MCP_ClientPlaneTickHandler`), integrated flap effects into the energy/drag and control-authority calculations, and lowered safe overspeed while flaps are deployed via `NewFlightCombatFlapOverspeed`.
- HUD and debug: added `THR ###%` HUD display for new-flight pilots (`MCP_GuiPlane.drawNewFlightThrottleHud`) showing `FLP` when flaps are deployed and using overspeed coloring, and extended debug flight logging to include throttle percent, flap state, and overspeed state (`MCH_ClientCommonTickHandler` / `MCH_EntityBaseVehicle` hooks).
- Documentation: updated `docs/vehicle-config/planes.md` and `docs/vehicle-config-reference.md` documenting the new keys, recommended tuning ranges for props/jets/heavy aircraft, and notes that all new behavior is gated behind `useNewMobilitySystem`.

### Testing

- Ran `git diff --check` which passed with no whitespace/error diffs reported. 
- Attempted project compile with `./gradlew compileJava` but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so compilation could not be completed locally. 
- Attempted `gradle compileJava` (non-wrapper) but Maven/remote artifact resolution failed due to network/proxy HTTP 403, so a full automated build/test could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4b9eb9d483298a150dde9c4b49be)