### PR TITLE
Add code-only `buildcode` Jar task and restore runClient asset handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,35 @@ processResources {
     }
 }
 
+// ------------------ CODE-ONLY PACKAGING ------------------
+// Use this task for release/code artifacts. It depends only on Java
+// compilation and packages compiled class files without processing, scanning,
+// copying, or including the root assets folder or any resource assets.
+task buildcode(type: Jar, dependsOn: compileJava) {
+    group = 'build'
+    description = 'Builds a code-only jar from compiled classes without packaging assets or resources.'
+
+    baseName = archivesBaseName
+    version = project.version
+    classifier = 'code'
+
+    if (sourceSets.main.output.hasProperty('classesDirs')) {
+        from sourceSets.main.output.classesDirs
+    } else {
+        from sourceSets.main.output.classesDir
+    }
+
+    include '**/*.class'
+    exclude 'assets'
+    exclude 'assets/**'
+}
+
+// Camel-case alias for users who naturally type Gradle task names this way.
+task buildCode(dependsOn: buildcode) {
+    group = 'build'
+    description = 'Alias for buildcode.'
+}
+
 // ------------------ ASSETS COPY TASK ------------------
 // Copies 'assets/' from project root to the run directory for IDE dev environment
 task copyAssetsToRun(type: Copy) {


### PR DESCRIPTION
### Motivation

- Provide a code-only packaging path that never bundles the top-level `assets/` tree so release artifacts can be produced without asset content. 
- Restore the dev `runClient` asset flow so models, HUD elements, textures, shaders, sounds, and related files load correctly in the IDE/dev client. 
- Avoid changing the main ForgeGradle runtime behavior for developers while offering a separate artifact task that only packages compiled code. 

### Description

- Added a `buildcode` `Jar` task (and `buildCode` alias) that depends only on `compileJava`, includes compiled classes from `sourceSets.main.output.classesDirs` and `**/*.class`, and explicitly excludes `assets` and `assets/**`. 
- Restored `processResources` to perform `mcmod.info` expansion from the normal resource dirs without globally excluding `assets`. 
- Restored `copyAssetsToRun` to copy the entire root `assets` tree into `build/run/assets` and restored `syncMCHeliAssets` to sync runtime `mcheli` categories (hud, models, shaders, sounds, textures, `sounds.json`) back into `src/main/resources/assets/mcheli` for the dev client. 
- Wired the run/client-related tasks so `runClient` depends on asset copy/sync and also left `tasks.build` and `processResources` depending on `syncMCHeliAssets` (see `build.gradle` changes). 

### Testing

- Ran `git diff --check` and it completed with no whitespace errors. 
- Audited the Gradle script with `rg` for the introduced task names and asset hooks and confirmed the new `buildcode`, `buildCode`, `copyAssetsToRun`, and `syncMCHeliAssets` entries are present. 
- Attempted `./gradlew tasks --all` but the Gradle wrapper download failed due to a network/proxy `HTTP 403`, and offline Gradle configuration failed because `ForgeGradle` was not cached, so full Gradle configuration/build could not be executed. 
- Per repository instruction, no compile/build tasks that would produce `.class` files were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f7aadd04c8329871ba9ab97a18e4c)