### PR TITLE
Improve low-speed AoA, energy-gated lift, and stall-related control behavior

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -175,7 +175,7 @@ aoaSeverity = clamp((abs(AoA) - CriticalAoA) / CriticalAoA, 0, 1)
 demand = max(speedSeverity, aoaSeverity)
 ```
 
-`AoA` is the angle between where the aircraft nose points and where the aircraft is actually moving. It is not the pitch angle by itself. Near-zero airspeed reports `AoA = 0` so parked or nearly stationary aircraft do not feed invalid vectors into stall math.
+`AoA` is the angle between where the aircraft nose points and where the aircraft is actually moving. It is not the pitch angle by itself. At extremely low airspeed, the velocity vector is blended with nose-vs-horizontal attitude so a nose-high aircraft with collapsed airspeed remains aerodynamically stalled instead of appearing clean.
 
 If not already stalling, demand above the small entry hysteresis band starts a stall. While stalling, one good frame is not enough to recover unless both recovery conditions are true in the same tick:
 
@@ -192,20 +192,25 @@ target = stalling ? max(0.12, demand) : 0
 stallSeverity += (target - stallSeverity) * (0.35 if target is rising else 0.18)
 ```
 
-Airborne wing lift is then filtered by airspeed, AoA, throttle/flap lift power, and stall lift loss:
+Airborne wing lift is then filtered by airspeed, AoA, energy-gated throttle/flap lift power, and stall lift loss. Low-throttle lift retention is only available when airspeed, AoA, and stall state already indicate valid wing lift; it cannot hold up a below-stall aircraft by itself:
 
 ```text
 airspeedLift = clamp((airspeed - stallSpeed * 0.45) / max(0.05, stallSpeed * 1.35), 0, 1.25)
 aoaLift = clamp(1 - max(0, abs(AoA) - CriticalAoA) / max(1, CriticalAoA), 0, 1)
 liftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
 stallLift = 1 - liftLoss
+validLiftEnergy = clamp((airspeed - stallSpeed) / max(0.05, stallSpeed * 0.5), 0, 1)
+                  * aoaLift * stallLift
+liftPower = effectiveThrottle
+          + NewFlightLowThrottleLiftRetention * (1 - effectiveThrottle) * validLiftEnergy
+          + combatFlapLift * validLiftEnergy
 liftBeforeStallLoss = gravity * clamp(liftPower, 0, 2.5) * airspeedLift * aoaLift
 liftForce = liftBeforeStallLoss * stallLift
 ```
 
-`StallLiftLoss` is applied after throttle lift retention, combat flap lift, takeoff lift, and other lift bonuses are resolved. Stalled aircraft suppress takeoff/climb lift headroom until recovery, so `validTakeoff` or `validClimb` cannot bypass stall penalties.
+`StallLiftLoss` is applied after throttle lift retention, combat flap lift, takeoff lift, and other lift bonuses are resolved. Low-throttle retention and combat-flap bonuses are themselves gated by `validLiftEnergy`, so they cannot bypass the airspeed/AoA/stall filters. Stalled or below-stall aircraft suppress takeoff/climb lift headroom until recovery, so `validTakeoff` or `validClimb` cannot bypass stall penalties.
 
-This means pointing the nose near vertical does not create maximum lift unless the velocity vector, airspeed, lift-to-weight, and thrust-to-weight are still within valid flying conditions. Conventional fixed-wing thrust is also limited during unsupported vertical climbs: if thrust-to-weight is below 1.0, upward powered climb is scaled by speed headroom and remaining unstalled authority. High nose-up climbs add extra AoA/energy drag and bleed vertical energy unless the aircraft is truly tuned with enough thrust and speed to support them. Lowering throttle while holding a nose-up attitude now also adds a nose-down pitch moment, so the aircraft cannot keep the same climb angle without enough effective thrust/lift.
+This means pointing the nose near vertical does not create maximum lift unless the velocity vector, airspeed, lift-to-weight, and thrust-to-weight are still within valid flying conditions. Conventional fixed-wing thrust is also limited during unsupported vertical climbs: upward powered climb is scaled by thrust-to-weight, speed headroom, remaining unstalled authority, and AoA stall state. High nose-up climbs add extra AoA/energy drag and bleed vertical energy unless the aircraft is truly tuned with enough thrust and speed to support them. Lowering throttle while holding a nose-up attitude now also adds a nose-down pitch moment, so the aircraft cannot keep the same climb angle without enough effective thrust/lift.
 
 Developed stalls remove lift through the normal lift model and apply a deterministic nose-down pitch moment:
 
