### PR TITLE
Prevent idle-zero-throttle vertical pitch exploit (NewFlightIdleNoseUpLimit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Common examples:
 
 Operators can use all subcommands. Non-operators need matching `CommandPermission` entries in `mcheli.cfg`. See [docs/commands.md](docs/commands.md) for syntax, examples, and permission configuration.
 
+## Fixed-wing flight-model tuning
+
+Realistic fixed-wing aircraft use data-driven stall, speed, throttle, and pitch-protection values. See [docs/flight-model.md](docs/flight-model.md) for the idle-throttle nose-up limiter (`NewFlightIdleNoseUpLimit`) and related tuning guidance for preventing zero-throttle vertical pitch exploits.
+
 ## Troubleshooting
 
 ### Vehicles, models, textures, or sounds are missing

--- a/docs/flight-model.md
+++ b/docs/flight-model.md
@@ -1,0 +1,34 @@
+# Fixed-wing realistic flight model notes
+
+The 1.7.10 fixed-wing `EnableRealisticFlightModel` path treats closed throttle as an aerodynamic energy state, not as a free thrust-vectoring mode. A plane that is airborne, not in VTOL/nozzle mode, at zero propulsive throttle, nose-high, and below stall-recovery speed is now considered an **idle unsupported climb**.
+
+## Idle unsupported climb protection
+
+Minecraft/MCHeli pitch is inverted: negative pitch is nose-up, positive pitch is nose-down. When an idle unsupported climb is detected:
+
+- nose-up control input is fully suppressed as energy runs out;
+- accumulated nose-up pitch rate is cancelled when the limit is reached; and
+- aircraft pitch is clamped to `-NewFlightIdleNoseUpLimit` until airspeed recovers.
+
+This prevents the exploit where a pilot chops throttle to 0%, pulls to a near-vertical attitude, then throttles back up for an unrealistic space-shuttle climb. The stall and throttle-deficit pitch-down forces still handle normal recovery; this clamp only stops the zero-throttle, below-recovery-speed vertical setup.
+
+## Config key
+
+`NewFlightIdleNoseUpLimit` controls the maximum nose-up pitch, in degrees, while airborne at zero propulsive throttle and below stall-recovery speed.
+
+- Default: `38.0`
+- Valid range: `5.0` to `89.0`
+- Applies only to fixed-wing realistic flight (`EnableRealisticFlightModel = true`)
+- Ignored while on/near the ground or in VTOL/nozzle mode
+- Blends out as airspeed returns to `StallRecoverySpeed` (or `StallSpeed * 1.2` when no explicit recovery speed is configured)
+
+Recommended starting points:
+
+| Aircraft class | Suggested value | Notes |
+| --- | ---: | --- |
+| WW2 props / trainers | `34`-`42` | Lower values make idle stalls break earlier. |
+| Modern fighters | `38`-`48` | High thrust only helps after throttle is restored and speed recovers. |
+| Heavy bombers / transports | `28`-`38` | Heavier aircraft should not hold steep idle pitch. |
+| VTOL aircraft | `38` default | Protection is bypassed in nozzle/VTOL mode. |
+
+Keep `StallSpeed`, `StallRecoverySpeed`, `CriticalAoA`, `StallPitchRecoveryStrength`, and `StallBreakStrength` tuned from real-world class data where possible, then use `NewFlightIdleNoseUpLimit` as the final guard against idle vertical pitch exploits.

--- a/examples/vehicle-configs/plane_realistic_fm.txt
+++ b/examples/vehicle-configs/plane_realistic_fm.txt
@@ -25,6 +25,7 @@ EngineThrust = 1.0
 TakeoffDistanceMultiplier = 1.0
 ThrottleAcceleration = 0.026
 EngineDrag = 0.011
+NewFlightIdleNoseUpLimit = 38.0
 StallSpeed = 0.36
 CriticalAoA = 16.0
 StallLiftLoss = 0.820

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -464,6 +464,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
 
+   private double getIdleNoseUpPitchLimit(double stallSpeed) {
+      if(this.getPlaneInfo() == null) {
+         return 90.0D;
+      }
+
+      double configuredLimit = MCH_FlightModel.clamp((double)this.getPlaneInfo().newFlightIdleNoseUpLimit, 5.0D, 89.0D);
+      double recoverySpeed = this.getPlaneInfo().stallRecoverySpeed > 0.0F
+            ? (double)this.getPlaneInfo().stallRecoverySpeed : stallSpeed * 1.2D;
+      double speedDeficit = MCH_FlightModel.clamp((recoverySpeed - this.getAirspeed()) / Math.max(0.05D, recoverySpeed), 0.0D, 1.0D);
+      return configuredLimit + (90.0D - configuredLimit) * (1.0D - speedDeficit);
+   }
+
    private boolean isIdleUnsupportedClimb(double noseUpAttitude, double stallSpeed) {
       if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F || this.onGround) {
          return false;
@@ -472,6 +484,20 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double recoverySpeed = this.getPlaneInfo().stallRecoverySpeed > 0.0F
             ? (double)this.getPlaneInfo().stallRecoverySpeed : stallSpeed * 1.2D;
       return this.getPropulsiveEngineThrottle() <= 0.01D && noseUpAttitude > 0.05D && this.getAirspeed() < recoverySpeed;
+   }
+
+   private float clampIdleUnsupportedNoseUpPitch(float pitch, double stallSpeed) {
+      if(!this.isIdleUnsupportedClimb(MCH_FlightModel.clamp((double)(-pitch - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeed)) {
+         return pitch;
+      }
+
+      double pitchLimit = this.getIdleNoseUpPitchLimit(stallSpeed);
+      if((double)pitch < -pitchLimit) {
+         this.pitchAngularVelocity = Math.max(0.0F, this.pitchAngularVelocity);
+         this.lastNoseUpPitchSuppression = 1.0D;
+         return (float)(-pitchLimit);
+      }
+      return pitch;
    }
 
    private double getNoseUpPitchSuppression() {
@@ -880,6 +906,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          v.z = MCH_Lib.RNG(v.z, this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);
       }
 
+      double stallSpeed = MCH_FlightModel.getStallSpeed(planeInfo.stallSpeed, this.getMaxSpeed(), planeInfo.stallSpeedFactor);
+      v.x = this.clampIdleUnsupportedNoseUpPitch(v.x, stallSpeed);
+
       if(v.z > 180.0F) {
          v.z -= 360.0F;
       }
@@ -894,6 +923,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.onUpdateAngles(partialTicks);
       if(this.getAcInfo().limitRotation) {
          v.x = MCH_Lib.RNG(this.getRotPitch(), this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
+         v.x = this.clampIdleUnsupportedNoseUpPitch(v.x, stallSpeed);
          v.z = MCH_Lib.RNG(this.getRotRoll(), this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);
          this.setRotPitch(v.x);
          this.setRotRoll(v.z);

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -72,6 +72,8 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float newFlightLowThrottleLiftRetention = 0.700F;
    /** Maximum fraction of control authority lost at idle throttle. */
    public float newFlightThrottleControlAuthorityScale = 0.10F;
+   /** Nose-up pitch limit while airborne at closed throttle and below recovery speed. */
+   public float newFlightIdleNoseUpLimit = 38.0F;
    /** Show the normalized 0-100% throttle readout to pilots using the new flight model. */
    public boolean newFlightThrottleHudDisplay = true;
    /** Enables the new-flight-only combat-flap toggle. */
@@ -332,6 +334,8 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.newFlightLowThrottleLiftRetention = this.toFloat(data, 0.0F, 1.0F);
          } else if(item.equalsIgnoreCase("NewFlightThrottleControlAuthorityScale")) {
             this.newFlightThrottleControlAuthorityScale = this.toFloat(data, 0.0F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewFlightIdleNoseUpLimit")) {
+            this.newFlightIdleNoseUpLimit = this.toFloat(data, 5.0F, 89.0F);
          } else if(item.equalsIgnoreCase("NewFlightThrottleHudDisplay")) {
             this.newFlightThrottleHudDisplay = this.toBool(data);
          } else if(item.equalsIgnoreCase("NewFlightCombatFlaps")) {


### PR DESCRIPTION
### Motivation
- Prevent fixed-wing aircraft from being pitched to unrealistic near-vertical attitudes while at zero propulsive throttle and below stall/recovery speed (the “throttle-chop then space-shuttle climb” exploit).
- Provide a configurable, data-driven guard that fits into the existing realistic flight model rather than changing class files or legacy control paths.

### Description
- Added `NewFlightIdleNoseUpLimit` to `MCP_PlaneInfo` with a default of `38.0F` and parser range `5.0..89.0` so plane configs can tune the idle nose-up clamp. (`src/main/java/mcheli/plane/MCP_PlaneInfo.java`)
- Implemented an idle unsupported-climb limiter in `MCP_EntityPlane`: `getIdleNoseUpPitchLimit`, `clampIdleUnsupportedNoseUpPitch`, and integrated the clamp into the render/control angle path so airborne planes at zero propulsive throttle and below recovery speed cannot be pitched beyond the configured limit; accumulated nose-up pitch rate is cancelled when the clamp triggers. (`src/main/java/mcheli/plane/MCP_EntityPlane.java`)
- Updated the example realistic plane config to show `NewFlightIdleNoseUpLimit = 38.0`. (`examples/vehicle-configs/plane_realistic_fm.txt`)
- Added documentation describing the behavior, tuning guidance, and how it blends with stall/recovery logic. (`docs/flight-model.md`) and linked it from `README.md`.

### Testing
- Ran `git diff --check` to validate local changes and whitespace errors; the check passed. 
- Attempted `./gradlew compileJava` to compile the project; this failed due to an environment/network proxy blocking Gradle distribution download (`HTTP/1.1 403 Forbidden`), so a full compile was not performed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a320022e48483238ab33aaada06afc3)