### PR TITLE
Enhance flight diagnostics and fix new-flight stability calculations

### DIFF
--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -339,7 +339,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             : 0.0D;
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,authority=%.2f,noseUpSuppress=%.2f,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,horizontalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,pitchAuthority=%.2f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
               simDelta,
               mouseX,
               mouseY,
@@ -357,6 +357,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               Double.valueOf(plane != null ? plane.getDebugPropulsiveEngineThrottle() * 100.0D : ac.getNormalizedThrottle() * 100.0D),
               Boolean.valueOf(ac.isCombatFlapsDeployed()),
               Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ),
+              ac.getLastHorizontalSpeed(),
               forwardSpeed,
               ac.motionY,
               ac.getRotPitch(),
@@ -404,11 +405,56 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getCurrentGForce(),
               ac.getLastAerodynamicDrag(),
               ac.getLastLiftLoss(),
-              ac.getDebugControlAuthority(),
+              ac.getLastControlAuthority(),
+              ac.getLastPitchAuthority(),
               ac.getLastNoseUpPitchSuppression(),
+              Boolean.valueOf(ac.isUnsupportedClimb()),
+              ac.getLastUnsupportedClimbSeverity(),
+              Boolean.valueOf(ac.isLastIdleUnsupportedClimb()),
+              ac.getLastIdleThrottleWarning(),
+              ac.getLastLowHorizontalSpeedWarning(),
               Boolean.valueOf(ac.isPitchBreakActive()),
               plane != null ? plane.getLastPitchBreakAngularVelocity() : 0.0D
       ));
+
+      if(plane != null && plane.getLastLowHorizontalSpeedWarning().length() > 0) {
+         System.out.println(String.format(
+               "[MCHeli][WARN] low-horizontal-speed flight sanity: reason=%s motionX=%.4f motionZ=%.4f horizontalSpeed=%.3f airspeed=%.3f aoa=%.2f stallSpeed=%.3f speedSeverity=%.2f aoaSeverity=%.2f stallDemand=%.2f stallSeverity=%.2f liftToWeight=%.3f thrustToWeight=%.3f validClimb=%s validTakeoff=%s controlAuthority=%.2f pitchAuthority=%.2f unsupportedClimb=%.3f netY=%.4f",
+               plane.getLastLowHorizontalSpeedWarning(),
+               plane.motionX,
+               plane.motionZ,
+               plane.getLastHorizontalSpeed(),
+               plane.getAirspeed(),
+               plane.getAngleOfAttackDegrees(),
+               plane.getPlaneInfo() != null ? MCH_FlightModel.getStallSpeed(plane.getPlaneInfo().stallSpeed, plane.getMaxSpeed(), plane.getPlaneInfo().stallSpeedFactor) : 0.0D,
+               plane.getSpeedStallSeverity(),
+               plane.getAoAStallSeverity(),
+               plane.getStallDemand(),
+               plane.getStallSeverity(),
+               plane.getLiftToWeightRatio(),
+               plane.getThrustToWeightRatio(),
+               Boolean.valueOf(plane.isLastValidClimb()),
+               Boolean.valueOf(plane.isLastValidTakeoff()),
+               plane.getLastControlAuthority(),
+               plane.getLastPitchAuthority(),
+               plane.getLastUnsupportedClimbSeverity(),
+               plane.getLastNetVerticalAcceleration()));
+      }
+
+      if(plane != null && plane.getLastIdleThrottleWarning().length() > 0) {
+         System.out.println(String.format(
+               "[MCHeli][WARN] idle-throttle flight sanity: reason=%s throttle=%.3f propulsiveThrottle=%.3f thrustToWeight=%.3f liftToWeight=%.3f validClimb=%s unsupportedClimb=%.3f airspeed=%.3f netY=%.4f pitch=%.2f",
+               plane.getLastIdleThrottleWarning(),
+               plane.getNormalizedThrottle(),
+               plane.getDebugPropulsiveEngineThrottle(),
+               plane.getThrustToWeightRatio(),
+               plane.getLiftToWeightRatio(),
+               Boolean.valueOf(plane.isLastValidClimb()),
+               plane.getLastUnsupportedClimbSeverity(),
+               plane.getAirspeed(),
+               plane.getLastNetVerticalAcceleration(),
+               plane.getRotPitch()));
+      }
    }
 
    public void onRenderTickPre(float partialTicks) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1868,6 +1868,38 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return 0.0D;
    }
 
