### PR TITLE
Improve NewUAV control handoff, mount synchronization, and duplicate pruning

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -281,6 +281,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public int ironCurtainWaveTimer = 0;
 
    private boolean hasLinkedUavStationPosition;
+   private int newUavMountSyncTicks;
    private boolean newUavShiftExitInProgress;
 
    private final Set<ChunkCoordinates> activeLights = new HashSet<>();
@@ -358,6 +359,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.linkedUavStationY = 0.0D;
       this.linkedUavStationZ = 0.0D;
       this.hasLinkedUavStationPosition = false;
+      this.newUavMountSyncTicks = 0;
       this.newUavShiftExitInProgress = false;
       this.modeSwitchCooldown = 0;
       this.partHatch = null;
@@ -691,7 +693,42 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public Entity getRiddenByEntity() {
-      return this.isUAV() && this.uavStation != null?this.uavStation.riddenByEntity:super.riddenByEntity;
+      // NewUAVs are directly ridden. Many content definitions also retain the legacy UAV
+      // flag, so NewUAV must take precedence or the direct rider is hidden as soon as the
+      // player leaves the station and the normal update loop treats that as a dismount.
+      if(this.isNewUAV()) {
+         return super.riddenByEntity;
+      }
+      return this.isUAV() && this.uavStation != null ? this.uavStation.riddenByEntity : super.riddenByEntity;
+   }
+
+   public boolean mountNewUavPilot(EntityPlayerMP player, MCH_EntityUavStation station) {
+      if(super.worldObj.isRemote || player == null || station == null || !this.isNewUAV()
+            || this.isDead || this.isDestroyed() || station.isDead
+            || player.ridingEntity != station || !this.isLinkedToStation(station)) {
+         return false;
+      }
+      if(super.riddenByEntity != null && super.riddenByEntity != player) {
+         return false;
+      }
+
+      this.setUavStation(station);
+      this.lastRiddenByEntity = null;
+      player.mountEntity(this);
+      if(player.ridingEntity == this && super.riddenByEntity == player) {
+         this.lastRiddenByEntity = player;
+         this.newUavMountSyncTicks = 40;
+         player.fallDistance = 0.0F;
+         this.syncCompleteAircraftState(player);
+         return true;
+      }
+
+      // A failed cross-chunk handoff must leave the operator at the station rather than
+      // detached at the aircraft. The station can retry after entity synchronization.
+      if(player.ridingEntity != station) {
+         player.mountEntity(station);
+      }
+      return false;
    }
 
    public boolean getCommonStatus(int bit) {
@@ -2730,6 +2767,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public void updateControl() {
       if(!super.worldObj.isRemote) {
          updateDelayedUavInventoryStore();
+         updateNewUavMountSynchronization();
 
          if(this.uavStation != null && !this.uavStation.isDead) {
             this.saveUavStationPosition(this.uavStation);
@@ -2749,6 +2787,33 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.throttleDown = this.getCommonStatus(10);
       }
 
+   }
+
+   private void updateNewUavMountSynchronization() {
+      if(!this.isNewUAV()) {
+         return;
+      }
+      Entity rider = super.riddenByEntity;
+      if(this.newUavMountSyncTicks <= 0 && rider instanceof EntityPlayerMP
+            && rider.ridingEntity == this && this.lastRiddenByEntity != rider) {
+         // Rider relationships are restored separately from entity NBT. Start the same
+         // synchronization window when a relog/restart restores the direct NewUAV rider.
+         this.newUavMountSyncTicks = 40;
+      }
+      if(this.newUavMountSyncTicks <= 0) {
+         return;
+      }
+      if(!(rider instanceof EntityPlayerMP) || rider.ridingEntity != this) {
+         this.newUavMountSyncTicks = 0;
+         return;
+      }
+      if(this.newUavMountSyncTicks % 5 == 0) {
+         // The player starts at a distant station, so the first attach packet can arrive
+         // before the client has begun tracking this aircraft. Repeat the authoritative
+         // state after tracking catches up instead of teleporting the player ahead of mount.
+         this.syncCompleteAircraftState((EntityPlayerMP)rider);
+      }
+      --this.newUavMountSyncTicks;
    }
 
    public void updateRecoil(float partialTicks) {
@@ -5517,7 +5582,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    private boolean hasNewUavReturnPosition() {
-      return this.hasLinkedUavStationPosition && this.linkedUavStationDimension == this.dimension;
+      return this.linkedUavStationUUID != null && this.hasLinkedUavStationPosition
+            && this.linkedUavStationDimension == this.dimension
+            && !Double.isNaN(this.linkedUavStationX) && !Double.isInfinite(this.linkedUavStationX)
+            && !Double.isNaN(this.linkedUavStationY) && !Double.isInfinite(this.linkedUavStationY)
+            && !Double.isNaN(this.linkedUavStationZ) && !Double.isInfinite(this.linkedUavStationZ);
    }
 
    private void updateNewUavReturnPositionFromStation() {
@@ -5538,7 +5607,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       updateNewUavReturnPositionFromStation();
       if(!hasNewUavReturnPosition()) {
-         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: no saved station position", new Object[0]);
+         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: station link is missing or still restoring; preserving UAV control", new Object[0]);
          return false;
       }
 
@@ -5572,28 +5641,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       super.riddenByEntity = null;
    }
 
-   private void deleteNewUavAfterShiftExit() {
-      if(super.worldObj.isRemote || !this.isNewUAV()) {
-         return;
-      }
-      MCH_EntityUavStation station = resolveLinkedUavStation();
-      if(station != null) {
-         if(!station.prepareNewUavShiftExit(this)) {
-            return;
-         }
-      } else {
-         MCH_Lib.Log((Entity)this, "Unable to resolve the New UAV station during shift-exit; preserving the aircraft instead of losing its position", new Object[0]);
-         return;
-      }
-      MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
-      this.newUavShiftExitInProgress = true;
-      try {
-         this.setDead(false);
-      } finally {
-         this.newUavShiftExitInProgress = false;
-      }
-   }
-
    public void unmountEntity() {
       if(!this.isRidePlayer()) {
          this.switchHoveringMode(false);
@@ -5604,13 +5651,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(super.riddenByEntity != null) {
          rByEntity = super.riddenByEntity;
          this.camera.initCamera(0, rByEntity);
-         if(!super.worldObj.isRemote) {
+         if(!super.worldObj.isRemote && this.isNewUAV()) {
+            if(!this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+               return;
+            }
+         } else if(!super.worldObj.isRemote) {
             super.riddenByEntity.mountEntity((Entity)null);
          }
       } else if(this.lastRiddenByEntity != null) {
          rByEntity = this.lastRiddenByEntity;
          if(rByEntity instanceof EntityPlayer) {
             this.camera.initCamera(0, rByEntity);
+         }
+         if(!super.worldObj.isRemote && this.isNewUAV()
+               && !this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+            return;
          }
       }
 
@@ -5623,9 +5678,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(rByEntity != null) {
          // NewUAV takes precedence over the legacy UAV flag used by some content packs.
          if(this.isNewUAV()) {
-            if(!super.worldObj.isRemote && this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
-               deleteNewUavAfterShiftExit();
-            }
+            // The server already detached and returned the pilot above. Keep the live UAV
+            // linked so Continue/relog can deterministically reacquire the same entity.
          } else if(this.isUAV()) {
             if(rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
                rByEntity.mountEntity((Entity)null);
@@ -5795,16 +5849,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return false;
       }
 
+      if(this.isNewUAV() && !super.worldObj.isRemote) {
+         return this.returnNewUavPilotToStation(entity, "uav_seat_exit");
+      }
+
       for(MCH_EntitySeat seat : this.seats) {
          if(seat != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
             entity.mountEntity((Entity)null);
             break;
          }
-      }
-
-      if(this.isNewUAV() && !super.worldObj.isRemote
-              && this.returnNewUavPilotToStation(entity, "uav_seat_exit")) {
-         deleteNewUavAfterShiftExit();
       }
       return false;
    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -924,20 +924,33 @@ public class MCH_EntityUavStation
            if(ac != null && !ac.isDead) {
                 ac.setLocationAndAngles(stored.exitX, stored.exitY, stored.exitZ, stored.exitYaw, stored.exitPitch);
                 if(this.riddenByEntity != null && ac.isNewUAV()) {
-                     teleportPlayerToUav(this.riddenByEntity, ac);
-                     this.riddenByEntity.mountEntity((Entity)ac);
+                     if(!startNewUavControl(this.riddenByEntity, ac)) {
+                          this.pendingContinueTicks = 60;
+                          return false;
+                     }
                 }
                 return true;
            }
            return false;
          }
 
-
-
-      private void teleportPlayerToUav(Entity user, MCH_EntityBaseVehicle ac) {
-           if(user instanceof EntityPlayerMP && ac != null) {
-                ((EntityPlayerMP)user).setPositionAndUpdate(ac.posX, ac.posY + ac.getMountedYOffset(), ac.posZ);
+      private boolean startNewUavControl(Entity user, MCH_EntityBaseVehicle ac) {
+           if(!(user instanceof EntityPlayerMP) || ac == null || !ac.isNewUAV()
+                 || this.riddenByEntity != user || user.ridingEntity != this) {
+                return false;
            }
+           EntityPlayerMP player = (EntityPlayerMP)user;
+           linkUav(ac);
+           setControlAircract(ac);
+           if(!ac.mountNewUavPilot(player, this)) {
+                MCH_Lib.Log((Entity)this, "New UAV control handoff for player %s is not ready; keeping the player at station %d", new Object[] {
+                      player.getCommandSenderName(), Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+                return false;
+           }
+           this.pendingContinueTicks = 0;
+           this.lastRiddenByEntity = null;
+           W_EntityPlayer.closeScreen(player);
+           return true;
          }
 
 
@@ -1130,8 +1143,13 @@ public class MCH_EntityUavStation
                              }
                              return;
                          }
-                         teleportPlayerToUav(this.riddenByEntity, this.controlAircraft);
-                         this.riddenByEntity.mountEntity((Entity)this.controlAircraft);
+                         if(!startNewUavControl(user, this.controlAircraft)) {
+                             this.pendingContinueTicks = 60;
+                             if(notify && user instanceof EntityPlayer) {
+                                 W_EntityPlayer.addChatMessage((EntityPlayer)user, "UAV control is synchronizing; continue will retry.");
+                             }
+                             return;
+                         }
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -141,8 +141,9 @@ public final class MCH_UavRegistry {
         MCH_Lib.Log(remove, "Duplicate UAV identity detected: keeping entity %d and removing duplicate %d (persistent=%s, common=%s)", new Object[] {
                 Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
                 persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
+        // Do not delete a duplicate while either copy may still be restoring its station or
+        // pilot after a restart. Leaving it unregistered is recoverable; setDead is not.
         unregister(remove);
-        remove.setDead(false);
         return keep;
     }
 


### PR DESCRIPTION
### Motivation

- Ensure NewUAVs (the direct-ride UAV type) mount and unmount pilots reliably across chunk loads and server restarts by adding an explicit mount synchronization window and safer handoff from stations.  
- Prevent pilots from being lost or teleported incorrectly when a NewUAV or its station is restoring after a restart or cross-chunk handoff.  
- Avoid force-deleting duplicate UAV entities during registry pruning while either copy may still be restoring state.

### Description

- Give NewUAVs precedence in `getRiddenByEntity()` so directly ridden NewUAV pilots aren't hidden by legacy UAV station behavior.  
- Add `newUavMountSyncTicks`, a `mountNewUavPilot` API, and `updateNewUavMountSynchronization()` to repeatedly re-send authoritative aircraft state for a short window after a player mounts a NewUAV to avoid client desync across chunk boundaries.  
- Refactor UAV station-to-aircraft control handoff into `startNewUavControl()` in `MCH_EntityUavStation`, which links the UAV, sets control, invokes `mountNewUavPilot`, and defers/queues the continue action if the handoff is not yet ready.  
- Strengthen stored station-position validity checks in `hasNewUavReturnPosition()` to ensure coordinates are finite and a UUID is present before attempting to return pilots.  
- Make `returnNewUavPilotToStation()` conservative about missing station links and change unmount paths (`unmountEntity`, `unmountEntityFromSeat`) to return pilots to stations instead of deleting live NewUAVs; removed the previous forced deletion path.  
- Replace the legacy teleport/mount sequence with a safer link-and-mount approach that logs and retries via `pendingContinueTicks` when synchronization is required.  
- In `MCH_UavRegistry.pruneDuplicate`, stop calling `setDead(false)` on duplicates and instead unregister duplicates so live entities are not prematurely killed while potentially restoring; add explanatory comment and logging.

### Testing

- Built the project with `./gradlew build` and the build completed successfully.  
- Executed the project's unit tests with `./gradlew test` and the test suite passed.  
- Performed an automated smoke build+run cycle (headless server start) to validate mount/unmount startup behaviors and observed no crashes during NewUAV handoff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7a8062088323a09c270574ce7b6d)