### PR TITLE
Show new-UAV pilot on station and sync pilot profile via DataWatcher

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -1,5 +1,6 @@
 package mcheli.uav;
 
+import com.mojang.authlib.GameProfile;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.util.List;
@@ -43,6 +44,7 @@ import net.minecraft.world.World;
 public class MCH_EntityUavStation
            extends W_EntityContainer
          {
+      protected static final int DATAWT_ID_NEW_UAV_PILOT = 25;
       protected static final int DATAWT_ID_CONTINUE_STATE = 26;
       protected static final int DATAWT_ID_KIND = 27;
       private static final byte CONTINUE_NONE = 0;
@@ -145,6 +147,7 @@ public class MCH_EntityUavStation
       public float prevRotCover;
       protected void entityInit() {
            super.entityInit();
+           getDataWatcher().addObject(DATAWT_ID_NEW_UAV_PILOT, "");
            getDataWatcher().addObject(DATAWT_ID_CONTINUE_STATE, Byte.valueOf(CONTINUE_NONE));
            getDataWatcher().addObject(27, Byte.valueOf((byte)0));
            getDataWatcher().addObject(28, Integer.valueOf(0));
@@ -519,7 +522,16 @@ public class MCH_EntityUavStation
          }
 
       public double getMountedYOffset() {
-           if (getKind() == 2 && this.riddenByEntity != null) {
+           return getMountedYOffset(this.riddenByEntity != null);
+         }
+
+      @SideOnly(Side.CLIENT)
+      public double getMountedYOffsetForVisualPilot() {
+           return getMountedYOffset(true);
+         }
+
+      private double getMountedYOffset(boolean occupied) {
+           if (getKind() == 2 && occupied) {
                 double px = -Math.sin(this.rotationYaw * Math.PI / 180.0D) * 0.9D;
                 double pz = Math.cos(this.rotationYaw * Math.PI / 180.0D) * 0.9D;
                 int x = (int)(this.posX + px);
@@ -599,6 +611,9 @@ public class MCH_EntityUavStation
           if(!this.worldObj.isRemote && this.riddenByEntity instanceof EntityPlayer
                   && this.controlAircraft != null && this.controlAircraft.isNewUAV()) {
               this.controlAircraft.setUavStation(this);
+          }
+          if(!this.worldObj.isRemote) {
+              updateNewUavPilotProfile();
           }
 
 
@@ -976,8 +991,42 @@ public class MCH_EntityUavStation
            }
            this.pendingContinueTicks = 0;
            this.lastRiddenByEntity = null;
+           setNewUavPilotProfile(player);
            W_EntityPlayer.closeScreen(player);
            return true;
+         }
+
+      private void updateNewUavPilotProfile() {
+           Entity pilot = this.controlAircraft != null && this.controlAircraft.isNewUAV()
+                 ? this.controlAircraft.getRiddenByEntity() : null;
+           setNewUavPilotProfile(pilot instanceof EntityPlayer ? (EntityPlayer)pilot : null);
+         }
+
+      private void setNewUavPilotProfile(EntityPlayer player) {
+           String value = "";
+           if(player != null && !player.isDead) {
+                GameProfile profile = player.getGameProfile();
+                String uuid = profile.getId() == null ? "" : profile.getId().toString();
+                value = uuid + "|" + profile.getName();
+              }
+           if(!value.equals(getDataWatcher().getWatchableObjectString(DATAWT_ID_NEW_UAV_PILOT))) {
+                getDataWatcher().updateObject(DATAWT_ID_NEW_UAV_PILOT, value);
+              }
+         }
+
+      @SideOnly(Side.CLIENT)
+      public GameProfile getNewUavPilotProfile() {
+           String value = getDataWatcher().getWatchableObjectString(DATAWT_ID_NEW_UAV_PILOT);
+           if(value == null || value.isEmpty()) {
+                return null;
+              }
+           int separator = value.indexOf('|');
+           String uuid = separator >= 0 ? value.substring(0, separator) : "";
+           String name = separator >= 0 ? value.substring(separator + 1) : value;
+           if(name.isEmpty()) {
+                return null;
+              }
+           return new GameProfile(parseUavUUID(uuid), name);
          }
 
 
@@ -1278,7 +1327,13 @@ public class MCH_EntityUavStation
                         ((MCH_EntityBaseVehicle)ac).setDead(false);
                         linkUav(linked);
                         setControlAircract(linked);
-                        W_EntityPlayer.closeScreen(user);
+                        if(linked.isNewUAV()) {
+                             if(!startNewUavControl(user, linked)) {
+                                  this.pendingContinueTicks = 60;
+                                }
+                          } else {
+                             W_EntityPlayer.closeScreen(user);
+                          }
                         return;
                     }
                     if(MCH_Config.ItemDamage.prmBool) {
@@ -1306,7 +1361,13 @@ public class MCH_EntityUavStation
                           linkUav((MCH_EntityBaseVehicle) ac);
                           if (!((MCH_EntityBaseVehicle)ac).isTargetDrone()) {
                                ((MCH_EntityBaseVehicle)ac).setFuel((int)(((MCH_EntityBaseVehicle)ac).getMaxFuel() * 0.05F));
-                               W_EntityPlayer.closeScreen(user);
+                               if(((MCH_EntityBaseVehicle)ac).isNewUAV()) {
+                                    if(!startNewUavControl(user, (MCH_EntityBaseVehicle)ac)) {
+                                         this.pendingContinueTicks = 60;
+                                       }
+                                 } else {
+                                    W_EntityPlayer.closeScreen(user);
+                                 }
                              } else {
                                ((MCH_EntityBaseVehicle)ac).setFuel(((MCH_EntityBaseVehicle)ac).getMaxFuel());
                              }

--- a/src/main/java/mcheli/uav/MCH_RenderUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_RenderUavStation.java
@@ -1,12 +1,19 @@
 package mcheli.uav;
 
+import com.mojang.authlib.GameProfile;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.Map;
+import java.util.WeakHashMap;
 import mcheli.MCH_Lib;
 import mcheli.MCH_ModelManager;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.uav.MCH_EntityUavStation;
 import mcheli.wrapper.W_Render;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.client.entity.EntityOtherPlayerMP;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
@@ -17,6 +24,8 @@ public class MCH_RenderUavStation extends W_Render {
    public static final String[] TEX_NAME_ON = new String[]{"uav_station_on", "uav_portable_controller_on"};
    public static final String[] TEX_NAME_OFF = new String[]{"uav_station", "uav_portable_controller"};
 
+   private final Map<MCH_EntityUavStation, EntityOtherPlayerMP> stationPilots =
+         new WeakHashMap<MCH_EntityUavStation, EntityOtherPlayerMP>();
 
    public MCH_RenderUavStation() {
       super.shadowSize = 1.0F;
@@ -68,8 +77,47 @@ public class MCH_RenderUavStation extends W_Render {
             GL11.glBlendFunc(srcBlend, dstBlend);
             GL11.glDisable(3042);
             GL11.glPopMatrix();
+            this.renderNewUavStationPilot(uavSt, posX, posY, posZ, tickTime);
          }
       }
+   }
+
+   private void renderNewUavStationPilot(MCH_EntityUavStation station, double posX, double posY,
+         double posZ, float partialTicks) {
+      MCH_EntityBaseVehicle aircraft = station.getControlAircract();
+      Entity operator = aircraft != null && aircraft.isNewUAV() ? aircraft.getRiddenByEntity() : null;
+      GameProfile profile = station.getNewUavPilotProfile();
+      if(profile == null) {
+         this.stationPilots.remove(station);
+         return;
+      }
+
+      EntityOtherPlayerMP fakePlayer = this.stationPilots.get(station);
+      if(fakePlayer == null || !fakePlayer.getGameProfile().equals(profile)) {
+         fakePlayer = new EntityOtherPlayerMP(station.worldObj, profile);
+         this.stationPilots.put(station, fakePlayer);
+      }
+
+      if(operator instanceof EntityPlayer && !operator.isDead && operator.ridingEntity == aircraft) {
+         fakePlayer.inventory.copyInventory(((EntityPlayer)operator).inventory);
+      }
+      fakePlayer.ridingEntity = station;
+      fakePlayer.rotationYaw = station.rotationYaw;
+      fakePlayer.prevRotationYaw = station.prevRotationYaw;
+      fakePlayer.rotationYawHead = station.rotationYaw;
+      fakePlayer.prevRotationYawHead = station.prevRotationYaw;
+      fakePlayer.renderYawOffset = station.rotationYaw;
+      fakePlayer.prevRenderYawOffset = station.prevRotationYaw;
+      fakePlayer.rotationPitch = 0.0F;
+      fakePlayer.prevRotationPitch = 0.0F;
+
+      double yaw = station.rotationYaw * Math.PI / 180.0D;
+      double offsetX = -Math.sin(yaw) * 0.9D;
+      double offsetZ = Math.cos(yaw) * 0.9D;
+      double offsetY = station.getMountedYOffsetForVisualPilot() + fakePlayer.getYOffset();
+      fakePlayer.setPosition(station.posX + offsetX, station.posY + offsetY, station.posZ + offsetZ);
+      RenderManager.instance.renderEntityWithPosYaw(fakePlayer, posX + offsetX, posY + offsetY,
+            posZ + offsetZ, fakePlayer.rotationYaw, partialTicks);
    }
 
    public void renderPortableController(MCH_EntityUavStation uavSt, String name, float tickTime) {


### PR DESCRIPTION
### Motivation

- Allow the UAV station to show a visible pilot avatar for "new" UAVs and synchronize which player is piloting the UAV between server and client. 
- Provide a lightweight way to transmit the pilot identity (UUID + name) to clients so the renderer can create a fake player and render it seated at the station.
- Ensure the station properly hands off control for new-UAV types and falls back to pending continuation when immediate handoff fails.

### Description

- Added a new DataWatcher field `DATAWT_ID_NEW_UAV_PILOT` to store the pilot identity string (`uuid|name`) and methods `setNewUavPilotProfile`, `updateNewUavPilotProfile`, and `getNewUavPilotProfile` to manage server/client synchronization via `GameProfile`.
- Updated `onUpdate` to call `updateNewUavPilotProfile`, and call `setNewUavPilotProfile` when a player starts new-UAV control in `startNewUavControl`.
- Refactored mounted offset logic by adding `getMountedYOffsetForVisualPilot()` and a shared private `getMountedYOffset(boolean)` helper to compute correct vertical offsets for the visual pilot placement.
- Modified UAV spawn/link flows to attempt `startNewUavControl` for `isNewUAV()` vehicles, setting `pendingContinueTicks` as fallback when immediate control handoff fails.
- Implemented client-side rendering support in `MCH_RenderUavStation`: added a `WeakHashMap` cache `stationPilots` of `EntityOtherPlayerMP` per station, and added `renderNewUavStationPilot` which constructs or reuses a fake player from the synced `GameProfile`, copies inventory when the real operator is present, positions it on the station and triggers `RenderManager` to draw it.

### Testing

- Ran a full project build with `gradlew build`, which completed successfully.
- Executed `gradlew test` (unit tests target); no failing tests were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de4f59a548323983b1486d71f600f)