### PR TITLE
Improve NewUAV mounting/return logic, station handoff, and UAV registry deduplication

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -281,6 +281,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public int ironCurtainWaveTimer = 0;
 
    private boolean hasLinkedUavStationPosition;
+   private int newUavMountSyncTicks;
    private boolean newUavShiftExitInProgress;
 
    private final Set<ChunkCoordinates> activeLights = new HashSet<>();
@@ -358,6 +359,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.linkedUavStationY = 0.0D;
       this.linkedUavStationZ = 0.0D;
       this.hasLinkedUavStationPosition = false;
+      this.newUavMountSyncTicks = 0;
       this.newUavShiftExitInProgress = false;
       this.modeSwitchCooldown = 0;
       this.partHatch = null;
@@ -691,7 +693,42 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public Entity getRiddenByEntity() {
-      return this.isUAV() && this.uavStation != null?this.uavStation.riddenByEntity:super.riddenByEntity;
+      // NewUAVs are directly ridden. Many content definitions also retain the legacy UAV
+      // flag, so NewUAV must take precedence or the direct rider is hidden as soon as the
+      // player leaves the station and the normal update loop treats that as a dismount.
+      if(this.isNewUAV()) {
+         return super.riddenByEntity;
+      }
+      return this.isUAV() && this.uavStation != null ? this.uavStation.riddenByEntity : super.riddenByEntity;
+   }
+
+   public boolean mountNewUavPilot(EntityPlayerMP player, MCH_EntityUavStation station) {
+      if(super.worldObj.isRemote || player == null || station == null || !this.isNewUAV()
+            || this.isDead || this.isDestroyed() || station.isDead
+            || player.ridingEntity != station || !this.isLinkedToStation(station)) {
+         return false;
+      }
+      if(super.riddenByEntity != null && super.riddenByEntity != player) {
+         return false;
+      }
+
+      this.setUavStation(station);
+      this.lastRiddenByEntity = null;
+      player.mountEntity(this);
+      if(player.ridingEntity == this && super.riddenByEntity == player) {
+         this.lastRiddenByEntity = player;
+         this.newUavMountSyncTicks = 40;
+         player.fallDistance = 0.0F;
+         this.syncCompleteAircraftState(player);
+         return true;
+      }
+
+      // A failed cross-chunk handoff must leave the operator at the station rather than
+      // detached at the aircraft. The station can retry after entity synchronization.
+      if(player.ridingEntity != station) {
+         player.mountEntity(station);
+      }
+      return false;
    }
 
    public boolean getCommonStatus(int bit) {
@@ -2730,6 +2767,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public void updateControl() {
       if(!super.worldObj.isRemote) {
          updateDelayedUavInventoryStore();
+         updateNewUavMountSynchronization();
 
          if(this.uavStation != null && !this.uavStation.isDead) {
             this.saveUavStationPosition(this.uavStation);
@@ -2749,6 +2787,33 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.throttleDown = this.getCommonStatus(10);
       }
 
+   }
+
+   private void updateNewUavMountSynchronization() {
+      if(!this.isNewUAV()) {
+         return;
+      }
+      Entity rider = super.riddenByEntity;
+      if(this.newUavMountSyncTicks <= 0 && rider instanceof EntityPlayerMP
+            && rider.ridingEntity == this && this.lastRiddenByEntity != rider) {
+         // Rider relationships are restored separately from entity NBT. Start the same
+         // synchronization window when a relog/restart restores the direct NewUAV rider.
+         this.newUavMountSyncTicks = 40;
+      }
+      if(this.newUavMountSyncTicks <= 0) {
+         return;
+      }
+      if(!(rider instanceof EntityPlayerMP) || rider.ridingEntity != this) {
+         this.newUavMountSyncTicks = 0;
+         return;
+      }
+      if(this.newUavMountSyncTicks % 5 == 0) {
+         // The player starts at a distant station, so the first attach packet can arrive
+         // before the client has begun tracking this aircraft. Repeat the authoritative
+         // state after tracking catches up instead of teleporting the player ahead of mount.
+         this.syncCompleteAircraftState((EntityPlayerMP)rider);
+      }
+      --this.newUavMountSyncTicks;
    }
 
    public void updateRecoil(float partialTicks) {
@@ -5479,6 +5544,18 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       MCH_Lib.DbgLog(super.worldObj, "setDead:" + (this.getAcInfo() != null?this.getAcInfo().name:"null"), new Object[0]);
    }
 
+   public void discardDuplicateUav() {
+      if(super.worldObj.isRemote || this.isDead) {
+         return;
+      }
+      this.newUavShiftExitInProgress = true;
+      try {
+         this.setDead(false);
+      } finally {
+         this.newUavShiftExitInProgress = false;
+      }
+   }
+
 
    private MCH_EntityUavStation resolveLinkedUavStation() {
       if(this.uavStation != null && !this.uavStation.isDead) {
@@ -5517,7 +5594,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    private boolean hasNewUavReturnPosition() {
-      return this.hasLinkedUavStationPosition && this.linkedUavStationDimension == this.dimension;
+      return this.linkedUavStationUUID != null && this.hasLinkedUavStationPosition
+            && this.linkedUavStationDimension == this.dimension
+            && !Double.isNaN(this.linkedUavStationX) && !Double.isInfinite(this.linkedUavStationX)
+            && !Double.isNaN(this.linkedUavStationY) && !Double.isInfinite(this.linkedUavStationY)
+            && !Double.isNaN(this.linkedUavStationZ) && !Double.isInfinite(this.linkedUavStationZ);
    }
 
    private void updateNewUavReturnPositionFromStation() {
@@ -5538,7 +5619,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       updateNewUavReturnPositionFromStation();
       if(!hasNewUavReturnPosition()) {
-         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: no saved station position", new Object[0]);
+         MCH_Lib.Log((Entity)this, "Unable to return New UAV pilot: station link is missing or still restoring; preserving UAV control", new Object[0]);
          return false;
       }
 
@@ -5572,28 +5653,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       super.riddenByEntity = null;
    }
 
-   private void deleteNewUavAfterShiftExit() {
-      if(super.worldObj.isRemote || !this.isNewUAV()) {
-         return;
-      }
-      MCH_EntityUavStation station = resolveLinkedUavStation();
-      if(station != null) {
-         if(!station.prepareNewUavShiftExit(this)) {
-            return;
-         }
-      } else {
-         MCH_Lib.Log((Entity)this, "Unable to resolve the New UAV station during shift-exit; preserving the aircraft instead of losing its position", new Object[0]);
-         return;
-      }
-      MCH_Lib.Log((Entity)this, "Deleting new UAV entity %d after player shift-exit; station Continue may relaunch it", new Object[] { Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
-      this.newUavShiftExitInProgress = true;
-      try {
-         this.setDead(false);
-      } finally {
-         this.newUavShiftExitInProgress = false;
-      }
-   }
-
    public void unmountEntity() {
       if(!this.isRidePlayer()) {
          this.switchHoveringMode(false);
@@ -5604,13 +5663,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(super.riddenByEntity != null) {
          rByEntity = super.riddenByEntity;
          this.camera.initCamera(0, rByEntity);
-         if(!super.worldObj.isRemote) {
+         if(!super.worldObj.isRemote && this.isNewUAV()) {
+            if(!this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+               return;
+            }
+         } else if(!super.worldObj.isRemote) {
             super.riddenByEntity.mountEntity((Entity)null);
          }
       } else if(this.lastRiddenByEntity != null) {
          rByEntity = this.lastRiddenByEntity;
          if(rByEntity instanceof EntityPlayer) {
             this.camera.initCamera(0, rByEntity);
+         }
+         if(!super.worldObj.isRemote && this.isNewUAV()
+               && !this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
+            return;
          }
       }
 
@@ -5623,9 +5690,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(rByEntity != null) {
          // NewUAV takes precedence over the legacy UAV flag used by some content packs.
          if(this.isNewUAV()) {
-            if(!super.worldObj.isRemote && this.returnNewUavPilotToStation(rByEntity, "uav_exit")) {
-               deleteNewUavAfterShiftExit();
-            }
+            // The server already detached and returned the pilot above. Keep the live UAV
+            // linked so Continue/relog can deterministically reacquire the same entity.
          } else if(this.isUAV()) {
             if(rByEntity.ridingEntity instanceof MCH_EntityUavStation) {
                rByEntity.mountEntity((Entity)null);
@@ -5795,16 +5861,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return false;
       }
 
+      if(this.isNewUAV() && !super.worldObj.isRemote) {
+         return this.returnNewUavPilotToStation(entity, "uav_seat_exit");
+      }
+
       for(MCH_EntitySeat seat : this.seats) {
          if(seat != null && W_Entity.isEqual(seat.riddenByEntity, entity)) {
             entity.mountEntity((Entity)null);
             break;
          }
-      }
-
-      if(this.isNewUAV() && !super.worldObj.isRemote
-              && this.returnNewUavPilotToStation(entity, "uav_seat_exit")) {
-         deleteNewUavAfterShiftExit();
       }
       return false;
    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -187,11 +187,12 @@ public class MCH_EntityUavStation
          }
 
       public void setControlAircract(MCH_EntityBaseVehicle ac) {
-           this.controlAircraft = ac;
-           if (ac != null && !ac.isDead ) {
-                linkUav(ac);
+           if (ac == null) {
+                this.controlAircraft = null;
+           } else if (!ac.isDead && linkUav(ac)) {
+                this.controlAircraft = ac;
                 setLastControlAircraft(ac);
-              }
+           }
          }
 
       public UUID getOwnerUUID() {
@@ -204,13 +205,25 @@ public class MCH_EntityUavStation
 
 
 
-      public void linkUav(MCH_EntityBaseVehicle ac) {
+      public boolean linkUav(MCH_EntityBaseVehicle ac) {
            if(ac == null) {
-                return;
+                return false;
+           }
+           UUID persistentId = ac.getUavPersistentUUID();
+           if(this.hasStoredUavLink && this.linkedUavEntityUUID != null
+                 && !this.linkedUavEntityUUID.equals(persistentId)
+                 && !this.linkedUavEntityUUID.equals(ac.getUniqueID())) {
+                MCH_Lib.Log((Entity)this, "Rejected UAV %d because station %d is locked to persistent UUID %s", new Object[] {
+                      Integer.valueOf(W_Entity.getEntityId((Entity)ac)), Integer.valueOf(W_Entity.getEntityId((Entity)this)),
+                      this.linkedUavEntityUUID.toString() });
+                return false;
+           }
+           MCH_UavRegistry.register(ac);
+           if(ac.isDead) {
+                return false;
            }
            this.assignedUav = ac;
            this.assignedUavId = ac.getEntityId();
-           UUID persistentId = ac.getUavPersistentUUID();
            this.assignedUavUUID = persistentId == null ? ac.getUniqueID().toString() : persistentId.toString();
            this.linkedUavEntityUUID = persistentId == null ? ac.getUniqueID() : persistentId;
            this.linkedUavCommonId = ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId();
@@ -223,7 +236,7 @@ public class MCH_EntityUavStation
            this.awaitingLoadedUav = false;
            setContinuationState(CONTINUE_AVAILABLE);
            setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
-           MCH_UavRegistry.register(ac);
+           return true;
          }
 
       public void updateLinkedUavPosition(MCH_EntityBaseVehicle ac) {
@@ -736,8 +749,7 @@ public class MCH_EntityUavStation
 
       private boolean relinkStoredUav(boolean requireLoaded) {
            MCH_EntityBaseVehicle ac = findLinkedUavEntity(this.worldObj);
-           if(ac != null && !ac.isDead) {
-                linkUav(ac);
+           if(ac != null && !ac.isDead && linkUav(ac)) {
                 setLastControlAircraft(ac);
                 setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
                 return true;
@@ -895,6 +907,16 @@ public class MCH_EntityUavStation
               }
               return false;
           }
+          if(this.linkedUavEntityUUID != null
+                || (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty())
+                || (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty())) {
+              // A persisted identity means a real entity is authoritative even if its chunk
+              // has not finished loading. Spawning from the legacy JSON token here creates a
+              // second live UAV and lets registration order decide which one the station uses.
+              this.awaitingLoadedUav = true;
+              markLinkedUavUnloaded();
+              return false;
+          }
 
           MCH_UavJsonStore.StoredUav stored = MCH_UavJsonStore.load(this.worldObj, this);
           if(stored == null) {
@@ -924,20 +946,38 @@ public class MCH_EntityUavStation
            if(ac != null && !ac.isDead) {
                 ac.setLocationAndAngles(stored.exitX, stored.exitY, stored.exitZ, stored.exitYaw, stored.exitPitch);
                 if(this.riddenByEntity != null && ac.isNewUAV()) {
-                     teleportPlayerToUav(this.riddenByEntity, ac);
-                     this.riddenByEntity.mountEntity((Entity)ac);
+                     if(!startNewUavControl(this.riddenByEntity, ac)) {
+                          this.pendingContinueTicks = 60;
+                          return false;
+                     }
                 }
                 return true;
            }
            return false;
          }
 
-
-
-      private void teleportPlayerToUav(Entity user, MCH_EntityBaseVehicle ac) {
-           if(user instanceof EntityPlayerMP && ac != null) {
-                ((EntityPlayerMP)user).setPositionAndUpdate(ac.posX, ac.posY + ac.getMountedYOffset(), ac.posZ);
+      private boolean startNewUavControl(Entity user, MCH_EntityBaseVehicle ac) {
+           if(!(user instanceof EntityPlayerMP) || ac == null || !ac.isNewUAV()
+                 || this.riddenByEntity != user || user.ridingEntity != this) {
+                return false;
            }
+           EntityPlayerMP player = (EntityPlayerMP)user;
+           if(!linkUav(ac)) {
+                return false;
+           }
+           setControlAircract(ac);
+           if(this.controlAircraft != ac) {
+                return false;
+           }
+           if(!ac.mountNewUavPilot(player, this)) {
+                MCH_Lib.Log((Entity)this, "New UAV control handoff for player %s is not ready; keeping the player at station %d", new Object[] {
+                      player.getCommandSenderName(), Integer.valueOf(W_Entity.getEntityId((Entity)this)) });
+                return false;
+           }
+           this.pendingContinueTicks = 0;
+           this.lastRiddenByEntity = null;
+           W_EntityPlayer.closeScreen(player);
+           return true;
          }
 
 
@@ -1107,8 +1147,15 @@ public class MCH_EntityUavStation
                  if (lastAc != null && !lastAc.isDead) {
 
                      if(!isValidLinkedUav(lastAc, user instanceof EntityPlayer ? (EntityPlayer)user : null)) { return; }
-                     linkUav(lastAc);
+                     if(!linkUav(lastAc)) {
+                         this.pendingContinueTicks = 60;
+                         return;
+                     }
                      setControlAircract(lastAc);
+                     if(this.controlAircraft != lastAc) {
+                         this.pendingContinueTicks = 60;
+                         return;
+                     }
                      //this.assignedUav = uav;
 
                      if(this.riddenByEntity instanceof EntityPlayer) {
@@ -1130,8 +1177,13 @@ public class MCH_EntityUavStation
                              }
                              return;
                          }
-                         teleportPlayerToUav(this.riddenByEntity, this.controlAircraft);
-                         this.riddenByEntity.mountEntity((Entity)this.controlAircraft);
+                         if(!startNewUavControl(user, this.controlAircraft)) {
+                             this.pendingContinueTicks = 60;
+                             if(notify && user instanceof EntityPlayer) {
+                                 W_EntityPlayer.addChatMessage((EntityPlayer)user, "UAV control is synchronizing; continue will retry.");
+                             }
+                             return;
+                         }
                      }
                      this.pendingContinueTicks = 0;
                      W_EntityPlayer.closeScreen(user);

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -85,6 +85,7 @@ public final class MCH_UavRegistry {
         if (world == null) return null;
         List list = world.loadedEntityList;
         MCH_EntityBaseVehicle first = null;
+        MCH_EntityBaseVehicle match = null;
         for (int i = 0; i < list.size(); ++i) {
             Object obj = list.get(i);
             if (obj instanceof MCH_EntityBaseVehicle) {
@@ -101,12 +102,16 @@ public final class MCH_UavRegistry {
                     if (entityUuid == null && (commonId == null || commonId.isEmpty()) && owner == null && first == null) {
                         first = ac;
                     } else if (entityMatch || commonMatch || ownerMatch) {
-                        return ac;
+                        match = match == null || match.isDead ? ac : chooseCanonical(match, ac);
                     }
                 }
             }
         }
-        return first;
+        if (match != null) {
+            register(match);
+            return getLive(match, world);
+        }
+        return first == null ? null : getLive(first, world);
     }
 
     private static MCH_EntityBaseVehicle getLive(MCH_EntityBaseVehicle ac, World world) {
@@ -142,16 +147,23 @@ public final class MCH_UavRegistry {
                 Integer.valueOf(keep.getEntityId()), Integer.valueOf(remove.getEntityId()),
                 persistentId == null ? "" : persistentId.toString(), ac.getCommonUniqueId() == null ? "" : ac.getCommonUniqueId() });
         unregister(remove);
-        remove.setDead(false);
+        remove.discardDuplicateUav();
         return keep;
     }
 
     private static MCH_EntityBaseVehicle chooseCanonical(MCH_EntityBaseVehicle a, MCH_EntityBaseVehicle b) {
         if (b.getRiddenByEntity() != null && a.getRiddenByEntity() == null) return b;
         if (a.getRiddenByEntity() != null && b.getRiddenByEntity() == null) return a;
+        UUID aPersistent = a.getUavPersistentUUID(false);
+        UUID bPersistent = b.getUavPersistentUUID(false);
+        boolean aOriginal = aPersistent != null && aPersistent.equals(a.getUniqueID());
+        boolean bOriginal = bPersistent != null && bPersistent.equals(b.getUniqueID());
+        if (aOriginal != bOriginal) return aOriginal ? a : b;
         if (b.getUavStation() != null && a.getUavStation() == null) return b;
         if (a.getUavStation() != null && b.getUavStation() == null) return a;
-        return a.ticksExisted >= b.ticksExisted ? a : b;
+        int uuidOrder = a.getUniqueID().toString().compareTo(b.getUniqueID().toString());
+        if (uuidOrder != 0) return uuidOrder < 0 ? a : b;
+        return a.getEntityId() <= b.getEntityId() ? a : b;
     }
 
     private static boolean isValidUav(MCH_EntityBaseVehicle ac) {


### PR DESCRIPTION
### Motivation

- Make NewUAV (isNewUAV) pilot handoff and unmount behavior robust across chunk loads and restarts to avoid lost control or duplicate entities.
- Prevent spawning duplicate live UAV entities when a station already has a persisted UAV identity and ensure deterministic canonical selection when duplicates are discovered.
- Add a short synchronization window after mount to repeatedly resend authoritative state to the pilot client while entity tracking catches up.

### Description

- Added `newUavMountSyncTicks`, `mountNewUavPilot`, `updateNewUavMountSynchronization`, and `discardDuplicateUav` to `MCH_EntityBaseVehicle` and made `getRiddenByEntity` prefer direct NewUAV riders; improved return/unmount flows to return pilots to a saved station position instead of immediately deleting or dropping control.
- Hardened NewUAV return position checks to validate stored coordinates and restored station resolution via UUID/coordinates lookup (`resolveLinkedUavStation`) and introduced safer handling when a station is missing or still restoring.
- Removed the old immediate-delete-on-shift-exit flow and replaced duplicate removal with `discardDuplicateUav` to avoid race conditions while preserving station linkage for Continue/relog.
- In `MCH_EntityUavStation` made `linkUav` return a boolean and enforce persistent-UUID locking (rejecting links that conflict with a stored persistent identity), registered UAVs with `MCH_UavRegistry` on link, and added `startNewUavControl` to perform coordinated station->UAV pilot handoff using `mountNewUavPilot` (with retries via `pendingContinueTicks`).
- Prevented relaunch-from-JSON when a station already references a persisted/identified UAV by deferring to the live entity and setting `awaitingLoadedUav` to avoid creating a duplicate live UAV.
- Updated continue/control flows to honor `linkUav` result and to defer Continue with `pendingContinueTicks` when synchronization or initialization is required.
- Improved `MCH_UavRegistry` `searchLoaded`, `pruneDuplicate`, and `chooseCanonical` logic to pick a deterministic canonical UAV when duplicates exist, register the chosen entity, and call `discardDuplicateUav` on the duplicate instead of directly killing it; canonical selection was enhanced to consider persistent-id origin, station attachment, UUID lexicographic order and entity id as tie-breakers.

### Testing

- Built the project with `./gradlew build` and the build completed successfully.
- Ran automated unit tests with `./gradlew test` and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d7a8062088323a09c270574ce7b6d)