### PR TITLE
Improve AA missile speed scaling and continuous homing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `DropItemInCreativeMode` | `false` | Allows item drops in creative mode for applicable actions. |
 | `BreakableOnlyPickaxe` | `false` | Restricts breakability to pickaxe behavior where implemented. |
 | `AllHeliSpeed` | `1.5` | Global helicopter speed scalar; clamped between 0 and 1000. |
-| `AllPlaneSpeed` | `1000.0` | Global plane speed scalar/clamp value; clamped between 0 and 1000. |
+| `AllPlaneSpeed` | `1000.0` | Global plane speed scalar/clamp value; clamped between 0 and 1000. Plane config speeds use `(mph / 1000) * 1.74` before this scalar is applied. AA-missile launch speed uses the matching normalized scale, `AllPlaneSpeed / 1000 * 1.74`, so the default makes AA missiles 1.74 times their configured `Acceleration`. |
 | `NewFlightGravity` | `0.008` | Global per-tick downward acceleration for new-flight-model aircraft; individual vehicle configs can override with `NewFlightGravity`, `FlightGravity`, or `GravityOverride`. |
 | `AllShipSpeed` | `2.0` | Global ship speed scalar; clamped between 0 and 1000. |
 | `AllTankSpeed` | `1.0` | Global tank speed scalar; clamped between 0 and 1000. |

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -23,6 +23,15 @@ Planes inherit every shared key from `base.md` and add visual VTOL/sweep-wing ke
 
 All values are optional. Speed-like values (`Speed`, `MaxLevelSpeed`, `StallSpeed`, `StallRecoverySpeed`, `CompressibilitySpeed`, `MaxSafeSpeed`, `sweepwingspeed`) are multiplied by the global `AllPlaneSpeed` config during validation.
 
+To author a plane speed from miles per hour, use:
+
+```text
+plane config speed = (mph / 1000) * 1.74
+validated speed = plane config speed * AllPlaneSpeed
+```
+
+With the default `AllPlaneSpeed = 1000`, a 500 mph plane therefore uses `Speed 0.87` before global scaling. AA-missile launch speed follows the same normalized `AllPlaneSpeed / 1000 * 1.74` scale; at the default, an AA missile travels at 1.74 times its configured `Acceleration`. AA missiles also keep homing for their full lifetime rather than stopping at the generic `TickEndHoming` cutoff.
+
 | Key | Type/range | Default | What it changes |
 |---|---:|---:|---|
 | `BaseDrag` | float[0..0.25] | 0.0015 | Baseline drag. Scales with speed ratio squared and also participates in AoA drag. |

--- a/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
@@ -1,9 +1,8 @@
 package mcheli.weapon;
 
+import mcheli.MCH_Config;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
-import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.flare.MCH_EntityChaff;
-import mcheli.uav.MCH_EntityUavStation;
 import mcheli.vector.Vector3f;
 import mcheli.wrapper.W_Entity;
 import net.minecraft.entity.Entity;
@@ -15,6 +14,9 @@ import java.util.List;
 
 public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEntityLockChecker {
 
+   private static final double PLANE_SPEED_CONFIG_BASELINE = 1000.0D;
+   private static final double MPH_TO_PLANE_SPEED_FACTOR = 1.74D;
+
    public MCH_EntityAAMissile(World par1World) {
       super(par1World);
       super.targetEntity = null;
@@ -22,6 +24,12 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
 
    public MCH_EntityAAMissile(World par1World, double posX, double posY, double posZ, double targetX, double targetY, double targetZ, float yaw, float pitch, double acceleration) {
       super(par1World, posX, posY, posZ, targetX, targetY, targetZ, yaw, pitch, acceleration);
+      this.acceleration = acceleration * getPlaneSpeedScale();
+      this.setMotion(targetX, targetY, targetZ);
+   }
+
+   private static double getPlaneSpeedScale() {
+      return MCH_Config.AllPlaneSpeed.prmDouble / PLANE_SPEED_CONFIG_BASELINE * MPH_TO_PLANE_SPEED_FACTOR;
    }
 
    public void onUpdate() {
@@ -109,6 +117,11 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
 
    public MCH_BulletModel getDefaultBulletModel() {
       return MCH_DefaultBulletModels.AAMissile;
+   }
+
+   @Override
+   protected boolean isHomingExpired() {
+      return false;
    }
 
    @Override

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -560,7 +560,7 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
     }
 
     public void guidanceToTarget(double targetPosX, double targetPosY, double targetPosZ, float accelerationFactor) {
-        if(getInfo().tickEndHoming > 0 && ticksExisted > getInfo().tickEndHoming) {
+        if (isHomingExpired()) {
             return;
         }
 
@@ -623,6 +623,9 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
         super.rotationPitch = -((float)(Math.atan2(super.motionY, r) * 180.0D / 3.141592653589793D));  // Calculate and set Pitch angle
     }
 
+    protected boolean isHomingExpired() {
+        return getInfo().tickEndHoming > 0 && ticksExisted > getInfo().tickEndHoming;
+    }
 
     public boolean checkValid() {
         if (this.shootingEntity == null && this.shootingAircraft == null) {


### PR DESCRIPTION
### Motivation
- AA missiles were losing guidance early and their launch speed did not account for the plane-speed authoring units; the change aligns AA missile launch speed with global plane-speed units and prevents premature loss of tracking.

### Description
- Add `isHomingExpired()` to `MCH_EntityBaseBullet` and make `guidanceToTarget` use it so homing expiration logic is centralized.
- Override `isHomingExpired()` in `MCH_EntityAAMissile` to disable the generic homing timeout for AA missiles so they continue steering for their lifetime.
- Scale AA missile initial `acceleration` in `MCH_EntityAAMissile` by the normalized plane-speed factor `AllPlaneSpeed / 1000 * 1.74` and recompute motion with `setMotion(...)` so missile speed matches plane-speed authoring units.
- Update docs in `docs/configuration.md` and `docs/vehicle-config/planes.md` to document the plane-speed conversion formula `plane config speed = (mph / 1000) * 1.74` and explain the default `AllPlaneSpeed = 1000` effect on AA missiles.

### Testing
- `git diff --check` was run and showed no whitespace/diff errors (success).
- Attempted to run `./gradlew compileJava` but the wrapper is not executable in the environment (permission error) and `bash ./gradlew compileJava` failed while downloading Gradle due to the environment proxy returning HTTP 403 (network restriction).
- Running the local `gradle compileJava` also failed to resolve ForgeGradle/Maven dependencies due to HTTP 403 responses from the environment proxy, so Java compilation could not be completed in this environment (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30078f4ff883238a0fc8a67b25385f)