### PR TITLE
Fix newUAV dismount and persistence edge cases

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5517,7 +5517,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    private boolean hasNewUavReturnPosition() {
-      return this.hasLinkedUavStationPosition && this.linkedUavStationDimension == this.dimension;
+      return this.linkedUavStationUUID != null && this.hasLinkedUavStationPosition
+            && this.linkedUavStationDimension == this.dimension
+            && !Double.isNaN(this.linkedUavStationX) && !Double.isInfinite(this.linkedUavStationX)
+            && !Double.isNaN(this.linkedUavStationY) && !Double.isInfinite(this.linkedUavStationY)
+            && !Double.isNaN(this.linkedUavStationZ) && !Double.isInfinite(this.linkedUavStationZ);
    }
 
    private void updateNewUavReturnPositionFromStation() {
@@ -5538,7 +5542,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       updateNewUavReturnPositionFromStation();
       if(!hasNewUavReturnPosition()) {
-         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: no saved station position", new Object[0]);
+         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: station link is missing or still restoring; preserving UAV control", new Object[0]);
          return false;
       }
 
@@ -5572,28 +5576,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       super.riddenByEntity = null;
    }
 
-   private void deleteNewUavAfterShiftExit() {
-      if(super.worldObj.isRemote || !this.isNewUAV()) {
-         return;
-      }
-      MCH_EntityUavStation station = resolveLinkedUavStation();
-      if(station != null) {
-         if(!station.prepareNewUavShiftExit(this)) {
-            return;
-         }
-      } else {
-         MCH_Lib.Log((Entity)this, "Unable to resolve the New UAV station during shift-exit; preserving the aircraft instead of losing its position", new Object[0]);
-         return;
-      }
-      MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
-      this.newUavShiftExitInProgress = true;
-      try {
-         this.setDead(false);
-      } finally {
-         this.newUavShiftExitInProgress = false;
-      }
-   }
-
    public void unmountEntity() {
       if(!this.isRidePlayer()) {
          this.switchHoveringMode(false);
@@ -5604,13 +5586,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(super.riddenByEntity != null) {
          rByEntity = super.riddenByEntity;
          this.camera.initCamera(0, rByEntity);
-         if(!super.worldObj.isRemote) {
+         if(!super.worldObj.isRemote && this.isNewUAV()) {
+            if(!this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+               return;
+            }
+         } else if(!super.worldObj.isRemote) {
             super.riddenByEntity.mountEntity((Entity)null);
          }
       } else if(this.lastRiddenByEntity != null) {
          rByEntity = this.lastRiddenByEntity;
          if(rByEntity instanceof EntityPlayer) {
             this.camera.initCamera(0, rByEntity);
+         }
+         if(!super.worldObj.isRemote && this.isNewUAV()
+               && !this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+            return;
          }
       }
 
@@ -5623,9 +5613,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(rByEntity != null) {
          // NewUAV takes precedence over the legacy UAV flag used by some content packs.
          if(this.isNewUAV()) {
-            if(!super.worldObj.isRemote && this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
-               deleteNewUavAfterShiftExit();
-            }
+            // The server already detached and returned the pilot above. Keep the live UAV
+            // linked so Continue/relog can deterministically reacquire the same entity.
          } else if(this.isUAV()) {
             if(rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
                rByEntity.mountEntity((Entity)null);
@@ -5795,16 +5784,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return false;
       }
 
+      if(this.isNewUAV() && !super.worldObj.isRemote) {
+         return this.returnNewUavPilotToStation(entity, "uav_seat_exit");
+      }
+
       for(MCH_EntitySeat seat : this.seats) {
          if(seat != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
             entity.mountEntity((Entity)null);
             break;
          }
-      }
-
-      if(this.isNewUAV() && !super.worldObj.isRemote
-              && this.returnNewUavPilotToStation(entity, "uav_seat_exit")) {
-         deleteNewUavAfterShiftExit();
       }
       return false;
    }

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -141,8 +141,9 @@ public final class MCH_UavRegistry {
         MCH_Lib.Log(remove, "Duplicate UAV identity detected: keeping entity %d and removing duplicate %d (persistent=%s, common=%s)", new Object[] {
                 Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
                 persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
+        // Do not delete a duplicate while either copy may still be restoring its station or
+        // pilot after a restart. Leaving it unregistered is recoverable; setDead is not.
         unregister(remove);
-        remove.setDead(false);
         return keep;
     }
 


### PR DESCRIPTION
### Motivation

- Fix a race/ordering where a `newUAV` dismount could leave the player at the UAV physical location (or falling) instead of reliably returning them to the linked UAV station after reconnect/continue/reload scenarios.
- Preserve recoverability across server restart, chunk unload/reload, continue/resume and relog flows by avoiding destructive deletion or orphaning of the live newUAV when station state is missing or restoring.
- Make seat and base vehicle dismount helpers deterministic so intentional dismounts return the player to the station when a valid link exists and otherwise fail safely.

### Description

- Strengthen station return validation in `hasNewUavReturnPosition()` to require a stored station UUID, matching dimension, and sane (non-NaN/finite) station coordinates. (file: `MCH_EntityBaseVehicle.java`)
- Reordered dismount flow so server-side `newUAV` dismounts attempt `returnNewUavPilotToStation(...)` before detaching/mount clearing, and abort the dismount when the station link is missing/restoring, preserving the live UAV and pilot state. (file: `MCH_EntityBaseVehicle.java`)
- Removed the previous shift-exit path that unconditionally deleted a `newUAV` after returning the pilot; the UAV now remains linked so Continue/relog can reacquire the same entity deterministically. (file: `MCH_EntityBaseVehicle.java`)
- Applied the same guarded behavior to seat-based dismounts so seat exits call the station-return helper and fail safely when needed. (file: `MCH_EntityBaseVehicle.java`)
- Made the UAV runtime registry's duplicate-pruning non-destructive by unregistering the non-canonical duplicate without calling `setDead`, preventing entity loss while server/restore logic is still resolving relationships. (file: `MCH_UavRegistry.java`)

### Testing

- Ran `git diff --check` and repository diff/stat checks to validate the patch format and whitespace; these passed.
- Performed code searches (`rg`) to confirm changed call-sites and to ensure the modified dismount paths and helpers are exercised; these checks passed.
- Attempted an automated Java build (`./gradlew compileJava`) to validate compilation, but the environment blocked Gradle wrapper download (HTTP 403 through proxy) and an offline build failed due to a missing cached ForgeGradle artifact; compilation could not be completed in this environment.
- No unit/integration tests were added; changes are limited, targeted, and focused on ordering and safety of existing persistence/dismount logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7a8062088323a09c270574ce7b6d)