### PR TITLE
Improve UAV reconnect handling and registry lookups to prefer loaded entities and robust chunk pinning

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -747,9 +747,11 @@ public class MCH_EntityUavStation
          }
 
       public MCH_EntityBaseVehicle findLinkedUavEntity(World world) {
-           if(this.assignedUav != null && !this.assignedUav.isDead) {
+           if(this.assignedUav != null && !this.assignedUav.isDead
+                 && MCH_UavRegistry.isPresentInLoadedEntityList(world, this.assignedUav)) {
                 return this.assignedUav;
            }
+           this.assignedUav = null;
            MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
            if(ac == null) {
                 loadLinkedUavChunk(world);
@@ -765,7 +767,11 @@ public class MCH_EntityUavStation
                 return false;
            }
 
-           releaseReconnectChunks("replace");
+           if(this.reconnectChunkTicket != null && this.reconnectUavChunk != null) {
+                this.worldObj.getChunkFromChunkCoords(this.reconnectUavChunk.chunkXPos, this.reconnectUavChunk.chunkZPos);
+                logReconnect("chunks-already-pinned", player, null);
+                return true;
+           }
            this.reconnectChunkTicket = ForgeChunkManager.requestTicket(MCH_MOD.instance, this.worldObj, ForgeChunkManager.Type.NORMAL);
            if(this.reconnectChunkTicket == null) {
                 logReconnect("ticket-unavailable", player, null);
@@ -807,7 +813,7 @@ public class MCH_EntityUavStation
       private void logReconnect(String step, EntityPlayerMP player, MCH_EntityBaseVehicle resolved) {
            Entity riding = player == null ? null : player.ridingEntity;
            MCH_Lib.Log((Entity)this,
-                 "[UAV-RECONNECT] step=%s station=(%.2f,%.2f,%.2f) uavUuid=%s uavDim=%d uavChunk=(%d,%d) stationLoaded=%s uavLoaded=%s riding=%s resolved=%s playerPos=%s finalMount=%s stationControl=%s",
+                 "[UAV-RECONNECT] step=%s station=(%.2f,%.2f,%.2f) uavUuid=%s uavDim=%d uavChunk=(%d,%d) stationLoaded=%s uavLoaded=%s loadedEntityList=%s riding=%s resolved=%s playerPos=%s finalMount=%s stationControl=%s",
                  new Object[] {
                        step, Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ),
                        this.linkedUavEntityUUID == null ? this.assignedUavUUID : this.linkedUavEntityUUID.toString(),
@@ -816,6 +822,7 @@ public class MCH_EntityUavStation
                        Integer.valueOf(MathHelper.floor_double(this.linkedUavZ) >> 4),
                        Boolean.valueOf(isChunkLoaded(this.reconnectStationChunk)),
                        Boolean.valueOf(isChunkLoaded(this.reconnectUavChunk)),
+                       Boolean.valueOf(MCH_UavRegistry.isPresentInLoadedEntityList(this.worldObj, resolved)),
                        riding == null ? "null" : riding.getClass().getSimpleName() + "#" + riding.getEntityId(),
                        resolved == null ? "null" : resolved.getClass().getSimpleName() + "#" + resolved.getEntityId() + "/dead=" + resolved.isDead,
                        player == null ? "null" : String.format("(%.2f,%.2f,%.2f)", player.posX, player.posY, player.posZ),
@@ -1076,14 +1083,21 @@ public class MCH_EntityUavStation
                 return false;
            }
            boolean attached = false;
+           boolean releaseTicket = false;
            try {
                 // Resolve only after both temporary tickets are active and both chunks have
                 // been synchronously requested from the server chunk provider.
-                MCH_EntityBaseVehicle resolved = MCH_UavRegistry.findLinkedUav(this.worldObj,
-                      this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+                MCH_EntityBaseVehicle resolved = MCH_UavRegistry.findLoadedByUuid(this.worldObj,
+                      this.linkedUavEntityUUID);
                 logReconnect("resolved", player, resolved);
                 if(resolved == null || resolved.isDead || resolved.isDestroyed()
-                      || !isValidLinkedUav(resolved, player) || !linkUav(resolved)) {
+                      || resolved.ticksExisted < 10
+                      || !MCH_UavRegistry.isPresentInLoadedEntityList(this.worldObj, resolved)) {
+                     logReconnect("resolve-pending", player, resolved);
+                     return false;
+                }
+                if(!isValidLinkedUav(resolved, player) || !linkUav(resolved)) {
+                     releaseTicket = true;
                      restorePlayerAtStation(player, ac, "invalid-uav");
                      return false;
                 }
@@ -1113,9 +1127,12 @@ public class MCH_EntityUavStation
                 setNewUavPilotProfile(player);
                 W_EntityPlayer.closeScreen(player);
                 logReconnect("complete", player, resolved);
+                releaseTicket = true;
                 return true;
            } finally {
-                releaseReconnectChunks(attached ? "transfer-complete" : "transfer-failed");
+                if(releaseTicket || attached) {
+                     releaseReconnectChunks(attached ? "transfer-complete" : "transfer-rejected");
+                }
            }
       }
 
@@ -1264,24 +1281,36 @@ public class MCH_EntityUavStation
                       this.motionZ = 0.0D;
                       setRotation(this.rotationYaw, this.rotationPitch);
                       if (this.riddenByEntity != null) {
+                            Entity stationRider = this.riddenByEntity;
                             if (this.pendingContinueTicks > 0) {
                                   --this.pendingContinueTicks;
                                   if(this.pendingContinueTicks % 10 == 0) {
-                                        controlLastAircraft(this.riddenByEntity, false);
+                                        controlLastAircraft(stationRider, false);
                                       }
                                 }
-                            if (this.riddenByEntity.isDead) {
+                            // Continue can transfer stationRider to the UAV and clear
+                            // riddenByEntity inside controlLastAircraft. Do not process the
+                            // transferred player as though they were still on the station.
+                            if(this.riddenByEntity != stationRider) {
+                                  return;
+                                }
+                            if (stationRider.isDead) {
+                                  releaseReconnectChunks("rider-dead");
                                   unmountEntity(true);
                                   this.riddenByEntity = null;
                                 } else {
                                   ItemStack item = getStackInSlot(0);
                                   if (item != null && item.stackSize > 0 && !hasContinuableUavLink()) {
-                                        handleItem(this.riddenByEntity, item);
+                                        handleItem(stationRider, item);
                                         if (item.stackSize == 0) {
                                               setInventorySlotContents(0, (ItemStack)null);
                                             }
                                       }
                                 }
+                          }
+                      else if(this.reconnectChunkTicket != null) {
+                            this.pendingContinueTicks = 0;
+                            releaseReconnectChunks("rider-left-station");
                           }
 
                       if (getLastControlAircraft() == null && this.ticksExisted % 40 == 0) {
@@ -1334,6 +1363,17 @@ public class MCH_EntityUavStation
                      return;
                  }
                  MCH_EntityBaseVehicle lastAc = getAndSearchLastControlAircraft();
+                 if(lastAc == null && user instanceof EntityPlayerMP && this.linkedUavEntityUUID != null) {
+                     EntityPlayerMP player = (EntityPlayerMP)user;
+                     logReconnect("continue-resolve-begin", player, null);
+                     if(pinReconnectChunks(player)) {
+                         lastAc = MCH_UavRegistry.findLoadedByUuid(this.worldObj, this.linkedUavEntityUUID);
+                         logReconnect("continue-resolve-result", player, lastAc);
+                         if(lastAc != null && linkUav(lastAc)) {
+                             setLastControlAircraft(lastAc);
+                         }
+                     }
+                 }
                  if (lastAc == null && relinkStoredUav(false)) {
                      lastAc = getLastControlAircraft();
                  }

--- a/src/main/java/mcheli/uav/MCH_UavRegistry.java
+++ b/src/main/java/mcheli/uav/MCH_UavRegistry.java
@@ -76,6 +76,29 @@ public final class MCH_UavRegistry {
         return findLinkedUav(world, null, null, owner);
     }
 
+    public static MCH_EntityBaseVehicle findLoadedByUuid(World world, UUID uuid) {
+        if (world == null || uuid == null) {
+            return null;
+        }
+        List list = world.loadedEntityList;
+        for (int i = 0; i < list.size(); ++i) {
+            Object obj = list.get(i);
+            if (obj instanceof MCH_EntityBaseVehicle) {
+                MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)obj;
+                UUID persistentId = ac.getUavPersistentUUID(false);
+                if (isValidUav(ac) && (uuid.equals(ac.getUniqueID()) || uuid.equals(persistentId))) {
+                    register(ac);
+                    return ac;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean isPresentInLoadedEntityList(World world, Entity entity) {
+        return world != null && entity != null && world.loadedEntityList.contains(entity);
+    }
+
     public static void rebuildUavRegistry(World world) {
         if (world == null) return;
         searchLoaded(world, null, null, null);
@@ -115,7 +138,8 @@ public final class MCH_UavRegistry {
     }
 
     private static MCH_EntityBaseVehicle getLive(MCH_EntityBaseVehicle ac, World world) {
-        if (isValidUav(ac) && (world == null || ac.worldObj == world)) {
+        if (isValidUav(ac) && (world == null || ac.worldObj == world)
+                && (world == null || isPresentInLoadedEntityList(world, ac))) {
             return ac;
         }
         unregister(ac);


### PR DESCRIPTION
### Motivation
- Ensure station-UAV reconnect/transfer logic only operates on entities actually present in the world's loaded entity list to avoid race conditions during chunk loads and entity resolution. 
- Avoid leaking or releasing Forge chunk tickets incorrectly and prevent double-processing the same player when transferring control to a UAV. 
- Provide stronger diagnostics in reconnect logs to help troubleshoot unresolved or pending UAV transfers.

### Description
- Added `findLoadedByUuid(World, UUID)` and `isPresentInLoadedEntityList(World, Entity)` in `MCH_UavRegistry` to find and validate UAVs only if they are present in `world.loadedEntityList`. 
- Tightened `getLive` to require the entity be present in the world's loaded entity list before returning a cached registry entry. 
- Updated `MCH_EntityUavStation.findLinkedUavEntity` to verify the assigned UAV is in the loaded list and clear `assignedUav` when it is not. 
- Changed chunk pinning in `pinReconnectChunks` to detect already-pinned chunks and avoid re-requesting/releasing tickets unnecessarily. 
- Improved reconnect logging (`logReconnect`) to include whether the resolved UAV is present in the loaded entity list. 
- Reworked `startNewUavControl` to resolve only loaded UAVs using `findLoadedByUuid`, require recently spawned entities (`ticksExisted >= 10`) and only release reconnect tickets when appropriate. 
- Prevented double-processing of the station rider during pending transfers by capturing `stationRider` and early-returning if the rider changed during transfer, and added logic to release reconnect tickets when the rider leaves or dies. 
- Enhanced `controlLastAircraft` to attempt to resolve and relink a UAV from the loaded list when continuing control. 

### Testing
- Built the mod using the project Gradle wrapper with `./gradlew build` and the build completed successfully. 
- Performed basic runtime smoke checks on a development server to exercise reconnect/control paths and observed expected behavior for resolving only loaded UAV entities and stable chunk ticket handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb3e5caf883238e01fea9a976d18b)