### PR TITLE
Improve fixed‑wing stall, takeoff and climb physics; add debug telemetry and docs

### DIFF
--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -73,7 +73,7 @@ if ceilingLift < 1:
 
 Planes use a sink of `0.012 * (1 - ceilingLift)` away from the runway; helicopters use `0.014 * (1 - ceilingLift)`.
 
-For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is the weight side of the lift/weight calculation documented in `planes.md`; valid wing lift is still limited by airspeed, velocity-derived AoA, stall lift loss, and pitch-break stall behavior rather than by pitch attitude alone. Legacy planes and non-fixed-wing vehicles continue to use their family-specific gravity behavior.
+For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is the weight side of the lift/weight calculation documented in `planes.md`; valid wing lift is still limited by airspeed, velocity-derived AoA, stall lift loss, takeoff/climb headroom suppression while stalled, thrust-to-weight during vertical climb, and pitch-break stall behavior rather than by pitch attitude alone. Legacy planes and non-fixed-wing vehicles continue to use their family-specific gravity behavior.
 
 ## Health, damage, resources, support
 

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -174,9 +174,10 @@ demand = max(speedSeverity, aoaSeverity)
 
 `AoA` is the angle between where the aircraft nose points and where the aircraft is actually moving. It is not the pitch angle by itself. Near-zero airspeed reports `AoA = 0` so parked or nearly stationary aircraft do not feed invalid vectors into stall math.
 
-If not already stalling, any positive demand starts a stall. While stalling, recovery requires both:
+If not already stalling, demand above the small entry hysteresis band starts a stall. While stalling, one good frame is not enough to recover unless both recovery conditions are true in the same tick:
 
 ```text
+demand > 0.03 starts a stall when not already stalling
 airspeed >= (StallRecoverySpeed if >0 else stallSpeed * 1.2)
 abs(AoA) <= CriticalAoA * 0.75
 ```
@@ -192,13 +193,16 @@ Airborne wing lift is then filtered by airspeed, AoA, throttle/flap lift power, 
 
 ```text
 airspeedLift = clamp((airspeed - stallSpeed * 0.45) / max(0.05, stallSpeed * 1.35), 0, 1.25)
-aoaLift = clamp(1 - max(0, AoA - CriticalAoA) / max(1, CriticalAoA), 0, 1)
+aoaLift = clamp(1 - max(0, abs(AoA) - CriticalAoA) / max(1, CriticalAoA), 0, 1)
 liftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
 stallLift = 1 - liftLoss
-liftForce = gravity * clamp(liftPower, 0, 2.5) * airspeedLift * aoaLift * stallLift
+liftBeforeStallLoss = gravity * clamp(liftPower, 0, 2.5) * airspeedLift * aoaLift
+liftForce = liftBeforeStallLoss * stallLift
 ```
 
-This means pointing the nose near vertical does not create maximum lift unless the velocity vector, airspeed, and AoA are still within valid flying conditions. Combat flaps and low-throttle lift retention preserve takeoff/climb headroom, but they are still multiplied by AoA and stall lift loss.
+`StallLiftLoss` is applied after throttle lift retention, combat flap lift, takeoff lift, and other lift bonuses are resolved. Stalled aircraft suppress takeoff/climb lift headroom until recovery, so `validTakeoff` or `validClimb` cannot bypass stall penalties.
+
+This means pointing the nose near vertical does not create maximum lift unless the velocity vector, airspeed, lift-to-weight, and thrust-to-weight are still within valid flying conditions. Conventional fixed-wing thrust is also limited during unsupported vertical climbs: if thrust-to-weight is below 1.0, upward powered climb is scaled by speed headroom and remaining unstalled authority. High nose-up climbs add extra AoA/energy drag and bleed vertical energy unless the aircraft is truly tuned with enough thrust and speed to support them.
 
 Developed stalls also apply sink and a deterministic pitch break:
 
@@ -206,7 +210,10 @@ Developed stalls also apply sink and a deterministic pitch break:
 if motionY > 0: motionY *= 1 - liftLoss * 0.12
 motionY -= 0.018 * liftLoss * StallStrength
 pitchBreak = stallSeverity * StallStrength * (0.12 + 0.18 * max(speedSeverity, aoaSeverity))
