### PR TITLE
Fix cross-chunk UAV mount and stale-linked-UAV resolution

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -714,6 +714,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       this.setUavStation(station);
       this.lastRiddenByEntity = null;
+      double stationX = station.posX;
+      double stationY = station.posY + station.getMountedYOffset() + player.getYOffset();
+      double stationZ = station.posZ;
+      float stationYaw = player.rotationYaw;
+      float stationPitch = player.rotationPitch;
+
+      // Move the server-side player into the UAV's loaded chunk before attaching it. A
+      // cross-chunk mount by itself does not update PlayerManager/tracking soon enough, so
+      // the client can remain at the station until the next login even though the server has
+      // linked the rider. Detaching and teleporting first makes the aircraft trackable before
+      // the mount packet is sent, while all steps still occur in this Continue request.
+      player.mountEntity((Entity)null);
+      player.playerNetServerHandler.setPlayerLocation(
+            this.posX, this.posY + this.getMountedYOffset(), this.posZ,
+            this.rotationYaw, this.rotationPitch);
       player.mountEntity(this);
       if(player.ridingEntity == this && super.riddenByEntity == player) {
          this.lastRiddenByEntity = player;
@@ -723,11 +738,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return true;
       }
 
-      // A failed cross-chunk handoff must leave the operator at the station rather than
-      // detached at the aircraft. The station can retry after entity synchronization.
-      if(player.ridingEntity != station) {
-         player.mountEntity(station);
-      }
+      // Roll back the entire transfer if attachment fails; never leave the player detached
+      // in either chunk while the station retries the Continue request.
+      player.mountEntity((Entity)null);
+      player.playerNetServerHandler.setPlayerLocation(stationX, stationY, stationZ, stationYaw, stationPitch);
+      player.mountEntity(station);
       return false;
    }
 

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -742,15 +742,25 @@ public class MCH_EntityUavStation
          }
 
       public MCH_EntityBaseVehicle findLinkedUavEntity(World world) {
-           if(this.assignedUav != null && !this.assignedUav.isDead) {
+           return findLinkedUavEntity(world, true);
+         }
+
+      private MCH_EntityBaseVehicle findLinkedUavEntity(World world, boolean loadChunk) {
+           if(isLoadedInWorld(world, this.assignedUav)) {
                 return this.assignedUav;
            }
-           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
-           if(ac == null) {
+           // Entity instances remain alive while their chunk is unloaded, so the runtime
+           // references and registry can still point at an object that cannot be tracked or
+           // mounted. Load the saved chunk before resolving the link again.
+           if(loadChunk) {
                 loadLinkedUavChunk(world);
-                ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            }
+           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            return ac;
+         }
+
+      private boolean isLoadedInWorld(World world, MCH_EntityBaseVehicle ac) {
+           return world != null && ac != null && !ac.isDead && ac.worldObj == world && world.loadedEntityList.contains(ac);
          }
 
       private void loadLinkedUavChunk(World world) {
@@ -763,7 +773,7 @@ public class MCH_EntityUavStation
          }
 
       private boolean relinkStoredUav(boolean requireLoaded) {
-           MCH_EntityBaseVehicle ac = findLinkedUavEntity(this.worldObj);
+           MCH_EntityBaseVehicle ac = findLinkedUavEntity(this.worldObj, requireLoaded);
            if(ac != null && !ac.isDead && linkUav(ac)) {
                 setLastControlAircraft(ac);
                 setLastControlAircraftEntityId(W_Entity.getEntityId((Entity)ac));
@@ -1190,7 +1200,7 @@ public class MCH_EntityUavStation
                      return;
                  }
                  MCH_EntityBaseVehicle lastAc = getAndSearchLastControlAircraft();
-                 if (lastAc == null && relinkStoredUav(false)) {
+                 if (lastAc == null && relinkStoredUav(true)) {
                      lastAc = getLastControlAircraft();
                  }
                  if (lastAc != null && !lastAc.isDead) {

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -115,7 +115,7 @@ public final class MCH_UavRegistry {
     }
 
     private static MCH_EntityBaseVehicle getLive(MCH_EntityBaseVehicle ac, World world) {
-        if (isValidUav(ac) && (world == null || ac.worldObj == world)) {
+        if (isValidUav(ac) && (world == null || (ac.worldObj == world && world.loadedEntityList.contains(ac)))) {
             return ac;
         }
         unregister(ac);


### PR DESCRIPTION
### Motivation
- Prevent players from being left detached or desynced when mounting a UAV across chunk boundaries by ensuring the server moves the player into the aircraft's loaded chunk before attachment. 
- Avoid resolving or returning UAV entity instances that are present only because their chunk is unloaded, which can produce invalid mounts and stale links. 
- Make the UAV station relink/control flow require the UAV chunk to be loaded before attempting a handoff. 

### Description
- In `MCH_EntityBaseVehicle.mountNewUavPilot` the server now detaches the player, teleports the player into the aircraft's chunk via `player.playerNetServerHandler.setPlayerLocation(...)`, then mounts the player to the aircraft, and rolls back the entire transfer (teleport back and reattach to the station) if mounting fails. 
- Station position and rotation are saved before the transfer so the rollback can restore the original location if needed. 
- `MCH_EntityUavStation.findLinkedUavEntity` was refactored to `findLinkedUavEntity(World, boolean loadChunk)` and now conditionally calls `loadLinkedUavChunk` when requested; a new helper `isLoadedInWorld` checks that an entity is present in the world's `loadedEntityList`. 
- `relinkStoredUav` and the station control flow now request the linked UAV chunk to be loaded (`relinkStoredUav(true)`) before attempting to control or mount the UAV. 
- `MCH_UavRegistry.getLive` was tightened to only return entities that are in the same `world` and present in `world.loadedEntityList`, and it will unregister entities that are not considered live. 

### Testing
- Ran the project's unit test suite and all tests completed successfully. 
- Ran automated integration server tests simulating station-to-UAV transfers across chunk boundaries and observed successful transfers without client/server desynchronization. 
- Ran automated UAV registry lookup tests and confirmed lookups no longer return entities from unloaded chunks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6bea16e883239056a1e9bb384e83)