### PR TITLE
Fix NewUAV continuation without relogging

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5641,6 +5641,16 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       } else {
          pilot.setPosition(this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
       }
+
+      // Put the operator back in the station as part of the same server-side handoff.
+      // Merely teleporting them beside it leaves the client with a stale NewUAV mount
+      // until its entity state is refreshed (commonly by relogging), so Continue cannot
+      // immediately satisfy its requirement that the requesting player rides this station.
+      MCH_EntityUavStation station = resolveLinkedUavStation();
+      if(station != null && !station.isDead
+            && (station.riddenByEntity == null || station.riddenByEntity == pilot)) {
+         pilot.mountEntity(station);
+      }
       return true;
    }
 


### PR DESCRIPTION
### Motivation

- Ensure the UAV station "Continue" flow can immediately reattach a player to a NewUAV after they exit instead of requiring the client to relog to clear a stale mount state.
- Prevent lost or unusable Continue state by performing the server-side handoff to the linked station when returning NewUAV pilots.

### Description

- In `returnNewUavPilotToStation` added a server-side remount that resolves the linked station with `resolveLinkedUavStation()` and mounts the operator to the station after teleporting and restoring inventory.
- Guarded the remount so it only mounts when the resolved station is not dead and is either empty or already ridden by the same pilot to avoid stealing an occupied station.
- Added explanatory comments describing why teleport-only behavior left a stale NewUAV mount on the client and why the immediate remount fixes the Continue flow.

### Testing

- Ran `git diff --check` with no reported issues.
- Verified repository status with `git status --short`.
- Attempted to run `bash gradlew compileJava` but Gradle wrapper failed to download the distribution due to an environment proxy returning HTTP 403, so compilation could not be completed in this environment.
- Attempted `./gradlew compileJava` but the wrapper was not executable in the environment, so the local wrapper execution was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e648b4dec8323963af3c69f751c4c)