+pitchAngularVelocity += clamp(pitchBreak * noseDownScale * 0.45, 0, 1.2)
 ```
+
+Pitch break uses the same pitch/angular velocity path as visible fixed-wing rotation. The moment is deterministic, scales with `stallSeverity`, `StallStrength`, and stall demand, and adds bounded nose-down pitch rather than only applying vertical sink.
 
 `pitchBreak` is applied as a nose-down pitch moment and damps excessive nose-up pitch angular velocity. MCHeli/Minecraft rotation pitch uses inverted sign convention: nose-up attitude is negative numeric pitch, and nose-down attitude is positive numeric pitch. The pitch-break code therefore adds a positive rotation-pitch delta to lower the nose. It is separate from `StallInstability`: `StallInstability` still adds repeatable roll/yaw buffet and wing drop, while `StallStrength` controls the predictable unloading/sink force that helps a stalled aircraft lower the nose, regain airspeed, and recover only after both speed and AoA meet the recovery limits.
 
@@ -365,4 +372,4 @@ Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy pa
 
 Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
 
-Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, airspeed, vertical velocity, physical mass, weight force, engine thrust force, lift force, lift-to-weight ratio, thrust-to-weight ratio, net forward acceleration, `TakeoffDistanceMultiplier`, base/effective takeoff thresholds, whether takeoff threshold scaling is active, applied gravity acceleration, resolved global/override gravity, placement motion-lock state, current motion/cached velocity, lift acceleration, net vertical acceleration, airborne state, velocity-derived `aoaFromVelocity`, `criticalAoA`, `stallDemand`, `speedSeverity`, `aoaSeverity`, smoothed stall severity, lift loss, drag, control authority, pitch-break state, and overspeed state for new-flight tuning.
+Debug flight logging (`DebugFlightControl`) includes throttle percent, flap state, pitch, airspeed, forward speed, vertical speed, physical mass, weight force, engine thrust force, lift force, lift before stall loss, lift after stall loss, lift-to-weight ratio, thrust-to-weight ratio, net forward acceleration, `TakeoffDistanceMultiplier`, base/effective takeoff thresholds, whether takeoff threshold scaling is active, `validTakeoff`, `validClimb`, whether stall suppressed takeoff/climb headroom, applied gravity acceleration, resolved global/override gravity, placement motion-lock state, current motion/cached velocity, lift acceleration, net vertical acceleration, airborne state, velocity-derived `aoaFromVelocity`, `criticalAoA`, `stallDemand`, `speedSeverity`, `aoaSeverity`, smoothed stall severity, stall state, lift loss, drag, control authority, pitch-break state, applied pitch-break angular velocity, and overspeed state for new-flight tuning.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -332,8 +332,14 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
       MCP_EntityPlane plane = ac instanceof MCP_EntityPlane ? (MCP_EntityPlane)ac : null;
 
+      double forwardSpeed = plane != null
+            ? ac.motionX * MCH_Lib.Rot2Vec3(ac.getRotYaw(), ac.getRotPitch()).xCoord
+                  + ac.motionY * MCH_Lib.Rot2Vec3(ac.getRotYaw(), ac.getRotPitch()).yCoord
+                  + ac.motionZ * MCH_Lib.Rot2Vec3(ac.getRotYaw(), ac.getRotPitch()).zCoord
+            : 0.0D;
+
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,speed=%.3f,vy=%.4f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stall=%.2f,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f,pitchBreak=%s)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,airspeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallState=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
               simDelta,
               mouseX,
               mouseY,
@@ -348,11 +354,15 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               Double.valueOf(ac.getNormalizedThrottle() * 100.0D),
               Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
+              forwardSpeed,
               ac.motionY,
+              ac.getRotPitch(),
               plane != null ? plane.getPhysicalMass() : 1.0D,
               plane != null ? plane.getLastWeightForce() : 0.0D,
               plane != null ? plane.getLastEngineThrustForce() : 0.0D,
               plane != null ? plane.getLastLiftForce() : 0.0D,
+              plane != null ? plane.getLastLiftForceBeforeStallLoss() : 0.0D,
+              plane != null ? plane.getLastLiftForceAfterStallLoss() : 0.0D,
               plane != null ? plane.getLiftToWeightRatio() : 0.0D,
               plane != null ? plane.getThrustToWeightRatio() : 0.0D,
               plane != null ? plane.getLastNetForwardAcceleration() : 0.0D,
@@ -360,6 +370,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               plane != null ? plane.getLastBaseTakeoffSpeed() : 0.0D,
               plane != null ? plane.getLastEffectiveTakeoffSpeed() : 0.0D,
               Boolean.valueOf(plane != null && plane.isLastTakeoffMultiplierActive()),
+              Boolean.valueOf(plane != null && plane.isLastValidTakeoff()),
+              Boolean.valueOf(plane != null && plane.isLastValidClimb()),
+              Boolean.valueOf(plane != null && plane.isLastStallSuppressedLiftHeadroom()),
               ac.getLastGravityAcceleration(),
               ac.getResolvedNewFlightGravity(),
               Boolean.valueOf(ac.isUsingNewFlightGravityOverride()),
@@ -379,12 +392,14 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getSpeedStallSeverity(),
               ac.getAoAStallSeverity(),
               ac.getStallSeverity(),
+              Boolean.valueOf(ac.getStallSeverity() > 0.0D),
               Boolean.valueOf(ac.isOverspeeding()),
               ac.getCurrentGForce(),
               ac.getLastAerodynamicDrag(),
               ac.getLastLiftLoss(),
               ac.getDebugControlAuthority(),
-              Boolean.valueOf(ac.isPitchBreakActive())
+              Boolean.valueOf(ac.isPitchBreakActive()),
+              plane != null ? plane.getLastPitchBreakAngularVelocity() : 0.0D
       ));
    }
 

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -65,6 +65,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastWeightForce;
    /** Last calculated lift force for new-flight debug output. */
    private double lastLiftForce;
+   /** Last calculated lift force before stall lift loss, exposed for stall tuning. */
+   private double lastLiftForceBeforeStallLoss;
+   /** Last calculated lift force after stall lift loss, exposed for stall tuning. */
+   private double lastLiftForceAfterStallLoss;
    /** Last calculated engine thrust force for new-flight debug output. */
    private double lastEngineThrustForce;
    /** Last net forward acceleration after thrust and energy effects. */
@@ -75,6 +79,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastEffectiveTakeoffSpeed;
    /** True when takeoff threshold scaling is actively gating/assisting rotation. */
    private boolean lastTakeoffMultiplierActive;
+   /** True when stall state suppressed takeoff/climb lift headroom this tick. */
+   private boolean lastStallSuppressedLiftHeadroom;
+   /** Debug validity flags for takeoff and climb lift headroom. */
+   private boolean lastValidTakeoff;
+   private boolean lastValidClimb;
+   /** Last stall pitch-break angular velocity applied through the normal rotation path. */
+   private double lastPitchBreakAngularVelocity;
    /** Last airborne state used by the new fixed-wing force model. */
    private boolean lastAirborne;
    /** Local-axis body rates used by fixed-wing damped control response. */
@@ -125,6 +136,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNetVerticalAcceleration = 0.0D;
       this.lastWeightForce = 0.0D;
       this.lastLiftForce = 0.0D;
+      this.lastLiftForceBeforeStallLoss = 0.0D;
+      this.lastLiftForceAfterStallLoss = 0.0D;
       this.lastEngineThrustForce = 0.0D;
       this.speedStallSeverity = 0.0D;
       this.aoaStallSeverity = 0.0D;
@@ -134,6 +147,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastBaseTakeoffSpeed = 0.0D;
       this.lastEffectiveTakeoffSpeed = 0.0D;
       this.lastTakeoffMultiplierActive = false;
+      this.lastStallSuppressedLiftHeadroom = false;
+      this.lastValidTakeoff = false;
+      this.lastValidClimb = false;
+      this.lastPitchBreakAngularVelocity = 0.0D;
       this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
@@ -462,6 +479,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return this.lastLiftForce;
    }
 
+   public double getLastLiftForceBeforeStallLoss() {
+      return this.lastLiftForceBeforeStallLoss;
+   }
+
+   public double getLastLiftForceAfterStallLoss() {
+      return this.lastLiftForceAfterStallLoss;
+   }
+
    public double getLastEngineThrustForce() {
       return this.lastEngineThrustForce;
    }
@@ -493,6 +518,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    public boolean isLastTakeoffMultiplierActive() {
       return this.lastTakeoffMultiplierActive;
+   }
+
+   public boolean isLastStallSuppressedLiftHeadroom() {
+      return this.lastStallSuppressedLiftHeadroom;
+   }
+
+   public boolean isLastValidTakeoff() {
+      return this.lastValidTakeoff;
+   }
+
+   public boolean isLastValidClimb() {
+      return this.lastValidClimb;
+   }
+
+   public double getLastPitchBreakAngularVelocity() {
+      return this.lastPitchBreakAngularVelocity;
    }
 
    public boolean isLastAirborne() {
@@ -780,17 +821,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double recoverySpeed = this.getPlaneInfo().stallRecoverySpeed > 0.0F
             ? (double)this.getPlaneInfo().stallRecoverySpeed : stallSpeed * 1.2D;
 
+      boolean safeRecoverySpeed = speed >= recoverySpeed;
+      boolean safeRecoveryAoA = Math.abs(this.angleOfAttack) <= (double)this.getPlaneInfo().criticalAoA * 0.75D;
       if(this.stalling) {
-         if(speed >= recoverySpeed && Math.abs(this.angleOfAttack) <= (double)this.getPlaneInfo().criticalAoA * 0.75D) {
+         if(safeRecoverySpeed && safeRecoveryAoA) {
             this.stalling = false;
          }
-      } else if(demand > 0.0D) {
+      } else if(demand > 0.03D) {
          this.stalling = true;
       }
 
       double targetSeverity = this.stalling ? Math.max(0.12D, demand) : 0.0D;
       this.stallSeverity += (targetSeverity - this.stallSeverity) * (targetSeverity > this.stallSeverity ? 0.35D : 0.18D);
-      if(this.stallSeverity < 1.0E-3D) {
+      if(!this.stalling && this.stallSeverity < 1.0E-3D) {
          this.stallSeverity = 0.0D;
       }
    }
@@ -841,7 +884,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
       double airspeed = this.getAirspeed();
       double airspeedLift = MCH_FlightModel.clamp((airspeed - stallSpeed * 0.45D) / Math.max(0.05D, stallSpeed * 1.35D), 0.0D, 1.25D);
-      double aoaLift = MCH_FlightModel.clamp(1.0D - Math.max(0.0D, this.angleOfAttack - (double)info.criticalAoA) / Math.max(1.0D, (double)info.criticalAoA), 0.0D, 1.0D);
+      double aoaLift = MCH_FlightModel.clamp(1.0D - Math.max(0.0D, Math.abs(this.angleOfAttack) - (double)info.criticalAoA) / Math.max(1.0D, (double)info.criticalAoA), 0.0D, 1.0D);
       double liftPower = (double)info.newFlightLowThrottleLiftRetention
             + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
       if(this.isCombatFlapsDeployed()) {
@@ -852,7 +895,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double stallLift = 1.0D - liftLoss;
       double mass = this.getPhysicalMass();
       double weightForce = gravityAccel * mass;
-      double liftForce = gravityAccel * MCH_FlightModel.clamp(liftPower, 0.0D, 2.5D) * airspeedLift * aoaLift * stallLift;
+      double liftBeforeStallLoss = gravityAccel * MCH_FlightModel.clamp(liftPower, 0.0D, 2.5D) * airspeedLift * aoaLift;
+      double liftForce = liftBeforeStallLoss * stallLift;
       double liftAccel = liftForce / mass;
       double netAccel = (liftForce - weightForce) / mass;
 
@@ -861,19 +905,24 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftAcceleration = liftAccel;
       this.lastWeightForce = weightForce;
       this.lastLiftForce = liftForce;
+      this.lastLiftForceBeforeStallLoss = liftBeforeStallLoss;
+      this.lastLiftForceAfterStallLoss = liftForce;
       this.lastNetVerticalAcceleration = netAccel;
+      this.lastValidClimb = liftForce > weightForce || this.getThrustToWeightRatio() >= 1.0D;
    }
 
    private void applyNewFlightTakeoffAssist(boolean levelOff, double waterDepth) {
       MCP_PlaneInfo info = this.getPlaneInfo();
       if(info == null || !this.useNewMobilitySystem() || levelOff || waterDepth != 0.0D || this.getNozzleRotation() > 0.01F) {
          this.lastTakeoffMultiplierActive = false;
+         this.lastValidTakeoff = false;
          return;
       }
 
       boolean nearGround = super.onGround || MCH_Lib.getBlockIdY(this, 3, -5) > 0;
       if(!nearGround) {
          this.lastTakeoffMultiplierActive = false;
+         this.lastValidTakeoff = false;
          return;
       }
 
@@ -885,7 +934,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastEffectiveTakeoffSpeed = effectiveTakeoffSpeed;
       boolean multiplierAdjusted = Math.abs(multiplier - 1.0D) > 1.0E-4D;
       this.lastTakeoffMultiplierActive = multiplierAdjusted && horizontalSpeed < baseTakeoffSpeed * 1.15D;
+      this.lastValidTakeoff = horizontalSpeed >= effectiveTakeoffSpeed && this.stallSeverity < 0.15D;
       if(!multiplierAdjusted) {
+         return;
+      }
+
+      if(this.stalling || this.stallSeverity >= 0.15D) {
+         this.lastStallSuppressedLiftHeadroom = true;
+         if(super.motionY > 0.0D) {
+            super.motionY *= 1.0D - MCH_FlightModel.clamp(this.stallSeverity * 0.35D, 0.0D, 0.35D);
+         }
          return;
       }
 
@@ -909,6 +967,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       super.motionY += liftAccel * 0.55D;
       this.lastLiftForce = Math.max(this.lastLiftForce, liftForce);
+      this.lastLiftForceBeforeStallLoss = Math.max(this.lastLiftForceBeforeStallLoss, liftForce);
+      this.lastLiftForceAfterStallLoss = Math.max(this.lastLiftForceAfterStallLoss, liftForce);
       this.lastLiftAcceleration = Math.max(this.lastLiftAcceleration, liftAccel);
    }
 
@@ -926,6 +986,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNetVerticalAcceleration = 0.0D;
       this.lastWeightForce = 0.0D;
       this.lastLiftForce = 0.0D;
+      this.lastLiftForceBeforeStallLoss = 0.0D;
+      this.lastLiftForceAfterStallLoss = 0.0D;
       this.lastEngineThrustForce = 0.0D;
       this.speedStallSeverity = 0.0D;
       this.aoaStallSeverity = 0.0D;
@@ -935,6 +997,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastBaseTakeoffSpeed = 0.0D;
       this.lastEffectiveTakeoffSpeed = 0.0D;
       this.lastTakeoffMultiplierActive = false;
+      this.lastStallSuppressedLiftHeadroom = false;
+      this.lastValidTakeoff = false;
+      this.lastValidClimb = false;
+      this.lastPitchBreakAngularVelocity = 0.0D;
       this.lastAirborne = false;
       this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;
       this.currentGForce = 1.0D;
@@ -1566,6 +1632,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastEngineThrustForce = 0.0D;
       }
       Vec3 v;
+      this.lastStallSuppressedLiftHeadroom = false;
+      this.lastPitchBreakAngularVelocity = 0.0D;
 
       // 如果喷嘴的旋转角度大于0.001F
       if(this.getNozzleRotation() > 0.001F) {
@@ -1587,7 +1655,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if(!levelOff) {
          // 如果喷嘴旋转角度小于等于0.01F，根据油门调整垂直方向上的速度
          if(this.getNozzleRotation() <= 0.01F) {
-            super.motionY += v.yCoord * (double)throttle1 / 2.0D;
+            double verticalThrust = v.yCoord * (double)throttle1 / 2.0D;
+            if(this.useNewMobilitySystem() && this.getPlaneInfo() != null && verticalThrust > 0.0D) {
+               double mass = this.getPhysicalMass();
+               double gravityAccel = Math.max(1.0E-6D, this.resolveNewFlightGravity());
+               double thrustToWeight = ((double)this.getPlaneInfo().engineThrust * propulsiveThrottle) / (gravityAccel * mass);
+               double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+                     this.getPlaneInfo().stallSpeedFactor);
+               double speedHeadroom = MCH_FlightModel.clamp(this.getAirspeed() / Math.max(0.05D, stallSpeed * 1.2D), 0.0D, 1.0D);
+               double supportedVerticalThrust = thrustToWeight >= 1.0D ? 1.0D
+                     : MCH_FlightModel.clamp(thrustToWeight * speedHeadroom * (1.0D - this.stallSeverity), 0.0D, 1.0D);
+               verticalThrust *= supportedVerticalThrust;
+               if(supportedVerticalThrust < 1.0D) {
+                  this.lastStallSuppressedLiftHeadroom = true;
+               }
+            }
+            super.motionY += verticalThrust;
          } else {
             super.motionY += v.yCoord * (double)throttle1 / 8.0D;
          }
@@ -1650,6 +1733,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                this.getPlaneInfo().controlSurfaceDrag, (float)engineBrakeDrag) / mass;
          drag += MCH_FlightModel.getAngleOfAttackDrag(this.angleOfAttack, this.getPlaneInfo().criticalAoA,
                this.getPlaneInfo().baseDrag, this.getPlaneInfo().aoaDragMultiplier) / mass;
+         if(super.motionY > 0.0D && this.getRotPitch() < -35.0F) {
+            double unsupportedClimb = MCH_FlightModel.clamp((-this.getRotPitch() - 35.0D) / 55.0D, 0.0D, 1.0D)
+                  * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
+            drag += unsupportedClimb * (0.08D + 0.22D * Math.max(this.stallSeverity, this.aoaStallSeverity));
+            super.motionY -= unsupportedClimb * (0.006D + 0.012D * this.stallSeverity);
+            if(unsupportedClimb > 0.0D) {
+               this.lastStallSuppressedLiftHeadroom = true;
+            }
+         }
          drag = MCH_FlightModel.clamp(drag, 0.0D, 0.5D);
          this.lastAerodynamicDrag = drag;
          double energyChange = MCH_FlightModel.getVerticalEnergyChange(super.motionY,
@@ -1741,6 +1833,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             // negative rotation pitch, and nose-down attitude is positive rotation pitch.
             double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
             double noseDownPitchDelta = pitchBreak * (0.35D + noseUpAttitude);
+            double appliedPitchBreakVelocity = MCH_FlightModel.clamp(noseDownPitchDelta * 0.45D, 0.0D, 1.2D);
+            this.pitchAngularVelocity += (float)appliedPitchBreakVelocity;
+            this.lastPitchBreakAngularVelocity = appliedPitchBreakVelocity;
             this.setRotPitch(this.getRotPitch() + (float)noseDownPitchDelta);
             if(this.pitchAngularVelocity < 0.0F) {
                this.pitchAngularVelocity *= (float)(1.0D - MCH_FlightModel.clamp(this.stallSeverity * 0.35D, 0.0D, 0.35D));


### PR DESCRIPTION
### Motivation
- Clarify and tighten fixed‑wing aerodynamic behavior (stall entry/recovery, lift ordering, unsupported vertical climbs, and pitch break) to better match intended flight dynamics and make tuning more robust. 
- Surface more internal telemetry for debugging and tuning of stalls, takeoff assist, lift breakdown, and pitch break moments. 
- Update documentation to describe the refined formulas and new debug output fields.

### Description
- Updated docs in `docs/vehicle-config/base.md` and `docs/vehicle-config/planes.md` to expand explanations about gravity, lift/weight limits, stall behavior, takeoff/climb suppression while stalled, and debug logging content. 
- Enhanced debug logging in `MCH_ClientCommonTickHandler.debugFlightControl` to include `forwardSpeed`, `pitch`, `liftBeforeStall`, `liftAfterStall`, `validTakeoff`, `validClimb`, `stallSuppressedHeadroom`, `stallSeverity`/`stallState`, `pitchBreakAngularVelocity`, and other telemetry fields. 
- Added new debug state fields and accessors to `MCP_EntityPlane` including `lastLiftForceBeforeStallLoss`, `lastLiftForceAfterStallLoss`, `lastStallSuppressedLiftHeadroom`, `lastValidTakeoff`, `lastValidClimb`, and `lastPitchBreakAngularVelocity`, with initialization and reset handling. 
- Adjusted stall entry/recovery logic in `updateAerodynamicState` to use a small hysteresis entry threshold (`demand > 0.03`) and require both speed and AoA recovery conditions in the same tick. 
- Split lift computation in `applyNewFlightVerticalForces` into `liftBeforeStallLoss` and final `liftForce = liftBeforeStallLoss * stallLift`, exposed both for debugging, and set `lastValidClimb` when lift exceeds weight or thrust‑to‑weight >= 1.0. 
- Modified `applyNewFlightTakeoffAssist` to set `lastValidTakeoff`, mark and suppress takeoff/climb headroom if stalled, and to clamp throttle takeoff assistance appropriately. 
- Added logic to scale vertical thrust contribution (when using the new mobility model) by `thrustToWeight`, speed headroom, and stall severity so unsupported vertical climbs are limited by thrust/speed and produce extra drag/sink when exceeding capability. 
- Applied deterministic pitch‑break angular velocity to the normal rotation path and expose `lastPitchBreakAngularVelocity` for debug consumers. 

### Testing
- Performed a project build with `./gradlew build` which completed successfully. 
- No automated unit tests were modified or added; no existing automated tests failed during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a305a6a6e7c83299c6d0a86f626db02)