### PR TITLE
Notify station when NewUAV is removed so Continue is disabled

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -908,15 +908,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       if(!super.worldObj.isRemote && this.isNewUAV()) {
-         if(this.linkedUavStationUUID != null) {
-            MCH_UavJsonStore.signalDestroyed(super.worldObj, this.linkedUavStationDimension, this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
-         }
-         MCH_EntityUavStation station = resolveLinkedUavStation();
-         if(station != null) {
-            station.markLinkedNewUavDestroyed(this);
-         } else if(this.linkedUavStationUUID != null) {
-            MCH_Lib.Log((Entity)this, "Destroyed New UAV could not resolve station %s at %.2f, %.2f, %.2f; queued station destruction state", new Object[] { this.linkedUavStationUUID.toString(), Double.valueOf(this.linkedUavStationX), Double.valueOf(this.linkedUavStationY), Double.valueOf(this.linkedUavStationZ) });
-         }
+         notifyLinkedStationNewUavRemoved();
       }
 
       this.rotDestroyedPitch = super.rand.nextFloat() - 0.5F;
@@ -5496,6 +5488,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void setDead(boolean dropItems) {
       if(!super.worldObj.isRemote && this.isNewUAV() && !this.newUavShiftExitInProgress) {
+         notifyLinkedStationNewUavRemoved();
          Entity pilot = super.riddenByEntity != null ? super.riddenByEntity : this.lastRiddenByEntity;
          if(pilot != null) {
             this.returnNewUavPilotToStation(pilot, "uav_destroyed");
@@ -5542,6 +5535,18 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       MCH_Lib.DbgLog(super.worldObj, "setDead:" + (this.getAcInfo() != null?this.getAcInfo().name:"null"), new Object[0]);
+   }
+
+   private void notifyLinkedStationNewUavRemoved() {
+      if(this.linkedUavStationUUID != null) {
+         MCH_UavJsonStore.signalDestroyed(super.worldObj, this.linkedUavStationDimension, this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
+      }
+      MCH_EntityUavStation station = resolveLinkedUavStation();
+      if(station != null) {
+         station.markLinkedNewUavDestroyed(this);
+      } else if(this.linkedUavStationUUID != null) {
+         MCH_Lib.Log((Entity)this, "Removed New UAV could not resolve station %s at %.2f, %.2f, %.2f; queued station destruction state", new Object[] { this.linkedUavStationUUID.toString(), Double.valueOf(this.linkedUavStationX), Double.valueOf(this.linkedUavStationY), Double.valueOf(this.linkedUavStationZ) });
+      }
    }
 
    public void discardDuplicateUav() {


### PR DESCRIPTION
### Motivation
- The Continue button remained enabled (and could show "Linked UAV chunk is loading; continue will retry shortly.") when a `newUAV` was broken, picked up, or otherwise removed through paths that bypassed the station destruction notification.
- Centralize the station notification so the station's Continue state is set to destroyed as soon as the UAV is removed.

### Description
- Added a helper `notifyLinkedStationNewUavRemoved()` to `MCH_EntityBaseVehicle` that signals JSON store destruction and calls `markLinkedNewUavDestroyed(...)` on the station if resolvable. (`src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`)
- Replaced duplicate inline destruction notification with the helper in the immediate-destroy path and invoked the helper from the common `setDead(boolean)` removal path so pickup/break paths also notify the station. (`destroyAircraft` and `setDead` now call `notifyLinkedStationNewUavRemoved()`)
- Kept the intentional shift-exit / duplicate-cleanup paths exempt by preserving the `newUavShiftExitInProgress` check.

### Testing
- Ran `git diff --check` and repository status checks; changes committed as `Fix Continue state after new UAV removal`.
- Attempted `./gradlew compileJava`, but the build was blocked by the environment when downloading the Gradle distribution (proxy returned HTTP 403), so bytecode compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e440c15048323982b0d196c8249bc)