### PR TITLE
Fix new-flight plane takeoff lift and ground clamp

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -45,7 +45,7 @@ All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpee
 | `NewFlightEngineBrakeDrag` | float[0..0.25] | 0.0035 | **New flight model only.** Closed-throttle/low-power drag used by the energy model. Replaces `IdleDrag` for opted-in planes. |
 | `NewFlightLowThrottleLiftRetention` | float[0..1] | 0.82 | Compatibility tuning for older new-flight configs; explicit gravity/lift now governs altitude retention for opted-in planes. |
 | `GravityStrength` | float[0..0.25] | 0.032 | **New flight model only.** Downward acceleration applied continuously in conventional fixed-wing flight. Lift and stall state decide how much is countered. |
-| `LiftGravityCompensation` | float[0..2] | 1.05 | **New flight model only.** Maximum share of `GravityStrength` that healthy airspeed and sane AoA can offset. Values over 1 provide tuning headroom before the applied lift is capped to gravity. |
+| `LiftGravityCompensation` | float[0..2] | 1.05 | **New flight model only.** Maximum share of `GravityStrength` that healthy airspeed and sane AoA can offset. Values over 1 provide takeoff/climb headroom when throttle, airspeed, lift factor, and rotation attitude indicate a real climb; non-climb cases are capped to gravity for stable level flight. |
 | `GroundBounceDamping` | float[0..1] | 0.25 | **New flight model only.** Multiplier applied to upward vertical bounce near/on ground when there is not enough speed/lift/thrust for takeoff. |
 | `GroundVerticalVelocityClamp` | float[0..0.25] | 0.015 | **New flight model only.** Upward velocity cap near/on ground without a valid aerodynamic climb reason. |
 | `NewFlightThrottleControlAuthorityScale` | float[0..1] | 0.18 | **New flight model only.** Maximum control-authority penalty at idle. Keep low so glide/landing controls remain useful. |
@@ -138,10 +138,11 @@ speedRatio = horizontalSpeed / max(0.05, MaxLevelSpeed or Speed)
 drag = BaseDrag * (0.5 + 0.5 * speedRatio^2)
 drag += InducedDrag * turnLoad^2
 drag += ControlSurfaceDrag * controlLoad
-drag += IdleDrag * (1 - engineThrottle)
-sustainableSpeed = levelSpeed * (0.35 + 0.65 * engineThrottle)
+lowPowerDrag = NewFlightEngineBrakeDrag  # replaces IdleDrag for opted-in new-flight planes
+drag += lowPowerDrag * (1 - effectiveThrottle)
+sustainableSpeed = levelSpeed * (0.35 + 0.65 * effectiveThrottle)
 if horizontalSpeed > sustainableSpeed:
-    drag += (BaseDrag + IdleDrag) * clamp((horizontalSpeed - sustainableSpeed) / levelSpeed, 0, 2)
+    drag += (BaseDrag + lowPowerDrag) * clamp((horizontalSpeed - sustainableSpeed) / levelSpeed, 0, 2)
 drag += BaseDrag * AoADragMultiplier * (abs(AoA) / max(1, CriticalAoA))^2
 drag = clamp(drag, 0, 0.5)
 ```
@@ -165,11 +166,34 @@ speedLift = clamp((airspeed - stallSpeed * 0.55) / (stallSpeed * 1.25), 0, 1)
 aoaLift = 1 - clamp((abs(AoA) - CriticalAoA * 0.65) / (CriticalAoA * 0.85), 0, 1)
 stallLiftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
 liftFactor = speedLift * aoaLift * (1 - stallLiftLoss)
-lift = min(GravityStrength * LiftGravityCompensation * liftFactor, GravityStrength)
+rawLift = GravityStrength * LiftGravityCompensation * liftFactor
+validTakeoff = nearGround
+            && pilotPresent
+            && throttlePercent >= 55
+            && effectiveThrottle >= 0.50
+            && airspeed >= stallSpeed * 0.85
+            && liftFactor >= 0.45
+            && stallSeverity < 0.85
+            && rotationAttitude
+validClimb = validTakeoff
+          || (pilotPresent
+              && throttlePercent >= 45
+              && effectiveThrottle >= 0.40
+              && airspeed >= stallSpeed * 1.05
+              && liftFactor >= 0.55
+              && stallSeverity < 0.60
+              && rotationAttitude)
+
+if validTakeoff:
+    rawLift = max(rawLift, GravityStrength * min(LiftGravityCompensation, 1.02))
+if validClimb:
+    lift = min(rawLift, GravityStrength * LiftGravityCompensation)
+else:
+    lift = min(rawLift, GravityStrength)
 motionY += lift - GravityStrength
 ```
 
