### PR TITLE
Fix false NewUAV destroyed state on Continue

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5487,7 +5487,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setDead(boolean dropItems) {
-      if(!super.worldObj.isRemote && this.isNewUAV() && !this.newUavShiftExitInProgress) {
+      if(!super.worldObj.isRemote && this.isNewUAV() && this.isDestroyed() && !this.newUavShiftExitInProgress) {
          notifyLinkedStationNewUavRemoved();
          Entity pilot = super.riddenByEntity != null ? super.riddenByEntity : this.lastRiddenByEntity;
          if(pilot != null) {


### PR DESCRIPTION
### Motivation
- Prevent a NewUAV entity being treated as "destroyed" when `setDead(boolean)` is invoked for non-destruction cleanup, which caused stations to show the wrong Continue message and require a replacement UAV.

### Description
- Change the condition in `MCH_EntityBaseVehicle.setDead(boolean)` to only call `notifyLinkedStationNewUavRemoved()` for NewUAVs that return `true` from `isDestroyed()`, limiting the change to `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java` and not altering other UAV/station behavior.

### Testing
- Ran `git diff --check` and `git status --short`, which succeeded; attempted `bash ./gradlew compileJava` but the Gradle distribution download failed due to an environment proxy returning HTTP 403, so a full compile could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e4df0f4d8832391d166eda712b47e)