### PR TITLE
Improve new-flight gravity, lift and stall behavior for planes

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -43,7 +43,11 @@ All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpee
 | `NewFlightThrottleChangeRateDown` | float[0..0.1] | 0.008 | **New flight model only.** Pilot-commanded throttle decrease per tick. Usually slightly faster than increase for approach and dogfight energy control. |
 | `NewFlightIdleThrottle` | float[0..0.35] | 0.08 | **New flight model only.** Minimum effective engine power at 0% commanded throttle; keeps idle physically plausible without making idle accelerate like cruise. |
 | `NewFlightEngineBrakeDrag` | float[0..0.25] | 0.0035 | **New flight model only.** Closed-throttle/low-power drag used by the energy model. Replaces `IdleDrag` for opted-in planes. |
-| `NewFlightLowThrottleLiftRetention` | float[0..1] | 0.82 | **New flight model only.** Retains this fraction of the legacy throttle-coupled vertical support at idle so lift does not vanish immediately when throttle is chopped. Stall is still driven by airspeed/AoA. |
+| `NewFlightLowThrottleLiftRetention` | float[0..1] | 0.82 | Compatibility tuning for older new-flight configs; explicit gravity/lift now governs altitude retention for opted-in planes. |
+| `GravityStrength` | float[0..0.25] | 0.032 | **New flight model only.** Downward acceleration applied continuously in conventional fixed-wing flight. Lift and stall state decide how much is countered. |
+| `LiftGravityCompensation` | float[0..2] | 1.05 | **New flight model only.** Maximum share of `GravityStrength` that healthy airspeed and sane AoA can offset. Values over 1 provide tuning headroom before the applied lift is capped to gravity. |
+| `GroundBounceDamping` | float[0..1] | 0.25 | **New flight model only.** Multiplier applied to upward vertical bounce near/on ground when there is not enough speed/lift/thrust for takeoff. |
+| `GroundVerticalVelocityClamp` | float[0..0.25] | 0.015 | **New flight model only.** Upward velocity cap near/on ground without a valid aerodynamic climb reason. |
 | `NewFlightThrottleControlAuthorityScale` | float[0..1] | 0.18 | **New flight model only.** Maximum control-authority penalty at idle. Keep low so glide/landing controls remain useful. |
 | `NewFlightThrottleHudDisplay` | boolean | true | **New flight model only.** Shows pilot HUD text like `THR 85%`. Legacy HUDs are unchanged for planes that do not opt in. |
 | `NewFlightCombatFlaps` | boolean | false | **New flight model only.** Enables the combat-flap toggle on the Extra key. Inactive on legacy planes even if present. |
@@ -59,6 +63,8 @@ All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpee
 | `StallRecoverySpeed` | float[0..10] | 0 = `StallSpeed*1.2` | Speed required, with low AoA, to exit a stall. |
 | `StallSpeedFactor` | float[0..0.95] | 0.22 | Legacy derived stall threshold when `StallSpeed` is omitted. |
 | `StallStrength` | float[0..4] | 0.6 | Legacy sink strength multiplier during stall. |
+| `StallNoseDownForce` | float[0..5] | 0.12 | **New flight model only.** Gentle nose-down pitch recovery applied during stalls so aircraft can rebuild energy. |
+| `StallNoseDownMinSpeed` | float[0..10] | 0.08 | **New flight model only.** Airspeed where stall nose-down recovery starts gaining authority; below this the tendency fades out. |
 | `DiveSpeedMultiplier` | float[1..2] | 1.25 | Maximum speed cap multiplier in a dive. |
 | `MaxComfortableG` | float[1..30] | 4 | G where high-G control fade starts. |
 | `MaxStructuralG` | float[1..50] | 8 | G where high-G fade reaches the configured penalty and structural hook begins. Warns if below `MaxComfortableG`. |
