### PR TITLE
Increase seat/rack capacity to 500, enforce combined limit, and widen packet seat fields

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -56,7 +56,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `addrecipe` | All | recipe | none | shaped recipe |
 | `addshapelessrecipe` | All | recipe | none | shapeless recipe |
 | `CanRide` | All | boolean | true | player mounting |
-| `AddSeat` | All | list | none; at least one seat required | passenger/pilot seat |
+| `AddSeat` | All | list | none; at least one seat required | passenger/pilot seat; vehicles support up to 500 combined seats and racks |
 | `AddGunnerSeat` | All | list | none | seat with gunner controls |
 | `AddFixRotSeat` | All | list | none | seat with fixed look rotation |
 | `ExclusionSeat` | All | list of seat ids | none | seats that cannot be occupied together |
@@ -158,7 +158,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `AddPartWeaponMissile` | All | part pose/list | none | missile visual part |
 | `AddPartWeaponBay` | All | part pose/list | none | weapon bay visual part |
 | `AddPartSlideWeaponBay` | All | list | none | sliding weapon bay visual part |
-| `AddRack` | All | list | none | entity/vehicle rack seat |
+| `AddRack` | All | list | none | entity/vehicle rack seat; counts toward the 500 combined seat/rack limit |
 | `RideRack` | All | list | none | ride-rack attachment point |
 | `MobDropOption` | All | list | default disabled option | mob drops from seats/racks |
 | `AddRepellingHook` | All | vec/list | none | fast-rope/repelling point |

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -24,7 +24,7 @@ Applies to planes, helicopters, tanks, turret/static weapons, ships, and any oth
 
 | Key | Type | Default | Notes |
 |---|---|---:|---|
