### PR TITLE
Detach station rider before New UAV continue/mount handoff

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -714,6 +714,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       this.setUavStation(station);
       this.lastRiddenByEntity = null;
+      if(!station.detachRiderForNewUavControl(player)) {
+         return false;
+      }
       player.mountEntity(this);
       if(player.ridingEntity == this && super.riddenByEntity == player) {
          this.lastRiddenByEntity = player;
@@ -725,7 +728,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       // A failed cross-chunk handoff must leave the operator at the station rather than
       // detached at the aircraft. The station can retry after entity synchronization.
-      if(player.ridingEntity != station) {
+      if(player.ridingEntity == null) {
          player.mountEntity(station);
       }
       return false;

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -996,6 +996,27 @@ public class MCH_EntityUavStation
            return true;
          }
 
+      public boolean detachRiderForNewUavControl(EntityPlayerMP player) {
+           if(this.worldObj.isRemote || player == null || this.riddenByEntity != player
+                 || player.ridingEntity != this) {
+                return false;
+           }
+
+           W_EntityPlayer.closeScreen(player);
+           player.mountEntity((Entity)null);
+           if(player.ridingEntity != null) {
+                return false;
+           }
+
+           // Do not leave the station's remote-control rider cache alive while the same
+           // player is attached directly to a New UAV. A stale station rider makes client
+           // camera/chunk tracking continue from the station until the player reconnects.
+           this.riddenByEntity = null;
+           this.lastRiddenByEntity = null;
+           player.fallDistance = 0.0F;
+           return true;
+         }
+
       private void updateNewUavPilotProfile() {
            Entity pilot = this.controlAircraft != null && this.controlAircraft.isNewUAV()
                  ? this.controlAircraft.getRiddenByEntity() : null;


### PR DESCRIPTION
### Motivation

- Provide a clean transition from a UAV station to a New UAV so the player is not left with stale station-mounted/camera state that can cause falling/chunk-unload and require relog.

### Description

- Add `detachRiderForNewUavControl(EntityPlayerMP)` to `MCH_EntityUavStation` to close the station GUI, unmount the player, clear `riddenByEntity`/`lastRiddenByEntity`, and reset `fallDistance` before a direct New UAV mount.
- Call `station.detachRiderForNewUavControl(player)` from `MCH_EntityBaseVehicle.mountNewUavPilot` before mounting the player on the New UAV so the handoff is performed in one clean transition.
- Preserve cross-chunk retry behavior by remounting the station when the direct mount fails (`if (player.ridingEntity == null) player.mountEntity(station)`) and keep existing synchronization/retry logic for New UAV initialization.

### Testing

- Ran `git diff --check` and inspected diffs for the modified files; no whitespace errors were reported.
- Attempted `bash ./gradlew compileJava` but the Gradle wrapper download failed because the environment proxy returned HTTP 403, so a full compilation could not be completed in this environment.
- Verified file changes and repository status via `git status` and line-level inspection of `src/main/java/mcheli/uav/MCH_EntityUavStation.java` and `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea5e1ed7c8323a1ea343df11f22c3)