@@ -150,7 +156,21 @@ targetHorizontalSpeed = horizontalSpeed * (1 - drag)
                       - climb * ClimbEnergyLoss
 ```
 
-### Stall, AoA, lift loss, and recovery
+### Gravity, lift, stall, AoA, and recovery
+
+For planes with `useNewMobilitySystem = true`, conventional fixed-wing flight applies explicit gravity after thrust and damping. Legacy planes keep the previous vertical-motion path.
+
+```text
+speedLift = clamp((airspeed - stallSpeed * 0.55) / (stallSpeed * 1.25), 0, 1)
+aoaLift = 1 - clamp((abs(AoA) - CriticalAoA * 0.65) / (CriticalAoA * 0.85), 0, 1)
+stallLiftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
+liftFactor = speedLift * aoaLift * (1 - stallLiftLoss)
+lift = min(GravityStrength * LiftGravityCompensation * liftFactor, GravityStrength)
+motionY += lift - GravityStrength
+```
+
+This means throttle by itself does not hold altitude: an aircraft must have enough airspeed and acceptable AoA to create lift. Cutting power increases drag and eventually reduces airspeed, so lift decays and the plane naturally descends. Near/on ground, upward bounce is damped unless throttle, airspeed, lift factor, and stall state indicate a real takeoff/climb.
+
 
 ```text
 AoA = degrees_between(nose_forward_vector, velocity_vector)
@@ -175,9 +195,12 @@ stallSeverity += (target - stallSeverity) * (0.35 if target is rising else 0.18)
 liftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
 if motionY > 0: motionY *= 1 - liftLoss * 0.12
 motionY -= 0.018 * liftLoss * StallStrength
