### PR TITLE
Fix low-speed pitch recovery physics

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -175,7 +175,7 @@ aoaSeverity = clamp((abs(AoA) - CriticalAoA) / CriticalAoA, 0, 1)
 demand = max(speedSeverity, aoaSeverity)
 ```
 
-`AoA` is the angle between where the aircraft nose points and where the aircraft is actually moving. It is not the pitch angle by itself. Near-zero airspeed reports `AoA = 0` so parked or nearly stationary aircraft do not feed invalid vectors into stall math.
+`AoA` is the angle between where the aircraft nose points and where the aircraft is actually moving. It is not the pitch angle by itself. At extremely low airspeed, the velocity vector is blended with nose-vs-horizontal attitude so a nose-high aircraft with collapsed airspeed remains aerodynamically stalled instead of appearing clean.
 
 If not already stalling, demand above the small entry hysteresis band starts a stall. While stalling, one good frame is not enough to recover unless both recovery conditions are true in the same tick:
 
@@ -247,6 +247,8 @@ highGAuthority = clamp(1 - highGSeverity * GControlPenalty, 0.05, 1)
 stallAuthority = clamp(1 - stallSeverity * 0.75, 0.25, 1)
 controlAuthority = highGAuthority * stallAuthority
 ```
+
+Throttle does not directly scale this control authority; cutting power reduces thrust-to-weight, lift-to-weight, and energy state, which then increases stall/unsupported-climb suppression and pitch-break recovery.
 
 Pitch also loses authority above compressibility speed:
 

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -80,13 +80,29 @@ public final class MCH_FlightModel {
                                                 double velocityX, double velocityY, double velocityZ) {
       double forwardLength = Math.sqrt(forwardX * forwardX + forwardY * forwardY + forwardZ * forwardZ);
       double speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
-      if(forwardLength < 1.0E-6D || speed < 1.0E-6D) {
+      if(forwardLength < 1.0E-6D) {
          return 0.0D;
+      }
+
+      // At very low airspeed the velocity vector becomes numerically unstable, but
+      // a nose-high fixed-wing aircraft should not look aerodynamically clean. Blend
+      // toward the nose-vs-horizontal attitude so stalled, nearly suspended aircraft
+      // continue to accumulate AoA/stall demand instead of escaping recovery logic.
+      double horizontalForward = Math.sqrt(forwardX * forwardX + forwardZ * forwardZ);
+      double attitudeAoA = Math.toDegrees(Math.atan2(Math.abs(forwardY), horizontalForward));
+      if(speed < 1.0E-6D) {
+         return attitudeAoA;
       }
 
       double dot = (forwardX * velocityX + forwardY * velocityY + forwardZ * velocityZ)
             / (forwardLength * speed);
-      return Math.toDegrees(Math.acos(clamp(dot, -1.0D, 1.0D)));
+      double velocityAoA = Math.toDegrees(Math.acos(clamp(dot, -1.0D, 1.0D)));
+      if(speed >= 0.08D) {
+         return velocityAoA;
+      }
+
+      double velocityBlend = clamp(speed / 0.08D, 0.0D, 1.0D);
+      return attitudeAoA * (1.0D - velocityBlend) + velocityAoA * velocityBlend;
    }
 
    /** Resolves an absolute stall speed while retaining compatibility with StallSpeedFactor. */

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -410,11 +410,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double highGAuthority = MCH_FlightModel.getHighGControlAuthority(this.currentGForce,
             info.maxComfortableG, info.maxStructuralG, info.gControlPenalty);
       double severity = Math.max(this.stallSeverity, this.getInstantStallSeverity());
-      double throttleAuthority = 1.0D - (1.0D - this.getEffectiveEngineThrottle())
-            * (double)info.newFlightThrottleControlAuthorityScale;
       double flapAuthority = this.isCombatFlapsDeployed() ? 1.0D + (double)info.newFlightCombatFlapControl : 1.0D;
       return (float)MCH_FlightModel.clamp(highGAuthority * MCH_FlightModel.getControlAuthority(severity)
-            * throttleAuthority * flapAuthority, 0.05D, 1.35D);
+            * flapAuthority, 0.05D, 1.35D);
    }
 
    private double getNoseUpPitchSuppression() {
@@ -425,9 +423,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double liftDeficit = this.lastWeightForce > 1.0E-6D
             ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
       double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
-      double unsupportedClimb = super.motionY > 0.0D && this.getRotPitch() < -15.0F
+      double lowEnergyNoseHigh = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.0D,
+            this.speedStallSeverity);
+      double unsupportedClimb = this.getRotPitch() < -15.0F
             ? MCH_FlightModel.clamp((-this.getRotPitch() - 15.0D) / 45.0D, 0.0D, 1.0D)
                   * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D)
+                  * lowEnergyNoseHigh
             : 0.0D;
       double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
             Math.max(this.speedStallSeverity, liftDeficit));
@@ -1045,11 +1046,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
-      double throttleDeficit = MCH_FlightModel.clamp(1.0D - this.getEffectiveEngineThrottle(), 0.0D, 1.0D);
       double thrustDeficit = MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
-      double climbDemand = super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.35D;
+      double climbDemand = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.35D,
+            this.speedStallSeverity);
       double liftDeficit = MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D);
-      double energyDeficit = Math.max(throttleDeficit * thrustDeficit, liftDeficit * 0.6D);
+      double energyDeficit = Math.max(Math.max(this.stallSeverity, Math.max(this.aoaStallSeverity, this.speedStallSeverity)),
+            Math.max(thrustDeficit * climbDemand, liftDeficit));
       double legacyStrengthScale = MCH_FlightModel.clamp((double)this.getPlaneInfo().stallStrength / 0.6D, 0.0D, 4.0D);
       double pitchMoment = energyDeficit * noseUpAttitude * (0.35D + 0.65D * climbDemand)
             * (double)this.getPlaneInfo().stallPitchRecoveryStrength * legacyStrengthScale * 0.45D;


### PR DESCRIPTION
### Motivation
- Correct runaway nose-up behavior at low throttle/airspeed by ensuring pitch limits and recovery are driven by aerodynamic/energy state rather than raw throttle. 
- Prevent nearly-stationary, nose-high aircraft from reporting artificially low AoA and escaping stall/recovery logic. 
- Make unsupported vertical climbs and throttle cuts produce appropriate nose-down recovery moments. 

### Description
- Blend attitude-derived AoA with velocity-derived AoA at very low airspeed in `MCH_FlightModel.getAngleOfAttackDegrees` so nose-high, near-zero-speed aircraft still accumulate AoA and stall demand instead of collapsing to zero AoA. 
- Remove the direct effective-throttle multiplier from fixed-wing control authority in `MCP_EntityPlane.getControlAuthorityFactor` so control authority is driven by G/stall state and flap authority rather than raw throttle. 
- Strengthen low-energy nose-up suppression in `MCP_EntityPlane.getNoseUpPitchSuppression` by factoring in `speedStallSeverity` and a low-energy blend to make unsupported climbs at low speed/thrust more suppressive. 
- Rework throttle-deficit pitch-down logic in `MCP_EntityPlane.applyThrottleDeficitPitchDown` to compute `energyDeficit` from `stallSeverity`, `aoaStallSeverity`, `speedStallSeverity`, `liftDeficit`, and `thrustDeficit` (with climb demand), producing stronger deterministic nose-down moments when energy is insufficient. 
- Update documentation in `docs/vehicle-config/planes.md` to describe the low-speed AoA blending and clarify that throttle does not directly scale control authority. 

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30846a6dd483299cc4b4089fd26dc2)