### PR TITLE
Fix NewUAV return: safe station teleport & stale-state cleanup

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -260,6 +260,7 @@ public class MCH_EventHook extends W_EventHook {
    @SubscribeEvent
    public void onPlayerTick(TickEvent.PlayerTickEvent event) {
       if(event.phase == TickEvent.Phase.END && event.player instanceof EntityPlayerMP && !event.player.worldObj.isRemote) {
+         MCH_EntityBaseVehicle.updateNewUavSafeReturn((EntityPlayerMP)event.player);
          if(MCH_UavInventory.hasStoredPilotInventory(event.player) && !(event.player.ridingEntity instanceof MCH_EntityBaseVehicle)) {
             MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.player, "not_piloting");
          }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -77,6 +77,8 @@ import org.lwjgl.Sys;
 /** Shared controllable vehicle entity base used by aircraft, ground vehicles, ships, and turrets. */
 
 public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements MCH_IEntityLockChecker, MCH_IEntityCanRideBaseVehicle, IEntityAdditionalSpawnData {
+   private static final Map<UUID, NewUavSafeReturn> NEW_UAV_SAFE_RETURNS = new HashMap<UUID, NewUavSafeReturn>();
+   private static final int NEW_UAV_SAFE_RETURN_MIN_TICKS = 20;
    private static MCH_EntityBaseVehicle aircraft;
     private ForgeChunkManager.Ticket chunkTicket;
    //MCH_EntityBaseVehicle ac = null;
@@ -5638,17 +5640,79 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(pilot.ridingEntity != null) {
          pilot.mountEntity((Entity)null);
       }
+      this.moveLeft = false;
+      this.moveRight = false;
+      this.throttleDown = false;
+      this.throttleUp = false;
+      this.switchGunnerMode(false);
+      this.setCommonStatus(CMN_ID_FREE_LOOK, false);
+      this.setCameraId(0);
+      this.camera.initCamera(0, pilot);
+      super.riddenByEntity = null;
+      this.lastRiddenByEntity = null;
+      this.lastRidingEntity = null;
       pilot.motionX = 0.0D;
       pilot.motionY = 0.0D;
       pilot.motionZ = 0.0D;
       pilot.fallDistance = 0.0F;
+      double safeY = this.linkedUavStationY + 2.0D;
       if(pilot instanceof EntityPlayerMP) {
-         ((EntityPlayerMP)pilot).setPositionAndUpdate(this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
-         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)pilot, inventoryReason);
+         EntityPlayerMP player = (EntityPlayerMP)pilot;
+         player.setPositionAndUpdate(this.linkedUavStationX, safeY, this.linkedUavStationZ);
+         NEW_UAV_SAFE_RETURNS.put(player.getUniqueID(), new NewUavSafeReturn(
+               this.linkedUavStationDimension, this.linkedUavStationX, safeY, this.linkedUavStationZ));
+         MCH_EntityUavStation station = resolveLinkedUavStation();
+         if(station != null) {
+            station.clearNewUavReturnState(player);
+         }
+         MCH_UavInventory.restorePilotInventory(player, inventoryReason);
       } else {
-         pilot.setPosition(this.linkedUavStationX, this.linkedUavStationY, this.linkedUavStationZ);
+         pilot.setPosition(this.linkedUavStationX, safeY, this.linkedUavStationZ);
       }
       return true;
+   }
+
+   public static void updateNewUavSafeReturn(EntityPlayerMP player) {
+      if(player == null) {
+         return;
+      }
+      NewUavSafeReturn pending = NEW_UAV_SAFE_RETURNS.get(player.getUniqueID());
+      if(pending == null) {
+         return;
+      }
+      if(player.dimension != pending.dimension || player.isDead) {
+         NEW_UAV_SAFE_RETURNS.remove(player.getUniqueID());
+         return;
+      }
+
+      int blockX = MathHelper.floor_double(pending.x);
+      int blockY = MathHelper.floor_double(pending.y);
+      int blockZ = MathHelper.floor_double(pending.z);
+      boolean stationChunkLoaded = player.worldObj.blockExists(blockX, blockY, blockZ);
+      if(pending.ticks++ < NEW_UAV_SAFE_RETURN_MIN_TICKS || !stationChunkLoaded) {
+         player.motionX = 0.0D;
+         player.motionY = 0.0D;
+         player.motionZ = 0.0D;
+         player.fallDistance = 0.0F;
+         player.setPositionAndUpdate(pending.x, pending.y, pending.z);
+      } else {
+         NEW_UAV_SAFE_RETURNS.remove(player.getUniqueID());
+      }
+   }
+
+   private static final class NewUavSafeReturn {
+      private final int dimension;
+      private final double x;
+      private final double y;
+      private final double z;
+      private int ticks;
+
+      private NewUavSafeReturn(int dimension, double x, double y, double z) {
+         this.dimension = dimension;
+         this.x = x;
+         this.y = y;
+         this.z = z;
+      }
    }
 
    /** Called by every concrete vehicle subclass when its pilot entity dies. */

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -1156,6 +1156,24 @@ public class MCH_EntityUavStation
            return true;
          }
 
