### PR TITLE
Fix new-flight plane gravity and placement motion

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -98,7 +98,7 @@ effectiveThrottle = NewFlightIdleThrottle
                   * pow(engineThrottle, NewFlightThrottleResponse)
 ```
 
-`effectiveThrottle`, not raw pilot throttle, drives new-flight thrust and sustainable speed. This makes 30-70% useful for cruise/formation/approach instead of forcing pilots to live near 100%. Cutting throttle reduces acceleration and adds engine-brake drag; it no longer directly deletes lift.
+`effectiveThrottle`, not raw pilot throttle, drives new-flight thrust and sustainable speed. This makes 30-70% useful for cruise/formation/approach instead of forcing pilots to live near 100%. Cutting throttle reduces acceleration and adds engine-brake drag; it no longer directly deletes lift. New-flight planes also always integrate the shared `gravity`/`gravityinwater` value as downward acceleration while airborne; valid wing lift is added upward against that gravity instead of replacing it, so low-speed or stalled aircraft descend naturally.
 
 Recommended starting ranges:
 
@@ -272,4 +272,4 @@ Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy pa
 
 Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
 
-Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, AoA, lift loss, drag, control authority, stall, and overspeed state for new-flight tuning.
+Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, vertical velocity, gravity acceleration, lift acceleration, net vertical acceleration, airborne state, AoA, lift loss, drag, control authority, stall, and overspeed state for new-flight tuning.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -331,7 +331,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,vy=%.4f,gravity=%.4f,lift=%.4f,netY=%.4f,airborne=%s,aoa=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f)",
               simDelta,
               mouseX,
               mouseY,
@@ -346,6 +346,11 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               Double.valueOf(ac.getNormalizedThrottle() * 100.0D),
               Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
+              ac.motionY,
+              ac.getLastGravityAcceleration(),
+              ac.getLastLiftAcceleration(),
+              ac.getLastNetVerticalAcceleration(),
+              Boolean.valueOf(ac.isLastAirborne()),
               ac.getAngleOfAttackDegrees(),
               ac.getStallSeverity(),
               Boolean.valueOf(ac.isOverspeeding()),

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1798,6 +1798,22 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return 0.0D;
    }
 
+   public double getLastGravityAcceleration() {
+      return 0.0D;
+   }
+
+   public double getLastLiftAcceleration() {
+      return 0.0D;
+   }
+
+   public double getLastNetVerticalAcceleration() {
+      return 0.0D;
+   }
+
+   public boolean isLastAirborne() {
+      return !super.onGround;
+   }
+
    /** Effective 0..1 control authority after stall and high-G penalties. */
    public float getDebugControlAuthority() {
       return this.getControlAuthorityFactor();

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -55,6 +55,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastAerodynamicDrag;
    /** Last stall lift-loss fraction applied to vertical motion, exposed for debug output. */
    private double lastLiftLoss;
+   /** Last downward gravity acceleration applied by the new fixed-wing model. */
+   private double lastGravityAcceleration;
+   /** Last upward lift acceleration applied by the new fixed-wing model. */
+   private double lastLiftAcceleration;
+   /** Last net fixed-wing vertical acceleration before velocity damping. */
+   private double lastNetVerticalAcceleration;
+   /** Last airborne state used by the new fixed-wing force model. */
+   private boolean lastAirborne;
    /** Local-axis body rates used by fixed-wing damped control response. */
    private float pitchAngularVelocity;
    private float rollAngularVelocity;
@@ -90,6 +98,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.engineThrottle = 0.0D;
       this.lastAerodynamicDrag = 0.0D;
       this.lastLiftLoss = 0.0D;
+      this.lastGravityAcceleration = 0.0D;
+      this.lastLiftAcceleration = 0.0D;
+      this.lastNetVerticalAcceleration = 0.0D;
+      this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
       this.stalling = false;
@@ -370,6 +382,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    public double getLastLiftLoss() {
       return this.lastLiftLoss;
+   }
+
+   public double getLastGravityAcceleration() {
+      return this.lastGravityAcceleration;
+   }
+
+   public double getLastLiftAcceleration() {
+      return this.lastLiftAcceleration;
+   }
+
+   public double getLastNetVerticalAcceleration() {
+      return this.lastNetVerticalAcceleration;
+   }
+
+   public boolean isLastAirborne() {
+      return this.lastAirborne;
    }
 
    public float getDebugControlAuthority() {
@@ -670,6 +698,64 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.overspeedDamageAccumulator -= (double)damage;
          this.setDamageTaken(this.getDamageTaken() + damage);
       }
+   }
+
+   private void applyNewFlightVerticalForces() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      boolean airborne = !super.onGround && MCH_Lib.getBlockIdY(this, 1, -2) == 0;
+      this.lastAirborne = airborne;
+      if(!airborne) {
+         this.lastGravityAcceleration = 0.0D;
+         this.lastLiftAcceleration = 0.0D;
+         this.lastNetVerticalAcceleration = 0.0D;
+         return;
+      }
+
+      double configuredGravity = !this.isInWater() ? (double)this.getAcInfo().gravity : (double)this.getAcInfo().gravityInWater;
+      double gravityAccel = Math.max(0.0D, -configuredGravity);
+      if(gravityAccel <= 1.0E-6D) {
+         gravityAccel = 0.04D;
+      }
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
+      double airspeed = this.getAirspeed();
+      double airspeedLift = MCH_FlightModel.clamp((airspeed - stallSpeed * 0.45D) / Math.max(0.05D, stallSpeed * 1.35D), 0.0D, 1.25D);
+      double aoaLift = MCH_FlightModel.clamp(1.0D - Math.max(0.0D, this.angleOfAttack - (double)info.criticalAoA) / Math.max(1.0D, (double)info.criticalAoA), 0.0D, 1.0D);
+      double liftPower = (double)info.newFlightLowThrottleLiftRetention
+            + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
+      if(this.isCombatFlapsDeployed()) {
+         liftPower += (double)info.newFlightCombatFlapLift;
+      }
+      double stallLift = 1.0D - MCH_FlightModel.clamp(this.stallSeverity * (double)info.stallLiftLoss, 0.0D, 1.0D);
+      double liftAccel = gravityAccel * MCH_FlightModel.clamp(liftPower, 0.0D, 1.2D) * airspeedLift * aoaLift * stallLift;
+      double netAccel = liftAccel - gravityAccel;
+
+      super.motionY += netAccel;
+      this.lastGravityAcceleration = gravityAccel;
+      this.lastLiftAcceleration = liftAccel;
+      this.lastNetVerticalAcceleration = netAccel;
+   }
+
+   public void resetNewFlightPlacementMotion() {
+      if(this.getPlaneInfo() == null || !this.getPlaneInfo().useNewMobilitySystem) {
+         return;
+      }
+      super.motionX = super.motionY = super.motionZ = 0.0D;
+      this.velocityX = this.velocityY = this.velocityZ = 0.0D;
+      this.engineThrottle = 0.0D;
+      this.lastAerodynamicDrag = 0.0D;
+      this.lastLiftLoss = 0.0D;
+      this.lastGravityAcceleration = 0.0D;
+      this.lastLiftAcceleration = 0.0D;
+      this.lastNetVerticalAcceleration = 0.0D;
+      this.lastAirborne = false;
+      this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;
+      this.currentGForce = 1.0D;
+      this.overspeedDamageAccumulator = 0.0D;
+      this.angleOfAttack = 0.0D;
+      this.stallSeverity = 0.0D;
+      this.stalling = false;
+      this.aircraftPosRotInc = 0;
    }
 
    protected void updateVehicleStress() {
@@ -1180,6 +1266,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.stallSeverity = 0.0D;
          this.lastAerodynamicDrag = 0.0D;
          this.lastLiftLoss = 0.0D;
+         this.lastGravityAcceleration = 0.0D;
+         this.lastLiftAcceleration = 0.0D;
+         this.lastNetVerticalAcceleration = 0.0D;
+         this.lastAirborne = false;
          this.stalling = false;
       }
 
@@ -1227,19 +1317,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
 
          if(!levelOff) {
-            super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
             if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
-               double liftPower = (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention
-                     + (1.0D - (double)this.getPlaneInfo().newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
-               if(this.isCombatFlapsDeployed()) {
-                  liftPower += (double)this.getPlaneInfo().newFlightCombatFlapLift;
-               }
-               super.motionY += -0.047D * (1.0D - MCH_FlightModel.clamp(liftPower, 0.0D, 1.0D));
+               this.applyNewFlightVerticalForces();
             } else {
+               super.motionY += 0.04D + (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
                super.motionY += -0.047D * (1.0D - this.getEngineThrottle());
             }
          } else {
             super.motionY *= 0.8D;
+            this.lastGravityAcceleration = 0.0D;
+            this.lastLiftAcceleration = 0.0D;
+            this.lastNetVerticalAcceleration = 0.0D;
+            this.lastAirborne = false;
          }
       } else {
          this.setRotPitch(this.getRotPitch() * 0.8F, "getWaterDepth != 0");

--- a/src/main/java/mcheli/plane/MCP_ItemPlane.java
+++ b/src/main/java/mcheli/plane/MCP_ItemPlane.java
@@ -34,6 +34,8 @@ public class MCP_ItemPlane extends MCH_ItemBaseVehicle {
       /* 30 */     plane.prevPosZ = z;
       /* 31 */     plane.camera.setPosition(x, y, z);
       /* 32 */     plane.setTypeName(info.name);
+      /*    */     plane.changeType(info.name);
+      /*    */     plane.resetNewFlightPlacementMotion();
       /* 33 */     if (!world.isRemote) {
          /* 34 */       plane.setTextureName(info.getTextureName());
          /*    */     }


### PR DESCRIPTION
### Motivation
- New-flight-model fixed-wing planes could cancel or omit gravity, allowing stalled or 0% throttle aircraft to float instead of descending.
- Placed/newly spawned new-flight planes occasionally inherited non-zero motion from placement paths, producing unrealistic initial movement.  
- Improved visibility into vertical dynamics was needed for debugging and tuning of lift/stall interactions.

### Description
- Implemented an additive vertical force model for planes using the new mobility system by adding `applyNewFlightVerticalForces()` in `MCP_EntityPlane`, which always integrates shared `gravity`/`gravityInWater` as downward acceleration and computes lift as an upward acceleration that is added against gravity (uses airspeed, AoA, throttle/lift power, combat flaps, and stall lift loss).  
- Added debug state fields and accessors (`lastGravityAcceleration`, `lastLiftAcceleration`, `lastNetVerticalAcceleration`, `lastAirborne`) to `MCP_EntityPlane` and no-op accessors in `MCH_EntityBaseVehicle` so debug code can call them safely on any vehicle.  
- Added `resetNewFlightPlacementMotion()` to `MCP_EntityPlane` and call site in `MCP_ItemPlane.createAircraft` to zero `motionX/motionY/motionZ`, `velocity*`, engine/aero state, smoothed angular rates, stall/aero caches, and interpolation state for freshly placed new-flight planes only.  
- Preserved legacy behavior by keeping the original vertical-motion path for non-new-mobility planes and gating new logic under the existing `useNewMobilitySystem` opt-in.  
- Expanded debug output in `MCH_ClientCommonTickHandler.debugFlightControl` to include vertical velocity, gravity, lift, net vertical acceleration, and airborne state, and updated `docs/vehicle-config/planes.md` to describe the additive gravity/lift behavior.  
- Changes touch the following files: `src/main/java/mcheli/plane/MCP_EntityPlane.java`, `src/main/java/mcheli/plane/MCP_ItemPlane.java`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`, and `docs/vehicle-config/planes.md`.

### Testing
- Ran a repository static content check via `python3` scripts to verify the presence of new hooks and placement/reset references, and it completed successfully.  
- Ran `git diff --check` (whitespace/static diff checks) and it returned no issues.  
- No Java/Gradle compilation or runtime simulation was executed to avoid producing `.class` files as requested.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f6da5d0b48329bace3a143a755f0b)