### PR TITLE
Scale fixed‑wing lift by aircraft weight to fix heavy plane takeoff

### DIFF
--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -199,7 +199,8 @@ airspeedLift = clamp((airspeed - stallSpeed * 0.45) / max(0.05, stallSpeed * 1.3
 aoaLift = clamp(1 - max(0, abs(AoA) - CriticalAoA) / max(1, CriticalAoA), 0, 1)
 liftLoss = clamp(stallSeverity * StallLiftLoss, 0, 1)
 stallLift = 1 - liftLoss
-liftBeforeStallLoss = gravity * clamp(liftPower, 0, 2.5) * airspeedLift * aoaLift
+weightForce = gravity * PhysicalMass
+liftBeforeStallLoss = weightForce * clamp(liftPower, 0, 2.5) * airspeedLift * aoaLift
 liftForce = liftBeforeStallLoss * stallLift
 ```
 
@@ -332,7 +333,7 @@ FlightCeilingRange = 48
 
 `EngineThrust` is a force value, not a top-speed value. The new flight model applies forward acceleration from `EngineThrust / PhysicalMass` after throttle response and engine spool are resolved. Higher thrust-to-weight improves acceleration, takeoff roll, climb, and post-maneuver energy recovery. If omitted, a conservative default is derived from existing speed tuning so older new-flight configs remain flyable.
 
-The model treats weight as `NewFlightGravity * PhysicalMass`. Lift is evaluated as a force and compared against that weight, so heavy aircraft need more airspeed, throttle, flap lift, or gentler AoA to hold altitude. Drag and climb/dive energy exchange are divided through mass, so heavy aircraft lose and gain speed more gradually while light aircraft respond quickly. Takeoff speed remains emergent from stall speed, lift, thrust, drag, and mass; do not add a separate takeoff-speed key.
+The model treats weight as `NewFlightGravity * PhysicalMass`. Lift is evaluated as a force against that weight, so correctly tuned heavy aircraft can still rotate and climb once they reach the required airspeed while still needing enough thrust, throttle, flap lift, and gentle AoA to sustain flight. Drag and climb/dive energy exchange are divided through mass, so heavy aircraft lose and gain speed more gradually while light aircraft respond quickly. Takeoff speed remains emergent from stall speed, lift, thrust, drag, and mass; do not add a separate takeoff-speed key.
 
 Recommended mass/thrust starting ranges:
 

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1063,7 +1063,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftCoefficient = aoaLift * stallLift;
       double mass = this.getPhysicalMass();
       double weightForce = gravityAccel * mass;
-      double liftBeforeStallLoss = gravityAccel * MCH_FlightModel.clamp(liftPower, 0.0D, 2.5D) * airspeedLift * aoaLift;
+      double liftBeforeStallLoss = weightForce * MCH_FlightModel.clamp(liftPower, 0.0D, 2.5D) * airspeedLift * aoaLift;
       double liftForce = liftBeforeStallLoss * stallLift;
       double liftAccel = liftForce / mass;
       double netAccel = (liftForce - weightForce) / mass;
@@ -1139,7 +1139,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
       double gravityAccel = this.resolveNewFlightGravity();
       double mass = this.getPhysicalMass();
-      double liftForce = gravityAccel * MCH_FlightModel.clamp(throttleLift, 0.0D, 1.5D) * runwayReadiness;
+      double liftForce = gravityAccel * mass * MCH_FlightModel.clamp(throttleLift, 0.0D, 1.5D) * runwayReadiness;
       double liftAccel = liftForce / mass;
 
       super.motionY += liftAccel * 0.55D;


### PR DESCRIPTION
### Motivation
- Large/new‑flight planes could not generate proportional wing lift because lift was scaled from gravity alone rather than the aircraft weight (`gravity * PhysicalMass`), preventing properly tuned heavy aircraft from rotating and climbing.

### Description
- In `MCP_EntityPlane`, compute airborne pre‑stall lift from weight by replacing the pre‑stall term with `weightForce * clamp(liftPower, ...)` so lift scales with `gravity * PhysicalMass` (`src/main/java/mcheli/plane/MCP_EntityPlane.java`).
- In the new‑flight runway takeoff assist, scale the takeoff assist lift by mass (use `gravityAccel * mass * ...`) so ground‑roll rotation assistance matches aircraft weight (`src/main/java/mcheli/plane/MCP_EntityPlane.java`).
- Update documentation to show the weight‑based lift formula and clarify heavy aircraft behavior in `docs/vehicle-config/planes.md`.

### Testing
- Ran `git diff --check` to verify no whitespace/diff issues (succeeded).
- Attempted `./gradlew test` but the wrapper was not executable in the environment (permission denied).
- Attempted `bash ./gradlew test` to download Gradle, but the wrapper failed to fetch the distribution due to an outgoing proxy returning HTTP 403, so tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ae1c3f708323973a0c2a0cd87c1c)