### PR TITLE
Fix aircraft accelerating on entry at zero throttle

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1067,6 +1067,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             + (1.0D - (double)info.newFlightIdleThrottle) * curved, 0.0D, 1.0D);
    }
 
+   protected double getPropulsiveEngineThrottle() {
+      // Idle power keeps an airborne engine and its lift response alive, but it
+      // must not make a parked plane taxi merely because a pilot entered it.
+      if(super.onGround && this.getCurrentThrottle() <= 0.0D) {
+         return 0.0D;
+      }
+      return this.getEffectiveEngineThrottle();
+   }
+
    protected void onUpdate_ControlNotHovering() {
       // 判断是否不处于炮手模式
       if (!super.isGunnerMode) {
@@ -1497,10 +1506,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       // 计算油门1的值，当前油门除以10
-      float throttle1 = (float)((this.useNewMobilitySystem() ? this.getEffectiveEngineThrottle() : this.getEngineThrottle()) / 10.0D);
+      double propulsiveThrottle = this.useNewMobilitySystem()
+            ? this.getPropulsiveEngineThrottle() : this.getEngineThrottle();
+      float throttle1 = (float)(propulsiveThrottle / 10.0D);
       if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
          double mass = this.getPhysicalMass();
-         double thrustForce = (double)this.getPlaneInfo().engineThrust * this.getEffectiveEngineThrottle();
+         double thrustForce = (double)this.getPlaneInfo().engineThrust * propulsiveThrottle;
          throttle1 = (float)(thrustForce / mass / 10.0D);
          this.lastEngineThrustForce = thrustForce;
       } else {


### PR DESCRIPTION
### Motivation
- New-flight planes applied configured idle throttle as physical thrust which caused parked aircraft to gain forward momentum when a pilot entered them. 
- The intended behavior is that idle engine power remains for airborne lift/engine state but should not generate propulsive ground thrust when the pilot has commanded zero throttle. 
- This change gates ground propulsion so ground movement only occurs when the pilot actually has positive throttle.

### Description
- Added `getPropulsiveEngineThrottle()` in `src/main/java/mcheli/plane/MCP_EntityPlane.java` which returns zero while `onGround` and `getCurrentThrottle() <= 0.0D`, otherwise defers to `getEffectiveEngineThrottle()`. 
- Replaced uses of `getEffectiveEngineThrottle()` for applied thrust with the new propulsive throttle so physical forward acceleration and `lastEngineThrustForce` use the gate that suppresses ground thrust at idle. 
- Updated the local `throttle1` calculation to use the propulsive throttle variable so ground motion computation respects the new gate while airborne behavior is unchanged.

### Testing
- `git diff --check` completed with no reported whitespace/patch errors. 
- Attempted `./gradlew compileJava` but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so a full compile could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ff0e48cd88323a811867ef78be3cc)