### PR TITLE
Fix Continue reconnecting to newUAV outside loaded chunks

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -742,15 +742,25 @@ public class MCH_EntityUavStation
          }
 
       public MCH_EntityBaseVehicle findLinkedUavEntity(World world) {
-           if(this.assignedUav != null && !this.assignedUav.isDead) {
+           return findLinkedUavEntity(world, true);
+         }
+
+      private MCH_EntityBaseVehicle findLinkedUavEntity(World world, boolean loadChunk) {
+           if(isLoadedInWorld(world, this.assignedUav)) {
                 return this.assignedUav;
            }
-           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
-           if(ac == null) {
+           // Entity instances remain alive while their chunk is unloaded, so the runtime
+           // references and registry can still point at an object that cannot be tracked or
+           // mounted. Load the saved chunk before resolving the link again.
+           if(loadChunk) {
                 loadLinkedUavChunk(world);
-                ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            }
+           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            return ac;
+         }
+
+      private boolean isLoadedInWorld(World world, MCH_EntityBaseVehicle ac) {
+           return world != null && ac != null && !ac.isDead && ac.worldObj == world && world.loadedEntityList.contains(ac);
          }
 
       private void loadLinkedUavChunk(World world) {
@@ -763,7 +773,7 @@ public class MCH_EntityUavStation
          }
 
       private boolean relinkStoredUav(boolean requireLoaded) {
-           MCH_EntityBaseVehicle ac = findLinkedUavEntity(this.worldObj);
+           MCH_EntityBaseVehicle ac = findLinkedUavEntity(this.worldObj, requireLoaded);
            if(ac != null && !ac.isDead && linkUav(ac)) {
                 setLastControlAircraft(ac);
                 setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
@@ -1190,7 +1200,7 @@ public class MCH_EntityUavStation
                      return;
                  }
                  MCH_EntityBaseVehicle lastAc = getAndSearchLastControlAircraft();
-                 if (lastAc == null && relinkStoredUav(false)) {
+                 if (lastAc == null && relinkStoredUav(true)) {
                      lastAc = getLastControlAircraft();
                  }
                  if (lastAc != null && !lastAc.isDead) {

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -115,7 +115,7 @@ public final class MCH_UavRegistry {
     }
 
     private static MCH_EntityBaseVehicle getLive(MCH_EntityBaseVehicle ac, World world) {
-        if (isValidUav(ac) && (world == null || ac.worldObj == world)) {
+        if (isValidUav(ac) && (world == null || (ac.worldObj == world && world.loadedEntityList.contains(ac)))) {
             return ac;
         }
         unregister(ac);


### PR DESCRIPTION
### Motivation
- The station `Continue` action could not immediately reconnect to a linked NewUAV when that UAV lived in an unloaded chunk because runtime references and the registry could point at entities that are not present in the world's loaded entity list.
- Routine relink polling should not force-load remote chunks, but an explicit Continue request should attempt to load the saved chunk and resolve the UAV so the player does not need to relog.

### Description
- Updated `MCH_EntityUavStation.findLinkedUavEntity` to optionally load the UAV's saved chunk before resolving the entity and added `isLoadedInWorld(World, MCH_EntityBaseVehicle)` to check that a referenced UAV instance is actually present in `world.loadedEntityList`.
- Made the `Continue` reconnect path call relinking with chunk loading enabled so an explicit Continue will attempt to load and resolve the linked UAV immediately.
- Tightened `MCH_UavRegistry.getLive` to treat UAV entities that are not currently in `world.loadedEntityList` as not "live", which prevents stale cached entries from blocking reconnection logic.
- Changes applied in `src/main/java/mcheli/uav/MCH_EntityUavStation.java` and `src/main/java/mcheli/uav/MCH_UavRegistry.java` and adjusted relink behavior to only load chunks for explicit reconnect attempts.

### Testing
- Ran `git diff --check` which reported no issues (success).
- Attempted `./gradlew compileJava` which failed due to an external Gradle distribution download being blocked by the environment proxy (HTTP 403), so a full compile could not be completed in this environment (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6bea16e883239056a1e9bb384e83)