### PR TITLE
Ignore stale NewUAV destruction signals during Continue

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -276,6 +276,26 @@ public class MCH_EntityUavStation
            return this.storedUavWasDestroyed || getContinuationState() == CONTINUE_DESTROYED;
          }
 
+      private boolean consumeConfirmedNewUavDestructionSignal() {
+           if(!MCH_UavJsonStore.consumeDestroyed(this.worldObj, this)) {
+                return false;
+           }
+
+           MCH_EntityBaseVehicle linked = getAndSearchLastControlAircraft();
+           if(linked == null) {
+                linked = findLinkedUavEntity(this.worldObj);
+           }
+           if(linked != null && !linked.isDead && !linked.isDestroyed()) {
+                MCH_Lib.Log((Entity)this, "Ignored stale New UAV destruction signal because linked UAV %d is still alive", new Object[] {
+                      Integer.valueOf(W_Entity.getEntityId((Entity)linked))
+                });
+                linkUav(linked);
+                setControlAircract(linked);
+                return false;
+           }
+           return true;
+         }
+
       private byte getContinuationState() {
            return getDataWatcher().getWatchableObjectByte(DATAWT_ID_CONTINUE_STATE);
          }
@@ -641,8 +661,8 @@ public class MCH_EntityUavStation
            this.prevPosZ = this.posZ;
            if(!this.worldObj.isRemote && this.ticksExisted % 10 == 0 && !this.storedUavWasDestroyed &&
               (this.hasStoredUavLink || getContinuationState() == CONTINUE_AVAILABLE) &&
-              MCH_UavJsonStore.consumeDestroyed(this.worldObj, this)) {
-                MCH_Lib.Log((Entity)this, "Consumed out-of-range New UAV destruction signal; disabling Continue", new Object[0]);
+              consumeConfirmedNewUavDestructionSignal()) {
+                MCH_Lib.Log((Entity)this, "Consumed confirmed out-of-range New UAV destruction signal; disabling Continue", new Object[0]);
                 markLinkedNewUavDestroyed((MCH_EntityBaseVehicle)null);
            }
            if (getControlAircract() != null && getControlAircract().isDestroyed()) {
@@ -1173,7 +1193,7 @@ public class MCH_EntityUavStation
 
              private void controlLastAircraft(Entity user, boolean notify) {
 
-                 if(!this.worldObj.isRemote && !this.storedUavWasDestroyed && MCH_UavJsonStore.consumeDestroyed(this.worldObj, this)) {
+                 if(!this.worldObj.isRemote && !this.storedUavWasDestroyed && consumeConfirmedNewUavDestructionSignal()) {
                      markLinkedNewUavDestroyed((MCH_EntityBaseVehicle)null);
                  }
                  if(wasLinkedUavDestroyed()) {


### PR DESCRIPTION
### Motivation
- Fix a bug where pressing `Continue` after dismounting a `NewUAV` could show "The linked drone was destroyed" and leave the `NewUAV` uncontrollable even though the vehicle was still alive. 
- The root cause was treating persisted destruction markers as authoritative without verifying whether the linked UAV entity had since been restored or remained live.

### Description
- Added a verification helper `consumeConfirmedNewUavDestructionSignal()` to `src/main/java/mcheli/uav/MCH_EntityUavStation.java` that calls `MCH_UavJsonStore.consumeDestroyed`, then checks for a live linked aircraft via `getAndSearchLastControlAircraft()` and `findLinkedUavEntity()`, and ignores the persisted destruction if the linked UAV is still alive while restoring the live link with `linkUav(...)` and `setControlAircract(...)`.
- Replaced direct uses of `MCH_UavJsonStore.consumeDestroyed(...)` in the periodic update path and the `Continue`/`controlLastAircraft` flow with `consumeConfirmedNewUavDestructionSignal()` to avoid marking the station destroyed on stale signals.
- Updated log messages to reflect that consumed signals are now validated before disabling `Continue`.

### Testing
- Ran repository checks: `git diff --check` reported no whitespace/errors and the modified file diff was inspected successfully.
- Verified the modified logic by searching and printing relevant sections of `MCH_EntityUavStation.java` to confirm the new helper and call sites were applied as intended.
- Attempted `./gradlew compileJava` but compilation via the Gradle wrapper was blocked in this environment due to the wrapper file not being executable and the Gradle distribution download being blocked by an HTTP 403 proxy, so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e50c20608832385daca15b400af5f)