### PR TITLE
Improve stall model: new parameters, nose-up suppression, and enhanced debug output

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -247,7 +247,10 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `StallInstability` | Plane | float[0..5] | 0.35 | buffet/wing-drop strength |
 | `StallRecoverySpeed` | Plane | float[0..10] | 0 = `StallSpeed*1.2` | stall recovery speed |
 | `StallSpeedFactor` | Plane | float[0..0.95] | 0.22 | legacy derived stall speed factor |
-| `StallStrength` | Plane | float[0..4] | 0.6 | legacy sink strength during stall |
+| `StallStrength` | Plane | float[0..4] | 0.6 | legacy stall response scale |
+| `StallPitchRecoveryStrength` | Plane | float[0..5] | 0.55 | nose-down stall recovery moment |
+| `StallBreakStrength` | Plane | float[0..5] | 0.65 | nonlinear deep-stall pitch-break impulse |
+| `StallRecoveryRate` | Plane | float[0.01..1] | 0.18 | stall severity fade-out/recovery blend rate |
 | `DiveSpeedMultiplier` | Plane | float[1..2] | 1.25 | max dive overspeed cap |
 | `MaxComfortableG` | Plane | float[1..30] | 4.0 | high-G authority fade starts |
 | `MaxStructuralG` | Plane | float[1..50] | 8.0 | high-G authority fade ends/damage hook threshold |
@@ -270,4 +273,3 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `addpart` | Turret/static | `drawFP,rotYaw,rotPitch,type,x,y,z[,recoilBuf]` | none | turret part |
 | `addchildpart` | Turret/static | same as `addpart` | none | child part of last turret part |
 | `PreventWaterBobbing` | Ship | boolean | false | ship water motion option |
-

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -70,7 +70,10 @@ With the default `AllPlaneSpeed = 1000`, a 500 mph plane therefore uses `Speed 0
 | `StallInstability` | float[0..5] | 0.35 | Buffet, yaw shake, and deterministic wing-drop strength. |
 | `StallRecoverySpeed` | float[0..10] | 0 = `StallSpeed*1.2` | Speed required, with low AoA, to exit a stall. |
 | `StallSpeedFactor` | float[0..0.95] | 0.22 | Legacy derived stall threshold when `StallSpeed` is omitted. |
-| `StallStrength` | float[0..4] | 0.6 | Stall sink and deterministic pitch-break strength. |
+| `StallStrength` | float[0..4] | 0.6 | Legacy stall response scale retained for older packs. |
+| `StallPitchRecoveryStrength` | float[0..5] | 0.55 | Nose-down angular-velocity moment applied during stalls. Higher values make light fighters break/recover more aggressively. |
+| `StallBreakStrength` | float[0..5] | 0.65 | Extra nonlinear nose-down impulse for deep stalls. Lower values suit transports or stable aircraft. |
+| `StallRecoveryRate` | float[0.01..1] | 0.18 | Blend rate used as stall severity fades after the aircraft unloads and meets recovery conditions. |
 | `DiveSpeedMultiplier` | float[1..2] | 1.25 | Maximum speed cap multiplier in a dive. |
 | `MaxComfortableG` | float[1..30] | 4 | G where high-G control fade starts. |
 | `MaxStructuralG` | float[1..50] | 8 | G where high-G fade reaches the configured penalty and structural hook begins. Warns if below `MaxComfortableG`. |
@@ -204,20 +207,36 @@ liftForce = liftBeforeStallLoss * stallLift
 
 This means pointing the nose near vertical does not create maximum lift unless the velocity vector, airspeed, lift-to-weight, and thrust-to-weight are still within valid flying conditions. Conventional fixed-wing thrust is also limited during unsupported vertical climbs: if thrust-to-weight is below 1.0, upward powered climb is scaled by speed headroom and remaining unstalled authority. High nose-up climbs add extra AoA/energy drag and bleed vertical energy unless the aircraft is truly tuned with enough thrust and speed to support them.
 
-Developed stalls also apply sink and a deterministic pitch break:
+Developed stalls remove lift through the normal lift model and apply a deterministic nose-down pitch moment:
 
 ```text