+      public void clearNewUavReturnState(EntityPlayerMP player) {
+           if(this.worldObj.isRemote) {
+                return;
+           }
+           if(this.riddenByEntity == player) {
+                this.riddenByEntity = null;
+           }
+           if(this.lastRiddenByEntity == player) {
+                this.lastRiddenByEntity = null;
+           }
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityBaseVehicle)null);
+           setLastControlAircraftEntityId(0);
+           setNewUavPilotProfile((EntityPlayer)null);
+           this.pendingContinueTicks = 0;
+           releaseReconnectChunks("new-uav-return");
+      }
+
       private void updateNewUavPilotProfile() {
            Entity pilot = this.controlAircraft != null && this.controlAircraft.isNewUAV()
                  ? this.controlAircraft.getRiddenByEntity() : null;


### PR DESCRIPTION
### Motivation
- Prevent players from sinking or clipping into blocks when returned from a NewUAV to its station after dismount or destruction by ensuring they are placed above the station and not left with stale UAV camera/control state.
- Ensure the player Y position is not overwritten or left inside unloaded/changing chunks while the station/UAV state and client chunk tracking finish synchronizing.
- Clear any lingering UAV camera, rider, or station control state so the transition back to the station does not retain the UAV view or broken controls.

### Description
- Return path: `returnNewUavPilotToStation` now teleports pilots to a safe elevation at `linkedUavStationY + 2`, zeroes motion/fall distance, resets camera/free-look/gunner controls, and clears local rider references in the vehicle before restoring inventory. (changes to `MCH_EntityBaseVehicle`)
- Temporary preservation: added a server-side pending safe-return map `NEW_UAV_SAFE_RETURNS` and `updateNewUavSafeReturn` which pins the player to the safe position across ticks until the station chunk is available or a minimum number of ticks elapse. This is invoked from the player tick hook. (new helper and tick integration in `MCH_EventHook`)
- Station cleanup: added `clearNewUavReturnState` on the `MCH_EntityUavStation` to clear cached rider, control, pilot-profile and to release reconnect chunk tickets during a return. (changes to `MCH_EntityUavStation`)
- Integration: `MCH_EventHook.onPlayerTick` now calls `MCH_EntityBaseVehicle.updateNewUavSafeReturn` each server player tick to preserve/finish the safe placement while chunks load.

### Testing
- Ran `git diff --check` and a repository diff/stat to validate the patch format and whitespace, which reported no issues.
- Attempted to run a Java compile with the Gradle wrapper (`./gradlew compileJava` / `bash gradlew compileJava`), but the environment blocked the wrapper distribution download (proxy returned HTTP 403) and the wrapper script was not executable, so a local compile could not be completed in this environment.
- No automated unit tests exist for this flow in-tree; changes are limited to NewUAV return/dismount/destruction paths and the player-tick integration to minimize unrelated impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec305f3088323a5742dcdebc43d4c)