### PR TITLE
Prevent block interactions while controlling newUAVs

### DIFF
--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -11,6 +11,7 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.aircraft.MCH_ItemBaseVehicle;
+import mcheli.uav.MCH_EntityUavStation;
 import mcheli.uav.MCH_UavInventory;
 import mcheli.uav.MCH_UavRegistry;
 import mcheli.chain.MCH_ItemChain;
@@ -37,7 +38,9 @@ import net.minecraftforge.event.entity.EntityEvent.CanUpdate;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.entity.player.EntityInteractEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.event.world.WorldEvent;
 
 // Shared event hooks for base vehicles and seats.
@@ -264,6 +267,62 @@ public class MCH_EventHook extends W_EventHook {
          if(MCH_UavInventory.hasStoredPilotInventory(event.player) && !(event.player.ridingEntity instanceof MCH_EntityBaseVehicle)) {
             MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.player, "not_piloting");
          }
+      }
+   }
+
+   public static boolean isPlayerControllingNewUav(EntityPlayer player) {
+      if(player == null) {
+         return false;
+      }
+
+      Entity ridden = player.ridingEntity;
+      if(ridden instanceof MCH_EntityBaseVehicle) {
+         return ((MCH_EntityBaseVehicle)ridden).isNewUAV();
+      }
+      if(ridden instanceof MCH_EntitySeat) {
+         MCH_EntityBaseVehicle parent = ((MCH_EntitySeat)ridden).getParent();
+         return parent != null && parent.isNewUAV();
+      }
+      if(ridden instanceof MCH_EntityUavStation) {
+         MCH_EntityBaseVehicle controlled = ((MCH_EntityUavStation)ridden).getControlAircract();
+         return controlled != null && controlled.isNewUAV();
+      }
+
+      return false;
+   }
+
+   private static boolean shouldBlockNewUavBlockAction(EntityPlayer player) {
+      return player != null && player.worldObj != null && !player.worldObj.isRemote
+            && isPlayerControllingNewUav(player);
+   }
+
+   @SubscribeEvent
+   public void onPlayerInteractBlock(PlayerInteractEvent event) {
+      if((event.action == PlayerInteractEvent.Action.LEFT_CLICK_BLOCK
+            || event.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK)
+            && shouldBlockNewUavBlockAction(event.entityPlayer)) {
+         event.setCanceled(true);
+      }
+   }
+
+   @SubscribeEvent
+   public void onBlockBreak(BlockEvent.BreakEvent event) {
+      if(shouldBlockNewUavBlockAction(event.getPlayer())) {
+         event.setCanceled(true);
+      }
+   }
+
+   @SubscribeEvent
+   public void onBlockPlace(BlockEvent.PlaceEvent event) {
+      if(shouldBlockNewUavBlockAction(event.player)) {
+         event.setCanceled(true);
+      }
+   }
+
+   @SubscribeEvent
+   public void onBlockMultiPlace(BlockEvent.MultiPlaceEvent event) {
+      if(shouldBlockNewUavBlockAction(event.player)) {
+         event.setCanceled(true);
       }
    }
 


### PR DESCRIPTION
### Motivation
- Prevent players from modifying the world while they are actively piloting a newUAV so server-side state remains authoritative and clients cannot bypass restrictions by sending normal block interaction packets.
- The restriction must apply when a player is directly riding a newUAV, riding a seat whose parent is a newUAV, or sitting in a UAV station that is actively controlling a linked newUAV, while not affecting ordinary seating in a station that is not controlling a newUAV.

### Description
- Add a shared predicate `isPlayerControllingNewUav(EntityPlayer)` in `MCH_EventHook` that returns true when the player is directly riding a `MCH_EntityBaseVehicle` with `isNewUAV()`, riding a `MCH_EntitySeat` whose parent is a newUAV, or riding a `MCH_EntityUavStation` that is currently controlling a newUAV.
- Add a server-only guard `shouldBlockNewUavBlockAction(EntityPlayer)` and subscribe handlers to `PlayerInteractEvent` (left/right block actions), `BlockEvent.BreakEvent`, `BlockEvent.PlaceEvent`, and `BlockEvent.MultiPlaceEvent` to cancel those events when the guard is true.
- Added imports for `MCH_EntityUavStation`, `PlayerInteractEvent`, and `BlockEvent` and implemented the handlers in `src/main/java/mcheli/MCH_EventHook.java`.

### Testing
- Ran `git diff --check` and repository diffs to validate the change formatting and patch context, which reported no whitespace errors.
- Performed repository status and file-diff inspections to verify the modified file is present and the new logic is in `MCH_EventHook` (lines introducing the helper and event handlers).
- Attempted to run `./gradlew compileJava`/`bash gradlew compileJava` to compile the project, but the build could not complete because the environment prevented the Gradle wrapper from downloading the distribution (proxy returned HTTP 403) and the wrapper script was not executable, so a full compile step was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eca7dc2c08323a769f1bb40dad1be)