### PR TITLE
Fix newUAV Continue reconnect chunk loading

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -747,9 +747,11 @@ public class MCH_EntityUavStation
          }
 
       public MCH_EntityBaseVehicle findLinkedUavEntity(World world) {
-           if(this.assignedUav != null && !this.assignedUav.isDead) {
+           if(this.assignedUav != null && !this.assignedUav.isDead
+                 && MCH_UavRegistry.isPresentInLoadedEntityList(world, this.assignedUav)) {
                 return this.assignedUav;
            }
+           this.assignedUav = null;
            MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            if(ac == null) {
                 loadLinkedUavChunk(world);
@@ -765,7 +767,11 @@ public class MCH_EntityUavStation
                 return false;
            }
 
-           releaseReconnectChunks("replace");
+           if(this.reconnectChunkTicket != null && this.reconnectUavChunk != null) {
+                this.worldObj.getChunkFromChunkCoords(this.reconnectUavChunk.chunkXPos, this.reconnectUavChunk.chunkZPos);
+                logReconnect("chunks-already-pinned", player, null);
+                return true;
+           }
            this.reconnectChunkTicket = ForgeChunkManager.requestTicket(MCH_MOD.instance, this.worldObj, ForgeChunkManager.Type.NORMAL);
            if(this.reconnectChunkTicket == null) {
                 logReconnect("ticket-unavailable", player, null);
@@ -807,7 +813,7 @@ public class MCH_EntityUavStation
       private void logReconnect(String step, EntityPlayerMP player, MCH_EntityBaseVehicle resolved) {
            Entity riding = player == null ? null : player.ridingEntity;
            MCH_Lib.Log((Entity)this,
-                 "[UAV-RECONNECT] step=%s station=(%.2f,%.2f,%.2f) uavUuid=%s uavDim=%d uavChunk=(%d,%d) stationLoaded=%s uavLoaded=%s riding=%s resolved=%s playerPos=%s finalMount=%s stationControl=%s",
+                 "[UAV-RECONNECT] step=%s station=(%.2f,%.2f,%.2f) uavUuid=%s uavDim=%d uavChunk=(%d,%d) stationLoaded=%s uavLoaded=%s loadedEntityList=%s riding=%s resolved=%s playerPos=%s finalMount=%s stationControl=%s",
                  new Object[] {
                        step, Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ),
                        this.linkedUavEntityUUID == null ? this.assignedUavUUID : this.linkedUavEntityUUID.toString(),
@@ -816,6 +822,7 @@ public class MCH_EntityUavStation
                        Integer.valueOf(MathHelper.floor_double(this.linkedUavZ) >> 4),
                        Boolean.valueOf(isChunkLoaded(this.reconnectStationChunk)),
                        Boolean.valueOf(isChunkLoaded(this.reconnectUavChunk)),
+                       Boolean.valueOf(MCH_UavRegistry.isPresentInLoadedEntityList(this.worldObj, resolved)),
                        riding == null ? "null" : riding.getClass().getSimpleName() + "#" + riding.getEntityId(),
                        resolved == null ? "null" : resolved.getClass().getSimpleName() + "#" + resolved.getEntityId() + "/dead=" + resolved.isDead,
                        player == null ? "null" : String.format("(%.2f,%.2f,%.2f)", player.posX, player.posY, player.posZ),
@@ -1076,14 +1083,21 @@ public class MCH_EntityUavStation
                 return false;
            }
            boolean attached = false;
+           boolean releaseTicket = false;
            try {
                 // Resolve only after both temporary tickets are active and both chunks have
                 // been synchronously requested from the server chunk provider.
-                MCH_EntityBaseVehicle resolved = MCH_UavRegistry.findLinkedUav(this.worldObj,
-                      this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+                MCH_EntityBaseVehicle resolved = MCH_UavRegistry.findLoadedByUuid(this.worldObj,
+                      this.linkedUavEntityUUID);
                 logReconnect("resolved", player, resolved);
                 if(resolved == null || resolved.isDead || resolved.isDestroyed()
-                      || !isValidLinkedUav(resolved, player) || !linkUav(resolved)) {
+                      || resolved.ticksExisted < 10
+                      || !MCH_UavRegistry.isPresentInLoadedEntityList(this.worldObj, resolved)) {
+                     logReconnect("resolve-pending", player, resolved);
+                     return false;
+                }
+                if(!isValidLinkedUav(resolved, player) || !linkUav(resolved)) {
+                     releaseTicket = true;
                      restorePlayerAtStation(player, ac, "invalid-uav");
                      return false;
                 }
@@ -1113,9 +1127,12 @@ public class MCH_EntityUavStation
                 setNewUavPilotProfile(player);
                 W_EntityPlayer.closeScreen(player);
                 logReconnect("complete", player, resolved);
+                releaseTicket = true;
                 return true;
            } finally {
-                releaseReconnectChunks(attached ? "transfer-complete" : "transfer-failed");
+                if(releaseTicket || attached) {
+                     releaseReconnectChunks(attached ? "transfer-complete" : "transfer-rejected");
+                }
            }
       }
 
@@ -1271,6 +1288,7 @@ public class MCH_EntityUavStation
                                       }
                                 }
                             if (this.riddenByEntity.isDead) {
+                                  releaseReconnectChunks("rider-dead");
                                   unmountEntity(true);
                                   this.riddenByEntity = null;
                                 } else {
@@ -1282,6 +1300,10 @@ public class MCH_EntityUavStation
                                             }
                                       }
                                 }
