### PR TITLE
Cache vehicle collision/hit boxes with MCH_VehicleBoxCache and centralize bounding box updates

### DIFF
--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -170,6 +170,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm RangeFinderConsume;
    public static MCH_ConfigPrm EnablePutRackInFlying;
    public static MCH_ConfigPrm EnableDebugBoundingBox;
+   public static MCH_ConfigPrm DebugVehicleBoxCache;
    public static MCH_ConfigPrm DebugFlightControl;
 
    //TODOne mch1.0.5 -> mchr?
@@ -413,6 +414,8 @@ public class MCH_Config {
       RangeFinderConsume = new MCH_ConfigPrm("RangeFinderConsume", true);
       EnablePutRackInFlying = new MCH_ConfigPrm("EnablePutRackInFlying", true);
       EnableDebugBoundingBox = new MCH_ConfigPrm("EnableDebugBoundingBox", false);
+      DebugVehicleBoxCache = new MCH_ConfigPrm("DebugVehicleBoxCache", false);
+      DebugVehicleBoxCache.desc = ";Print vehicle collision/hit box cache hits, rebuilds, invalidation reasons, and generated box counts.";
       DebugFlightControl = new MCH_ConfigPrm("DebugFlightControl", false);
       DebugFlightControl.desc = ";Print FPS, elapsed tick fraction, control inputs, angular velocity, and pitch/yaw/roll once per second while piloting.";
       DespawnCount = new MCH_ConfigPrm("DespawnCount", 25);
@@ -503,6 +506,7 @@ public class MCH_Config {
               RangeFinderConsume,
               EnablePutRackInFlying,
               EnableDebugBoundingBox,
+              DebugVehicleBoxCache,
               DebugFlightControl,
               null,
               InvertMouse,

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -66,7 +66,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
       if(!this.isDeckTopContact(this, other, true)) {
          offset = super.calculateXOffset(other, offset);
       }
-      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+      for(MCH_BoundingBox bb : this.ac.getCalculatedExtraBoundingBoxes()) {
          if(!this.isDeckTopContact(bb.boundingBox, other, true)) {
             offset = bb.boundingBox.calculateXOffset(other, offset);
          }
@@ -89,7 +89,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
       }
 
       offset = super.calculateYOffset(other, offset);
-      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+      for(MCH_BoundingBox bb : this.ac.getCalculatedExtraBoundingBoxes()) {
          AxisAlignedBB deck = bb.boundingBox;
          AxisAlignedBB previousDeck = bb.backupBoundingBox;
          offset = deck.calculateYOffset(other, offset);
@@ -115,7 +115,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
       if(!this.isDeckTopContact(this, other, false)) {
          offset = super.calculateZOffset(other, offset);
       }
-      for(MCH_BoundingBox bb : this.ac.extraBoundingBox) {
+      for(MCH_BoundingBox bb : this.ac.getCalculatedExtraBoundingBoxes()) {
          if(!this.isDeckTopContact(bb.boundingBox, other, false)) {
             offset = bb.boundingBox.calculateZOffset(other, offset);
          }
@@ -133,7 +133,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          ret = true;
       }
 
-      MCH_BoundingBox[] arr$ = this.ac.extraBoundingBox;
+      MCH_BoundingBox[] arr$ = this.ac.getCalculatedExtraBoundingBoxes();
       int len$ = arr$.length;
 
       for(int i$ = 0; i$ < len$; ++i$) {
@@ -261,7 +261,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          dist = v1.distanceTo(mop.hitVec);
       }
 
-      MCH_BoundingBox[] arr$ = this.ac.extraBoundingBox;
+      MCH_BoundingBox[] arr$ = this.ac.getCalculatedExtraBoundingBoxes();
       int len$ = arr$.length;
 
       for(int i$ = 0; i$ < len$; ++i$) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -78,6 +78,7 @@ import org.lwjgl.Sys;
 
 public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements MCH_IEntityLockChecker, MCH_IEntityCanRideBaseVehicle, IEntityAdditionalSpawnData {
    private static final Map<UUID, NewUavSafeReturn> NEW_UAV_SAFE_RETURNS = new HashMap<UUID, NewUavSafeReturn>();
+   private final MCH_VehicleBoxCache vehicleBoxCache = new MCH_VehicleBoxCache();
    private static final int NEW_UAV_SAFE_RETURN_MIN_TICKS = 20;
    private static MCH_EntityBaseVehicle aircraft;
     private ForgeChunkManager.Ticket chunkTicket;
@@ -2558,7 +2559,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.unmountEntity();
       }
 
-      this.updateExtraBoundingBox();
+      this.getCalculatedExtraBoundingBoxes();
 
       //this.updateExtraWheelBoundingBox();
 
@@ -2847,14 +2848,24 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void updateExtraBoundingBox() {
-      MCH_BoundingBox[] arr$ = this.extraBoundingBox;
-      int len$ = arr$.length;
+      this.markVehicleBoxCacheDirty("legacy updateExtraBoundingBox request");
+      this.getCalculatedExtraBoundingBoxes();
+   }
 
-      for(int i$ = 0; i$ < len$; ++i$) {
-         MCH_BoundingBox bb = arr$[i$];
-         bb.updatePosition(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(), this.getRotRoll());
-      }
+   /**
+    * Returns the current calculated extra collision / hit boxes for this vehicle.
+    *
+    * This method intentionally still produces the same AxisAlignedBB-backed MCH_BoundingBox
+    * data as the legacy path.  It centralizes the transform calculation and caches stationary
+    * vehicles so future yaw/pitch/roll oriented box math can be added in one place without
+    * making every collision, damage, and debug-render caller rebuild box geometry independently.
+    */
+   public MCH_BoundingBox[] getCalculatedExtraBoundingBoxes() {
+      return this.vehicleBoxCache.getBoxes(this);
+   }
 
+   public void markVehicleBoxCacheDirty(String reason) {
+      this.vehicleBoxCache.markDirty(reason);
    }
 
    //public void updateExtraWheelBoundingBox() {
@@ -7684,6 +7695,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.rotPartRotation = new float[info.partRotPart.size()];
          this.prevRotPartRotation = new float[info.partRotPart.size()];
          this.extraBoundingBox = this.createExtraBoundingBox();
+         this.markVehicleBoxCacheDirty("vehicle config changed");
          //this.extrawheelboundingbox = this.createannoyingboundingbox();
          this.partEntities = this.createParts();
          super.stepHeight = info.stepHeight;

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -439,7 +439,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          GL11.glPopMatrix();
          GL11.glPushMatrix();
          GL11.glTranslated(x, y, z);
-         MCH_BoundingBox[] arr$ = e.extraBoundingBox;
+         MCH_BoundingBox[] arr$ = e.getCalculatedExtraBoundingBoxes();
          int len$ = arr$.length;
 
          for(int i$ = 0; i$ < len$; ++i$) {

--- a/src/main/java/mcheli/aircraft/MCH_VehicleBoxCache.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleBoxCache.java
@@ -1,0 +1,109 @@
+package mcheli.aircraft;
+
+import java.util.List;
+import mcheli.MCH_Config;
+import mcheli.MCH_Lib;
+
+/**
+ * Caches calculated vehicle collision / hit box positions.
+ *
+ * The current MCHeli collision path still consumes AxisAlignedBB-backed MCH_BoundingBox objects.
+ * This cache is deliberately behavior-preserving: it updates those same boxes only when the
+ * vehicle transform or source definitions change.  It is the abstraction boundary where future
+ * rotating/oriented vehicle box calculations should be implemented.
+ */
+public class MCH_VehicleBoxCache {
+   private static final double POSITION_EPSILON = 1.0E-4D;
+   private static final float ROTATION_EPSILON = 1.0E-3F;
+
+   private boolean dirty = true;
+   private String dirtyReason = "initial";
+   private double posX;
+   private double posY;
+   private double posZ;
+   private float yaw;
+   private float pitch;
+   private float roll;
+   private MCH_BaseVehicleInfo acInfo;
+   private List sourceBoxes;
+   private MCH_BoundingBox[] boxes;
+   private int sourceBoxCount = -1;
+   private long lastUpdateTick = -1L;
+
+   public void markDirty(String reason) {
+      this.dirty = true;
+      this.dirtyReason = reason != null ? reason : "unknown";
+   }
+
+   public MCH_BoundingBox[] getBoxes(MCH_EntityBaseVehicle vehicle) {
+      if(vehicle == null) {
+         return new MCH_BoundingBox[0];
+      }
+
+      MCH_BoundingBox[] currentBoxes = vehicle.extraBoundingBox != null ? vehicle.extraBoundingBox : new MCH_BoundingBox[0];
+      MCH_BaseVehicleInfo currentInfo = vehicle.getAcInfo();
+      List currentSourceBoxes = currentInfo != null ? currentInfo.extraBoundingBox : null;
+      int currentSourceBoxCount = currentSourceBoxes != null ? currentSourceBoxes.size() : -1;
+      double currentPosX = vehicle.posX;
+      double currentPosY = vehicle.posY;
+      double currentPosZ = vehicle.posZ;
+      float currentYaw = vehicle.getRotYaw();
+      float currentPitch = vehicle.getRotPitch();
+      float currentRoll = vehicle.getRotRoll();
+
+      String reason = this.getInvalidationReason(currentBoxes, currentInfo, currentSourceBoxes, currentSourceBoxCount,
+              currentPosX, currentPosY, currentPosZ, currentYaw, currentPitch, currentRoll);
+      if(reason != null) {
+         this.markDirty(reason);
+      }
+
+      if(!this.dirty) {
+         this.debug(vehicle, "hit", "reusing", currentBoxes.length);
+         return currentBoxes;
+      }
+
+      for(int i = 0; i < currentBoxes.length; ++i) {
+         currentBoxes[i].updatePosition(currentPosX, currentPosY, currentPosZ, currentYaw, currentPitch, currentRoll);
+      }
+
+      this.boxes = currentBoxes;
+      this.acInfo = currentInfo;
+      this.sourceBoxes = currentSourceBoxes;
+      this.sourceBoxCount = currentSourceBoxCount;
+      this.posX = currentPosX;
+      this.posY = currentPosY;
+      this.posZ = currentPosZ;
+      this.yaw = currentYaw;
+      this.pitch = currentPitch;
+      this.roll = currentRoll;
+      this.lastUpdateTick = vehicle.worldObj != null ? vehicle.worldObj.getTotalWorldTime() : -1L;
+      reason = this.dirtyReason;
+      this.dirty = false;
+      this.dirtyReason = null;
+      this.debug(vehicle, "rebuild", reason, currentBoxes.length);
+      return currentBoxes;
+   }
+
+   private String getInvalidationReason(MCH_BoundingBox[] currentBoxes, MCH_BaseVehicleInfo currentInfo, List currentSourceBoxes,
+                                        int currentSourceBoxCount, double currentPosX, double currentPosY, double currentPosZ,
+                                        float currentYaw, float currentPitch, float currentRoll) {
+      if(this.boxes != currentBoxes) return "box array changed";
+      if(this.acInfo != currentInfo) return "vehicle config changed";
+      if(this.sourceBoxes != currentSourceBoxes) return "source box list changed";
+      if(this.sourceBoxCount != currentSourceBoxCount) return "source box count changed";
+      if(Math.abs(this.posX - currentPosX) > POSITION_EPSILON || Math.abs(this.posY - currentPosY) > POSITION_EPSILON || Math.abs(this.posZ - currentPosZ) > POSITION_EPSILON) return "vehicle moved";
+      if(Math.abs(this.yaw - currentYaw) > ROTATION_EPSILON || Math.abs(this.pitch - currentPitch) > ROTATION_EPSILON || Math.abs(this.roll - currentRoll) > ROTATION_EPSILON) return "vehicle rotated";
+      return null;
+   }
+
+   private void debug(MCH_EntityBaseVehicle vehicle, String action, String reason, int count) {
+      if(MCH_Config.DebugVehicleBoxCache != null && MCH_Config.DebugVehicleBoxCache.prmBool) {
+         String name = vehicle.getAcInfo() != null ? vehicle.getAcInfo().name : vehicle.getClass().getSimpleName();
+         if(vehicle.worldObj != null) {
+            MCH_Lib.DbgLog(vehicle.worldObj, "VehicleBoxCache %s %s reason=%s boxes=%d tick=%d", name, action, reason, Integer.valueOf(count), Long.valueOf(this.lastUpdateTick));
+         } else {
+            MCH_Lib.DbgLog(false, "VehicleBoxCache %s %s reason=%s boxes=%d tick=%d", name, action, reason, Integer.valueOf(count), Long.valueOf(this.lastUpdateTick));
+         }
+      }
+   }
+}

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -718,9 +718,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
                            prm.size = ((float)super.rand.nextInt(5) + 5.0F) * 1.0F;
                            prm.setColor(0.7F + super.rand.nextFloat() * 0.1F, c, c, c);
                            MCH_ParticlesUtil.spawnParticle(prm);
-                           int ebi = super.rand.nextInt(1 + super.extraBoundingBox.length);
+                           MCH_BoundingBox[] boxes = this.getCalculatedExtraBoundingBoxes();
+                           int ebi = super.rand.nextInt(1 + boxes.length);
                            if(p < 0.3D && ebi > 0) {
-                              AxisAlignedBB bb = super.extraBoundingBox[ebi - 1].boundingBox;
+                              AxisAlignedBB bb = boxes[ebi - 1].boundingBox;
                               double bx = (bb.maxX + bb.minX) / 2.0D;
                               double by = (bb.maxY + bb.minY) / 2.0D;
                               double bz = (bb.maxZ + bb.minZ) / 2.0D;
@@ -1063,7 +1064,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    public void updateCollisionBox() {
       if(this.getAcInfo() != null) {
          //this.WheelMng.updateBlock();
-         MCH_BoundingBox[] arr$ = super.extraBoundingBox;
+         MCH_BoundingBox[] arr$ = this.getCalculatedExtraBoundingBoxes();
          int len$ = arr$.length;
 
          MCH_Config var10000;

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1587,7 +1587,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public void updateCollisionBox() {
       if(this.getAcInfo() != null) {
          //this.WheelMng.updateBlock();
-         MCH_BoundingBox[] arr$ = super.extraBoundingBox;
+         MCH_BoundingBox[] arr$ = this.getCalculatedExtraBoundingBoxes();
          int len$ = arr$.length;
 
          MCH_Config var10000;

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -1003,7 +1003,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
     private AxisAlignedBB getDeckSearchBox() {
         AxisAlignedBB search = AxisAlignedBB.getBoundingBox(super.boundingBox.minX, super.boundingBox.minY,
                 super.boundingBox.minZ, super.boundingBox.maxX, super.boundingBox.maxY, super.boundingBox.maxZ);
-        for(MCH_BoundingBox bb : super.extraBoundingBox) {
+        for(MCH_BoundingBox bb : this.getCalculatedExtraBoundingBoxes()) {
             search = search.func_111270_a(bb.boundingBox);
         }
         return search.expand(0.25D, 0.6D, 0.25D);
@@ -1013,8 +1013,9 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         int surfaceIndex = this.isOnTopOf(entityBox, super.boundingBox)?-1:Integer.MIN_VALUE;
         double highestSurface = surfaceIndex == -1?super.boundingBox.maxY:-Double.MAX_VALUE;
 
-        for(int i = 0; i < super.extraBoundingBox.length; ++i) {
-            AxisAlignedBB deckBox = super.extraBoundingBox[i].boundingBox;
+        MCH_BoundingBox[] deckBoxes = this.getCalculatedExtraBoundingBoxes();
+        for(int i = 0; i < deckBoxes.length; ++i) {
+            AxisAlignedBB deckBox = deckBoxes[i].boundingBox;
             if(this.isOnTopOf(entityBox, deckBox) && deckBox.maxY > highestSurface) {
                 surfaceIndex = i;
                 highestSurface = deckBox.maxY;
@@ -1036,7 +1037,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
     }
 
     private AxisAlignedBB getDeckSurface(int surfaceIndex) {
-        return surfaceIndex < 0?super.boundingBox:super.extraBoundingBox[surfaceIndex].boundingBox;
+        return surfaceIndex < 0?super.boundingBox:this.getCalculatedExtraBoundingBoxes()[surfaceIndex].boundingBox;
     }
 
     private void finishDeckMovement(List<DeckContact> deckEntities, float oldYaw) {
@@ -1044,7 +1045,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
         // Extra boxes are normally updated before onUpdateAircraft. Refresh them at
         // the final ship position so support uses this tick's water-bob height.
-        this.updateExtraBoundingBox();
+        this.getCalculatedExtraBoundingBoxes();
 
         for(DeckContact contact : deckEntities) {
             Entity entity = contact.entity;
@@ -1203,7 +1204,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
     public void updateCollisionBox() {
         if(this.getAcInfo() != null) {
             //this.WheelMng.updateBlock();
-            MCH_BoundingBox[] arr$ = super.extraBoundingBox;
+            MCH_BoundingBox[] arr$ = this.getCalculatedExtraBoundingBoxes();
             int len$ = arr$.length;
 
             MCH_Config var10000;

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -1169,7 +1169,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    public void updateCollisionBox() {
       if(this.getAcInfo() != null) {
          this.WheelMng.updateBlock();
-         MCH_BoundingBox[] arr$ = super.extraBoundingBox;
+         MCH_BoundingBox[] arr$ = this.getCalculatedExtraBoundingBoxes();
          int len$ = arr$.length;
 
          MCH_Config var10000;


### PR DESCRIPTION
### Motivation
- Reduce repeated rebuilds of per-vehicle collision/hit boxes and centralize transform logic to improve performance and make future oriented-box support easier.
- Provide a single cache and invalidation policy so bounding boxes are only recomputed when vehicle position, rotation, or config changes.
- Add optional debug logging to inspect cache hits, rebuilds, and invalidation reasons.

### Description
- Add a new `MCH_VehicleBoxCache` class that caches and invalidates calculated `MCH_BoundingBox` arrays with position/rotation/config heuristics and optional debug logging.
- Add a `vehicleBoxCache` field to `MCH_EntityBaseVehicle` and expose `getCalculatedExtraBoundingBoxes()` and `markVehicleBoxCacheDirty()` to centralize obtaining/updating extra bounding boxes.
- Replace direct accesses to `extraBoundingBox` with calls to `getCalculatedExtraBoundingBoxes()` across collision, rendering, ship/helicopter/plane/tank update code and make `updateExtraBoundingBox()` mark the cache dirty instead of manually updating boxes.
- Introduce a new config parameter `DebugVehicleBoxCache` in `MCH_Config` with a descriptive `desc` string to enable cache debug logging.

### Testing
- Performed a full project build/compile to validate API and type changes; the build succeeded without compilation errors.
- Exercised runtime collision/update paths via a basic automated smoke run to confirm cache reuse and rebuild logging paths; no exceptions were observed during the smoke run.
- No additional unit tests were present for the modified collision path, so behavior coverage relied on the build and smoke execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f680235cc83298645db50aab36eb3)