-if motionY > 0: motionY *= 1 - liftLoss * 0.12
-motionY -= 0.018 * liftLoss * StallStrength
-pitchBreak = stallSeverity * StallStrength * (0.12 + 0.18 * max(speedSeverity, aoaSeverity))
-pitchAngularVelocity += clamp(pitchBreak * noseDownScale * 0.45, 0, 1.2)
+aerodynamicDemand = max(stallDemand, speedSeverity, aoaSeverity)
+liftDeficit = clamp(1 - liftToWeight, 0, 1)
+authorityLoss = clamp(1 - controlAuthority, 0, 1)
+legacyStrengthScale = clamp(StallStrength / 0.6, 0, 4)
+pitchRecovery = stallSeverity * StallPitchRecoveryStrength * legacyStrengthScale
+              * (0.25 + 0.75 * aerodynamicDemand)
+              * (0.55 + 0.45 * max(noseUpAttitude, liftDeficit))
+deepStallBreak = stallSeverity^2 * StallBreakStrength * legacyStrengthScale
+               * (0.35 + 0.65 * max(aoaSeverity, authorityLoss))
+pitchAngularVelocity += clamp((pitchRecovery + deepStallBreak) * 0.45, 0, 1.8)
 ```
 
-Pitch break uses the same pitch/angular velocity path as visible fixed-wing rotation. The moment is deterministic, scales with `stallSeverity`, `StallStrength`, and stall demand, and adds bounded nose-down pitch rather than only applying vertical sink.
+Pitch break uses the same pitch/angular velocity path as visible fixed-wing rotation. The moment is deterministic, scales with `stallSeverity`, the existing aerodynamic state, and the configured recovery/break strengths, then adds bounded nose-down angular velocity instead of directly injecting stall-only downward Y velocity.
 
-`pitchBreak` is applied as a nose-down pitch moment and damps excessive nose-up pitch angular velocity. MCHeli/Minecraft rotation pitch uses inverted sign convention: nose-up attitude is negative numeric pitch, and nose-down attitude is positive numeric pitch. The pitch-break code therefore adds a positive rotation-pitch delta to lower the nose. It is separate from `StallInstability`: `StallInstability` still adds repeatable roll/yaw buffet and wing drop, while `StallStrength` controls the predictable unloading/sink force that helps a stalled aircraft lower the nose, regain airspeed, and recover only after both speed and AoA meet the recovery limits.
+Pilot nose-up input is also suppressed when the aircraft lacks energy or lift to support a climb:
 
-If stalling feels too weak for a specific aircraft, tune the asset first. Lower `CriticalAoA` to make excessive-AoA stalls begin earlier, raise `StallLiftLoss` to remove more lift at full stall, raise `StallStrength` to increase sink and pitch-break unloading, and raise `StallInstability` only when you want more buffet/wing drop. Change code only when the same weakness appears across many correctly tuned `useNewMobilitySystem = true` planes or when the documented formulas no longer match observed behavior.
+```text
+unsupportedClimb = nose-up attitude while climbing * max(0, 1 - thrustToWeight)
+energyDeficit = max(stallSeverity, aoaSeverity, speedSeverity, liftDeficit, unsupportedClimb)
+noseUpPitchInput *= 1 - clamp(energyDeficit * (0.35 + 0.65 * noseUpAttitude), 0, 1)
+```
+
+This does not block nose-down unloading input. It only prevents the pilot from continuing to command more nose-up pitch when the aircraft is already stalled, lift-deficient, too slow, or trying to climb without enough thrust/energy.
+
+`pitchBreak` is applied as a nose-down pitch moment and damps excessive nose-up pitch angular velocity. MCHeli/Minecraft rotation pitch uses inverted sign convention: nose-up attitude is negative numeric pitch, and nose-down attitude is positive numeric pitch. The pitch-break code therefore adds positive pitch angular velocity to lower the nose. It is separate from `StallInstability`: `StallInstability` still adds repeatable roll/yaw buffet and wing drop, while `StallPitchRecoveryStrength` and `StallBreakStrength` control how strongly a stalled aircraft lowers the nose, regains airspeed, and recovers only after both speed and AoA meet the recovery limits. `StallStrength` remains a legacy multiplier over both pitch moments so older aircraft packs keep their relative stall-break tuning. `StallRecoveryRate` controls how smoothly the smoothed stall severity fades out after recovery begins.
+
+If stalling feels too weak for a specific aircraft, tune the asset first. Lower `CriticalAoA` to make excessive-AoA stalls begin earlier, raise `StallLiftLoss` to remove more lift at full stall, raise `StallPitchRecoveryStrength` for stronger normal stall unloading, raise `StallBreakStrength` for more aggressive deep-stall nose drops, and raise `StallInstability` only when you want more buffet/wing drop. Change code only when the same weakness appears across many correctly tuned `useNewMobilitySystem = true` planes or when the documented formulas no longer match observed behavior.
 
 ### G-force, speed scaling, and compressibility
 
@@ -290,6 +309,9 @@ StallLiftLoss = 0.70
 AoADragMultiplier = 1.8
 StallInstability = 0.45
 StallRecoverySpeed = 0.46
+StallPitchRecoveryStrength = 0.75
+StallBreakStrength = 0.90
+StallRecoveryRate = 0.22
 DiveSpeedMultiplier = 1.22
 MaxComfortableG = 4.5
 MaxStructuralG = 8.5

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -339,7 +339,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             : 0.0D;
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,airspeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallState=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,flaps=%s,airspeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f,noseUpSuppress=%.2f,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
               simDelta,
               mouseX,
               mouseY,
@@ -363,6 +363,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               plane != null ? plane.getLastLiftForce() : 0.0D,
               plane != null ? plane.getLastLiftForceBeforeStallLoss() : 0.0D,
               plane != null ? plane.getLastLiftForceAfterStallLoss() : 0.0D,
+              ac.getLastLiftCoefficient(),
               plane != null ? plane.getLiftToWeightRatio() : 0.0D,
               plane != null ? plane.getThrustToWeightRatio() : 0.0D,
               plane != null ? plane.getLastNetForwardAcceleration() : 0.0D,
@@ -392,12 +393,15 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getSpeedStallSeverity(),
               ac.getAoAStallSeverity(),
               ac.getStallSeverity(),
+              ac.getLastStallPitchMoment(),
               Boolean.valueOf(ac.getStallSeverity() > 0.0D),
+              Boolean.valueOf(ac.isStallRecovering()),
               Boolean.valueOf(ac.isOverspeeding()),
               ac.getCurrentGForce(),
               ac.getLastAerodynamicDrag(),
               ac.getLastLiftLoss(),
               ac.getDebugControlAuthority(),
+              ac.getLastNoseUpPitchSuppression(),
               Boolean.valueOf(ac.isPitchBreakActive()),
               plane != null ? plane.getLastPitchBreakAngularVelocity() : 0.0D
       ));

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1852,6 +1852,22 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return false;
    }
 
+   public double getLastStallPitchMoment() {
+      return 0.0D;
+   }
+
+   public double getLastLiftCoefficient() {
+      return 0.0D;
+   }
+
+   public boolean isStallRecovering() {
+      return false;
+   }
+
+   public double getLastNoseUpPitchSuppression() {
+      return 0.0D;
+   }
+
    /** Most recent fixed-wing drag fraction applied by the energy model. */
    public double getLastAerodynamicDrag() {
       return 0.0D;

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -86,6 +86,14 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private boolean lastValidClimb;
    /** Last stall pitch-break angular velocity applied through the normal rotation path. */
    private double lastPitchBreakAngularVelocity;
+   /** Last total nose-down stall pitch moment applied for debug output. */
+   private double lastStallPitchMoment;
+   /** Last lift coefficient multiplier after AoA and stall lift loss. */
+   private double lastLiftCoefficient;
+   /** True when current stall state is blending back toward normal flight. */
+   private boolean stallRecovering;
+   /** Fraction of pilot nose-up pitch input currently suppressed by energy/stall state. */
+   private double lastNoseUpPitchSuppression;
    /** Last airborne state used by the new fixed-wing force model. */
    private boolean lastAirborne;
    /** Local-axis body rates used by fixed-wing damped control response. */
@@ -151,6 +159,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastValidTakeoff = false;
       this.lastValidClimb = false;
       this.lastPitchBreakAngularVelocity = 0.0D;
+      this.lastStallPitchMoment = 0.0D;
+      this.lastLiftCoefficient = 0.0D;
+      this.stallRecovering = false;
+      this.lastNoseUpPitchSuppression = 0.0D;
       this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
@@ -402,6 +414,24 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             * throttleAuthority * flapAuthority, 0.05D, 1.35D);
    }
 
+   private double getNoseUpPitchSuppression() {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
+         return 0.0D;
+      }
+
+      double liftDeficit = this.lastWeightForce > 1.0E-6D
+            ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
+      double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
+      double unsupportedClimb = super.motionY > 0.0D && this.getRotPitch() < -15.0F
+            ? MCH_FlightModel.clamp((-this.getRotPitch() - 15.0D) / 45.0D, 0.0D, 1.0D)
+                  * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D)
+            : 0.0D;
+      double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
+            Math.max(this.speedStallSeverity, liftDeficit));
+      double energyDeficit = Math.max(aerodynamicDeficit, unsupportedClimb);
+      return MCH_FlightModel.clamp(energyDeficit * (0.35D + 0.65D * noseUpAttitude), 0.0D, 1.0D);
+   }
+
    public double getCurrentGForce() {
       return this.currentGForce;
    }
@@ -534,6 +564,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    public double getLastPitchBreakAngularVelocity() {
       return this.lastPitchBreakAngularVelocity;
+   }
+
+   public double getLastStallPitchMoment() {
+      return this.lastStallPitchMoment;
+   }
+
+   public double getLastLiftCoefficient() {
+      return this.lastLiftCoefficient;
+   }
+
+   public boolean isStallRecovering() {
+      return this.stallRecovering;
+   }
+
+   public double getLastNoseUpPitchSuppression() {
+      return this.lastNoseUpPitchSuppression;
    }
 
    public boolean isLastAirborne() {
@@ -703,6 +749,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double pitchAuthority = MCH_FlightModel.getCompressibilityPitchAuthority(this.getAirspeed(),
             this.getCompressibilitySpeed(), this.getMaxSafeSpeed(), this.getPlaneInfo().compressibilityPitchPenalty);
       pitch *= controlAuthority * (float)pitchAuthority;
+      this.lastNoseUpPitchSuppression = this.getNoseUpPitchSuppression();
+      if(pitch < 0.0F && this.lastNoseUpPitchSuppression > 0.0D) {
+         pitch *= (float)(1.0D - this.lastNoseUpPitchSuppression);
+      }
       roll *= controlAuthority;
       yaw *= controlAuthority;
 
@@ -832,9 +882,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       double targetSeverity = this.stalling ? Math.max(0.12D, demand) : 0.0D;
-      this.stallSeverity += (targetSeverity - this.stallSeverity) * (targetSeverity > this.stallSeverity ? 0.35D : 0.18D);
+      double recoveryRate = MCH_FlightModel.clamp((double)this.getPlaneInfo().stallRecoveryRate, 0.01D, 1.0D);
+      this.stallSeverity += (targetSeverity - this.stallSeverity)
+            * (targetSeverity > this.stallSeverity ? 0.35D : recoveryRate);
+      this.stallRecovering = !this.stalling && this.stallSeverity > 0.0D;
       if(!this.stalling && this.stallSeverity < 1.0E-3D) {
          this.stallSeverity = 0.0D;
+         this.stallRecovering = false;
       }
    }
 
@@ -873,6 +927,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastNetVerticalAcceleration = 0.0D;
          this.lastWeightForce = 0.0D;
          this.lastLiftForce = 0.0D;
+         this.lastLiftCoefficient = 0.0D;
          return;
       }
 
@@ -893,6 +948,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)info.stallLiftLoss, 0.0D, 1.0D);
       this.lastLiftLoss = liftLoss;
       double stallLift = 1.0D - liftLoss;
+      this.lastLiftCoefficient = aoaLift * stallLift;
       double mass = this.getPhysicalMass();
       double weightForce = gravityAccel * mass;
       double liftBeforeStallLoss = gravityAccel * MCH_FlightModel.clamp(liftPower, 0.0D, 2.5D) * airspeedLift * aoaLift;
@@ -941,9 +997,6 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       if(this.stalling || this.stallSeverity >= 0.15D) {
          this.lastStallSuppressedLiftHeadroom = true;
-         if(super.motionY > 0.0D) {
-            super.motionY *= 1.0D - MCH_FlightModel.clamp(this.stallSeverity * 0.35D, 0.0D, 0.35D);
-         }
          return;
       }
 
@@ -1001,6 +1054,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastValidTakeoff = false;
       this.lastValidClimb = false;
       this.lastPitchBreakAngularVelocity = 0.0D;
+      this.lastStallPitchMoment = 0.0D;
+      this.lastLiftCoefficient = 0.0D;
+      this.stallRecovering = false;
+      this.lastNoseUpPitchSuppression = 0.0D;
       this.lastAirborne = false;
       this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;
       this.currentGForce = 1.0D;
@@ -1634,6 +1691,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       Vec3 v;
       this.lastStallSuppressedLiftHeadroom = false;
       this.lastPitchBreakAngularVelocity = 0.0D;
+      this.lastStallPitchMoment = 0.0D;
 
       // 如果喷嘴的旋转角度大于0.001F
       if(this.getNozzleRotation() > 0.001F) {
@@ -1737,7 +1795,6 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             double unsupportedClimb = MCH_FlightModel.clamp((-this.getRotPitch() - 35.0D) / 55.0D, 0.0D, 1.0D)
                   * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
             drag += unsupportedClimb * (0.08D + 0.22D * Math.max(this.stallSeverity, this.aoaStallSeverity));
-            super.motionY -= unsupportedClimb * (0.006D + 0.012D * this.stallSeverity);
             if(unsupportedClimb > 0.0D) {
                this.lastStallSuppressedLiftHeadroom = true;
             }
@@ -1813,10 +1870,6 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if(this.useNewMobilitySystem() && !nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff && this.stallSeverity > 0.0D) {
          double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)this.getPlaneInfo().stallLiftLoss, 0.0D, 1.0D);
          this.lastLiftLoss = liftLoss;
-         if(super.motionY > 0.0D) {
-            super.motionY *= 1.0D - liftLoss * 0.12D;
-         }
-         super.motionY -= 0.018D * liftLoss * (double)this.getPlaneInfo().stallStrength;
 
          double phase = (double)(super.ticksExisted + this.getEntityId() * 13) * 0.37D;
          double buffet = Math.sin(phase) * (double)this.getPlaneInfo().stallInstability * this.stallSeverity;
@@ -1825,18 +1878,27 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.setRotRoll(this.getRotRoll() + (float)(wingDrop * 0.08D + buffet * 0.04D));
          this.setRotYaw(this.getRotYaw() + (float)(buffet * 0.02D));
 
-         double pitchBreak = this.stallSeverity * (double)this.getPlaneInfo().stallStrength
-               * (0.12D + 0.18D * Math.max(this.speedStallSeverity, this.aoaStallSeverity));
-         if(pitchBreak > 1.0E-4D) {
+         double aerodynamicDemand = Math.max(this.stallDemand, Math.max(this.speedStallSeverity, this.aoaStallSeverity));
+         double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
+         double liftDeficit = MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D);
+         double authorityLoss = MCH_FlightModel.clamp(1.0D - (double)this.getControlAuthorityFactor(), 0.0D, 1.0D);
+         double legacyStrengthScale = MCH_FlightModel.clamp((double)this.getPlaneInfo().stallStrength / 0.6D, 0.0D, 4.0D);
+         double pitchRecovery = this.stallSeverity * (double)this.getPlaneInfo().stallPitchRecoveryStrength
+               * legacyStrengthScale
+               * (0.25D + 0.75D * aerodynamicDemand)
+               * (0.55D + 0.45D * Math.max(noseUpAttitude, liftDeficit));
+         double deepStallBreak = this.stallSeverity * this.stallSeverity * (double)this.getPlaneInfo().stallBreakStrength
+               * legacyStrengthScale
+               * (0.35D + 0.65D * Math.max(this.aoaStallSeverity, authorityLoss));
+         double stallPitchMoment = pitchRecovery + deepStallBreak;
+         if(stallPitchMoment > 1.0E-4D) {
             this.pitchBreakActive = true;
             // MCHeli/Minecraft pitch is inverted from aerodynamic sign: nose-up attitude is
             // negative rotation pitch, and nose-down attitude is positive rotation pitch.
-            double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
-            double noseDownPitchDelta = pitchBreak * (0.35D + noseUpAttitude);
-            double appliedPitchBreakVelocity = MCH_FlightModel.clamp(noseDownPitchDelta * 0.45D, 0.0D, 1.2D);
+            double appliedPitchBreakVelocity = MCH_FlightModel.clamp(stallPitchMoment * 0.45D, 0.0D, 1.8D);
             this.pitchAngularVelocity += (float)appliedPitchBreakVelocity;
             this.lastPitchBreakAngularVelocity = appliedPitchBreakVelocity;
-            this.setRotPitch(this.getRotPitch() + (float)noseDownPitchDelta);
+            this.lastStallPitchMoment = stallPitchMoment;
             if(this.pitchAngularVelocity < 0.0F) {
                this.pitchAngularVelocity *= (float)(1.0D - MCH_FlightModel.clamp(this.stallSeverity * 0.35D, 0.0D, 0.35D));
             }

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -96,6 +96,12 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float stallSpeedFactor = 0.22F;
    /** Legacy stall response strength, retained for plane packs that already tune it. */
    public float stallStrength = 0.6F;
+   /** Nose-down angular velocity added during stalls; higher values recover AoA more aggressively. */
+   public float stallPitchRecoveryStrength = 0.55F;
+   /** Additional nonlinear pitch-break impulse for deep stalls. */
+   public float stallBreakStrength = 0.65F;
+   /** Blend rate used when stall severity and pitch recovery fade out after unloading. */
+   public float stallRecoveryRate = 0.18F;
    /** Maximum extra horizontal speed available while a plane is diving. */
    public float diveSpeedMultiplier = 1.25F;
    /** Load factor where high-G control authority begins to fade. */
@@ -354,6 +360,12 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.stallSpeedFactor = this.toFloat(data, 0.0F, 0.95F);
          } else if(item.equalsIgnoreCase("StallStrength")) {
             this.stallStrength = this.toFloat(data, 0.0F, 4.0F);
+         } else if(item.equalsIgnoreCase("StallPitchRecoveryStrength")) {
+            this.stallPitchRecoveryStrength = this.toFloat(data, 0.0F, 5.0F);
+         } else if(item.equalsIgnoreCase("StallBreakStrength")) {
+            this.stallBreakStrength = this.toFloat(data, 0.0F, 5.0F);
+         } else if(item.equalsIgnoreCase("StallRecoveryRate")) {
+            this.stallRecoveryRate = this.toFloat(data, 0.01F, 1.0F);
          } else if(item.equalsIgnoreCase("DiveSpeedMultiplier")) {
             this.diveSpeedMultiplier = this.toFloat(data, 1.0F, 2.0F);
          } else if(item.equalsIgnoreCase("MaxComfortableG")) {


### PR DESCRIPTION
### Motivation

- Replace legacy single-parameter stall response with a more expressive and tunable model that separates normal stall recovery, deep-stall break, and recovery blending. 
- Prevent pilots from commanding nose-up when the aircraft lacks energy or lift, improving realistic stall behaviour and avoiding unrealistic climbs. 
- Expose more internal debug state for tuning and documentation so pack authors can adjust stalls more predictably.

### Description

- Added three new plane config keys and documentation: `StallPitchRecoveryStrength`, `StallBreakStrength`, and `StallRecoveryRate`, and updated `StallStrength` description to remain a legacy multiplier; docs updated in `vehicle-config-reference.md` and `vehicle-config/planes.md`.
- Reworked stall handling in `MCP_EntityPlane`: split legacy `StallStrength` into separate `pitchRecovery` and `deepStallBreak` contributions, compute `stallPitchMoment`, apply bounded nose-down angular velocity rather than injecting direct downward motion, and use `stallRecoveryRate` when fading stall severity.
- Added nose-up input suppression (`getNoseUpPitchSuppression`) to reduce pilot up-input when the aircraft is energy- or lift-deficient and applied suppression to control integration.
- Added debug state fields and accessors: `lastStallPitchMoment`, `lastLiftCoefficient`, `stallRecovering`, `lastNoseUpPitchSuppression` in `MCP_EntityPlane` and corresponding getters in `MCH_EntityBaseVehicle`; expanded flight debug logging in `MCH_ClientCommonTickHandler` to print these values.
- Updated parser in `MCP_PlaneInfo` to read new keys and initialized defaults; updated plane instance initialization and resets to manage new fields.

### Testing

- Performed a full project build with `./gradlew build`, which completed successfully.
- Ran the JVM test task with `./gradlew test`; the project test suite (if present) completed without failures.
- Exercised runtime behaviour in local development runs to verify no crashes on entity update and that new debug output prints the additional stall/Lift fields when `DebugFlightControl` is enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3077883d0c83298a796c927fb36aa8)