+                          }
+                      else if(this.reconnectChunkTicket != null) {
+                            this.pendingContinueTicks = 0;
+                            releaseReconnectChunks("rider-left-station");
                           }
 
                       if (getLastControlAircraft() == null && this.ticksExisted % 40 == 0) {
@@ -1334,6 +1356,17 @@ public class MCH_EntityUavStation
                      return;
                  }
                  MCH_EntityBaseVehicle lastAc = getAndSearchLastControlAircraft();
+                 if(lastAc == null && user instanceof EntityPlayerMP && this.linkedUavEntityUUID != null) {
+                     EntityPlayerMP player = (EntityPlayerMP)user;
+                     logReconnect("continue-resolve-begin", player, null);
+                     if(pinReconnectChunks(player)) {
+                         lastAc = MCH_UavRegistry.findLoadedByUuid(this.worldObj, this.linkedUavEntityUUID);
+                         logReconnect("continue-resolve-result", player, lastAc);
+                         if(lastAc != null && linkUav(lastAc)) {
+                             setLastControlAircraft(lastAc);
+                         }
+                     }
+                 }
                  if (lastAc == null && relinkStoredUav(false)) {
                      lastAc = getLastControlAircraft();
                  }

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -76,6 +76,29 @@ public final class MCH_UavRegistry {
         return findLinkedUav(world, null, null, owner);
     }
 
+    public static MCH_EntityBaseVehicle findLoadedByUuid(World world, UUID uuid) {
+        if (world == null || uuid == null) {
+            return null;
+        }
+        List list = world.loadedEntityList;
+        for (int i = 0; i < list.size(); ++i) {
+            Object obj = list.get(i);
+            if (obj instanceof MCH_EntityBaseVehicle) {
+                MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)obj;
+                UUID persistentId = ac.getUavPersistentUUID(false);
+                if (isValidUav(ac) && (uuid.equals(ac.getUniqueID()) || uuid.equals(persistentId))) {
+                    register(ac);
+                    return ac;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean isPresentInLoadedEntityList(World world, Entity entity) {
+        return world != null && entity != null && world.loadedEntityList.contains(entity);
+    }
+
     public static void rebuildUavRegistry(World world) {
         if (world == null) return;
         searchLoaded(world, null, null, null);
@@ -115,7 +138,8 @@ public final class MCH_UavRegistry {
     }
 
     private static MCH_EntityBaseVehicle getLive(MCH_EntityBaseVehicle ac, World world) {
-        if (isValidUav(ac) && (world == null || ac.worldObj == world)) {
+        if (isValidUav(ac) && (world == null || ac.worldObj == world)
+                && (world == null || isPresentInLoadedEntityList(world, ac))) {
             return ac;
         }
         unregister(ac);


### PR DESCRIPTION
### Motivation

- Ensure the "Continue" reconnect flow for NewUAVs force-loads the UAV chunk, resolves the actual UAV entity by UUID from loaded entities, and does not teleport or mount the player until the UAV is present and initialized.
- Avoid creating a half-mounted state caused by stale cached UAV references that are not present in the server world's `loadedEntityList`, and improve diagnostics to make reconnect behavior observable.

### Description

- Add `findLoadedByUuid(World, UUID)` and `isPresentInLoadedEntityList(World, Entity)` to `MCH_UavRegistry` and make `getLive(...)` reject UAVs not present in `world.loadedEntityList` to prevent stale cached references from being used.
- Force-load and retain the UAV chunk ticket during Continue retries in `MCH_EntityUavStation.pinReconnectChunks(...)`, reusing an already-pinned ticket and synchronously requesting the UAV chunk via `getChunkFromChunkCoords(...)`.
- Change resolution in `startNewUavControl(...)` and the Continue retry path to resolve the UAV by exact UUID from loaded entities only, require the UAV to be alive and initialized (`ticksExisted` check) and present in `loadedEntityList` before performing `mountNewUavPilot(...)`, and keep the player safely at the station while resolution is pending.
- Add defensive cleanup and ticket release logic on success, rejection, rider death, or player leaving the station, plus additional `[UAV-RECONNECT]` debug fields (UUID, dimension, chunk coords, chunk loaded state, `loadedEntityList` presence, resolved entity, riding/player state, and final mount/control state).

### Testing

- Ran `git diff --check` and repository diff/stat checks which passed without whitespace errors.
- Attempted to compile with the Gradle wrapper (`./gradlew compileJava` via `bash gradlew compileJava`), but the build could not complete because the environment blocked Gradle distribution download (proxy returned HTTP 403), so a full compile test could not be executed in this environment.
- Verified repository diffs and applied changes via local commit; runtime verification advised in a server environment where Gradle can run and a live Minecraft server can exercise the Continue reconnect scenario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb3e5caf883238e01fea9a976d18b)