### PR TITLE
Prevent crashes from undecodable vehicle textures

### DIFF
--- a/src/main/java/mcheli/MCH_TextureManagerDummy.java
+++ b/src/main/java/mcheli/MCH_TextureManagerDummy.java
@@ -5,6 +5,7 @@ import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.client.renderer.texture.ITextureObject;
 import net.minecraft.client.renderer.texture.ITickableTextureObject;
 import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.renderer.texture.TextureUtil;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.resources.IResourceManager;
 import net.minecraft.util.ResourceLocation;
@@ -20,13 +21,30 @@ public class MCH_TextureManagerDummy extends TextureManager {
       this.tm = t;
    }
 
-   public void bindTexture(ResourceLocation resouce) {
-      if(MCH_ClientCommonTickHandler.cameraMode == 2) {
-         this.tm.bindTexture(R);
-      } else {
-         this.tm.bindTexture(resouce);
+   public void bindTexture(ResourceLocation resource) {
+      ResourceLocation texture = MCH_ClientCommonTickHandler.cameraMode == 2 ? R : resource;
+
+      try {
+         this.tm.bindTexture(texture);
+      } catch(RuntimeException e) {
+         if(!isCausedByNullPointerException(e)) {
+            throw e;
+         }
+
+         MCH_Lib.Log("Failed to decode texture %s; using Minecraft's missing-texture image instead.", texture);
+         this.tm.loadTexture(texture, TextureUtil.missingTexture);
+         this.tm.bindTexture(texture);
+      }
+   }
+
+   private static boolean isCausedByNullPointerException(Throwable error) {
+      for(Throwable cause = error; cause != null; cause = cause.getCause()) {
+         if(cause instanceof NullPointerException) {
+            return true;
+         }
       }
 
+      return false;
    }
 
    public ResourceLocation getResourceLocation(int p_130087_1_) {


### PR DESCRIPTION
### Motivation

- A NullPointerException during vanilla texture registration (`TextureUtil.uploadTextureImageAllocate`) was crashing the client when an undecodable vehicle PNG reached the Minecraft uploader, so a narrow interception point was required to avoid whole-client crashes while rendering vehicles.

### Description

- Updated `MCH_TextureManagerDummy.bindTexture` to try the delegated bind and catch `RuntimeException` failures caused by a `NullPointerException` in the cause chain. 
- When the cause chain contains a `NullPointerException`, the code logs the failed resource and substitutes `TextureUtil.missingTexture` for the problematic `ResourceLocation` so rendering can continue. 
- Added a helper `isCausedByNullPointerException(Throwable)` and an import for `TextureUtil`, and preserved existing behavior by rethrowing unrelated runtime exceptions. 
- The change targets only the dummy texture manager interception point used by the mod, avoiding broad behavioral changes elsewhere.

### Testing

- Ran `git diff --check` to validate code formatting and there were no whitespace/check errors. 
- Verified repository status with `git status --short --branch` to confirm the modified file is staged/recorded. 
- Attempted `bash ./gradlew compileJava` which failed because the environment blocked the Gradle wrapper download via proxy (HTTP 403). 
- Attempted `gradle compileJava --offline` which failed because the required ForgeGradle artifact (`com.anatawa12.forge:ForgeGradle:1.2-1.0.+`) was not available in the local Gradle cache, so an offline build could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c8606ea488323b58cd64a0e45379d)