+   public double getLastUnsupportedClimbSeverity() {
+      return 0.0D;
+   }
+
+   public boolean isUnsupportedClimb() {
+      return false;
+   }
+
+   public boolean isLastIdleUnsupportedClimb() {
+      return false;
+   }
+
+   public String getLastIdleThrottleWarning() {
+      return "";
+   }
+
+   public double getLastHorizontalSpeed() {
+      return 0.0D;
+   }
+
+   public String getLastLowHorizontalSpeedWarning() {
+      return "";
+   }
+
+   public double getLastPitchAuthority() {
+      return 1.0D;
+   }
+
+   public double getLastControlAuthority() {
+      return this.getDebugControlAuthority();
+   }
+
    /** Most recent fixed-wing drag fraction applied by the energy model. */
    public double getLastAerodynamicDrag() {
       return 0.0D;

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -96,6 +96,20 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private boolean stallRecovering;
    /** Fraction of pilot nose-up pitch input currently suppressed by energy/stall state. */
    private double lastNoseUpPitchSuppression;
+   /** Last calculated unsupported-climb severity used by energy and pitch protection. */
+   private double lastUnsupportedClimbSeverity;
+   /** True when the idle-throttle sanity guard detected a low-energy nose-high climb. */
+   private boolean lastIdleUnsupportedClimb;
+   /** Last idle-throttle warning reason emitted through debug output. */
+   private String lastIdleThrottleWarning;
+   /** Last combined horizontal speed used by low-speed stall diagnostics. */
+   private double lastHorizontalSpeed;
+   /** Last low-horizontal-speed warning reason emitted through debug output. */
+   private String lastLowHorizontalSpeedWarning;
+   /** Last compressibility-limited pitch authority multiplier. */
+   private double lastPitchAuthority;
+   /** Last full control authority multiplier applied before pitch-axis modifiers. */
+   private double lastControlAuthority;
    /** Last airborne state used by the new fixed-wing force model. */
    private boolean lastAirborne;
    /** Local-axis body rates used by fixed-wing damped control response. */
@@ -160,12 +174,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastStallSuppressedLiftHeadroom = false;
       this.lastValidTakeoff = false;
       this.lastValidClimb = false;
+      this.lastIdleUnsupportedClimb = false;
+      this.lastIdleThrottleWarning = "";
+      this.lastHorizontalSpeed = 0.0D;
+      this.lastLowHorizontalSpeedWarning = "";
       this.lastPitchBreakAngularVelocity = 0.0D;
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
       this.lastLiftCoefficient = 0.0D;
       this.stallRecovering = false;
       this.lastNoseUpPitchSuppression = 0.0D;
+      this.lastUnsupportedClimbSeverity = 0.0D;
+      this.lastPitchAuthority = 1.0D;
+      this.lastControlAuthority = 1.0D;
       this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
       this.stallSeverity = 0.0D;
@@ -415,6 +436,44 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             * flapAuthority, 0.05D, 1.35D);
    }
 
