### PR TITLE
Fix ships trapped underwater when PreventWaterBobbing is enabled

### DIFF
--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -929,7 +929,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         }
 
         if(preventWaterBobbing) {
-            if(dp <= 1.0D) {
+            if(dp < 1.0D) {
                 super.motionY *= 0.25D;
 
                 if(Math.abs(super.motionY) < 0.003D) {


### PR DESCRIPTION
### Motivation
- Ships that end up fully below water level were unable to rise when `PreventWaterBobbing` was enabled because the anti-bobbing clamp applied even at full submersion, which is not the intended behavior.

### Description
- Change the surface-only bobbing suppression condition from `dp <= 1.0D` to `dp < 1.0D` in `src/main/java/mcheli/ship/MCH_EntityShip.java` so fully submerged ships retain positive buoyancy while downward motion remains damped.

### Testing
- Ran `git diff --check` and a small source-level assertion script (confirmed the `dp < 1.0D` branch is present and preserves upward motion), and attempted `bash ./gradlew compileJava` which was blocked by the environment proxy (Gradle distribution download returned HTTP 403) and wrapper permission, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d505a59c48323b9ba2eac69f17999)