-This means throttle by itself does not hold altitude: an aircraft must have enough airspeed and acceptable AoA to create lift. Cutting power increases drag and eventually reduces airspeed, so lift decays and the plane naturally descends. Near/on ground, upward bounce is damped unless throttle, airspeed, lift factor, and stall state indicate a real takeoff/climb.
+This means throttle by itself does not hold altitude: an aircraft must have enough airspeed, acceptable AoA, effective engine output, and takeoff/climb attitude to create lift greater than gravity. Cutting power increases drag and eventually reduces airspeed, so lift decays and the plane naturally descends. Near/on ground, upward bounce is damped unless throttle, airspeed, lift factor, stall state, and rotation attitude indicate a real takeoff/climb. Ground roll no longer applies full airborne stall sink/recovery behavior; stall severity is blended in near the ground and the heavy stall sink/nose-down recovery remains an airborne behavior.
 
 
 ```text

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -331,7 +331,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,vertical=%.4f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,gravity=%.4f,lift=%.4f,liftLoss=%.2f,noseDown=%.3f,authority=%.2f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(onGround=%s,nearGround=%s,throttlePercent=%.0f%%,engineThrottle=%.2f,effectiveThrottle=%.2f,flaps=%s,airspeed=%.3f,vertical=%.4f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,gravity=%.4f,lift=%.4f,liftFactor=%.2f,liftLoss=%.2f,noseDown=%.3f,validTakeoff=%s,groundClamp=%s,bounceDamping=%s,authority=%.2f)",
               simDelta,
               mouseX,
               mouseY,
@@ -343,7 +343,11 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getRotPitch(),
               ac.getRotYaw(),
               ac.getRotRoll(),
+              Boolean.valueOf(ac.onGround),
+              Boolean.valueOf(ac.isDebugNearGround()),
               Double.valueOf(ac.getNormalizedThrottle() * 100.0D),
+              ac.getDebugEngineThrottle(),
+              ac.getDebugEffectiveThrottle(),
               Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
               ac.motionY,
@@ -354,8 +358,12 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getLastAerodynamicDrag(),
               ac.getLastGravityForce(),
               ac.getLastLiftForce(),
+              ac.getLastLiftFactor(),
               ac.getLastLiftLoss(),
               ac.getLastStallNoseDownForce(),
+              Boolean.valueOf(ac.isDebugValidTakeoff()),
+              Boolean.valueOf(ac.wasDebugGroundClampApplied()),
+              Boolean.valueOf(ac.wasDebugBounceDampingApplied()),
               ac.getDebugControlAuthority()
       ));
    }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1769,6 +1769,41 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return 0.0D;
    }
 
+   /** Most recent 0..1 lift factor used by the fixed-wing gravity/lift model. */
+   public double getLastLiftFactor() {
+      return 0.0D;
+   }
+
+   /** Smoothed engine output before new-flight response/idle curves. */
+   public double getDebugEngineThrottle() {
+      return this.getNormalizedThrottle();
+   }
+
+   /** Effective engine output after new-flight response/idle curves. */
+   public double getDebugEffectiveThrottle() {
+      return this.getNormalizedThrottle();
+   }
+
+   /** True when the new fixed-wing model currently sees a takeoff/climb reason near ground. */
+   public boolean isDebugValidTakeoff() {
+      return false;
+   }
+
+   /** True when the latest new-flight ground vertical clamp changed upward velocity. */
+   public boolean wasDebugGroundClampApplied() {
+      return false;
+   }
+
+   /** True when the latest new-flight ground bounce damping changed upward velocity. */
+   public boolean wasDebugBounceDampingApplied() {
+      return false;
+   }
+
+   /** True when the vehicle is on or within a few blocks of ground for flight-model purposes. */
+   public boolean isDebugNearGround() {
+      return super.onGround;
+   }
+
    /** Most recent stall nose-down pitch recovery force. */
    public double getLastStallNoseDownForce() {
       return 0.0D;

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -59,7 +59,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastGravityForce;
    /** Last aerodynamic lift compensation applied against gravity. */
    private double lastLiftForce;
-   /** Last stall nose-down recovery pitch force. */
+   /** Last 0..1 lift factor used by the explicit gravity/lift model. */
+   private double lastLiftFactor;
+   /** Last new-flight takeoff/rotation decision used by lift and ground-clamp logic. */
+   private boolean lastValidTakeoff;
+   /** True when the latest ground-clamp pass limited positive vertical velocity. */
+   private boolean lastGroundClampApplied;
+   /** True when the latest ground-bounce pass damped positive vertical velocity. */
+   private boolean lastBounceDampingApplied;
+   /** Last stall nose-down pitch recovery force. */
    private double lastStallNoseDownForce;
    /** Local-axis body rates used by fixed-wing damped control response. */
    private float pitchAngularVelocity;
@@ -98,6 +106,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftLoss = 0.0D;
       this.lastGravityForce = 0.0D;
       this.lastLiftForce = 0.0D;
+      this.lastLiftFactor = 0.0D;
+      this.lastValidTakeoff = false;
+      this.lastGroundClampApplied = false;
+      this.lastBounceDampingApplied = false;
       this.lastStallNoseDownForce = 0.0D;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
@@ -389,6 +401,34 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return this.lastLiftForce;
    }
 
+   public double getLastLiftFactor() {
+      return this.lastLiftFactor;
+   }
+
+   public double getDebugEngineThrottle() {
+      return MCH_FlightModel.clamp(this.getEngineThrottle(), 0.0D, 1.0D);
+   }
+
+   public double getDebugEffectiveThrottle() {
+      return MCH_FlightModel.clamp(this.getEffectiveEngineThrottle(), 0.0D, 1.0D);
+   }
+
+   public boolean isDebugValidTakeoff() {
+      return this.lastValidTakeoff;
+   }
+
+   public boolean wasDebugGroundClampApplied() {
+      return this.lastGroundClampApplied;
+   }
+
+   public boolean wasDebugBounceDampingApplied() {
+      return this.lastBounceDampingApplied;
+   }
+
+   public boolean isDebugNearGround() {
+      return this.useNewMobilitySystem() && (super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0);
+   }
+
    public double getLastStallNoseDownForce() {
       return this.lastStallNoseDownForce;
    }
@@ -673,6 +713,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       double targetSeverity = this.stalling ? Math.max(0.12D, demand) : 0.0D;
+      boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
+      if(nearGround) {
+         double groundStallBlend = MCH_FlightModel.clamp((speed - stallSpeed * 0.55D) / (stallSpeed * 0.45D), 0.0D, 1.0D);
+         targetSeverity *= groundStallBlend;
+         if(super.onGround && targetSeverity <= 0.0D) {
+            this.stalling = false;
+         }
+      }
       this.stallSeverity += (targetSeverity - this.stallSeverity) * (targetSeverity > this.stallSeverity ? 0.35D : 0.18D);
       if(this.stallSeverity < 1.0E-3D) {
          this.stallSeverity = 0.0D;
@@ -713,46 +761,91 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       MCP_PlaneInfo info = this.getPlaneInfo();
       this.lastGravityForce = 0.0D;
       this.lastLiftForce = 0.0D;
+      this.lastLiftFactor = 0.0D;
+      this.lastValidTakeoff = false;
+      this.lastGroundClampApplied = false;
+      this.lastBounceDampingApplied = false;
       if(!this.useNewMobilitySystem() || info == null || waterDepth != 0.0D || this.getNozzleRotation() > 0.01F) {
          return;
       }
 
       boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
-      if(super.onGround) {
-         return;
-      }
-
       double gravity = Math.max(0.0D, (double)info.gravityStrength);
       double liftFactor = this.getLiftGravityFactor();
       if(levelOff) {
          liftFactor = Math.min(liftFactor, 0.85D);
       }
-      double lift = gravity * Math.max(0.0D, (double)info.liftGravityCompensation) * liftFactor;
-      if(this.stallSeverity > 0.0D) {
-         lift *= 1.0D - MCH_FlightModel.clamp(this.stallSeverity * (double)info.stallLiftLoss, 0.0D, 1.0D);
+
+      this.lastLiftFactor = liftFactor;
+      boolean validTakeoff = this.hasValidNewFlightTakeoffReason(nearGround, liftFactor);
+      boolean validClimb = validTakeoff || this.hasValidNewFlightClimbReason(liftFactor);
+      this.lastValidTakeoff = validTakeoff;
+
+      if(super.onGround && !validTakeoff) {
+         return;
+      }
+
+      double compensation = Math.max(0.0D, (double)info.liftGravityCompensation);
+      double lift = gravity * compensation * liftFactor;
+      if(validTakeoff && compensation > 1.0D) {
+         lift = Math.max(lift, gravity * Math.min(compensation, 1.02D));
+      }
+      if(!validClimb || levelOff) {
+         lift = Math.min(lift, gravity);
+      } else {
+         lift = Math.min(lift, gravity * compensation);
       }
 
       this.lastGravityForce = gravity;
-      this.lastLiftForce = Math.min(lift, gravity);
+      this.lastLiftForce = lift;
       super.motionY += this.lastLiftForce - gravity;
 
-      if(nearGround && super.motionY > (double)info.groundVerticalVelocityClamp && !this.hasValidNewFlightClimbReason()) {
+      if(nearGround && super.motionY > (double)info.groundVerticalVelocityClamp && !validTakeoff) {
          super.motionY = (double)info.groundVerticalVelocityClamp
                + (super.motionY - (double)info.groundVerticalVelocityClamp) * (double)info.groundBounceDamping;
+         this.lastGroundClampApplied = true;
+         this.lastBounceDampingApplied = true;
       }
    }
 
-   private boolean hasValidNewFlightClimbReason() {
+   private boolean hasNewFlightRotationAttitude() {
+      return this.getRotPitch() <= 5.0F || this.pitchAngularVelocity < -0.02F || super.motionY > 0.0D;
+   }
+
+   private boolean hasValidNewFlightTakeoffReason(boolean nearGround, double liftFactor) {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null || !nearGround || this.getRiddenByEntity() == null) {
+         return false;
+      }
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
+      return this.getNormalizedThrottle() >= 0.55D
+            && this.getEffectiveEngineThrottle() >= 0.50D
+            && this.getAirspeed() >= stallSpeed * 0.85D
+            && liftFactor >= 0.45D
+            && this.stallSeverity < 0.85D
+            && this.hasNewFlightRotationAttitude();
+   }
+
+   private boolean hasValidNewFlightClimbReason(double liftFactor) {
       MCP_PlaneInfo info = this.getPlaneInfo();
       if(info == null) {
          return false;
       }
 
       double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
-      return this.getEffectiveEngineThrottle() > 0.35D
-            && this.getAirspeed() > stallSpeed * 1.15D
-            && this.getLiftGravityFactor() > 0.65D
-            && this.stallSeverity < 0.45D;
+      boolean hasPilot = this.getRiddenByEntity() != null;
+      return hasPilot
+            && this.getNormalizedThrottle() >= 0.45D
+            && this.getEffectiveEngineThrottle() >= 0.40D
+            && this.getAirspeed() >= stallSpeed * 1.05D
+            && liftFactor >= 0.55D
+            && this.stallSeverity < 0.60D
+            && this.hasNewFlightRotationAttitude();
+   }
+
+   private boolean hasValidNewFlightClimbReason() {
+      return this.hasValidNewFlightClimbReason(this.getLiftGravityFactor());
    }
 
    private void dampNewFlightGroundBounce(boolean nearGround) {
@@ -761,9 +854,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
-      if(!this.hasValidNewFlightClimbReason()) {
+      double liftFactor = this.getLiftGravityFactor();
+      boolean validTakeoff = this.hasValidNewFlightTakeoffReason(nearGround, liftFactor);
+      this.lastLiftFactor = liftFactor;
+      this.lastValidTakeoff = validTakeoff;
+      if(!validTakeoff) {
          super.motionY = Math.min(super.motionY * (double)info.groundBounceDamping,
                (double)info.groundVerticalVelocityClamp);
+         this.lastGroundClampApplied = true;
+         this.lastBounceDampingApplied = true;
       }
    }
 
@@ -1291,6 +1390,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastLiftLoss = 0.0D;
          this.lastGravityForce = 0.0D;
          this.lastLiftForce = 0.0D;
+         this.lastLiftFactor = 0.0D;
+         this.lastValidTakeoff = false;
+         this.lastGroundClampApplied = false;
+         this.lastBounceDampingApplied = false;
          this.lastStallNoseDownForce = 0.0D;
          this.stalling = false;
       }


### PR DESCRIPTION
### Motivation
- New-flight planes were unable to take off because the lift/gavity/ground-clamp logic prevented any net upward acceleration near the ground. 
- The documented formula capped lift to gravity and ground-clamp/bounce code could suppress legitimate takeoff motion and applied full airborne stall penalties during ground roll. 
- The goal is to let valid rotation/takeoff conditions exceed gravity while preserving stable level flight, preventing landing bounce, and keeping legacy planes unchanged. 

### Description
- Allow lift headroom: change the lift computation so raw lift = `GravityStrength * LiftGravityCompensation * liftFactor`, then permit lift > gravity when a `validTakeoff` or `validClimb` condition is met and otherwise cap to `GravityStrength` for stable non-climb cases. 
- Add explicit takeoff/climb checks using pilot presence, `throttle`/`effectiveThrottle`, `airspeed` vs stallSpeed, `liftFactor`, stall severity and rotation/pitch attitude, and use those flags to control lift caps and ground-clamp behavior. 
- Adjust ground clamp/bounce damping so upward motion is only clamped/damped when there is no valid takeoff reason, and preserve aggressive suppression for no-pilot or low-energy post-exit cases. 
- Blend stall severity near the ground so ground roll does not immediately apply full airborne stall sink/nose-down recovery, and transition stall effects progressively as the aircraft leaves ground. 
- Add debug state and accessors: expose `lastLiftFactor`, `DebugEngineThrottle`, `DebugEffectiveThrottle`, `isDebugValidTakeoff`, `wasDebugGroundClampApplied`, `wasDebugBounceDampingApplied`, and `isDebugNearGround`, and expand `DebugFlightControl` output to include onGround/nearGround, throttle/engine/effective throttle, lift/liftFactor, stall, validTakeoff, and ground-clamp diagnostics. 
- Use `NewFlightEngineBrakeDrag`/`effectiveThrottle` path for new-flight low-power drag documentation and ensure it replaces `IdleDrag` for opted-in planes instead of stacking. 
- Update `docs/vehicle-config/planes.md` to reflect the revised lift formula, takeoff/climb eligibility, and the new low-power drag description. 

### Testing
- Ran `git diff --check` to verify there are no trivial whitespace/conflict issues, which returned clean results. (success) 
- Attempted to run `./gradlew compileJava` but the wrapper was initially not executable and then failed to download Gradle due to environment proxy/permission; compilation could not complete in this environment. (blocked) 
- Attempted `gradle compileJava` which failed during dependency resolution against remote Maven/ForgeGradle repositories (HTTP 403) in this environment, so full build verification was not possible here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b68d7b64083299ccaa9228e084162)