### PR TITLE
Increase vehicle seat/rack limit to 126 and enforce combined cap

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -56,7 +56,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `addrecipe` | All | recipe | none | shaped recipe |
 | `addshapelessrecipe` | All | recipe | none | shapeless recipe |
 | `CanRide` | All | boolean | true | player mounting |
-| `AddSeat` | All | list | none; at least one seat required | passenger/pilot seat |
+| `AddSeat` | All | list | none; at least one seat required | passenger/pilot seat; vehicles support up to 126 combined seats and racks |
 | `AddGunnerSeat` | All | list | none | seat with gunner controls |
 | `AddFixRotSeat` | All | list | none | seat with fixed look rotation |
 | `ExclusionSeat` | All | list of seat ids | none | seats that cannot be occupied together |
@@ -158,7 +158,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `AddPartWeaponMissile` | All | part pose/list | none | missile visual part |
 | `AddPartWeaponBay` | All | part pose/list | none | weapon bay visual part |
 | `AddPartSlideWeaponBay` | All | list | none | sliding weapon bay visual part |
-| `AddRack` | All | list | none | entity/vehicle rack seat |
+| `AddRack` | All | list | none | entity/vehicle rack seat; counts toward the 126 combined seat/rack limit |
 | `RideRack` | All | list | none | ride-rack attachment point |
 | `MobDropOption` | All | list | default disabled option | mob drops from seats/racks |
 | `AddRepellingHook` | All | vec/list | none | fast-rope/repelling point |

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -24,7 +24,7 @@ Applies to planes, helicopters, tanks, turret/static weapons, ships, and any oth
 
 | Key | Type | Default | Notes |
 |---|---|---:|---|
-| `AddSeat` | `x,y,z[,rotYaw,rotPitch,...]` | none | Adds a normal seat. At least one seat is required unless a UAV flag creates one. |
+| `AddSeat` | `x,y,z[,rotYaw,rotPitch,...]` | none | Adds a normal seat. At least one seat is required unless a UAV flag creates one. A vehicle can define up to 126 combined seats and racks. |
 | `AddGunnerSeat` | list | none | Adds a gunner seat. |
 | `AddFixRotSeat` | list | none | Adds a fixed-rotation seat. |
 | `ExclusionSeat` | seat ids | none | One-based seat ids; parser stores zero-based exclusions. |

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -508,7 +508,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    }
 
    public int getInfo_MaxSeatNum() {
-      return 30;
+      // Seat-count packets add the pilot and store the result in a signed byte.
+      return 126;
    }
 
    public int getNumSeatAndRack() {
@@ -711,6 +712,10 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                         if(item.equalsIgnoreCase("AddRack")) {
                            //parent vehicle to eat child
                            //todo: fix addrack bug where it won't go up block with a vehicle racked or something
+                           if(this.seatList.size() + this.entityRackList.size() >= this.getInfo_MaxSeatNum()) {
+                              return;
+                           }
+
                            s = data.toLowerCase().split("\\s*,\\s*");
                            if(s != null && s.length >= 7) {
                               var17 = s[0].split("\\s*/\\s*");
@@ -1231,7 +1236,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                                  }
                               }
                            } else {
-                              if(this.seatList.size() >= this.getInfo_MaxSeatNum()) {
+                              if(this.seatList.size() + this.entityRackList.size() >= this.getInfo_MaxSeatNum()) {
                                  return;
                               }
 


### PR DESCRIPTION
### Motivation
- The vehicle parser previously capped seats at 30 which limited large multi-seat configurations. 
- `AddRack` could bypass the seat cap, so seats and racks should share a single capacity. 
- The new limit is chosen to fit safely into the signed-byte seat-count packets after accounting for the pilot. 

### Description
- Changed `getInfo_MaxSeatNum()` to return `126` and added a clarifying comment about the signed-byte packet constraint in `src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java`. 
- Enforced the combined cap by checking `this.seatList.size() + this.entityRackList.size()` before parsing/adding both `AddSeat` variants and `AddRack` in `MCH_BaseVehicleInfo`. 
- Updated documentation to mention the new combined limit in `docs/vehicle-config-reference.md` and `docs/vehicle-config/base.md`. 

### Testing
- Ran `git diff --check` which reported no issues. 
- Verified repository state with `git status` and committed the changes with `git commit` (commit `Increase vehicle seat and rack limit`). 
- Attempted to run `./gradlew compileJava` but the Gradle wrapper was not executable in this environment, and a follow-up `bash gradlew compileJava` failed because the Gradle distribution download was blocked by the environment proxy (HTTP 403), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6d37d8d88323bacfcdead7e075a7)