+   private double getUnsupportedClimbSeverity() {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
+         return 0.0D;
+      }
+
+      double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 42.0D, 0.0D, 1.0D);
+      if(noseUpAttitude <= 0.0D || super.motionY <= 0.0D) {
+         return 0.0D;
+      }
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+            this.getPlaneInfo().stallSpeedFactor);
+      double climbSpeedDeficit = MCH_FlightModel.clamp((stallSpeed * 1.2D - this.getAirspeed())
+            / Math.max(0.05D, stallSpeed * 1.2D), 0.0D, 1.0D);
+      double liftDeficit = this.lastWeightForce > 1.0E-6D
+            ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
+      double thrustDeficit = MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
+      double climbDemand = MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D);
+      double supportDeficit = Math.max(Math.max(thrustDeficit, liftDeficit),
+            Math.max(climbSpeedDeficit, Math.max(this.stallSeverity, Math.max(this.speedStallSeverity, this.aoaStallSeverity))));
+      double unsupportedClimb = noseUpAttitude * climbDemand * supportDeficit;
+      if(this.isIdleUnsupportedClimb(noseUpAttitude, stallSpeed)) {
+         unsupportedClimb = Math.max(unsupportedClimb, 0.35D + 0.65D * noseUpAttitude);
+      }
+      return MCH_FlightModel.clamp(unsupportedClimb, 0.0D, 1.0D);
+   }
+
+
+   private boolean isIdleUnsupportedClimb(double noseUpAttitude, double stallSpeed) {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
+         return false;
+      }
+
+      double recoverySpeed = this.getPlaneInfo().stallRecoverySpeed > 0.0F
+            ? (double)this.getPlaneInfo().stallRecoverySpeed : stallSpeed * 1.2D;
+      return this.getPropulsiveEngineThrottle() <= 0.01D && noseUpAttitude > 0.05D && this.getAirspeed() < recoverySpeed;
+   }
+
    private double getNoseUpPitchSuppression() {
       if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
          return 0.0D;
@@ -423,16 +482,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double liftDeficit = this.lastWeightForce > 1.0E-6D
             ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
       double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
-      double lowEnergyNoseHigh = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.0D,
-            this.speedStallSeverity);
-      double unsupportedClimb = this.getRotPitch() < -15.0F
-            ? MCH_FlightModel.clamp((-this.getRotPitch() - 15.0D) / 45.0D, 0.0D, 1.0D)
-                  * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D)
-                  * lowEnergyNoseHigh
-            : 0.0D;
       double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
             Math.max(this.speedStallSeverity, liftDeficit));
-      double energyDeficit = Math.max(aerodynamicDeficit, unsupportedClimb);
+      double energyDeficit = Math.max(aerodynamicDeficit, this.getUnsupportedClimbSeverity());
       return MCH_FlightModel.clamp(energyDeficit * (0.35D + 0.65D * noseUpAttitude), 0.0D, 1.0D);
    }
 
@@ -530,7 +582,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    public double getThrustToWeightRatio() {
-      return this.lastWeightForce > 1.0E-6D ? this.lastEngineThrustForce / this.lastWeightForce : 0.0D;
+      return this.lastEngineThrustForce / Math.max(this.lastWeightForce, 1.0E-6D);
    }
 
    public double getLastNetForwardAcceleration() {
@@ -589,6 +641,39 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public double getLastNoseUpPitchSuppression() {
       return this.lastNoseUpPitchSuppression;
    }
+
+   public double getLastUnsupportedClimbSeverity() {
+      return this.lastUnsupportedClimbSeverity;
+   }
+
+   public boolean isLastIdleUnsupportedClimb() {
+      return this.lastIdleUnsupportedClimb;
+   }
+
+   public String getLastIdleThrottleWarning() {
+      return this.lastIdleThrottleWarning;
+   }
+
+   public double getLastHorizontalSpeed() {
+      return this.lastHorizontalSpeed;
+   }
+
+   public String getLastLowHorizontalSpeedWarning() {
+      return this.lastLowHorizontalSpeedWarning;
+   }
+
+   public boolean isUnsupportedClimb() {
+      return this.lastUnsupportedClimbSeverity > 1.0E-3D;
+   }
+
+   public double getLastPitchAuthority() {
+      return this.lastPitchAuthority;
+   }
+
+   public double getLastControlAuthority() {
+      return this.lastControlAuthority;
+   }
+
 
    public boolean isLastAirborne() {
       return this.lastAirborne;
@@ -674,13 +759,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       Vec3 forward = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch());
-      double speed = Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY
-            + super.motionZ * super.motionZ);
+      double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      double speed = Math.sqrt(horizontalSpeed * horizontalSpeed + super.motionY * super.motionY);
       double aoa = MCH_FlightModel.getAngleOfAttackDegrees(forward.xCoord, forward.yCoord, forward.zCoord,
             super.motionX, super.motionY, super.motionZ);
       double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
             this.getPlaneInfo().stallSpeedFactor);