-| `AddSeat` | `x,y,z[,rotYaw,rotPitch,...]` | none | Adds a normal seat. At least one seat is required unless a UAV flag creates one. |
+| `AddSeat` | `x,y,z[,rotYaw,rotPitch,...]` | none | Adds a normal seat. At least one seat is required unless a UAV flag creates one. A vehicle can define up to 500 combined seats and racks. |
 | `AddGunnerSeat` | list | none | Adds a gunner seat. |
 | `AddFixRotSeat` | list | none | Adds a fixed-rotation seat. |
 | `ExclusionSeat` | seat ids | none | One-based seat ids; parser stores zero-based exclusions. |

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -508,7 +508,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    }
 
    public int getInfo_MaxSeatNum() {
-      return 30;
+      return 500;
    }
 
    public int getNumSeatAndRack() {
@@ -711,6 +711,10 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                         if(item.equalsIgnoreCase("AddRack")) {
                            //parent vehicle to eat child
                            //todo: fix addrack bug where it won't go up block with a vehicle racked or something
+                           if(this.seatList.size() + this.entityRackList.size() >= this.getInfo_MaxSeatNum()) {
+                              return;
+                           }
+
                            s = data.toLowerCase().split("\\s*,\\s*");
                            if(s != null && s.length >= 7) {
                               var17 = s[0].split("\\s*/\\s*");
@@ -1231,7 +1235,7 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                                  }
                               }
                            } else {
-                              if(this.seatList.size() >= this.getInfo_MaxSeatNum()) {
+                              if(this.seatList.size() + this.entityRackList.size() >= this.getInfo_MaxSeatNum()) {
                                  return;
                               }
 

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -300,7 +300,7 @@ public class MCH_BaseVehiclePacketHandler {
             if(e instanceof MCH_EntityBaseVehicle) {
                MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)e;
                MCH_Lib.DbgLog(player.worldObj, "[MCH-SYNC][SEAT-RESPONSE-RECEIVE] aircraftId=%d aircraftUuid=%s packetSeats=%d localSeats=%d",
-                       new Object[]{Integer.valueOf(seatList.entityID_AC), ac.getUniqueID(), Byte.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
+                       new Object[]{Integer.valueOf(seatList.entityID_AC), ac.getUniqueID(), Integer.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
                if(seatList.seatNum > 0 && seatList.seatNum == ac.getSeats().length && seatList.seatEntityID != null && seatList.seatEntityID.length == seatList.seatNum) {
                   for(int i = 0; i < seatList.seatNum; ++i) {
                      Entity entity = player.worldObj.getEntityByID(seatList.seatEntityID[i]);
@@ -320,7 +320,7 @@ public class MCH_BaseVehiclePacketHandler {
                   ac.debugVehicleState("SEAT-RESPONSE-APPLIED", player);
                } else {
                   MCH_Lib.DbgLog(player.worldObj, "[MCH-SYNC][SEAT-APPLY-FAIL] reason=count_mismatch aircraftId=%d packetSeats=%d localSeats=%d",
-                          new Object[]{Integer.valueOf(seatList.entityID_AC), Byte.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
+                          new Object[]{Integer.valueOf(seatList.entityID_AC), Integer.valueOf(seatList.seatNum), Integer.valueOf(ac.getSeats().length)});
                }
             }
 

--- a/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
@@ -25,7 +25,7 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
       try {
          this.entityID_Ac = data.readInt();
          this.entityID_rider = data.readInt();
-         this.seatID = data.readByte();
+         this.seatID = data.readShort();
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -36,7 +36,7 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
       try {
          dos.writeInt(this.entityID_Ac);
          dos.writeInt(this.entityID_rider);
-         dos.writeByte(this.seatID);
+         dos.writeShort(this.seatID);
       } catch (IOException var3) {
          var3.printStackTrace();
       }

--- a/src/main/java/mcheli/aircraft/MCH_PacketNotifyWeaponID.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketNotifyWeaponID.java
@@ -24,7 +24,7 @@ public class MCH_PacketNotifyWeaponID extends MCH_Packet {
    public void readData(ByteArrayDataInput data) {
       try {
          this.entityID_Ac = data.readInt();
-         this.seatID = data.readByte();
+         this.seatID = data.readShort();
          this.weaponID = data.readByte();
          this.ammo = data.readShort();
          this.restAmmo = data.readShort();
@@ -37,7 +37,7 @@ public class MCH_PacketNotifyWeaponID extends MCH_Packet {
    public void writeData(DataOutputStream dos) {
       try {
          dos.writeInt(this.entityID_Ac);
-         dos.writeByte(this.seatID);
+         dos.writeShort(this.seatID);
          dos.writeByte(this.weaponID);
          dos.writeShort(this.ammo);
          dos.writeShort(this.restAmmo);

--- a/src/main/java/mcheli/aircraft/MCH_PacketSeatListResponse.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketSeatListResponse.java
@@ -13,7 +13,7 @@ import net.minecraft.entity.player.EntityPlayer;
 public class MCH_PacketSeatListResponse extends MCH_Packet {
 
    public int entityID_AC = -1;
-   public byte seatNum = -1;
+   public int seatNum = -1;
    public int[] seatEntityID = new int[]{-1};
 
 
@@ -24,7 +24,7 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
    public void readData(ByteArrayDataInput data) {
       try {
          this.entityID_AC = data.readInt();
-         this.seatNum = data.readByte();
+         this.seatNum = data.readShort();
          if(this.seatNum > 0) {
             this.seatEntityID = new int[this.seatNum];
 
@@ -42,13 +42,13 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
       try {
          dos.writeInt(this.entityID_AC);
          if(this.seatNum > 0 && this.seatEntityID != null && this.seatEntityID.length == this.seatNum) {
-            dos.writeByte(this.seatNum);
+            dos.writeShort(this.seatNum);
 
             for(int e = 0; e < this.seatNum; ++e) {
                dos.writeInt(this.seatEntityID[e]);
             }
          } else {
-            dos.writeByte(-1);
+            dos.writeShort(-1);
          }
       } catch (IOException var3) {
          var3.printStackTrace();
@@ -69,7 +69,7 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
    protected void setParameter(MCH_EntityBaseVehicle ac) {
       if(ac != null) {
          this.entityID_AC = W_Entity.getEntityId(ac);
-         this.seatNum = (byte)ac.getSeats().length;
+         this.seatNum = ac.getSeats().length;
          if(this.seatNum > 0) {
             this.seatEntityID = new int[this.seatNum];
 

--- a/src/main/java/mcheli/aircraft/MCH_PacketStatusResponse.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketStatusResponse.java
@@ -12,7 +12,7 @@ import net.minecraft.entity.player.EntityPlayer;
 public class MCH_PacketStatusResponse extends MCH_Packet {
 
    public int entityID_AC = -1;
-   public byte seatNum = -1;
+   public int seatNum = -1;
    public byte[] weaponIDs = new byte[]{(byte)-1};
 
 
@@ -23,7 +23,7 @@ public class MCH_PacketStatusResponse extends MCH_Packet {
    public void readData(ByteArrayDataInput data) {
       try {
          this.entityID_AC = data.readInt();
-         this.seatNum = data.readByte();
+         this.seatNum = data.readShort();
          if(this.seatNum > 0) {
             this.weaponIDs = new byte[this.seatNum];
 
@@ -41,13 +41,13 @@ public class MCH_PacketStatusResponse extends MCH_Packet {
       try {
          dos.writeInt(this.entityID_AC);
          if(this.seatNum > 0 && this.weaponIDs != null && this.weaponIDs.length == this.seatNum) {
-            dos.writeByte(this.seatNum);
+            dos.writeShort(this.seatNum);
 
             for(int e = 0; e < this.seatNum; ++e) {
                dos.writeByte(this.weaponIDs[e]);
             }
          } else {
-            dos.writeByte(-1);
+            dos.writeShort(-1);
          }
       } catch (IOException var3) {
          var3.printStackTrace();
@@ -64,7 +64,7 @@ public class MCH_PacketStatusResponse extends MCH_Packet {
    protected void setParameter(MCH_EntityBaseVehicle ac) {
       if(ac != null) {
          this.entityID_AC = W_Entity.getEntityId(ac);
-         this.seatNum = (byte)(ac.getSeatNum() + 1);
+         this.seatNum = ac.getSeatNum() + 1;
          if(this.seatNum > 0) {
             this.weaponIDs = new byte[this.seatNum];
 


### PR DESCRIPTION
### Motivation

- Allow vehicles to define many more seats and racks while preventing parser overflow and avoid byte-range truncation in network messages.

### Description

- Increase `getInfo_MaxSeatNum()` from `30` to `500` and update docs to state the new 500 combined seats and racks limit in `docs/vehicle-config-reference.md` and `docs/vehicle-config/base.md`.
- Enforce the combined seat and rack limit during parsing by checking `seatList.size() + entityRackList.size() >= getInfo_MaxSeatNum()` before accepting `AddSeat` and `AddRack` entries.
- Widen seat-count/seat-id packet fields and serialization from 1-byte to 2-byte (`short`) where required by changing reads/writes from `readByte`/`writeByte` to `readShort`/`writeShort` in `MCH_PacketNotifyOnMountEntity`, `MCH_PacketNotifyWeaponID`, `MCH_PacketSeatListResponse`, and `MCH_PacketStatusResponse`, and adjust the corresponding in-memory types accordingly.
- Fix debug log formatting in `MCH_BaseVehiclePacketHandler` to pass `Integer` values instead of `Byte` for seat counts.

### Testing

- Project build completed successfully via `./gradlew build`.
- Automated unit test suite run with `./gradlew test` completed and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6d37d8d88323bacfcdead7e075a7)