### PR TITLE
Clear stale destroyed state when inserting replacement NewUAV

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -304,6 +304,12 @@ public class MCH_EntityUavStation
            setContinuationState(CONTINUE_NONE);
          }
 
+      private void clearDestroyedStateForNewUavItem() {
+           this.storedUavWasDestroyed = false;
+           MCH_UavJsonStore.consumeDestroyed(this.worldObj, this);
+           setContinuationState(CONTINUE_NONE);
+         }
+
 
       public void setUavPosition(int x, int y, int z) {
            if (!this.worldObj.isRemote) {
@@ -1344,7 +1350,11 @@ public class MCH_EntityUavStation
                      ((Entity)ac).prevRotationYaw = ((Entity)ac).rotationYaw;
                      user.rotationYaw = this.rotationYaw - 180.0F;
                      if (this.worldObj.getCollidingBoundingBoxes((Entity)ac, ((Entity)ac).boundingBox.expand(-0.1D, -0.1D, -0.1D)).isEmpty()) {
-                         this.storedUavWasDestroyed = false;
+                         // A newly inserted item starts a new UAV lifecycle. Clear both the
+                         // in-memory destruction flag and any queued out-of-range tombstone
+                         // before linking it, otherwise the next Continue press can consume
+                         // the stale tombstone and incorrectly mark this replacement destroyed.
+                         clearDestroyedStateForNewUavItem();
                          this.lastUavItemStack = itemStack.copy();
                          this.lastUavItemStack.stackSize = 1;
                          itemStack.stackSize--;


### PR DESCRIPTION
### Motivation
- Prevent a persisted "destroyed" tombstone from being consumed after a player inserts a replacement `NewUAV` item, which caused the station to show "The linked drone was destroyed. Insert a new UAV item to launch again" on the next Continue press.

### Description
- Add `clearDestroyedStateForNewUavItem()` and call it when a new UAV `ItemStack` is accepted in `MCH_EntityUavStation.handleItem`, which clears `storedUavWasDestroyed`, consumes any persisted out-of-range destruction record via `MCH_UavJsonStore.consumeDestroyed`, and resets the continuation state to `CONTINUE_NONE` (`src/main/java/mcheli/uav/MCH_EntityUavStation.java`).

### Testing
- Ran automated pre-commit checks: `git diff --check` and `git status` (both OK) and committed the change; attempted `./gradlew compileJava` but the Gradle wrapper download was blocked by an environment proxy (HTTP 403), so a local compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4a6e3778832398a6f1f0fa546f8c)