### PR TITLE
Exclude project assets from packaging and make assets copy runClient-only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,38 +70,71 @@ compileJava {
 }
 
 // ------------------ RESOURCE PROCESSING ------------------
+sourceSets {
+    main {
+        resources {
+            srcDir 'src/main/resources'
+            exclude 'assets/**'
+        }
+    }
+}
+
 processResources {
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
 
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
+        exclude 'assets/**'
         expand 'version': project.version, 'mcversion': project.minecraft.version
     }
 
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
+        exclude 'assets/**'
     }
 }
 
-// ------------------ ASSETS COPY TASK ------------------
-// Copies 'assets/' from project root to the run directory for IDE dev environment
+tasks.withType(Jar) {
+    exclude 'assets'
+    exclude 'assets/**'
+}
+
+tasks.matching { it.name == 'reobfJar' }.all {
+    if (it.metaClass.respondsTo(it, 'exclude', Object[])) {
+        it.exclude 'assets'
+        it.exclude 'assets/**'
+    }
+}
+
+// ------------------ RUNCLIENT-ONLY ASSET SETUP ------------------
+// Keep the IDE/dev runtime asset setup, but do not wire these tasks into
+// processResources, jar, reobfJar, build, or any release packaging path.
 task copyAssetsToRun(type: Copy) {
-    from 'assets' // <-- your root assets folder
-    into "$buildDir/run/assets" // copied to run folder
-}
+    onlyIf {
+        file('assets').isDirectory()
+    }
 
-// Make runClient depend on assets copy
-tasks.whenTaskAdded { task ->
-    if (task.name == 'runClient') {
-        task.dependsOn copyAssetsToRun
+    from 'assets'
+    into "$buildDir/run/assets"
+
+    doFirst {
+        println "[MCH] Copying root assets to run directory for runClient only"
+        println "  from: ${file('assets')}"
+        println "  into: ${file("$buildDir/run/assets")}"
     }
 }
 
-//HOPEFULLY fix retarded issue with missing textures and other retarded shit in IDE
 task syncMCHeliAssets(type: Copy) {
     def srcDir = file("$buildDir/run/mods/mcheli/assets/mcheli")
-    def dstDir = file("src/main/resources/assets/mcheli")
+    def dstDir = file("${sourceSets.main.output.resourcesDir}/assets/mcheli")
+
+    onlyIf {
+        srcDir.isDirectory()
+    }
+
+    dependsOn processResources
+    mustRunAfter processResources
 
     from(srcDir) {
         include "hud/**"
@@ -115,19 +148,25 @@ task syncMCHeliAssets(type: Copy) {
     into(dstDir)
 
     doFirst {
-        println "[MCH] Syncing runtime assets -> resources"
+        println "[MCH] Syncing runtime assets -> runClient resources"
         println "  from: $srcDir"
         println "  into: $dstDir"
     }
 }
 
-tasks.runClient.dependsOn syncMCHeliAssets
-tasks.build.dependsOn syncMCHeliAssets
-processResources.dependsOn syncMCHeliAssets
+def configureRunClientAssets = { task ->
+    task.dependsOn copyAssetsToRun
+    task.dependsOn syncMCHeliAssets
+}
 
+tasks.matching { it.name == 'runClient' }.all configureRunClientAssets
+tasks.whenTaskAdded { task ->
+    if (task.name == 'runClient') {
+        configureRunClientAssets(task)
+    }
+}
 
-
-// Optional: ensure clean removes copied assets
 clean.doLast {
     delete "$buildDir/run/assets"
+    delete "${sourceSets.main.output.resourcesDir}/assets"
 }


### PR DESCRIPTION
### Motivation

- Prevent root `assets/` from being included in jars and reobf outputs so release artifacts do not contain IDE/dev-only assets.
- Keep IDE/dev runtime asset copying for `runClient` without wiring those copies into `processResources`, `jar`, `reobfJar`, `build`, or release packaging.

### Description

- Configure `sourceSets.main.resources` to exclude `assets/**` and adjust `processResources` to exclude `assets/**` while still expanding `mcmod.info` from the resources directory.
- Exclude `assets/**` from all `Jar` tasks and from the `reobfJar` task if supported by the task metaClass.
- Add a `copyAssetsToRun` `Copy` task that only runs when an `assets` directory exists and only copies into the run directory for IDE/dev usage, with informative logging, and do not hook it into global build tasks.
- Update `syncMCHeliAssets` to target the runtime output resources directory (`sourceSets.main.output.resourcesDir`), add an `onlyIf` guard and `dependsOn processResources`, and ensure it runs after `processResources`; attach `copyAssetsToRun` and `syncMCHeliAssets` only to `runClient` tasks.
- Ensure `clean` removes the copied run assets and synced resource assets.

### Testing

- Ran `./gradlew clean assemble` and it completed successfully.
- Ran `./gradlew processResources` to verify resource filtering and it completed successfully.
- Executed `./gradlew runClient` to verify the run-only asset copy and sync actions are executed and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f7aadd04c8329871ba9ab97a18e4c)