### PR TITLE
Fix plane takeoff vertical lift

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1135,7 +1135,24 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    private void applyNewFlightVerticalForces() {
       AeroState state = this.aeroState;
-      if(state == null || !state.airborne) {
+      if(state == null) {
+         this.lastGravityAcceleration = 0.0D;
+         this.lastLiftAcceleration = 0.0D;
+         this.lastNetVerticalAcceleration = 0.0D;
+         this.lastWeightForce = 0.0D;
+         this.lastLiftForce = 0.0D;
+         this.lastLiftCoefficient = 0.0D;
+         this.lastValidClimb = false;
+         return;
+      }
+
+      // A plane starts its takeoff roll with onGround still true, so waiting for
+      // state.airborne before applying lift creates a deadlock: the aircraft cannot
+      // leave the runway because no positive Y motion is ever generated. Once the
+      // takeoff gate is valid, apply the same force balance that airborne flight uses
+      // so rotation can produce the first upward tick. Keep grounded, invalid
+      // takeoff states from adding weight/lift forces that would pin the plane down.
+      if(!state.airborne && !state.validTakeoff) {
          this.lastGravityAcceleration = 0.0D;
          this.lastLiftAcceleration = 0.0D;
          this.lastNetVerticalAcceleration = 0.0D;
@@ -1148,6 +1165,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       double mass = this.getPhysicalMass();
       double netAccel = (state.liftForce - state.weightForce) / mass;
+      if(!state.airborne) {
+         netAccel = Math.max(0.0D, netAccel);
+      }
       super.motionY += netAccel;
       this.lastGravityAcceleration = state.gravityForce;
       this.lastLiftAcceleration = state.liftForce / mass;


### PR DESCRIPTION
### Motivation
- Planes using the new fixed-wing model could never generate the first upward tick during a grounded takeoff because lift was only applied when `state.airborne` was true, creating a takeoff deadlock. 
- Grounded invalid takeoff states could still produce downward forces that pinned aircraft to the runway.

### Description
- Updated `applyNewFlightVerticalForces` to bail out only when `state == null` and to allow the lift/weight force balance to be evaluated for grounded but `validTakeoff` states. 
- Added a guard that skips applying lift/weight forces when the plane is grounded and the takeoff gate is not valid by checking `!state.airborne && !state.validTakeoff`. 
- When applying the computed vertical acceleration during a grounded but valid takeoff, clamp `netAccel` to `>= 0` so the method cannot add downward Y motion that would pin the plane to the runway. 
- Added explanatory comments documenting the grounded-takeoff rationale and updated the `last*` diagnostics to reflect the applied forces.

### Testing
- Ran `git diff --check` which passed with no style errors. 
- Attempted `gradle compileJava` and `bash ./gradlew compileJava` but both were blocked by external repository/Gradle download failures (HTTP 403 from Maven/Gradle proxy), so compilation could not be verified in this environment. 
- Changes were committed to the branch containing `src/main/java/mcheli/plane/MCP_EntityPlane.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a893ed248323b2270a9ee1232661)