### PR TITLE
Fix remote ship extra bounding box discovery

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -141,7 +141,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          //wheelBoundingBox wb = arr$[i$];
 
          if(bb.boundingBox.intersectsWith(aabb)) {
-            double dist2 = this.getDistSq(aabb, this);
+            double dist2 = this.getDistSq(aabb, bb.boundingBox);
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -144,15 +144,20 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
 
     private void updateWorldCollisionSearchRadius() {
-        double requiredRadius = (double)super.width / 2.0D;
+        double requiredRadius = Math.sqrt((double)super.width * (double)super.width / 2.0D
+                + (double)super.height * (double)super.height / 4.0D);
         for(MCH_BoundingBox bb : super.extraBoundingBox) {
-            double offsetRadius = Math.sqrt(bb.offsetX * bb.offsetX + bb.offsetZ * bb.offsetZ);
-            requiredRadius = Math.max(requiredRadius, offsetRadius + (double)bb.width / 2.0D);
+            double offsetRadius = Math.sqrt(bb.offsetX * bb.offsetX + bb.offsetY * bb.offsetY
+                    + bb.offsetZ * bb.offsetZ);
+            double halfDiagonal = Math.sqrt((double)bb.width * (double)bb.width / 2.0D
+                    + (double)bb.height * (double)bb.height / 4.0D);
+            requiredRadius = Math.max(requiredRadius, offsetRadius + halfDiagonal);
         }
 
-        // Forge uses this value when deciding which chunk entity lists to search.
-        // Without accounting for a carrier's remote boxes, vanilla stops finding
-        // the ship once a player is roughly 50 blocks from its center.
+        // Forge expands chunk entity-list searches by this radius. The ship remains
+        // indexed in its origin chunk, so the radius must contain every corner of
+        // every rotated extra box or world collision/ray queries near a remote box
+        // never discover the ship entity whose composite AABB owns that box.
         World.MAX_ENTITY_RADIUS = Math.max(World.MAX_ENTITY_RADIUS, requiredRadius + 2.0D);
     }
 
@@ -188,6 +193,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 this.setDead();
             } else {
                 this.setAcInfo(this.planeInfo);
+                this.updateWorldCollisionSearchRadius();
             }
         }
 


### PR DESCRIPTION
### Motivation

- Far-away invisible ship extra bounding boxes were often not discovered by world collision and ray queries because the engine’s entity-search radius did not always contain every rotated/corner point of an extra box, and the extra-box selection used the wrong distance reference when deciding which box applied damage/type.

### Description

- Recompute the ship composite search radius in `updateWorldCollisionSearchRadius()` to be rotation- and dimension-safe by including `offsetY`, box half-diagonals (using box `width` and `height`), and the ship height when computing `requiredRadius` so every corner of every rotated extra box is contained. (`src/main/java/mcheli/ship/MCH_EntityShip.java`)
- Restore calling `updateWorldCollisionSearchRadius()` when ship info is loaded from NBT so persisted ships keep the corrected radius at load time. (`src/main/java/mcheli/ship/MCH_EntityShip.java`)
- Fix extra-box hit selection in `MCH_BaseVehicleBoundingBox.intersectsWith(...)` so the distance used to choose the closest intersected component is measured against the actual extra box (`bb.boundingBox`) instead of the composite AABB (`this`), ensuring the proper `lastBBDamageFactor` and `lastHitBoundingBoxType` are forwarded. (`src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java`)
- Preserve the original invisible composite-AABB approach and do not introduce proxy entities, new registration, rendering, ticking, networking, or visible collision markers.

### Testing

- Ran `git diff --check` which reported no whitespace/patch errors. (success)
- Ran a restricted-path change check (scanned for proxy/entity/renderer additions) to ensure no proxy hit-box entities or render/registration changes were introduced. (success)
- Searched the codebase for proxy/proxy-entity indicators and hit-box-spawn calls to confirm no new proxy system was added. (success)
- Attempted to run `./gradlew compileJava`, but the Gradle wrapper attempted to download the distribution and failed due to an environment proxy returning HTTP 403, so an on-machine Java build could not be completed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d68707f7c8323941e7f54026ef480)