### PR TITLE
Fix dedicated-server LOD brightness snapshots

### DIFF
--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -16,6 +16,7 @@ import mcheli.tank.MCH_EntityTank;
 import mcheli.vehicle.MCH_EntityTurret;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.MathHelper;
 import net.minecraft.world.WorldServer;
 
 /** Sends render-only vehicle snapshots without changing Forge entity tracking. */
@@ -88,10 +89,39 @@ public class MCH_ServerTickHandler {
          entry.pitch = vehicle.getRotPitch();
          entry.roll = vehicle.getRotRoll();
          entry.scale = 1.0F;
-         entry.packedLight = vehicle.getBrightnessForRender(1.0F);
+         entry.packedLight = getPackedLight(world, vehicle);
          entries.add(entry);
       }
       return entries;
+   }
+
+   /**
+    * Samples the vehicle's actual world light without calling the client-only
+    * Entity#getBrightnessForRender override. Dedicated servers strip that
+    * override, and its gradual sky-light smoothing is inappropriate for the
+    * once-per-second LOD snapshots.
+    */
+   private static int getPackedLight(WorldServer world, MCH_EntityBaseVehicle vehicle) {
+      if(vehicle.haveSearchLight() && vehicle.isSearchLightON()) {
+         return 15728880;
+      }
+
+      int x = MathHelper.floor_double(vehicle.posX);
+      int z = MathHelper.floor_double(vehicle.posZ);
+      if(!world.blockExists(x, 0, z)) {
+         return 0;
+      }
+
+      double sampleOffset = (vehicle.boundingBox.maxY - vehicle.boundingBox.minY) * 0.66D;
+      float flotationOffset = vehicle.getAcInfo() != null
+         ? vehicle.getAcInfo().submergedDamageHeight : 0.0F;
+      if(vehicle.canFloatWater()) {
+         flotationOffset = Math.abs(vehicle.getAcInfo().floatOffset) + 1.0F;
+      }
+
+      int y = MathHelper.floor_double(vehicle.posY + (double)flotationOffset
+         - (double)vehicle.yOffset + sampleOffset);
+      return world.getLightBrightnessForSkyBlocks(x, y, z, 0);
    }
 
    private static byte categoryOf(MCH_EntityBaseVehicle vehicle) {


### PR DESCRIPTION
### Motivation
- The server tick handler invoked the client-only `getBrightnessForRender(float)`, causing `NoSuchMethodError` on dedicated servers where that override is absent. 
- LOD displays also showed incorrect/stale brightness because the client-side smoothing used by `getBrightnessForRender` is inappropriate for once-per-second server snapshots. 

### Description
- Replace the server-side call to `vehicle.getBrightnessForRender(1.0F)` with a server-safe helper `getPackedLight(WorldServer, MCH_EntityBaseVehicle)` in `src/main/java/mcheli/MCH_ServerTickHandler.java`. 
- Add `getPackedLight(...)` which samples packed block/sky light from the `WorldServer` at a vehicle-relative height and preserves full-bright (`15728880`) while a vehicle searchlight is active. 
- The new value is written into `PacketVehicleLODSnapshot.Entry.packedLight` so client LOD rendering receives accurate server-side lighting information. 

### Testing
- Ran `git diff --check` to verify no style/obvious whitespace issues and it passed. 
- Ran a source-level assertion script that confirmed the server snapshot path no longer references `getBrightnessForRender` and instead calls the new `getPackedLight` helper, and that check passed. 
- Attempted `bash gradlew compileJava` which failed due to the environment proxy returning HTTP 403 when downloading the legacy Gradle distribution. 
- Attempted `gradle compileJava --offline` which failed because the required legacy ForgeGradle dependency is not available in the local Gradle cache, so a full build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5b0570a883238249836a3dab687d)