+noseDown = StallNoseDownForce * stallSeverity
+         * clamp((airspeed - StallNoseDownMinSpeed)
+                 / (stallSpeed - StallNoseDownMinSpeed), 0, 1)
 ```
 
-Stall instability adds repeatable roll/yaw/pitch buffet using `StallInstability * stallSeverity`.
+Stall instability adds repeatable roll/yaw/pitch buffet using `StallInstability * stallSeverity`. `noseDown` is added as a gradual positive-pitch recovery tendency and a small body-rate nudge, so pilot input remains partially effective instead of being overridden by a forced dive.
 
 ### G-force, speed scaling, and compressibility
 
@@ -272,4 +295,4 @@ Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy pa
 
 Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
 
-Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, AoA, lift loss, drag, control authority, stall, and overspeed state for new-flight tuning.
+Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, vertical speed, AoA, explicit gravity, lift compensation, lift loss, stall nose-down recovery force, drag, control authority, stall, and overspeed state for new-flight tuning.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -331,7 +331,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,vertical=%.4f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,gravity=%.4f,lift=%.4f,liftLoss=%.2f,noseDown=%.3f,authority=%.2f)",
               simDelta,
               mouseX,
               mouseY,
@@ -346,12 +346,16 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               Double.valueOf(ac.getNormalizedThrottle() * 100.0D),
               Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
+              ac.motionY,
               ac.getAngleOfAttackDegrees(),
               ac.getStallSeverity(),
               Boolean.valueOf(ac.isOverspeeding()),
               ac.getCurrentGForce(),
               ac.getLastAerodynamicDrag(),
+              ac.getLastGravityForce(),
+              ac.getLastLiftForce(),
               ac.getLastLiftLoss(),
+              ac.getLastStallNoseDownForce(),
               ac.getDebugControlAuthority()
       ));
    }

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -414,7 +414,7 @@ public class MCH_Config {
       EnablePutRackInFlying = new MCH_ConfigPrm("EnablePutRackInFlying", true);
       EnableDebugBoundingBox = new MCH_ConfigPrm("EnableDebugBoundingBox", false);
       DebugFlightControl = new MCH_ConfigPrm("DebugFlightControl", false);
-      DebugFlightControl.desc = ";Print FPS, elapsed tick fraction, control inputs, angular velocity, and pitch/yaw/roll once per second while piloting.";
+      DebugFlightControl.desc = ";Print FPS, elapsed tick fraction, controls, angular velocity, attitude, and new-flight aero values (vertical speed, lift, gravity, stall, nose-down recovery) once per second while piloting.";
       DespawnCount = new MCH_ConfigPrm("DespawnCount", 25);
       HitBoxDelayTick = new MCH_ConfigPrm("HitBoxDelayTick", 0);
       EnableRotationLimit = new MCH_ConfigPrm("EnableRotationLimit", false);

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1759,6 +1759,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return 0.0D;
    }
 
+   /** Most recent explicit fixed-wing gravity acceleration. */
+   public double getLastGravityForce() {
+      return 0.0D;
+   }
+
+   /** Most recent fixed-wing lift compensation against gravity. */
+   public double getLastLiftForce() {
+      return 0.0D;
+   }
+
+   /** Most recent stall nose-down pitch recovery force. */
+   public double getLastStallNoseDownForce() {
+      return 0.0D;
+   }
+
    /** Effective 0..1 control authority after stall and high-G penalties. */
    public float getDebugControlAuthority() {
       return this.getControlAuthorityFactor();

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -120,6 +120,29 @@ public final class MCH_FlightModel {
             * normalizedAoA * normalizedAoA;
    }
 
+   /**
+    * Returns how much fixed-wing lift is available to counter gravity. Healthy
+    * airspeed and modest AoA approach 1; low speed, excessive AoA, and stalls
+    * progressively remove lift without making aircraft fall like rocks.
+    */
+   public static double getLiftGravityFactor(double airspeed, double angleOfAttack, double stallSpeed,
+                                             float criticalAoA, double stallSeverity, float stallLiftLoss) {
+      double stall = Math.max(0.05D, stallSpeed);
+      double speedLift = clamp((Math.max(0.0D, airspeed) - stall * 0.55D) / (stall * 1.25D), 0.0D, 1.0D);
+      double critical = Math.max(1.0D, (double)criticalAoA);
+      double aoaLift = 1.0D - clamp((Math.abs(angleOfAttack) - critical * 0.65D) / (critical * 0.85D), 0.0D, 1.0D);
+      double liftLoss = clamp(clamp(stallSeverity, 0.0D, 1.0D) * clamp((double)stallLiftLoss, 0.0D, 1.0D), 0.0D, 1.0D);
+      return clamp(speedLift * aoaLift * (1.0D - liftLoss), 0.0D, 1.0D);
+   }
+
+   /** Stall recovery pitch authority ramps in with airspeed so it is a tendency, not a forced snap. */
+   public static double getStallNoseDownRecovery(double airspeed, double stallSpeed, double minSpeed,
+                                                  double stallSeverity, float noseDownForce) {
+      double usableRange = Math.max(0.05D, stallSpeed - minSpeed);
+      double speedAuthority = clamp((airspeed - minSpeed) / usableRange, 0.0D, 1.0D);
+      return Math.max(0.0D, (double)noseDownForce) * clamp(stallSeverity, 0.0D, 1.0D) * speedAuthority;
+   }
+
    /** Returns a 0..1 severity value as airspeed falls below the stall threshold. */
    public static double getStallSeverity(double horizontalSpeed, float topSpeed, float stallSpeedFactor) {
       double stallSpeed = Math.max(0.05D, (double)topSpeed * (double)stallSpeedFactor);

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -55,6 +55,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastAerodynamicDrag;
    /** Last stall lift-loss fraction applied to vertical motion, exposed for debug output. */
    private double lastLiftLoss;
+   /** Last explicit gravity acceleration applied by the new fixed-wing model. */
+   private double lastGravityForce;
+   /** Last aerodynamic lift compensation applied against gravity. */
+   private double lastLiftForce;
+   /** Last stall nose-down recovery pitch force. */
+   private double lastStallNoseDownForce;
    /** Local-axis body rates used by fixed-wing damped control response. */
    private float pitchAngularVelocity;
    private float rollAngularVelocity;
@@ -90,6 +96,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.engineThrottle = 0.0D;
       this.lastAerodynamicDrag = 0.0D;
       this.lastLiftLoss = 0.0D;
+      this.lastGravityForce = 0.0D;
+      this.lastLiftForce = 0.0D;
+      this.lastStallNoseDownForce = 0.0D;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
       this.stalling = false;
@@ -370,6 +379,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    public double getLastLiftLoss() {
       return this.lastLiftLoss;
+   }
+
+   public double getLastGravityForce() {
+      return this.lastGravityForce;
+   }
+
+   public double getLastLiftForce() {
+      return this.lastLiftForce;
+   }
+
+   public double getLastStallNoseDownForce() {
+      return this.lastStallNoseDownForce;
    }
 
    public float getDebugControlAuthority() {
@@ -672,6 +693,80 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
    }
 
+   private double getLiftGravityFactor() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null) {
+         return 0.0D;
+      }
+
+      double airspeed = this.getAirspeed();
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
+      double lift = MCH_FlightModel.getLiftGravityFactor(airspeed, this.angleOfAttack, stallSpeed,
+            info.criticalAoA, this.stallSeverity, info.stallLiftLoss);
+      if(this.isCombatFlapsDeployed()) {
+         lift = MCH_FlightModel.clamp(lift + (double)info.newFlightCombatFlapLift * 0.35D, 0.0D, 1.0D);
+      }
+      return lift;
+   }
+
+   private void applyNewFlightGravityAndLift(boolean levelOff, double waterDepth) {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      this.lastGravityForce = 0.0D;
+      this.lastLiftForce = 0.0D;
+      if(!this.useNewMobilitySystem() || info == null || waterDepth != 0.0D || this.getNozzleRotation() > 0.01F) {
+         return;
+      }
+
+      boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
+      if(super.onGround) {
+         return;
+      }
+
+      double gravity = Math.max(0.0D, (double)info.gravityStrength);
+      double liftFactor = this.getLiftGravityFactor();
+      if(levelOff) {
+         liftFactor = Math.min(liftFactor, 0.85D);
+      }
+      double lift = gravity * Math.max(0.0D, (double)info.liftGravityCompensation) * liftFactor;
+      if(this.stallSeverity > 0.0D) {
+         lift *= 1.0D - MCH_FlightModel.clamp(this.stallSeverity * (double)info.stallLiftLoss, 0.0D, 1.0D);
+      }
+
+      this.lastGravityForce = gravity;
+      this.lastLiftForce = Math.min(lift, gravity);
+      super.motionY += this.lastLiftForce - gravity;
+
+      if(nearGround && super.motionY > (double)info.groundVerticalVelocityClamp && !this.hasValidNewFlightClimbReason()) {
+         super.motionY = (double)info.groundVerticalVelocityClamp
+               + (super.motionY - (double)info.groundVerticalVelocityClamp) * (double)info.groundBounceDamping;
+      }
+   }
+
+   private boolean hasValidNewFlightClimbReason() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null) {
+         return false;
+      }
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
+      return this.getEffectiveEngineThrottle() > 0.35D
+            && this.getAirspeed() > stallSpeed * 1.15D
+            && this.getLiftGravityFactor() > 0.65D
+            && this.stallSeverity < 0.45D;
+   }
+
+   private void dampNewFlightGroundBounce(boolean nearGround) {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(!this.useNewMobilitySystem() || info == null || !nearGround || super.motionY <= 0.0D) {
+         return;
+      }
+
+      if(!this.hasValidNewFlightClimbReason()) {
+         super.motionY = Math.min(super.motionY * (double)info.groundBounceDamping,
+               (double)info.groundVerticalVelocityClamp);
+      }
+   }
+
    protected void updateVehicleStress() {
       if(!this.useNewMobilitySystem()) {
          this.currentGForce = 1.0D;
@@ -776,7 +871,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          super.throttleUp = true;
          this.onUpdate_ControlNotHovering();
       } else if(this.getCurrentThrottle() > 0.0D) {
-         this.addCurrentThrottle(-0.0025D * (double)this.getAcInfo().throttleUpDown);
+         double throttleDecay = 0.0025D * (double)this.getAcInfo().throttleUpDown;
+         if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
+            throttleDecay = Math.max(throttleDecay, (double)this.getPlaneInfo().newFlightThrottleChangeRateDown);
+         }
+         this.addCurrentThrottle(-throttleDecay);
       } else {
          this.setCurrentThrottle(0.0D);
       }
@@ -813,6 +912,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       if(!this.canUseCombatFlaps()) {
          this.combatFlapsDeployed = false;
+      }
+
+      if(this.useNewMobilitySystem() && this.getRiddenByEntity() == null) {
+         this.pitchAngularVelocity *= 0.75F;
+         this.rollAngularVelocity *= 0.75F;
+         this.yawAngularVelocity *= 0.75F;
+         if(super.onGround || MCH_Lib.getBlockIdY(this, 3, -3) > 0) {
+            this.combatFlapsDeployed = false;
+            this.dampNewFlightGroundBounce(true);
+         }
       }
    }
 
@@ -1180,6 +1289,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.stallSeverity = 0.0D;
          this.lastAerodynamicDrag = 0.0D;
          this.lastLiftLoss = 0.0D;
+         this.lastGravityForce = 0.0D;
+         this.lastLiftForce = 0.0D;
+         this.lastStallNoseDownForce = 0.0D;
          this.stalling = false;
       }
 
@@ -1227,15 +1339,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
 
          if(!levelOff) {
-            super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
             if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
-               double liftPower = (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention
-                     + (1.0D - (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
-               if(this.isCombatFlapsDeployed()) {
-                  liftPower += (double)this.getPlaneInfo().newFlightCombatFlapLift;
-               }
-               super.motionY += -0.047D * (1.0D - MCH_FlightModel.clamp(liftPower, 0.0D, 1.0D));
+               // New fixed-wing gravity/lift is applied after thrust and damping, where
+               // current airspeed/AoA are known. Do not run the legacy throttle-lift
+               // shortcut for opted-in planes because it can let idle throttle hover.
             } else {
+               super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
                super.motionY += -0.047D * (1.0D - this.getEngineThrottle());
             }
          } else {
@@ -1315,6 +1424,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       // 对垂直速度进行衰减
       super.motionY *= 0.95D;
+      this.applyNewFlightGravityAndLift(levelOff, dp);
       // 根据飞行器的运动系数衰减水平速度
       super.motionX *= this.getAcInfo().motionFactor;
       super.motionZ *= this.getAcInfo().motionFactor;
@@ -1392,6 +1502,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // buffet/wing drop. Lowering the nose reduces AoA and lets speed build to recovery.
       boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
       this.lastLiftLoss = 0.0D;
+      this.lastStallNoseDownForce = 0.0D;
       if(this.useNewMobilitySystem() && !nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff && this.stallSeverity > 0.0D) {
          double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)this.getPlaneInfo().stallLiftLoss, 0.0D, 1.0D);
          this.lastLiftLoss = liftLoss;
@@ -1406,8 +1517,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                * (double)this.getPlaneInfo().stallInstability * this.stallSeverity;
          this.setRotRoll(this.getRotRoll() + (float)(wingDrop * 0.08D + buffet * 0.04D));
          this.setRotYaw(this.getRotYaw() + (float)(buffet * 0.02D));
+         double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+               this.getPlaneInfo().stallSpeedFactor);
+         double recoveryForce = MCH_FlightModel.getStallNoseDownRecovery(this.getAirspeed(), stallSpeed,
+               (double)this.getPlaneInfo().stallNoseDownMinSpeed, this.stallSeverity,
+               this.getPlaneInfo().stallNoseDownForce);
+         this.lastStallNoseDownForce = recoveryForce;
+         this.pitchAngularVelocity += (float)(recoveryForce * 0.35D);
          this.setRotPitch(this.getRotPitch() + (float)(0.04D * (double)this.getPlaneInfo().stallInstability
-               * this.stallSeverity));
+               * this.stallSeverity + recoveryForce));
       }
 
       // Lift fades through a band below the configured ceiling instead of hitting an invisible wall.
@@ -1423,6 +1541,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       // 如果飞行器在地面或距离地面较近，则缩减水平速度，应用地面俯仰角度
       if(nearGround) {
+         this.dampNewFlightGroundBounce(nearGround);
          super.motionX *= this.getAcInfo().motionFactor;
          super.motionZ *= this.getAcInfo().motionFactor;
          // 如果俯仰角度小于40度，则根据地面状态调整俯仰角度

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -63,6 +63,18 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float newFlightEngineBrakeDrag = 0.0035F;
    /** Fraction of legacy throttle-coupled lift retained at idle. */
    public float newFlightLowThrottleLiftRetention = 0.82F;
+   /** Explicit new-flight gravity applied to conventional fixed-wing flight. */
+   public float gravityStrength = 0.032F;
+   /** Maximum fraction of gravity that aerodynamic lift can counter at healthy speed/AoA. */
+   public float liftGravityCompensation = 1.05F;
+   /** Nose-down pitch recovery force applied during developed stalls. */
+   public float stallNoseDownForce = 0.12F;
+   /** Minimum airspeed where stall nose-down recovery starts to gain authority. */
+   public float stallNoseDownMinSpeed = 0.08F;
+   /** Upward vertical velocity damping after ground contact. */
+   public float groundBounceDamping = 0.25F;
+   /** Maximum upward vertical velocity allowed near ground without valid lift/thrust. */
+   public float groundVerticalVelocityClamp = 0.015F;
    /** Maximum fraction of control authority lost at idle throttle. */
    public float newFlightThrottleControlAuthorityScale = 0.18F;
    /** Show the normalized 0-100% throttle readout to pilots using the new flight model. */
@@ -304,6 +316,18 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.newFlightEngineBrakeDrag = this.toFloat(data, 0.0F, 0.25F);
          } else if(item.equalsIgnoreCase("NewFlightLowThrottleLiftRetention")) {
             this.newFlightLowThrottleLiftRetention = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("GravityStrength")) {
+            this.gravityStrength = this.toFloat(data, 0.0F, 0.25F);
+         } else if(item.equalsIgnoreCase("LiftGravityCompensation")) {
+            this.liftGravityCompensation = this.toFloat(data, 0.0F, 2.0F);
+         } else if(item.equalsIgnoreCase("StallNoseDownForce")) {
+            this.stallNoseDownForce = this.toFloat(data, 0.0F, 5.0F);
+         } else if(item.equalsIgnoreCase("StallNoseDownMinSpeed")) {
+            this.stallNoseDownMinSpeed = this.toFloat(data, 0.0F, 10.0F);
+         } else if(item.equalsIgnoreCase("GroundBounceDamping")) {
+            this.groundBounceDamping = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("GroundVerticalVelocityClamp")) {
+            this.groundVerticalVelocityClamp = this.toFloat(data, 0.0F, 0.25F);
          } else if(item.equalsIgnoreCase("NewFlightThrottleControlAuthorityScale")) {
             this.newFlightThrottleControlAuthorityScale = this.toFloat(data, 0.0F, 1.0F);
          } else if(item.equalsIgnoreCase("NewFlightThrottleHudDisplay")) {


### PR DESCRIPTION
### Motivation

- Planes using the new flight model could hover at 0% throttle, fail to bleed altitude when power is cut, and exhibit post-landing upward bounces and Y-gain when pilots exit.  
- Stalled aircraft did not present a natural nose-down recovery tendency, causing unrealistic energy-freezing quirks.  
- Introduce an explicit gravity vs lift interaction and a gentle stall nose-down tendency for the new flight model only while preserving legacy behavior and providing tunable defaults.

### Description

- Added new per-plane config keys with safe defaults in `MCP_PlaneInfo`: `GravityStrength`, `LiftGravityCompensation`, `StallNoseDownForce`, `StallNoseDownMinSpeed`, `GroundBounceDamping`, and `GroundVerticalVelocityClamp`, plus parser support for each.  
- Implemented lift-vs-gravity helpers in `MCH_FlightModel`: `getLiftGravityFactor` and `getStallNoseDownRecovery` and used them to compute gravity/lift interactions and stall recovery authority.  
- Implemented new-flight gravity/lift and ground-bounce handling in `MCP_EntityPlane`: added debug fields (`lastGravityForce`, `lastLiftForce`, `lastStallNoseDownForce`), `getLiftGravityFactor`, `applyNewFlightGravityAndLift`, `dampNewFlightGroundBounce`, a safer throttle decay for new-flight planes, and a stall nose-down tendency that nudges pitch/body rates while preserving player authority.  
- Extended debug output and getters: added debug values to `MCH_EntityBaseVehicle` and include vertical speed, gravity, lift, and stall recovery in `DebugFlightControl` output (`MCH_ClientCommonTickHandler`), and documented the behaviour and new keys in `docs/vehicle-config/planes.md`; updated `MCH_Config` debug description.

### Testing

- Ran `git diff --check` to validate no obvious whitespace/error diffs, which passed.  
- Compiled the new `MCH_FlightModel` with `javac -proc:none -source 1.8 -target 1.8 src/main/java/mcheli/aircraft/MCH_FlightModel.java`, which succeeded with only harmless warnings.  
- Attempted full project builds with `./gradlew compileJava` and `gradle compileJava`, both of which failed due to external dependency resolution (Gradle/Forge/Maven access blocked by network/proxy returning HTTP 403 in this environment).  
- Tried compiling `MCP_EntityPlane` with `javac` to check syntax, but the compile failed in this environment because Minecraft/Forge classes are not available on the local classpath; changes were reviewed and exercised by non-IDE compilation attempts and local static analysis only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b6012b3488329a383708ec7d0b5c6)