-      return MCH_FlightModel.getAerodynamicStallSeverity(speed, aoa, stallSpeed, this.getPlaneInfo().criticalAoA);
+      double speedSeverity = Math.max(MCH_FlightModel.getSpeedStallSeverity(speed, stallSpeed),
+            MCH_FlightModel.getSpeedStallSeverity(horizontalSpeed, stallSpeed));
+      return Math.max(speedSeverity, MCH_FlightModel.getAoAStallSeverity(aoa, this.getPlaneInfo().criticalAoA));
    }
 
 
@@ -756,6 +843,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       float controlAuthority = this.getControlAuthorityFactor();
       double pitchAuthority = MCH_FlightModel.getCompressibilityPitchAuthority(this.getAirspeed(),
             this.getCompressibilitySpeed(), this.getMaxSafeSpeed(), this.getPlaneInfo().compressibilityPitchPenalty);
+      this.lastControlAuthority = controlAuthority;
+      this.lastPitchAuthority = pitchAuthority;
       pitch *= controlAuthority * (float)pitchAuthority;
       this.lastNoseUpPitchSuppression = this.getNoseUpPitchSuppression();
       if(pitch < 0.0F && this.lastNoseUpPitchSuppression > 0.0D) {
@@ -865,14 +954,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    private void updateAerodynamicState() {
       Vec3 forward = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch());
-      double speed = Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY
-            + super.motionZ * super.motionZ);
+      double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      this.lastHorizontalSpeed = horizontalSpeed;
+      double speed = Math.sqrt(horizontalSpeed * horizontalSpeed + super.motionY * super.motionY);
       this.angleOfAttack = MCH_FlightModel.getAngleOfAttackDegrees(forward.xCoord, forward.yCoord, forward.zCoord,
             super.motionX, super.motionY, super.motionZ);
 
       double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
             this.getPlaneInfo().stallSpeedFactor);
-      this.speedStallSeverity = MCH_FlightModel.getSpeedStallSeverity(speed, stallSpeed);
+      this.speedStallSeverity = Math.max(MCH_FlightModel.getSpeedStallSeverity(speed, stallSpeed),
+            MCH_FlightModel.getSpeedStallSeverity(horizontalSpeed, stallSpeed));
       this.aoaStallSeverity = MCH_FlightModel.getAoAStallSeverity(this.angleOfAttack, this.getPlaneInfo().criticalAoA);
       double demand = Math.max(this.speedStallSeverity, this.aoaStallSeverity);
       this.stallDemand = demand;
@@ -925,6 +1016,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return 0.008D;
    }
 
+
+   private void updateNewFlightThrustForce() {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null) {
+         this.lastEngineThrustForce = 0.0D;
+         return;
+      }
+      double propulsiveThrottle = MCH_FlightModel.clamp(this.getPropulsiveEngineThrottle(), 0.0D, 1.0D);
+      this.lastEngineThrustForce = Math.max(0.0D, (double)this.getPlaneInfo().engineThrust * propulsiveThrottle);
+   }
+
    private void applyNewFlightVerticalForces() {
       MCP_PlaneInfo info = this.getPlaneInfo();
       boolean airborne = !super.onGround && MCH_Lib.getBlockIdY(this, 1, -2) == 0;
@@ -936,6 +1037,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastWeightForce = 0.0D;
          this.lastLiftForce = 0.0D;
          this.lastLiftCoefficient = 0.0D;
+         this.lastValidClimb = false;
          return;
       }
 
@@ -946,7 +1048,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
       double airspeed = this.getAirspeed();