@@ -247,6 +252,8 @@ highGAuthority = clamp(1 - highGSeverity * GControlPenalty, 0.05, 1)
 stallAuthority = clamp(1 - stallSeverity * 0.75, 0.25, 1)
 controlAuthority = highGAuthority * stallAuthority
 ```
+
+Throttle does not directly scale this control authority; cutting power reduces thrust-to-weight, lift-to-weight, and energy state, which then increases stall/unsupported-climb suppression and pitch-break recovery.
 
 Pitch also loses authority above compressibility speed:
 

--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -80,13 +80,29 @@ public final class MCH_FlightModel {
                                                 double velocityX, double velocityY, double velocityZ) {
       double forwardLength = Math.sqrt(forwardX * forwardX + forwardY * forwardY + forwardZ * forwardZ);
       double speed = Math.sqrt(velocityX * velocityX + velocityY * velocityY + velocityZ * velocityZ);
-      if(forwardLength < 1.0E-6D || speed < 1.0E-6D) {
+      if(forwardLength < 1.0E-6D) {
          return 0.0D;
+      }
+
+      // At very low airspeed the velocity vector becomes numerically unstable, but
+      // a nose-high fixed-wing aircraft should not look aerodynamically clean. Blend
+      // toward the nose-vs-horizontal attitude so stalled, nearly suspended aircraft
+      // continue to accumulate AoA/stall demand instead of escaping recovery logic.
+      double horizontalForward = Math.sqrt(forwardX * forwardX + forwardZ * forwardZ);
+      double attitudeAoA = Math.toDegrees(Math.atan2(Math.abs(forwardY), horizontalForward));
+      if(speed < 1.0E-6D) {
+         return attitudeAoA;
       }
 
       double dot = (forwardX * velocityX + forwardY * velocityY + forwardZ * velocityZ)
             / (forwardLength * speed);
-      return Math.toDegrees(Math.acos(clamp(dot, -1.0D, 1.0D)));
+      double velocityAoA = Math.toDegrees(Math.acos(clamp(dot, -1.0D, 1.0D)));
+      if(speed >= 0.08D) {
+         return velocityAoA;
+      }
+
+      double velocityBlend = clamp(speed / 0.08D, 0.0D, 1.0D);
+      return attitudeAoA * (1.0D - velocityBlend) + velocityAoA * velocityBlend;
    }
 
    /** Resolves an absolute stall speed while retaining compatibility with StallSpeedFactor. */

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -410,11 +410,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double highGAuthority = MCH_FlightModel.getHighGControlAuthority(this.currentGForce,
             info.maxComfortableG, info.maxStructuralG, info.gControlPenalty);
       double severity = Math.max(this.stallSeverity, this.getInstantStallSeverity());
-      double throttleAuthority = 1.0D - (1.0D - this.getEffectiveEngineThrottle())
-            * (double)info.newFlightThrottleControlAuthorityScale;
       double flapAuthority = this.isCombatFlapsDeployed() ? 1.0D + (double)info.newFlightCombatFlapControl : 1.0D;
       return (float)MCH_FlightModel.clamp(highGAuthority * MCH_FlightModel.getControlAuthority(severity)
-            * throttleAuthority * flapAuthority, 0.05D, 1.35D);
+            * flapAuthority, 0.05D, 1.35D);
    }
 
    private double getNoseUpPitchSuppression() {
@@ -425,9 +423,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double liftDeficit = this.lastWeightForce > 1.0E-6D
             ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
       double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
-      double unsupportedClimb = super.motionY > 0.0D && this.getRotPitch() < -15.0F
+      double lowEnergyNoseHigh = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.0D,
+            this.speedStallSeverity);
+      double unsupportedClimb = this.getRotPitch() < -15.0F
             ? MCH_FlightModel.clamp((-this.getRotPitch() - 15.0D) / 45.0D, 0.0D, 1.0D)
                   * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D)
+                  * lowEnergyNoseHigh
             : 0.0D;
       double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
             Math.max(this.speedStallSeverity, liftDeficit));
@@ -947,14 +948,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double airspeed = this.getAirspeed();
       double airspeedLift = MCH_FlightModel.clamp((airspeed - stallSpeed * 0.45D) / Math.max(0.05D, stallSpeed * 1.35D), 0.0D, 1.25D);
       double aoaLift = MCH_FlightModel.clamp(1.0D - Math.max(0.0D, Math.abs(this.angleOfAttack) - (double)info.criticalAoA) / Math.max(1.0D, (double)info.criticalAoA), 0.0D, 1.0D);
-      double liftPower = (double)info.newFlightLowThrottleLiftRetention
-            + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
-      if(this.isCombatFlapsDeployed()) {
-         liftPower += (double)info.newFlightCombatFlapLift;
-      }
       double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)info.stallLiftLoss, 0.0D, 1.0D);
       this.lastLiftLoss = liftLoss;
       double stallLift = 1.0D - liftLoss;
+      double validLiftEnergy = MCH_FlightModel.clamp((airspeed - stallSpeed) / Math.max(0.05D, stallSpeed * 0.5D), 0.0D, 1.0D)
+            * aoaLift * stallLift;
+      double retainedLowThrottleLift = (double)info.newFlightLowThrottleLiftRetention
+            * (1.0D - this.getEffectiveEngineThrottle()) * validLiftEnergy;
+      double liftPower = this.getEffectiveEngineThrottle() + retainedLowThrottleLift;
+      if(this.isCombatFlapsDeployed()) {
+         liftPower += (double)info.newFlightCombatFlapLift * validLiftEnergy;
+      }
       this.lastLiftCoefficient = aoaLift * stallLift;
       double mass = this.getPhysicalMass();
       double weightForce = gravityAccel * mass;
@@ -971,7 +975,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftForceBeforeStallLoss = liftBeforeStallLoss;
       this.lastLiftForceAfterStallLoss = liftForce;
       this.lastNetVerticalAcceleration = netAccel;
-      this.lastValidClimb = liftForce > weightForce || this.getThrustToWeightRatio() >= 1.0D;
+      boolean validWingLift = liftForce > weightForce && this.speedStallSeverity < 0.25D
+            && this.stallSeverity < 0.15D && this.aoaStallSeverity < 0.25D;
+      boolean validPoweredClimb = this.getThrustToWeightRatio() >= 1.0D && this.speedStallSeverity < 0.35D
+            && this.stallSeverity < 0.25D;
+      this.lastValidClimb = validWingLift || validPoweredClimb;
    }
 
    private void applyNewFlightTakeoffAssist(boolean levelOff, double waterDepth) {
@@ -997,7 +1005,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastEffectiveTakeoffSpeed = effectiveTakeoffSpeed;
       boolean multiplierAdjusted = Math.abs(multiplier - 1.0D) > 1.0E-4D;
       this.lastTakeoffMultiplierActive = multiplierAdjusted && horizontalSpeed < baseTakeoffSpeed * 1.15D;
-      this.lastValidTakeoff = horizontalSpeed >= effectiveTakeoffSpeed && this.stallSeverity < 0.15D;
+      this.lastValidTakeoff = horizontalSpeed >= effectiveTakeoffSpeed && this.stallSeverity < 0.15D
+            && this.speedStallSeverity < 0.35D && this.aoaStallSeverity < 0.25D;
       if(!multiplierAdjusted) {
          return;
       }
@@ -1045,11 +1054,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
-      double throttleDeficit = MCH_FlightModel.clamp(1.0D - this.getEffectiveEngineThrottle(), 0.0D, 1.0D);
       double thrustDeficit = MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
-      double climbDemand = super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.35D;
+      double climbDemand = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.35D,
+            this.speedStallSeverity);
       double liftDeficit = MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D);
-      double energyDeficit = Math.max(throttleDeficit * thrustDeficit, liftDeficit * 0.6D);
+      double energyDeficit = Math.max(Math.max(this.stallSeverity, Math.max(this.aoaStallSeverity, this.speedStallSeverity)),
+            Math.max(thrustDeficit * climbDemand, liftDeficit));
       double legacyStrengthScale = MCH_FlightModel.clamp((double)this.getPlaneInfo().stallStrength / 0.6D, 0.0D, 4.0D);
       double pitchMoment = energyDeficit * noseUpAttitude * (0.35D + 0.65D * climbDemand)
             * (double)this.getPlaneInfo().stallPitchRecoveryStrength * legacyStrengthScale * 0.45D;
@@ -1775,8 +1785,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
                      this.getPlaneInfo().stallSpeedFactor);
                double speedHeadroom = MCH_FlightModel.clamp(this.getAirspeed() / Math.max(0.05D, stallSpeed * 1.2D), 0.0D, 1.0D);
-               double supportedVerticalThrust = thrustToWeight >= 1.0D ? 1.0D
-                     : MCH_FlightModel.clamp(thrustToWeight * speedHeadroom * (1.0D - this.stallSeverity), 0.0D, 1.0D);
+               double unstalledEnergy = speedHeadroom * (1.0D - this.stallSeverity)
+                     * (1.0D - MCH_FlightModel.clamp(this.aoaStallSeverity, 0.0D, 1.0D));
+               double supportedVerticalThrust = MCH_FlightModel.clamp(thrustToWeight * unstalledEnergy, 0.0D, 1.0D);
                verticalThrust *= supportedVerticalThrust;
                if(supportedVerticalThrust < 1.0D) {
                   this.lastStallSuppressedLiftHeadroom = true;


### PR DESCRIPTION
### Motivation

- Make stall and low-speed behavior more physically consistent by preventing nearly-stationary, nose-high aircraft from appearing aerodynamically clean and by gating low-throttle and flap lift bonuses behind valid energy/airspeed/AoA conditions.
- Reduce unexpected pilot control authority changes driven directly by throttle and ensure pitch suppression and vertical thrust support respect stall/AoA/speed state.
- Update documentation to reflect the new AoA blending and lift/authority gating rules.

### Description

- Docs: updated `docs/vehicle-config/planes.md` to explain AoA blending at very low speeds, the energy gating of low-throttle lift and combat-flap bonuses, and that throttle no longer directly scales control authority.
- `MCH_FlightModel.getAngleOfAttackDegrees`: added low-speed handling by computing an attitude-based AoA and blending it with the velocity-based AoA for speeds below `0.08`, returning attitude AoA when speed is essentially zero to keep nose-high aircraft aerodynamically stalled.
- `MCP_EntityPlane`: removed direct throttle scaling from `getControlAuthorityFactor`, added new low-energy and stall-derived modifiers used by nose-up pitch suppression, and tightened conditions for `lastValidClimb` and `lastValidTakeoff` to require valid speed/AoA/stall thresholds.
- `MCP_EntityPlane.applyNewFlightVerticalForces`: compute `validLiftEnergy` and apply low-throttle retained lift and combat-flap lift scaled by that energy gate; adjust `liftPower` composition accordingly.
- `MCP_EntityPlane.applyNewFlightTakeoffAssist` and `applyThrottleDeficitPitchDown`: incorporate `speedStallSeverity` and `aoaStallSeverity` into climb/thrust support and energy deficit calculations so vertical thrust and pitch-down moments respect stall/AoA/speed state.
- Vertical thrust support during nozzle/vertical thrust scenarios is reduced when unstalled energy (speed headroom, stall, AoA) is insufficient.

### Testing

- Project built successfully after the changes with no compilation errors. 
- Ran the project's automated test suite and build checks; all tests and checks completed successfully. 
- Smoke-checked the modified flight code paths in runtime (automated integration/smoke checks where available) to confirm no runtime exceptions were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30846a6dd483299cc4b4089fd26dc2)