-      double airspeedLift = MCH_FlightModel.clamp((airspeed - stallSpeed * 0.45D) / Math.max(0.05D, stallSpeed * 1.35D), 0.0D, 1.25D);
+      double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      this.lastHorizontalSpeed = horizontalSpeed;
+      double airspeedLift = MCH_FlightModel.clamp((horizontalSpeed - stallSpeed * 0.45D) / Math.max(0.05D, stallSpeed * 1.35D), 0.0D, 1.25D);
       double aoaLift = MCH_FlightModel.clamp(1.0D - Math.max(0.0D, Math.abs(this.angleOfAttack) - (double)info.criticalAoA) / Math.max(1.0D, (double)info.criticalAoA), 0.0D, 1.0D);
       double liftPower = (double)info.newFlightLowThrottleLiftRetention
             + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
@@ -972,7 +1076,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftForceBeforeStallLoss = liftBeforeStallLoss;
       this.lastLiftForceAfterStallLoss = liftForce;
       this.lastNetVerticalAcceleration = netAccel;
-      this.lastValidClimb = liftForce > weightForce || this.getThrustToWeightRatio() >= 1.0D;
+      double propulsiveThrottle = this.getPropulsiveEngineThrottle();
+      double thrustForce = Math.max(0.0D, (double)info.engineThrust * propulsiveThrottle);
+      double thrustToWeight = thrustForce / Math.max(weightForce, 1.0E-6D);
+      double liftToWeight = liftForce / Math.max(weightForce, 1.0E-6D);
+      double climbSustainSpeed = stallSpeed * 1.2D;
+      boolean aeroClimbValid = liftToWeight > 1.0D && this.speedStallSeverity < 0.15D
+            && this.stallSeverity < 0.15D && this.aoaStallSeverity < 0.15D;
+      boolean poweredClimbValid = propulsiveThrottle > 0.01D && thrustToWeight > 0.75D
+            && airspeed > climbSustainSpeed && this.stallSeverity < 0.15D && this.aoaStallSeverity < 0.15D;
+      this.lastValidClimb = aeroClimbValid || poweredClimbValid;
+      if(this.isIdleUnsupportedClimb(MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeed)) {
+         this.lastValidClimb = false;
+      }
    }
 
    private void applyNewFlightTakeoffAssist(boolean levelOff, double waterDepth) {
@@ -1095,12 +1211,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastStallSuppressedLiftHeadroom = false;
       this.lastValidTakeoff = false;
       this.lastValidClimb = false;
+      this.lastIdleUnsupportedClimb = false;
+      this.lastIdleThrottleWarning = "";
       this.lastPitchBreakAngularVelocity = 0.0D;
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
       this.lastLiftCoefficient = 0.0D;
       this.stallRecovering = false;
       this.lastNoseUpPitchSuppression = 0.0D;
+      this.lastUnsupportedClimbSeverity = 0.0D;
+      this.lastIdleUnsupportedClimb = false;
+      this.lastIdleThrottleWarning = "";
+      this.lastPitchAuthority = 1.0D;
+      this.lastControlAuthority = 1.0D;
       this.lastAirborne = false;
       this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;
       this.currentGForce = 1.0D;
@@ -1245,10 +1368,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       if(this.useNewMobilitySystem()) {
-         this.engineThrottle = MCH_FlightModel.approachEngineOutput(this.engineThrottle, this.getCurrentThrottle(),
-               this.getPlaneInfo().throttleAcceleration, this.getPlaneInfo().engineDrag);
+         this.engineThrottle = MCH_FlightModel.clamp(MCH_FlightModel.approachEngineOutput(this.engineThrottle,
+               MCH_FlightModel.clamp(this.getCurrentThrottle(), 0.0D, 1.0D),
+               this.getPlaneInfo().throttleAcceleration, this.getPlaneInfo().engineDrag), 0.0D, 1.0D);
       } else {
-         this.engineThrottle = this.getCurrentThrottle();
+         this.engineThrottle = MCH_FlightModel.clamp(this.getCurrentThrottle(), 0.0D, 1.0D);
       }
 
       if(!this.canUseCombatFlaps()) {
@@ -1257,7 +1381,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected double getEngineThrottle() {
-      return this.useNewMobilitySystem() ? this.engineThrottle : this.getCurrentThrottle();
+      return MCH_FlightModel.clamp(this.useNewMobilitySystem() ? this.engineThrottle : this.getCurrentThrottle(), 0.0D, 1.0D);
    }
 
    public double getDebugEngineThrottle() {
@@ -1274,7 +1398,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    protected double getEffectiveEngineThrottle() {
       if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null) {
-         return this.getEngineThrottle();
+         return MCH_FlightModel.clamp(this.getEngineThrottle(), 0.0D, 1.0D);
       }
 
       MCP_PlaneInfo info = this.getPlaneInfo();
@@ -1286,12 +1410,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected double getPropulsiveEngineThrottle() {
-      // Idle power keeps an airborne engine and its lift response alive, but it
-      // must not make a parked plane taxi merely because a pilot entered it.
-      if(this.isGroundedForPropulsion() && this.getCurrentThrottle() <= 0.0D) {
+      // Zero commanded throttle means zero propulsive thrust. Keep aerodynamic
+      // evaluation active; do not turn idle into a powered-climb fallback.
+      if(this.getCurrentThrottle() <= 0.01D || this.isGroundedForPropulsion() && this.getCurrentThrottle() <= 0.01D) {
          return 0.0D;
       }
-      return this.getEffectiveEngineThrottle();
+      return MCH_FlightModel.clamp(this.getEffectiveEngineThrottle(), 0.0D, 1.0D);
    }
 
    private boolean isGroundedForPropulsion() {
@@ -1640,6 +1764,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
       if(this.useNewMobilitySystem()) {
          this.updateAerodynamicState();
+         this.updateNewFlightThrustForce();
       } else {
          this.angleOfAttack = 0.0D;
          this.stallSeverity = 0.0D;
@@ -1654,6 +1779,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.stallDemand = 0.0D;
          this.pitchBreakActive = false;
          this.stalling = false;
+         this.lastEngineThrustForce = 0.0D;
+         this.lastValidClimb = false;
+         this.lastUnsupportedClimbSeverity = 0.0D;
+         this.lastIdleUnsupportedClimb = false;
+         this.lastIdleThrottleWarning = "";
+         this.lastHorizontalSpeed = 0.0D;
+         this.lastLowHorizontalSpeedWarning = "";
       }
 
       boolean levelOff = super.isGunnerMode;
@@ -1734,10 +1866,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // 计算油门1的值，当前油门除以10
       double propulsiveThrottle = this.useNewMobilitySystem()
             ? this.getPropulsiveEngineThrottle() : this.getEngineThrottle();
+      propulsiveThrottle = MCH_FlightModel.clamp(propulsiveThrottle, 0.0D, 1.0D);
       float throttle1 = (float)(propulsiveThrottle / 10.0D);
       if(this.useNewMobilitySystem() && this.getPlaneInfo() != null) {
          double mass = this.getPhysicalMass();
-         double thrustForce = (double)this.getPlaneInfo().engineThrust * propulsiveThrottle;
+         double thrustForce = Math.max(0.0D, (double)this.getPlaneInfo().engineThrust * propulsiveThrottle);
          throttle1 = (float)(thrustForce / mass / 10.0D);
          this.lastEngineThrustForce = thrustForce;
       } else {
@@ -1847,13 +1980,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                this.getPlaneInfo().controlSurfaceDrag, (float)engineBrakeDrag) / mass;
          drag += MCH_FlightModel.getAngleOfAttackDrag(this.angleOfAttack, this.getPlaneInfo().criticalAoA,
                this.getPlaneInfo().baseDrag, this.getPlaneInfo().aoaDragMultiplier) / mass;
-         if(super.motionY > 0.0D && this.getRotPitch() < -35.0F) {
-            double unsupportedClimb = MCH_FlightModel.clamp((-this.getRotPitch() - 35.0D) / 55.0D, 0.0D, 1.0D)
-                  * MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
-            drag += unsupportedClimb * (0.08D + 0.22D * Math.max(this.stallSeverity, this.aoaStallSeverity));
-            if(unsupportedClimb > 0.0D) {
-               this.lastStallSuppressedLiftHeadroom = true;
-            }
+         double stallSpeedForIdleDrag = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+               this.getPlaneInfo().stallSpeedFactor);
+         this.lastIdleUnsupportedClimb = this.isIdleUnsupportedClimb(
+               MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeedForIdleDrag);
+         this.lastUnsupportedClimbSeverity = this.getUnsupportedClimbSeverity();
+         if(this.lastUnsupportedClimbSeverity > 0.0D) {
+            double idleDragBoost = this.lastIdleUnsupportedClimb ? 0.12D : 0.0D;
+            drag += this.lastUnsupportedClimbSeverity * (0.08D + idleDragBoost + 0.22D * Math.max(this.stallSeverity, this.aoaStallSeverity));
+            this.lastStallSuppressedLiftHeadroom = true;
          }
          drag = MCH_FlightModel.clamp(drag, 0.0D, 0.5D);
          this.lastAerodynamicDrag = drag;
@@ -1923,6 +2058,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastLiftLoss = 0.0D;
       }
       this.pitchBreakActive = false;
+      this.lastUnsupportedClimbSeverity = this.getUnsupportedClimbSeverity();
+      double stallSpeedForIdle = this.getPlaneInfo() != null
+            ? MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(), this.getPlaneInfo().stallSpeedFactor) : 0.0D;
+      this.lastIdleUnsupportedClimb = this.isIdleUnsupportedClimb(
+            MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeedForIdle);
+      this.updateIdleThrottleWarning();
+      this.updateLowHorizontalSpeedWarning();
       this.applyThrottleDeficitPitchDown(nearGround, dp, levelOff);
       if(this.useNewMobilitySystem() && !nearGround && dp == 0.0D && this.getNozzleRotation() <= 0.01F && !levelOff && this.stallSeverity > 0.0D) {
          double liftLoss = MCH_FlightModel.clamp(this.stallSeverity * (double)this.getPlaneInfo().stallLiftLoss, 0.0D, 1.0D);
@@ -1994,6 +2136,69 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.handleDeadPilot();
 
 
+   }
+
+
+
+   private void updateLowHorizontalSpeedWarning() {
+      this.lastLowHorizontalSpeedWarning = "";
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || !this.lastAirborne || this.getNozzleRotation() > 0.01F) {
+         return;
+      }
+
+      double noseUpDegrees = Math.max(0.0D, (double)-this.getRotPitch());
+      if(this.lastHorizontalSpeed >= 0.12D) {
+         return;
+      }
+
+      if(this.speedStallSeverity < 0.8D) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalSpeedSeverity";
+      } else if(this.stallDemand < 0.8D) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalStallDemand";
+      } else if(this.lastValidClimb) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalValidClimb";
+      } else if(this.getLiftToWeightRatio() >= 1.0D) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalLiftSupport";
+      } else if(this.lastUnsupportedClimbSeverity < 0.2D && noseUpDegrees > 10.0D) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalUnsupportedTooLow";
+      } else if(this.lastNetVerticalAcceleration >= 0.0D) {
+         this.lastLowHorizontalSpeedWarning = "lowHorizontalNetClimb";
+      }
+   }
+
+   private void updateIdleThrottleWarning() {
+      this.lastIdleThrottleWarning = "";
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || !this.lastAirborne) {
+         return;
+      }
+
+      double propulsiveThrottle = this.getPropulsiveEngineThrottle();
+      double liftToWeight = this.getLiftToWeightRatio();
+      double thrustToWeight = this.getThrustToWeightRatio();
+      double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+            this.getPlaneInfo().stallSpeedFactor);
+      double recoverySpeed = this.getPlaneInfo().stallRecoverySpeed > 0.0F
+            ? (double)this.getPlaneInfo().stallRecoverySpeed : stallSpeed * 1.2D;
+      double noseUpDegrees = Math.max(0.0D, (double)-this.getRotPitch());
+      boolean finite = Double.isNaN(propulsiveThrottle) || Double.isInfinite(propulsiveThrottle)
+            || Double.isNaN(thrustToWeight) || Double.isInfinite(thrustToWeight)
+            || Double.isNaN(liftToWeight) || Double.isInfinite(liftToWeight)
+            || Double.isNaN(this.lastUnsupportedClimbSeverity) || Double.isInfinite(this.lastUnsupportedClimbSeverity)
+            || Double.isNaN((double)this.lastControlAuthority) || Double.isInfinite((double)this.lastControlAuthority)
+            || Double.isNaN(this.lastPitchAuthority) || Double.isInfinite(this.lastPitchAuthority)
+            || Double.isNaN(this.stallSeverity) || Double.isInfinite(this.stallSeverity);
+      if(finite) {
+         this.lastIdleThrottleWarning = "nonFinite";
+      } else if(propulsiveThrottle <= 0.01D && thrustToWeight > 0.05D) {
+         this.lastIdleThrottleWarning = "idleHasThrust";
+      } else if(propulsiveThrottle <= 0.01D && this.lastValidClimb && liftToWeight < 1.0D) {
+         this.lastIdleThrottleWarning = "idleValidClimbWithoutLift";
+      } else if(propulsiveThrottle <= 0.01D && this.lastUnsupportedClimbSeverity < 0.1D
+            && this.getAirspeed() < recoverySpeed && noseUpDegrees > 10.0D) {
+         this.lastIdleThrottleWarning = "idleUnsupportedTooLow";
+      } else if(propulsiveThrottle <= 0.01D && this.lastNetVerticalAcceleration >= 0.0D && liftToWeight < 1.0D) {
+         this.lastIdleThrottleWarning = "idleNetClimbWithoutLift";
+      }
    }
 
    private void collisionEntity(AxisAlignedBB bb) {


### PR DESCRIPTION
### Motivation
- Improve debugging output and diagnostic warnings for the new flight mobility model to make low-energy/idle-climb and low-horizontal-speed issues easier to detect. 
- Make aerodynamic and thrust calculations more robust by clamping values and separating horizontal speed from full 3D speed for stall/energy logic.

### Description
- Extended `debugFlightControl` logging in `MCH_ClientCommonTickHandler` to include horizontal speed, control/pitch authority, unsupported-climb and idle-throttle warnings, and to print targeted warning lines for low-horizontal-speed and idle-throttle sanity conditions.
- Added new debug accessor methods to `MCH_EntityBaseVehicle` such as `getLastUnsupportedClimbSeverity`, `isUnsupportedClimb`, `getLastIdleThrottleWarning`, `getLastHorizontalSpeed`, `getLastPitchAuthority`, and `getLastControlAuthority` to expose plane-specific diagnostics.
- Implemented new unsupported-climb detection and idle-throttle guards in `MCP_EntityPlane`, including `getUnsupportedClimbSeverity`, `isIdleUnsupportedClimb`, `updateIdleThrottleWarning`, and `updateLowHorizontalSpeedWarning`, and a helper `updateNewFlightThrustForce` to keep `lastEngineThrustForce` consistent.
- Refactored stall and aerodynamic calculations to separately compute `horizontalSpeed` and use it alongside full 3D `speed` when evaluating stall severity, `takeoff` and `aerodynamic` state, and to persist `lastHorizontalSpeed` and various `last*` debug fields.
- Strengthened numeric safety by clamping engine/throttle-related values in multiple places (engine throttle, effective throttle, propulsive throttle), ensuring `thrustToWeight`/`liftToWeight` use safe denominators, and bounding intermediate values used in diagnostics and drag computation.
- Wired new fields into initialization, reset and server update paths so the debug fields are kept current and consistent.

### Testing
- Built the project with `./gradlew build` and ran automated unit tests with `./gradlew test`, and both completed successfully. 
- Ran integration smoke checks by launching a dev client and verifying that the expanded debug logging and additional warnings appear when `DebugFlightControl` is enabled (automated smoke pass succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308ba1389483299fb5086c8470a2f5)