### PR TITLE
Translate Chinese comments and display names to English (exclude mcheliCE)

### DIFF
--- a/configreference/planes/h6k.txt
+++ b/configreference/planes/h6k.txt
@@ -1,5 +1,5 @@
 DisplayName = Xi'an H-6K "God Of War"
-AddDisplayName = zh_CN, 轰6K“战神”
+AddDisplayName = zh_CN, H-6K "God of War"
 AddDisplayName = en_US, Xi'an H-6K "God of War"
 ItemID = 45600
 MaxHp = 250

--- a/configreference/planes/j11b.txt
+++ b/configreference/planes/j11b.txt
@@ -1,6 +1,6 @@
 DisplayName = J-11B
 AddDisplayName = en_US, J-11B
-AddDisplayName = zh_CN, 歼11B
+AddDisplayName = zh_CN, J-11B
 ItemID = 6855
 MaxHp = 100
 EnableNightVision = true
@@ -20,7 +20,7 @@ VariableSweepWing = true
 SweepWingSpeed = 0.8
 
 ;modern light plane (late jet), AOW3 style (fcs)
-AddRecipe = "ABC", "DEF", "GGG", A, mcheli:airframe2, B, mcheli:advancedmechanicparts, C, mcheli:engine3, D, mcheli:wheelair, E, mcheli:cannon1, F, mcheli:fcs3, G, mcheli:electronics 
+AddRecipe = "ABC", "DEF", "GGG", A, mcheli:airframe2, B, mcheli:advancedmechanicparts, C, mcheli:engine3, D, mcheli:wheelair, E, mcheli:cannon1, F, mcheli:fcs3, G, mcheli:electronics
 
 Category = ASF
 EnableRealisticFlightModel = true

--- a/configreference/planes/j15.txt
+++ b/configreference/planes/j15.txt
@@ -1,6 +1,6 @@
 DisplayName = J-15 Fly Shark
 AddDisplayName = en_US, J-15 Fly Shark
-AddDisplayName = zh_CN, 歼15 飞鲨
+AddDisplayName = zh_CN, J-15 Flying Shark
 ItemID = 6655
 MaxHp = 100
 EnableNightVision = true
@@ -133,7 +133,7 @@ AddPartWeaponBay = targeting_pod_ph50s/ none,   0.00, 3.5784, -6.8482,  1,0,0, -
 AddPartWeaponBay = targeting_pod_ph50s/ none,   0.00, 3.9204, -3.927,  1,0,0, 40
 
 ;modern light plane (late jet), AOW3 style (fcs)
-AddRecipe = "ABC", "DEF", "GG ", A, mcheli:airframe2, B, mcheli:advancedmechanicparts, C, mcheli:engine3, D, mcheli:wheelair, E, mcheli:cannon1, F, mcheli:fcs3, G, mcheli:electronics 
+AddRecipe = "ABC", "DEF", "GG ", A, mcheli:airframe2, B, mcheli:advancedmechanicparts, C, mcheli:engine3, D, mcheli:wheelair, E, mcheli:cannon1, F, mcheli:fcs3, G, mcheli:electronics
 
 BoundingBox =  0.00, 2.8, 3.5,  1.5, 1.5,0.5
 BoundingBox =  0.00, 3.3,  -5.0,  3.5, 2.0,1

--- a/configreference/planes/mirageiv.txt
+++ b/configreference/planes/mirageiv.txt
@@ -1,5 +1,5 @@
 DisplayName = Mirage IVP
-AddDisplayName = zh_CN, 幻影IVP战略轰炸机
+AddDisplayName = zh_CN, Mirage IVP Strategic Bomber
 
 MaxHp = 100
 Speed = 4.0

--- a/configreference/planes/rafalem.txt
+++ b/configreference/planes/rafalem.txt
@@ -1,6 +1,6 @@
 DisplayName = Dassault Rafale M
 AddDisplayName = en_US, Dassault Rafale M
-AddDisplayName = zh_CN, Dassault 阵风M舰载战斗机
+AddDisplayName = zh_CN, Dassault Rafale M Carrier-Based Fighter
 MaxHp = 100
 Speed = 3.327
 Sound = rafale

--- a/configreference/planes/su57.txt
+++ b/configreference/planes/su57.txt
@@ -1,6 +1,6 @@
 DisplayName = Su-57
 AddDisplayName = en_US, Su-57
-AddDisplayName = zh_CN, 老毛子的苏-57
+AddDisplayName = zh_CN, Russian Su-57
 ItemID = 7788
 MaxHp = 100
 ThrottleUpDown = 0.3

--- a/configreference/planes/tu160m.txt
+++ b/configreference/planes/tu160m.txt
@@ -1,6 +1,6 @@
 DisplayName = Tu-160M Super Blackjack Conventional Bombs
 AddDisplayName = en_US, Tu-160M Super Blackjack Conventional Bombs
-AddDisplayName =  zh_CN, 图-160M 超级海盗旗 Conventional Bombs
+AddDisplayName =  zh_CN, Tu-160M Blackjack Conventional Bombs
 ItemID = 30714
 MaxHp = 250
 EnableNightVision = true
@@ -135,7 +135,7 @@ AddWeapon = odab9000, 0.0, 4.0, -7.0, 0.0, 0.0, true, 2
 ;1
 
 AddWeapon = tu160rbk500umpk16, 0.0, 4.0, -30.0, 0.0, 0.0, true, 2, 0,-90,90, -5,90
-;8 
+;8
 AddWeapon = tu160fab3000umpk4, 0.0, 4.0, -30.0, 0.0, 0.0, true, 2, 0,-90,90, -5,90
 ;2
 

--- a/configreference/planes/tu160mmsl.txt
+++ b/configreference/planes/tu160mmsl.txt
@@ -1,6 +1,6 @@
 DisplayName = Tu-160M Super Blackjack with Rotary Launchers
 AddDisplayName = en_US, Tu-160M Super Blackjack with Rotary Launchers
-AddDisplayName =  zh_CN, 图-160M 超级海盗旗 Rotary Launchers
+AddDisplayName =  zh_CN, Tu-160M Blackjack Rotary Launchers
 ;ItemID = 30714
 MaxHp = 250
 EnableNightVision = true

--- a/configreference/planes/tu95ms.txt
+++ b/configreference/planes/tu95ms.txt
@@ -1,7 +1,7 @@
 DisplayName = TU-95MSM
 AddDisplayName = en_US, TU-95MSM
 AddDisplayName = ja_JP, TU-95MSM
-AddDisplayName = zh_CN, 图95MSM“熊”
+AddDisplayName = zh_CN, Tu-95MSM "Bear"
 ItemID = 19112
 MaxHp = 250
 EnableNightVision = true

--- a/configreference/planes/tu95org.txt
+++ b/configreference/planes/tu95org.txt
@@ -1,7 +1,7 @@
 DisplayName = TU-95 Bear
 AddDisplayName = en_US, TU-95 Bear
 AddDisplayName = ja_JP, TU-95 Bear
-AddDisplayName = zh_CN, 图95 Bear
+AddDisplayName = zh_CN, Tu-95 Bear
 ;ItemID = 19112
 MaxHp = 250
 EnableNightVision = false

--- a/src/main/java/mcheli/MCH_EntityInfoManager.java
+++ b/src/main/java/mcheli/MCH_EntityInfoManager.java
@@ -39,7 +39,7 @@ public class MCH_EntityInfoManager {
 
     public void serverTick() {
 
-        //更新实体到集合
+        //Updates entities into the collection
         for (WorldServer world : MinecraftServer.getServer().worldServers) {
             for (Entity entity : (List<Entity>) world.loadedEntityList) {
                 if (shouldTrack(world, entity)) {
@@ -49,7 +49,7 @@ public class MCH_EntityInfoManager {
         }
 
         if(tickCounter % 10 == 0) {
-            //删除过期实体
+            //Deletes expired entities
             Iterator<Map.Entry<Integer, MCH_EntityInfo>> it = serverEntities.entrySet().iterator();
             List<MCH_EntityInfo> removed = new ArrayList<>();
             while (it.hasNext()) {
@@ -61,16 +61,16 @@ public class MCH_EntityInfoManager {
                     it.remove();
                 }
             }
-            //发送移除包
+            //Sends removal packets
             if (!removed.isEmpty()) {
-//                System.out.println("向客户端移除了" + removed.size() + "个实体信息");
+//                System.out.println("Removed from client: " + removed.size() + " entity info entries");
                 sendEntityPacket(removed, OPERATION_REMOVE);
             }
         }
 
-        //发送实体数据包
+        //Sends entity data packets
         List<MCH_EntityInfo> list = new ArrayList<>(serverEntities.values());
-//        System.out.println("向客户端发送了" + list.size() + "个实体信息");
+//        System.out.println("Sent to client: " + list.size() + " entity info entries");
         sendEntityPacket(list, OPERATION_UPDATE);
     }
 

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -204,7 +204,7 @@ public class MCH_MOD {
          System.out.println("Mods Directory: " + sourcePath);
       }
 
-      ///sourcePath = "D:\\软件\\GitHub\\MCHeli-Reforged\\src\\main\\resources";
+      ///sourcePath = "D:\\Software\\GitHub\\MCHeli-Reforged\\src\\main\\resources";
               //new File(evt.getModConfigurationDirectory().getParentFile(), "/mods").getPath();
       MCH_Lib.Log("SourcePath: " + sourcePath, new Object[0]);
       System.out.println("SourcePath: " + sourcePath);

--- a/src/main/java/mcheli/MCH_PlayerViewHandler.java
+++ b/src/main/java/mcheli/MCH_PlayerViewHandler.java
@@ -7,12 +7,12 @@ import java.util.Random;
 public class MCH_PlayerViewHandler {
 
     /**
-     * 通过射击作用于玩家视野的后坐力
+     * Recoil applied to the player view by shooting
      */
     public static float playerRecoilPitch;
     public static float playerRecoilYaw;
     /**
-     * 为使后坐力恢复正常，对后坐力施加的补偿量
+     * Compensation applied to restore recoil to normal
      */
     public static float antiRecoilPitch;
     public static float antiRecoilYaw;
@@ -28,7 +28,7 @@ public class MCH_PlayerViewHandler {
     }
 
     /**
-     * 每帧更新视角抖动效果
+     * Updates the view shake effect every frame
      */
     public static void onUpdate() {
 

--- a/src/main/java/mcheli/MCH_RenderBVRLockBox.java
+++ b/src/main/java/mcheli/MCH_RenderBVRLockBox.java
@@ -35,7 +35,7 @@ public class MCH_RenderBVRLockBox {
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
 
-        //获取基本信息
+        //Gets basic information
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer player = mc.thePlayer;
         World world = mc.theWorld;
@@ -43,7 +43,7 @@ public class MCH_RenderBVRLockBox {
         if (player == null || world == null) return;
         if (mc.gameSettings.thirdPersonView != 0) return;
 
-        //获取玩家机载武器
+        //Gets the player aircraft weapon
         MCH_EntityBaseVehicle ac = null;
         if(player.ridingEntity instanceof MCH_EntityBaseVehicle) {
             ac = (MCH_EntityBaseVehicle)player.ridingEntity;
@@ -56,7 +56,7 @@ public class MCH_RenderBVRLockBox {
         MCH_WeaponInfo wi = ac.getCurrentWeapon(player).getCurrentWeapon().getInfo();
         if(wi == null || !wi.enableBVR) return;
 
-        //开始渲染
+        //Starts rendering
         GL11.glPushMatrix();
         {
             List<MCH_EntityInfo> entities = new ArrayList<>(getServerLoadedEntity());
@@ -150,11 +150,11 @@ public class MCH_RenderBVRLockBox {
         if(Math.toDegrees(Vector3f.angle(rPos, lookVec)) > 45) {
             return new double[] {-1, -1, -1, -1};
         }
-        // 计算相机坐标系
+        // Calculates the camera coordinate system
         Vector3f worldUp = new Vector3f(0, 1, 0);
         Vector3f R = new Vector3f();
         Vector3f.cross(lookVec, worldUp, R);
-        // 处理叉积为零的情况（如直视上方/下方）
+        // Handles the case where the cross product is zero (such as looking straight up/down)
         if (R.lengthSquared() < 1e-5) {
             float yawRad = (float) Math.toRadians(player.rotationYaw + 90);
             R.set((float) Math.cos(yawRad), 0, (float) -Math.sin(yawRad));
@@ -163,20 +163,20 @@ public class MCH_RenderBVRLockBox {
         Vector3f U = new Vector3f();
         Vector3f.cross(R, lookVec, U);
         U.normalise();
-        // 分解相对坐标到相机轴
+        // Decomposes relative coordinates onto the camera axes
         float dx = Vector3f.dot(rPos, R);
         float dy = Vector3f.dot(rPos, U);
         float dz = Vector3f.dot(rPos, lookVec);
         if (dz <= 0) return new double[]{-1, -1, -1, -1};
-        // 获取显示参数
+        // Gets display parameters
         ScaledResolution sc = new ScaledResolution(Minecraft.getMinecraft(), Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
         float fov = Minecraft.getMinecraft().gameSettings.fovSetting;
         double tanHalfFov = Math.tan(Math.toRadians(fov) * 0.5);
         double aspect = (double) sc.getScaledWidth() / sc.getScaledHeight();
-        // 透视投影计算
+        // Perspective projection calculation
         double xProj = (dx / dz) / (aspect * tanHalfFov);
         double yProj = (dy / dz) / tanHalfFov;
-        // 转换为屏幕坐标
+        // Converts to screen coordinates
         double screenX = sc.getScaledWidth() / 2.0 + xProj * (sc.getScaledWidth() / 2.0);
         double screenY = sc.getScaledHeight() / 2.0 - yProj * (sc.getScaledHeight() / 2.0);
         return new double[]{screenX, screenY, screenX - sc.getScaledWidth() / 2.0, screenY - sc.getScaledHeight() / 2.0};
@@ -214,7 +214,7 @@ public class MCH_RenderBVRLockBox {
         return old + (now - old) * partialTicks;
     }
 
-    // 修改后的渲染状态设置
+    // Modified render state setup
     private void prepareRenderState(boolean lock, float alpha) {
         GL11.glEnable(3042);
         if(lock) {
@@ -247,11 +247,11 @@ public class MCH_RenderBVRLockBox {
 //        if (buffer.capacity() < 16) {
 //            throw new IllegalArgumentException("FloatBuffer must have at least 16 elements.");
 //        }
-//        int originalPosition = buffer.position(); // 保存原始位置
-//        buffer.position(0); // 重置到起始位置
+//        int originalPosition = buffer.position(); // Saves the original position
+//        buffer.position(0); // Resets to the start position
 //        float[] array = new float[16];
-//        buffer.get(array); // 读取16个元素
-//        buffer.position(originalPosition); // 恢复原始位置
+//        buffer.get(array); // Reads 16 elements
+//        buffer.position(originalPosition); // Restores the original position
 //        return array;
 //    }
 //

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -31,21 +31,21 @@ public class MCH_RenderRWR {
     private static final int RWR_CENTER_Y = 280;
     private static final double SCREEN_HEIGHT_ADAPT_CONSTANT = 520;
 
-    private static final double MIN_DISTANCE = 50.0;  // 最小显示距离（米）
-    private static final double MAX_DISTANCE = 1000.0; // 最大显示距离（米）
-    private static final int MIN_RADIUS = 30;          // 最小显示半径（像素
+    private static final double MIN_DISTANCE = 50.0;  // Minimum display distance (meters)
+    private static final double MAX_DISTANCE = 1000.0; // Maximum display distance (meters)
+    private static final int MIN_RADIUS = 30;          // Minimum display radius (pixels
 
     @SubscribeEvent
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
-        //获取基本信息
+        //Gets basic information
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer player = mc.thePlayer;
         World world = mc.theWorld;
         ScaledResolution sc = new ScaledResolution(Minecraft.getMinecraft(), Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
         if (player == null || world == null) return;
 
-        //获取玩家机载武器
+        //Gets the player aircraft weapon
         MCH_EntityBaseVehicle ac = null;
         if(player.ridingEntity instanceof MCH_EntityBaseVehicle) {
             ac = (MCH_EntityBaseVehicle)player.ridingEntity;
@@ -57,24 +57,24 @@ public class MCH_RenderRWR {
         if(!(ac instanceof MCP_EntityPlane || ac instanceof MCH_EntityHeli)) return;
         if(ac.getAcInfo().rwrType == null || ac.getAcInfo().rwrType == EnumRWRType.NONE) return;
 
-        //开始渲染
+        //Starts rendering
         GL11.glPushMatrix();
         {
             double sx = sc.getScaledHeight() * (RWR_CENTER_X / SCREEN_HEIGHT_ADAPT_CONSTANT);
             double sy = sc.getScaledHeight() * (RWR_CENTER_Y / SCREEN_HEIGHT_ADAPT_CONSTANT);
             drawRWRCircle(sx, sy, sc);
 
-            // 新增实体渲染逻辑
+            // New entity rendering logic
             double circleRadius = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
             for(MCH_EntityInfo entity : getServerLoadedEntity()) {
                 if(!isValidEntity(entity, player)) continue;
 
-                // 计算插值位置
+                // Calculates interpolated position
                 double xPos = interpolate(entity.posX, entity.lastTickPosX, event.partialTicks);
                 double yPos = interpolate(entity.posY, entity.lastTickPosY, event.partialTicks);
                 double zPos = interpolate(entity.posZ, entity.lastTickPosZ, event.partialTicks);
 
-                // 计算相对向量
+                // Calculates relative vector
                 Vec3 delta = Vec3.createVectorHelper(
                         xPos - (player.posX + (player.posX - player.lastTickPosX) * event.partialTicks),
                         yPos - (player.posY + (player.posY - player.lastTickPosY) * event.partialTicks),
@@ -89,17 +89,17 @@ public class MCH_RenderRWR {
                 double angle = Math.toDegrees(Math.acos(Math.max(-1, Math.min(1, dot))));
                 if(lookHorizontal.crossProduct(deltaHorizontal).yCoord < 0) angle = -angle;
 
-                // 计算距离相关参数
+                // Calculates distance-related parameters
                 double distance = Math.sqrt(delta.xCoord*delta.xCoord + delta.yCoord*delta.yCoord + delta.zCoord*delta.zCoord);
-                double radiusRatio = Math.min(Math.max((distance - MIN_DISTANCE) / (MAX_DISTANCE - MIN_DISTANCE), 0), 1); // 100-1000米映射到0-1
-                double renderRadius = MIN_RADIUS + (circleRadius - MIN_RADIUS) * radiusRatio; // 20像素到最大半径
+                double radiusRatio = Math.min(Math.max((distance - MIN_DISTANCE) / (MAX_DISTANCE - MIN_DISTANCE), 0), 1); // 100-1000metersmaps to0-1
+                double renderRadius = MIN_RADIUS + (circleRadius - MIN_RADIUS) * radiusRatio; // 20pixelsto maximum radius
 
-                // 计算屏幕坐标
+                // Calculates screen coordinates
                 double radian = Math.toRadians(angle);
                 double markerX = sx + renderRadius * Math.sin(-radian);
                 double markerY = sy - renderRadius * Math.cos(radian);
 
-                // 绘制文字
+                // Draws text
                 MCH_RWRResult rwrResult = getTargetTypeOnRadar(entity, ac);
                 String text = rwrResult.name;
                 int color = rwrResult.color;
@@ -140,7 +140,7 @@ public class MCH_RenderRWR {
     }
 
 
-    // 新增实体校验方法
+    // New entity validation method
     private boolean isValidEntity(MCH_EntityInfo entity, EntityPlayer player) {
         if (entity.entityClassName.contains("MCH_EntityChaff") || entity.entityClassName.contains("MCH_EntityFlare")
                 || entity.entityClassName.contains("EntityPlayer")) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -58,15 +58,15 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
    public MCH_Key KeyCurrentWeaponLock;
 
    /**
-    * 箔条按键
+    * Chaff key
     */
    public MCH_Key KeyChaff;
    /**
-    * 维修按键
+    * Maintenance key
     */
    public MCH_Key KeyMaintenance;
    /**
-    * APS按键
+    * APSkey
     */
    public MCH_Key KeyAPS;
 

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -171,76 +171,76 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    private MCH_BaseVehicleInfo.PartWeapon lastWeaponPart;
 
    /**
-    * 雷达种类
+    * Radar type
     */
    public EnumRadarType radarType = EnumRadarType.EARLY_AA;
 
    /**
-    * RWR种类
+    * RWR type
     */
    public EnumRWRType rwrType = EnumRWRType.NONE;
 
    /**
-    * 当前载具在现代对空雷达中显示的名字
+    * Name shown for this vehicle on modern air-search radar
     */
    public String nameOnModernAARadar = "?";
    /**
-    * 当前载具在早期对空雷达中显示的名字
+    * Name shown for this vehicle on early air-search radar
     */
    public String nameOnEarlyAARadar = "?";
    /**
-    * 当前载具在现代对地雷达中显示的名字
+    * Name shown for this vehicle on modern ground-search radar
     */
    public String nameOnModernASRadar = "?";
    /**
-    * 当前载具在早期对地雷达中显示的名字
+    * Name shown for this vehicle on early ground-search radar
     */
    public String nameOnEarlyASRadar = "?";
    /**
-    * 载具被摧毁时爆炸范围
+    * Explosion range when the vehicle is destroyed
     */
    public float explosionSizeByCrash = 5;
    /**
-    * 倒车速度倍率，默认1
+    * Reverse speed multiplier, default 1
     */
    public float throttleDownFactor = 1;
 
    /**
-    * 箔条生效时长
+    * Chaff active duration
     */
    public int chaffUseTime = 100;
 
    /**
-    * 箔条冷却时长
+    * Chaff cooldown duration
     */
    public int chaffWaitTime = 400;
 
    /**
-    * 维修系统生效时长 （时长即为回血百分比）
+    * Maintenance system active duration  (duration is the healing percentage)
     */
    public int maintenanceUseTime = 20;
 
    /**
-    * 维修系统冷却时长
+    * Maintenance system cooldown duration
     */
    public int maintenanceWaitTime = 300;
 
    /**
-    * 载具瘫痪阈值，血量低于此百分比将关闭载具引擎
+    * Vehicle disable threshold; engine shuts down below this health percentage
     */
    public int engineShutdownThreshold = 20;
 
    /**
-    * APS生效时长
+    * APS active duration
     */
    public int apsUseTime = 100;
    /**
-    * APS冷却时长
+    * APS cooldown duration
     */
    public int apsWaitTime = 400;
 
    /**
-    * APS范围
+    * APS range
     */
    public int apsRange = 8;
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -958,22 +958,22 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
 
          //float dmg = MCH_Config.KillPassengersWhenDestroyed.prmBool ? 100000.0F : 0.001F;
-         //DamageSource damageSource = DamageSource.generic; // 默认的伤害来源为generic
+         //DamageSource damageSource = DamageSource.generic; // Default damage source isgeneric
          //if (this.worldObj.difficultySetting.getDifficultyId() == 0) {
-         //   // 如果最后攻击这个实体的是玩家，创建一个基于玩家的伤害来源
+         //   // If the last attacker of this entity is a player, creates a player-based damage source
          //   if (this.lastAttackedEntity instanceof EntityPlayer) {
          //      damageSource = DamageSource.causePlayerDamage((EntityPlayer) this.lastAttackedEntity);
          //   }
          //} else {
-         //   // 如果世界难度不为和平模式，创建一个基于爆炸的伤害来源
+         //   // If world difficulty is not Peaceful, creates an explosion-based damage source
          //   damageSource = DamageSource.setExplosionSource(new Explosion(this.worldObj, this.lastAttackedEntity,
          //           this.posX, this.posY, this.posZ, 1.0F));
          //}
-         //// 如果当前实体存在，应用伤害
+         //// If the current entity exists, applies damage
          //if (this.riddenByEntity != null) {
          //   this.riddenByEntity.attackEntityFrom(damageSource, dmg);
          //}
-         //// 遍历所有座位上的实体，如果座位上有实体，应用伤害
+         //// Iterates all seat entities and applies damage if a seat is occupied
          //for (MCH_EntitySeat seat : getSeats()) {
          //   if (seat != null && seat.riddenByEntity != null) {
          //      seat.riddenByEntity.attackEntityFrom(damageSource, dmg);
@@ -2400,7 +2400,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(ironCurtainRunningTick > 0) {
          ironCurtainRunningTick--;
          ironCurtainWaveTimer++;
-         ironCurtainLastFactor = ironCurtainCurrentFactor;//基于计时器生成波动曲线（0.5~1.0）
+         ironCurtainLastFactor = ironCurtainCurrentFactor;//Generates a fluctuation curve based on timer (0.5~1.0)
          float waveSpeed = 0.25f;
          ironCurtainCurrentFactor = 0.75f + 0.25f * (float) Math.sin(ironCurtainWaveTimer * waveSpeed);
       } else {

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -1146,7 +1146,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
       if(player != null) {
          if(!W_Entity.isEqual(player, entity)) {
-            MCH_EntityBaseVehicle ac = null; //玩家乘坐的实体
+            MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
             if(player.ridingEntity instanceof MCH_EntityBaseVehicle) {
                ac = (MCH_EntityBaseVehicle)player.ridingEntity;
             } else if(player.ridingEntity instanceof MCH_EntitySeat) {
@@ -1165,10 +1165,10 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
                   if (guidanceSystem instanceof MCH_EntityGuidanceSystem) {
                      MCH_EntityGuidanceSystem gs = (MCH_EntityGuidanceSystem) guidanceSystem;
-                     // 检查当前武器是否有引导系统，并且该引导系统是否能锁定目标实体
+                     // Checks whether the current weapon has a guidance system and whether it can lock the target entity
                      if(gs.canLockEntity(entity)) {
                         RenderManager rm = RenderManager.instance;
-                        // 计算目标实体与玩家之间的平方距离
+                        // Calculates squared distance between target entity and player
                         double dist = entity.getDistanceSqToEntity(rm.livingPlayer);
                         double distance = Math.sqrt(dist);
                         if(wi != null && wi.enableBVR && distance > wi.minRangeBVR) {
@@ -1176,11 +1176,11 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
                         }
 //                     if(entity instanceof MCH_EntityFlare) {
 //                        long worldTime = Minecraft.getMinecraft().theWorld.getTotalWorldTime();
-//                        float blinkBaseFrequency = 1.0F; // 基本闪烁频率（每秒闪烁一次）
-//                        float randomFrequencyFactor = 0.5F + rand.nextFloat() * 0.5F; // 随机频率范围 [0.5, 1.0]
+//                        float blinkBaseFrequency = 1.0F; // Base blink frequency (blinks once per second)
+//                        float randomFrequencyFactor = 0.5F + rand.nextFloat() * 0.5F; // Random frequency range [0.5, 1.0]
 //                        float blinkFrequency = blinkBaseFrequency * randomFrequencyFactor;
-//                        float sinValue = (float) Math.sin(worldTime * blinkFrequency * Math.PI * 2.0F); // 正弦波函数
-//                        boolean isFlareVisible = sinValue > 0.0F; // 通过正弦波的值来决定是否显示框
+//                        float sinValue = (float) Math.sin(worldTime * blinkFrequency * Math.PI * 2.0F); // Sine wave function
+//                        boolean isFlareVisible = sinValue > 0.0F; // Determines whether to show the box from the sine value
 //                        if(!isFlareVisible) return;
 //                     }
                         Vec3 src = Vec3.createVectorHelper(RenderManager.renderPosX, RenderManager.renderPosY, RenderManager.renderPosZ);
@@ -1190,71 +1190,71 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
                            return;
                         }
 
-                        // 计算实体相对于玩家的坐标偏移
+                        // Calculates coordinate offset of the entity relative to the player
                         double x = entity.posX - RenderManager.renderPosX;
                         double y = entity.posY - RenderManager.renderPosY;
                         double z = entity.posZ - RenderManager.renderPosZ;
 
-                        // 如果目标实体与玩家的距离小于1000，则进行渲染
+                        // Renders if target entity is within 1000 units of the player
                         if(dist < 1000000.0D) {
-                           float scl = 0.02666667F; // 缩放因子
+                           float scl = 0.02666667F; // Scale factor
                            GL11.glPushMatrix();
-                           // 进行位置变换，将目标实体渲染到玩家视角中
+                           // Transforms position to render target entity in the player view
                            GL11.glTranslatef((float)x, (float)y + entity.height + 2F, (float)z);
                            GL11.glNormal3f(0.0F, 1.0F, 0.0F);
                            GL11.glRotatef(-rm.playerViewY, 0.0F, 1.0F, 0.0F);
                            GL11.glRotatef(rm.playerViewX, 1.0F, 0.0F, 0.0F);
                            GL11.glScalef(-0.02666667F, -0.02666667F, 0.02666667F);
-                           GL11.glDisable(2896); // 禁用深度测试
-                           GL11.glTranslatef(0.0F, 9.374999F, 0.0F); // 上移一些偏移量
-                           GL11.glDepthMask(false); // 禁用深度写入
-                           GL11.glEnable(3042); // 启用混合
-                           GL11.glBlendFunc(770, 771); // 设置混合模式
-                           GL11.glDisable(3553); // 禁用纹理
+                           GL11.glDisable(2896); // Disables depth testing
+                           GL11.glTranslatef(0.0F, 9.374999F, 0.0F); // Moves up by an offset
+                           GL11.glDepthMask(false); // Disables depth writes
+                           GL11.glEnable(3042); // Enables blending
+                           GL11.glBlendFunc(770, 771); // Sets blend mode
+                           GL11.glDisable(3553); // Disables textures
                            GL11.glDisable(2929 /* GL_DEPTH_TEST */);
 
-                           // 获取绘制前的屏幕宽度
+                           // Gets screen width before drawing
                            int prevWidth = GL11.glGetInteger(2849);
-                           // 设置目标实体大小（根据实体的宽度和高度进行调整）
+                           // Sets target entity size (adjusted based on entity width and height)
                            float size1 = Math.max(entity.width, entity.height) * 20.0F;
                            if(entity instanceof MCH_EntityBaseVehicle
                                    || entity instanceof MCH_EntityFlare
                                    || entity instanceof MCH_EntityChaff) {
-                              size1 *= 2.0F; // 飞机类型实体大小加倍
+                              size1 *= 2.0F; // Doubles size for aircraft-type entities
                            }
                            float size = size1 + (float)((distance - 10.0D) / (300.0D - 10.0D)) * (300.0F - size1);
-                           // 确保字体大小在size1和100之间
+                           // Ensures font size is between size1 and 100
                            size = Math.max(size1, Math.min(300.0F, size));
 
-                           // 创建Tessellator对象，用于绘制图形
+                           // Creates a Tessellator object for drawing graphics
                            Tessellator tessellator = Tessellator.instance;
-                           tessellator.startDrawing(2); // 开始绘制线条
-                           tessellator.setBrightness(240); // 设置亮度
+                           tessellator.startDrawing(2); // Starts drawing lines
+                           tessellator.setBrightness(240); // Sets brightness
 
-                           Vector3f playerVelocity = new Vector3f(ac.motionX, ac.motionY, ac.motionZ);  // 玩家机体的速度向量
-                           Vector3f targetVelocity = new Vector3f(entity.motionX, entity.motionY, entity.motionZ);  // 目标机体的速度向量
+                           Vector3f playerVelocity = new Vector3f(ac.motionX, ac.motionY, ac.motionZ);  // Velocity vector of the player aircraft
+                           Vector3f targetVelocity = new Vector3f(entity.motionX, entity.motionY, entity.motionZ);  // Velocity vector of the target aircraft
                            float angleInDegrees = 0;
                            if(playerVelocity.length() > 0.001 && targetVelocity.length() > 0.001) {
-                              // 计算两个向量的点积
+                              // Calculates the dot product of the two vectors
                               float dotProduct = Vector3f.dot(playerVelocity, targetVelocity);
-                              // 计算两个向量的长度
+                              // Calculates lengths of the two vectors
                               float playerSpeed = playerVelocity.length();
                               float targetSpeed = targetVelocity.length();
-                              // 计算夹角的余弦值
+                              // Calculates the cosine of the angle
                               float cosAngle = dotProduct / (playerSpeed * targetSpeed);
-                              // 确保夹角余弦值在合法范围内 [-1, 1]，避免浮动导致的异常值
+                              // Ensures the angle cosine is within the valid range [-1, 1],avoids abnormal values caused by floating-point error
                               cosAngle = Math.max(-1.0f, Math.min(1.0f, cosAngle));
-                              // 计算夹角（弧度）
+                              // Calculates the angle (radians)
                               float angle = (float) Math.acos(cosAngle);
-                              // 如果夹角大于90度，将其转换为锐角（90度以内）
+                              // If the angle is greater than 90 degrees, converts it to an acute angle (within 90 degrees)
                               if (angle > Math.PI / 2) {
-                                 angle = (float) (Math.PI - angle);  // 转换为锐角
+                                 angle = (float) (Math.PI - angle);  // Converts to an acute angle
                               }
-                              // 将角度转化为度数（可选）
+                              // Converts angle to degrees (optional)
                               angleInDegrees = (float) Math.toDegrees(angle);
                            }
 
-                           // 检查当前是否锁定了目标实体
+                           // Checks whether the target entity is currently locked
                            boolean isLockEntity = gs.isLockingEntity(entity);
                            float alpha = 1.0F;
                            if (angleInDegrees > ac.getCurrentWeapon(player).getCurrentWeapon().getInfo().pdHDNMaxDegree) {
@@ -1266,33 +1266,33 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
                            }
 
                            if(isLockEntity) {
-                              GL11.glLineWidth((float)MCH_Gui.scaleFactor * 2.5F); // 设置线宽
-                              tessellator.setColorRGBA_F(1.0F, 0.0F, 0.0F, alpha); // 锁定状态下显示红色
+                              GL11.glLineWidth((float)MCH_Gui.scaleFactor * 2.5F); // Sets line width
+                              tessellator.setColorRGBA_F(1.0F, 0.0F, 0.0F, alpha); // Shows red while locked
                            } else {
-                              GL11.glLineWidth((float)MCH_Gui.scaleFactor * 1.5F); // 设置线宽
-                              tessellator.setColorRGBA_F(0.0F, 1.0F, 0.0F, alpha); // 绿色
+                              GL11.glLineWidth((float)MCH_Gui.scaleFactor * 1.5F); // Sets line width
+                              tessellator.setColorRGBA_F(0.0F, 1.0F, 0.0F, alpha); // Green
                            }
 
-                           // 绘制矩形框，表示锁定范围
+                           // Draws a rectangle representing the lock range
                            tessellator.addVertex(-size - 1.0F, 0.0D, 0.0D);
                            tessellator.addVertex(-size - 1.0F, size * 2.0F, 0.0D);
                            tessellator.addVertex(size + 1.0F, size * 2.0F, 0.0D);
                            tessellator.addVertex(size + 1.0F, 0.0D, 0.0D);
-                           tessellator.draw(); // 绘制线条
+                           tessellator.draw(); // Draws lines
 
-                           // 获取距离并绘制文字
-                           String distanceText = String.format("%.1f", distance); // 格式化为一位小数
+                           // Gets distance and draws text
+                           String distanceText = String.format("%.1f", distance); // Formats with one decimal place
 
-                           // 获取 FontRenderer 对象并设置颜色为绿色
+                           // Gets the FontRenderer object and sets the color to green
                            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
                            {
                               GL11.glPushMatrix();
-                              GL11.glTranslatef(0.0F, size * 2.0F + 1.0F, 0.0F); // 将文本放置在矩形框的下方
+                              GL11.glTranslatef(0.0F, size * 2.0F + 1.0F, 0.0F); // Places text below the rectangle
                               float fontSize = 5.0F + (float)((distance - 10.0D) / (300.0D - 10.0D)) * (40.0F - 5.0F);
-                              // 确保字体大小在5和40之间
+                              // Ensures font size is between 5 and 40
                               fontSize = Math.max(5.0F, Math.min(40.0F, fontSize));
                               GL11.glScalef(fontSize, fontSize, fontSize);
-                              // 绘制绿色文字，显示与目标的距离
+                              // Draws green text showing distance to target
                               String text = "";
                               if (gs.isHeatSeekerMissile) {
                                  text = "HEAT";
@@ -1307,8 +1307,8 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
                               text += " " + distanceText;
 
                               if(ac instanceof MCP_EntityPlane && entity instanceof MCP_EntityPlane && angleInDegrees != 0) {
-                                 // 将角度值作为文本输出
-                                 String angleText = String.format("%.1f", angleInDegrees);  // 保留一位小数
+                                 // Outputs the angle value as text
+                                 String angleText = String.format("%.1f", angleInDegrees);  // Keeps one decimal place
                                  text += " " + angleText;
                               }
 
@@ -1321,28 +1321,28 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
 
 
-                           // 如果实体是无人机且当前视角是第一人称视角，并且目标实体被锁定，则绘制连接线
+                           // Draws a connecting line if the entity is a UAV, current view is first person, and target entity is locked
                            if(!ac.isUAV() && isLockEntity && Minecraft.getMinecraft().gameSettings.thirdPersonView == 0) {
                               GL11.glPushMatrix();
-                              tessellator.startDrawing(1); // 绘制点到点的连线
+                              tessellator.startDrawing(1); // Draws a point-to-point line
                               GL11.glLineWidth(1.0F);
-                              tessellator.setColorRGBA_F(1.0F, 0.0F, 0.0F, 1.0F); // 设置颜色为红色
-                              // 连接线从实体的中心到飞机的上一个位置
+                              tessellator.setColorRGBA_F(1.0F, 0.0F, 0.0F, 1.0F); // Sets color to red
+                              // Connecting line goes from entity center to aircraft previous position
                               tessellator.addVertex(x, y + (double)(entity.height / 2.0F), z);
                               tessellator.addVertex(ac.lastTickPosX - RenderManager.renderPosX, ac.lastTickPosY - RenderManager.renderPosY - 1.0D, ac.lastTickPosZ - RenderManager.renderPosZ);
-                              tessellator.setBrightness(240); // 设置亮度
-                              tessellator.draw(); // 绘制线条
-                              GL11.glPopMatrix(); // 恢复矩阵状态
+                              tessellator.setBrightness(240); // Sets brightness
+                              tessellator.draw(); // Draws lines
+                              GL11.glPopMatrix(); // Restores matrix state
                            }
 
-                           // 恢复之前的线宽，启用纹理，恢复深度写入和深度测试
+                           // Restores previous line width, enables textures, restores depth writes and depth testing
                            GL11.glLineWidth((float)prevWidth);
                            GL11.glEnable(3553);
                            GL11.glDepthMask(true);
                            GL11.glEnable(2896);
                            GL11.glDisable(3042);
                            GL11.glEnable(2929 /* GL_DEPTH_TEST */);
-                           GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F); // 恢复默认颜色
+                           GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F); // Restores default color
                         }
                      }
                   }

--- a/src/main/java/mcheli/flare/MCH_Chaff.java
+++ b/src/main/java/mcheli/flare/MCH_Chaff.java
@@ -8,17 +8,17 @@ import java.util.Random;
 
 public class MCH_Chaff {
 
-    //冷却时长 0代表冷却结束
+    //Cooldown duration 0means cooldown ended
     public int tick;
-    //生效时长 0代表使用结束
+    //Active duration 0means use ended
     public int useTick;
-    //箔条使用时间
+    //Chaff use time
     public int chaffUseTime;
-    //箔条等待时间
+    //Chaff wait time
     public int chaffWaitTime;
     public World worldObj;
     public MCH_EntityBaseVehicle aircraft;
-    //箔条使用时分批间隔
+    //Batch interval while using chaff
     private int spawnChaffEntityIntervalTick;
     public final Random rand = new Random();
 
@@ -81,17 +81,17 @@ public class MCH_Chaff {
     }
 
     private void spawnChaffEntity() {
-        // 获取飞机的最后位置
+        // Gets the aircraft last position
         double x = this.aircraft.lastTickPosX;
         double y = this.aircraft.lastTickPosY;
         double z = this.aircraft.lastTickPosZ;
 
-        // 获取飞机的运动速度
+        // Gets the aircraft motion speed
         double motionX = this.aircraft.motionX;
         double motionY = this.aircraft.motionY;
         double motionZ = this.aircraft.motionZ;
 
-        // 创建干扰箔条实体
+        // Creates the chaff countermeasure entity
         double offsetX = -motionX * 20D;
         double offsetY = -motionY * 20D;
         double offsetZ = -motionZ * 20D;
@@ -100,7 +100,7 @@ public class MCH_Chaff {
                 x + offsetX, y + offsetY, z + offsetZ,
                 motionX * 0.5, motionY * 0.5, motionZ * 0.5);
 
-        // 将干扰箔条实体加入到世界中
+        // Adds the chaff countermeasure entity to the world
         this.worldObj.spawnEntityInWorld(e);
     }
 

--- a/src/main/java/mcheli/flare/MCH_Maintenance.java
+++ b/src/main/java/mcheli/flare/MCH_Maintenance.java
@@ -6,13 +6,13 @@ import net.minecraft.world.World;
 
 public class MCH_Maintenance {
 
-    //冷却时长 0代表冷却结束
+    //Cooldown duration 0means cooldown ended
     public int tick;
-    //生效时长 0代表使用结束
+    //Active duration 0means use ended
     public int useTick;
-    //维修系统生效时间
+    //Maintenance system active time
     public int useTime;
-    //维修系统等待时间
+    //Maintenance system wait time
     public int waitTime;
 
     public World worldObj;

--- a/src/main/java/mcheli/network/PacketBase.java
+++ b/src/main/java/mcheli/network/PacketBase.java
@@ -8,19 +8,19 @@ import io.netty.channel.ChannelHandlerContext;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 
-/** MCH里所有包的父类 */
+/** Base class for all MCH packets */
 public abstract class PacketBase 
 {
-	/**把包编码为ByteBuf . Advanced data handlers can be found at @link{cpw.mods.fml.common.network.ByteBufUtils} */
+	/** Encodes the packet into ByteBuf. Advanced data handlers can be found at @link{cpw.mods.fml.common.network.ByteBufUtils} */
 	public abstract void encodeInto(ChannelHandlerContext ctx, ByteBuf data);
 
 	/** Decode the packet from a ByteBuf stream. Advanced data handlers can be found at @link{cpw.mods.fml.common.network.ByteBufUtils} */
 	public abstract void decodeInto(ChannelHandlerContext ctx, ByteBuf data);
 
-	/** 在服务器端处理数据包 */
+	/** Handles packets on the server side */
 	public abstract void handleServerSide(EntityPlayerMP playerEntity);
 
-	/** 在客户端处理数据包 */
+	/** Handles packets on the client side */
 	@SideOnly(Side.CLIENT)
 	public abstract void handleClientSide(EntityPlayer clientPlayer);
 	

--- a/src/main/java/mcheli/network/packets/PacketEntityInfoSync.java
+++ b/src/main/java/mcheli/network/packets/PacketEntityInfoSync.java
@@ -31,7 +31,7 @@ public class PacketEntityInfoSync extends PacketBase {
         buf.writeByte(operation);
         buf.writeInt(entities.size());
         for (MCH_EntityInfo info : entities) {
-            // 编码实体信息
+            // Encodes entity information
             buf.writeInt(info.entityId);
             writeUTF(buf, info.worldName);
             writeUTF(buf, info.entityName);
@@ -71,7 +71,7 @@ public class PacketEntityInfoSync extends PacketBase {
 
     }
 
-    // 客户端处理
+    // Client-side handling
     @Override
     public void handleClientSide(EntityPlayer player) {
         switch (operation) {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1453,9 +1453,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected void onUpdate_ControlNotHovering() {
-      // 判断是否不处于炮手模式
+      // Determines whether not in gunner mode
       if (!super.isGunnerMode) {
-         // 获取油门上下状态
+         // Gets throttle up/down state
          float throttleUpDown = this.getAcInfo().throttleUpDown;
          double throttleRateUp = 0.01D * (double)throttleUpDown;
          double throttleRateDown = 0.01D * (double)throttleUpDown;
@@ -1464,29 +1464,29 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             throttleRateDown = (double)this.getPlaneInfo().newFlightThrottleChangeRateDown;
          }
 
-         // 判断是否是转向状态（只左转或只右转）
+         // Determines whether it is a turning state (only turning left or only turning right)
          boolean turn = super.moveLeft && !super.moveRight || !super.moveLeft && super.moveRight;
 
-         // 获取旋转转向油门
+         // Gets rotary steering throttle
          float pivotTurnThrottle = this.getAcInfo().pivotTurnThrottle;
 
-         // 本地油门上升状态
+         // Local throttle-up state
          boolean localThrottleUp = super.throttleUp;
 
-         // 如果是转向且当前油门小于旋转油门阈值，并且没有加速和减速
+         // If turning, current throttle is below rotary throttle threshold, and neither accelerating nor decelerating
          if (turn && this.getCurrentThrottle() < (double) this.getAcInfo().pivotTurnThrottle && !localThrottleUp && !super.throttleDown) {
-            // 设置本地油门上升状态为true
+            // Sets local throttle-up state to true
             localThrottleUp = true;
-            // 加速倍增
+            // Acceleration multiplier
             throttleUpDown *= 2.0F;
          }
 
-         // 如果本地油门上升
+         // If local throttle is increasing
          if (localThrottleUp) {
-            // 设置油门为当前油门
+            // Sets throttle to current throttle
             float f = throttleUpDown;
 
-            // 如果骑乘的实体不为空，调整油门
+            // If the ridden entity is not null, adjusts throttle
             if (this.getRidingEntity() != null && !this.isMountedOnRack()) {
                double mx = this.getRidingEntity().motionX;
                double mz = this.getRidingEntity().motionZ;
@@ -1494,43 +1494,43 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                f = throttleUpDown * MathHelper.sqrt_double(mx * mx + mz * mz) * this.getAcInfo().throttleUpDownOnEntity;
             }
 
-            // 如果允许倒车并且油门向后，则递减后退油门
+            // If reverse is allowed and throttle is backward, decreases reverse throttle
             if (this.getAcInfo().enableBack && super.throttleBack > 0.0F) {
                super.throttleBack = (float) ((double) super.throttleBack - 0.01D * (double) f);
             } else {
-               // 否则，设置后退油门为0
+               // Otherwise sets reverse throttle to 0
                super.throttleBack = 0.0F;
-               // 如果当前油门小于1，则增加油门
+               // If current throttle is less than 1, increases throttle
                if (this.getCurrentThrottle() < 1.0D) {
                   this.addCurrentThrottle(this.useNewMobilitySystem() && this.getPlaneInfo() != null ? throttleRateUp : 0.01D * (double) f);
                } else {
-                  // 否则，设置油门为最大值1
+                  // Otherwise sets throttle to maximum value 1
                   this.setCurrentThrottle(1.0D);
                }
             }
          }
-         // 如果本地油门下降
+         // If local throttle is decreasing
          else if (super.throttleDown) {
-            // 如果当前油门大于0，则递减油门
+            // If current throttle is greater than 0, decreases throttle
             if (this.getCurrentThrottle() > 0.0D) {
                this.addCurrentThrottle(-throttleRateDown);
             } else {
-               // 否则，设置油门为0
+               // Otherwise sets throttle to 0
                this.setCurrentThrottle(0.0D);
-               // 如果允许倒车，则增加后退油门
+               // If reverse is allowed, increases reverse throttle
                if (this.getAcInfo().enableBack) {
                   super.throttleBack = (float) ((double) super.throttleBack + 0.0025D * (double) throttleUpDown);
-                  // 限制后退油门不超过0.6
+                  // Limits reverse throttle to no more than 0.6
                   if (super.throttleBack > 0.6F) {
                      super.throttleBack = 0.6F;
                   }
                }
             }
          }
-         // 如果启用了自动油门降低，并且当前油门大于0，则逐步降低油门
+         // If automatic throttle reduction is enabled and current throttle is greater than 0, gradually reduces throttle
          else if (super.cs_planeAutoThrottleDown && this.getCurrentThrottle() > 0.0D) {
             this.addCurrentThrottle(-(this.useNewMobilitySystem() && this.getPlaneInfo() != null ? throttleRateDown * 0.5D : 0.005D * (double) throttleUpDown));
-            // 如果油门低于0，则设置为0
+            // If throttle is below 0, sets it to 0
             if (this.getCurrentThrottle() <= 0.0D) {
                this.setCurrentThrottle(0.0D);
             }
@@ -1820,42 +1820,42 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       boolean levelOff = super.isGunnerMode;
       if(dp == 0.0D) {
-         // 如果是目标无人机，并且有足够的燃料且没有被摧毁，则执行以下代码
+         // If this is a target UAV with enough fuel and not destroyed, executes the following code
          if (this.isTargetDrone() && this.canUseFuel() && !this.isDestroyed()) {
 
-            // 获取无人机当前位置3个单位向下、40个单位向前的方块
+            // Gets the block 3 units down and 40 units forward from the UAV current position
             Block throttle = MCH_Lib.getBlockY(this, 3, -100, true);
 
-            // 如果方块不为空且不是空气方块（即存在某个物体）
+            // If the block is not null and is not an air block (meaning some object exists)
             if (throttle != null && !W_Block.isEqual(throttle, Blocks.air)) {
 
-               // 如果没有找到目标方块，或者目标方块是空气方块，则执行下面的代码
+               // If no target block is found or the target block is an air block, executes the following code
                throttle = MCH_Lib.getBlockY(this, 3, -5, true);
 
-               // 如果目标方块为空或是空气方块，进行自动驾驶的旋转和俯仰调整
+               // If target block is null or an air block, performs autopilot yaw and pitch adjustment
                if (throttle == null || W_Block.isEqual(throttle, Blocks.air)) {
 
-                  // 根据自动驾驶旋转量调整航向（Yaw）
+                  // Adjusts heading based on autopilot rotation amount (Yaw)
                   this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 2.0F);
 
-                  // 如果俯仰角度大于-20度，则逐渐减小俯仰角度
+                  // If pitch is greater than -20 degrees, gradually decreases pitch
                   if (this.getRotPitch() > -20.0F) {
                      this.setRotPitch(this.getRotPitch() - 0.5F);
                   }
                }
             } else {
-               // 如果没有遇到障碍物，则按照自动驾驶的旋转量调整航向（Yaw）
+               // If no obstacle is encountered, adjusts heading by autopilot rotation amount (Yaw)
                this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
 
-               // 自动调整俯仰角度，使其逐渐减小
+               // Automatically adjusts pitch so it gradually decreases
                this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
 
-               // 如果可以收起起落架，则执行收起起落架的操作
+               // If landing gear can be retracted, retracts it
                if (this.canFoldLandingGear()) {
                   this.foldLandingGear();
                }
 
-               // 标记为平稳飞行状态
+               // Marks as steady flight state
                levelOff = true;
             }
          }
@@ -1893,7 +1893,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
       }
 
-      // 计算油门1的值，当前油门除以10
+      // Calculates throttle1 as current throttle divided by 10
       double propulsiveThrottle = this.useNewMobilitySystem()
             ? this.getPropulsiveEngineThrottle() : this.getEngineThrottle();
       propulsiveThrottle = MCH_FlightModel.clamp(propulsiveThrottle, 0.0D, 1.0D);
@@ -1912,25 +1912,25 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
 
-      // 如果喷嘴的旋转角度大于0.001F
+      // If nozzle rotation angle is greater than0.001F
       if(this.getNozzleRotation() > 0.001F) {
-         // 根据喷嘴旋转角度调整飞机俯仰角度
+         // Adjusts aircraft pitch according to nozzle rotation angle
          this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
-         // 根据航向角和俯仰角计算方向向量
+         // Calculates direction vector from yaw and pitch
          v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch() - this.getNozzleRotation());
-         // 如果喷嘴旋转角度大于等于90度，缩小x和z方向的速度
+         // If nozzle rotation angle is at least 90 degrees, scales down x and z speeds
          if(this.getNozzleRotation() >= 90.0F) {
             v.xCoord *= 0.800000011920929D;
             v.zCoord *= 0.800000011920929D;
          }
       } else {
-         // 否则，计算默认的方向向量，俯仰角度减去10度
+         // Otherwise calculates default direction vector with pitch minus 10 degrees
          v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch() - 10.0F);
       }
 
-      // 如果没有达到平稳飞行状态
+      // If steady flight state has not been reached
       if(!levelOff) {
-         // 如果喷嘴旋转角度小于等于0.01F，根据油门调整垂直方向上的速度
+         // If nozzle rotation angle is <= 0.01F, adjusts vertical speed based on throttle
          if(this.getNozzleRotation() <= 0.01F) {
             double verticalThrust = v.yCoord * (double)throttle1 / 2.0D;
             if(this.useNewMobilitySystem() && this.getPlaneInfo() != null && verticalThrust > 0.0D) {
@@ -1953,12 +1953,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
       }
 
-      // 判断是否可以在地面移动
+      // Determines whether it can move on the ground
       boolean canMove = true;
       if(!this.getAcInfo().canMoveOnGround) {
-         // 获取地面方块信息，判断是否可以移动
+         // Gets ground block information to determine whether it can move
          Block motion = MCH_Lib.getBlockY(this, 3, -2, false);
-         // 如果方块不是水或者空气方块，设置canMove为false，表示不能移动
+         // If the block is not water or air, sets canMove to false to indicate it cannot move
          if(!W_Block.isEqual(motion, W_Block.getWater()) && !W_Block.isEqual(motion, Blocks.air) && !W_Block.isEqual(motion, Blocks.flowing_water)) {
             canMove = false;
          }
@@ -1984,22 +1984,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       double forwardSpeedBefore = super.motionX * horizontalThrustX + super.motionZ * horizontalThrustZ;
 
-      // 如果可以移动，则更新水平速度
+      // If movement is possible, updates horizontal speed
       if(canMove) {
-         // 如果启用了倒车功能，并且油门向后，则根据油门倒退
+         // If reverse is enabled and throttle is backward, reverses based on throttle
          if (this.getAcInfo().enableBack && super.throttleBack > 0.0F) {
             super.motionX -= horizontalThrustX * (double) super.throttleBack;
             super.motionZ -= horizontalThrustZ * (double) super.throttleBack;
          } else {
-            // 否则，根据油门前进
+            // Otherwise moves forward based on throttle
             super.motionX += horizontalThrustX * (double) throttle1;
             super.motionZ += horizontalThrustZ * (double) throttle1;
          }
       }
 
-      // 对垂直速度进行衰减
+      // Dampens vertical speed
       super.motionY *= 0.95D;
-      // 根据飞行器的运动系数衰减水平速度
+      // Dampens horizontal speed based on aircraft motion factor
       super.motionX *= this.getAcInfo().motionFactor;
       super.motionZ *= this.getAcInfo().motionFactor;
 
@@ -2058,7 +2058,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNetForwardAcceleration = super.motionX * horizontalThrustX + super.motionZ * horizontalThrustZ - forwardSpeedBefore;
       this.applyNewFlightTakeoffAssist(levelOff, dp);
 
-      // 计算当前水平速度的大小
+      // Calculates current horizontal speed magnitude
       double motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
       if(this.isGroundedForPropulsion() && this.getCurrentThrottle() <= 0.0D
             && super.throttleBack <= 0.0F && motion1 > prevMotion) {
@@ -2077,21 +2077,21 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       float speedLimit = this.useNewMobilitySystem()
             ? (float)MCH_FlightModel.getDiveSpeedLimit(levelSpeed, this.getRotPitch(), super.motionY, this.getPlaneInfo().diveSpeedMultiplier)
             : baseSpeedLimit;
-      // 如果当前速度超过最大速度限制，按最大速度比例缩小水平速度
+      // If current speed exceeds max speed limit, scales horizontal speed down by max speed ratio
       if(motion1 > (double)speedLimit) {
          super.motionX *= (double)speedLimit / motion1;
          super.motionZ *= (double)speedLimit / motion1;
          motion1 = speedLimit;
       }
 
-      // 如果当前速度大于上一帧的速度，并且当前速度小于最大速度限制，逐步增加速度
+      // If current speed is greater than previous frame speed and below max speed limit, gradually increases speed
       if(motion1 > prevMotion && super.currentSpeed < (double)speedLimit) {
          super.currentSpeed += ((double)speedLimit - super.currentSpeed) / 35.0D;
          if(super.currentSpeed > (double)speedLimit) {
             super.currentSpeed = (double)speedLimit;
          }
       } else {
-         // 否则逐步减少速度，保持最低速度0.07
+         // Otherwise gradually reduces speed while keeping minimum speed 0.07
          super.currentSpeed -= (super.currentSpeed - 0.07D) / 35.0D;
          if(super.currentSpeed < 0.07D) {
             super.currentSpeed = 0.07D;
@@ -2163,22 +2163,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
       }
 
-      // 如果飞行器在地面或距离地面较近，则缩减水平速度，应用地面俯仰角度
+      // If aircraft is on or near the ground, reduces horizontal speed and applies ground pitch
       if(nearGround) {
          super.motionX *= this.getAcInfo().motionFactor;
          super.motionZ *= this.getAcInfo().motionFactor;
-         // 如果俯仰角度小于40度，则根据地面状态调整俯仰角度
+         // If pitch is less than 40 degrees, adjusts pitch based on ground state
          if(MathHelper.abs(this.getRotPitch()) < 40.0F) {
             this.applyOnGroundPitch(0.8F);
          }
       }
 
-      // 更新飞行器位置
+      // Updates aircraft position
       this.moveEntity(super.motionX, super.motionY, super.motionZ);
 
-      // 更新旋转角度
+      // Updates rotation angles
       this.setRotation(this.getRotYaw(), this.getRotPitch());
-      // 更新方块信息
+      // Updates block information
       this.onUpdate_updateBlock();
 
       this.handleDeadPilot();

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -702,19 +702,19 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
    @SideOnly(Side.CLIENT)
    public void onUpdate_IronCurtainParticle(int ri, double x, double y, double z, float size) {
-      // 仅在客户端且铁幕激活时生成粒子
+      // Generates particles only on the client while Iron Curtain is active
       if(worldObj.isRemote && ironCurtainRunningTick > 0) {
-         // 颜色波动参数（使用插值后的实际因子）
+         // Color fluctuation parameters (uses the interpolated actual factor)
          float factor = 0.5f + 0.5f * (float)Math.sin(ironCurtainRunningTick * 0.15f);
          final float DARK_RED_R = 0.5f * factor;
          final float DARK_RED_G = 0.1f * factor;
          final float DARK_RED_B = 0.1f * factor;
 
-         // 粒子基础参数
-         int particleCount = 2 + rand.nextInt(3); // 每个碰撞箱生成2-4个粒子
-         float baseSize = size * (0.8f + rand.nextFloat() * 0.4f); // 尺寸波动
+         // Base particle parameters
+         int particleCount = 2 + rand.nextInt(3); // Generates 2-4 particles per collision box
+         float baseSize = size * (0.8f + rand.nextFloat() * 0.4f); // Size fluctuation
 
-         // 生成环绕粒子群
+         // Generates surrounding particle groups
          for(int i = 0; i < particleCount; i++) {
             EntityCloudFX particle = new EntityCloudFX(worldObj,
                     x + (rand.nextGaussian() * 0.3),
@@ -722,7 +722,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
                     z + (rand.nextGaussian() * 0.3),
                     0, 0, 0) {
 
-               // 重写渲染逻辑强制应用颜色
+               // Overrides render logic to force color application
                @Override
                public void renderParticle(Tessellator tess, float partialTicks,
                                           float rotX, float rotZ, float rotYZ,
@@ -732,20 +732,20 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
                }
             };
 
-            // 粒子动态参数配置
+            // Particle dynamic parameter configuration
             particle.setRBGColorF(DARK_RED_R, DARK_RED_G, DARK_RED_B);
 
-            // 运动参数（带旋转扩散）
+            // Motion parameters (with rotational spread)
             float motionSpread = 0.015f * (ironCurtainRunningTick % 40 + 1);
             particle.motionX = (rand.nextFloat() - 0.5f) * motionSpread;
             particle.motionY = 0.01f + rand.nextFloat() * 0.02f;
             particle.motionZ = (rand.nextFloat() - 0.5f) * motionSpread;
 
-            // 添加特效
+            // Adds special effects
             Minecraft.getMinecraft().effectRenderer.addEffect(particle);
          }
 
-         // 10%概率生成核心高亮粒子
+         // 10%chance to generate core highlight particles
          if(rand.nextFloat() < 0.1f) {
             EntityCloudFX coreParticle = new EntityCloudFX(worldObj, x, y, z, 0, 0, 0) {
                @Override

--- a/src/main/java/mcheli/weapon/MCH_EntityATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityATMissile.java
@@ -103,10 +103,10 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
                     this.setDead();
                 } else if (this.getCountOnUpdate() > this.getInfo().rigidityTime) {
 
-                    //攻顶导弹逻辑
+                    //Top-attack missile logic
                     if (this.guidanceType == 1) {
                         float af = this.getCountOnUpdate() < getInfo().rigidityTime + getInfo().trajectoryParticleStartTick ? 0.5F : 1.0F;
-                        //攻顶向上运动
+                        //Top-attack upward movement
                         if (this.getCountOnUpdate() <= getInfo().rigidityTime + 20) {
                             doingTopAttack = true;
                             this.guidanceToTarget(super.targetEntity.posX, super.shootingEntity.posY + 100.0D, super.targetEntity.posZ, af);
@@ -124,7 +124,7 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
                         }
                     }
 
-                    //非攻顶
+                    //Non-top-attack
                     else {
                         if (this.getInfo().proximityFuseDist >= 0.1F && d < (double) this.getInfo().proximityFuseDist) {
                             MovingObjectPosition mop = new MovingObjectPosition(super.targetEntity);
@@ -190,7 +190,7 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
 
             if (closestTarget != null) {
                 super.targetEntity = closestTarget;
-                System.out.println("主动AT弹锁定实体" + ((MCH_EntityBaseVehicle)closestTarget).getAcInfo().name + " 距离" + (int)getDistanceToEntity(closestTarget));
+                System.out.println("Active AT missile locked entity " + ((MCH_EntityBaseVehicle)closestTarget).getAcInfo().name + "  distance " + (int)getDistanceToEntity(closestTarget));
             }
         }
     }

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -677,7 +677,7 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
             }
         }
 
-        
+
 
         if(!worldObj.isRemote) {
             if (shootingAircraft instanceof MCH_EntityBaseVehicle && !speedAddedFromAircraft && getInfo().speedDependsAircraft) {
@@ -790,20 +790,20 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
         // Apply gravity effects based on whether it's in water
         if(!this.isInWater()) {
             if(ticksExisted > getInfo().speedFactorStartTick && ticksExisted < getInfo().speedFactorEndTick) {
-                // 计算当前总速度
+                // Calculates current total speed
                 double currentSpeed = Math.sqrt(
                         motionX * motionX +
                                 motionY * motionY +
                                 motionZ * motionZ
                 );
 
-                if(currentSpeed > 0) { // 避免除以零
-                    // 获取速度方向单位向量
+                if(currentSpeed > 0) { // Avoids division by zero
+                    // Gets unit vector in velocity direction
                     double dirX = motionX / currentSpeed;
                     double dirY = motionY / currentSpeed;
                     double dirZ = motionZ / currentSpeed;
 
-                    // 沿速度方向叠加固定增量
+                    // Adds fixed increment along velocity direction
                     motionX += dirX * getInfo().speedFactor;
                     motionY += dirY * getInfo().speedFactor;
                     motionZ += dirZ * getInfo().speedFactor;
@@ -1238,7 +1238,7 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
 
     @SideOnly(Side.CLIENT)
     public void spawnIronCurtainParticle(MovingObjectPosition raytraceResult, int xTile, int yTile, int zTile) {
-        // 定义暗红色参数（RGB：0.5, 0.1, 0.1）
+        // Defines dark red parameters (RGB：0.5, 0.1, 0.1)
         final float DARK_RED_R = 0.5f;
         final float DARK_RED_G = 0.1f;
         final float DARK_RED_B = 0.1f;
@@ -1256,11 +1256,11 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
                     this.worldObj.getBlockMetadata(xTile, yTile, zTile)
             );
 
-            // 覆盖原有颜色设置
-            fx.setRBGColorF(DARK_RED_R, DARK_RED_G, DARK_RED_B); // 强制设置为暗红色
-            fx.multipleParticleScaleBy(scale * 0.8f); // 适当缩小粒子尺寸
+            // Overrides original color setting
+            fx.setRBGColorF(DARK_RED_R, DARK_RED_G, DARK_RED_B); // Forces color to dark red
+            fx.multipleParticleScaleBy(scale * 0.8f); // Appropriately reduces particle size
 
-            // 调整运动参数
+            // Adjusts motion parameters
             fx.motionX += getInfo().flakParticlesDiff * (rand.nextGaussian() * 0.5);
             fx.motionZ += getInfo().flakParticlesDiff * (rand.nextGaussian() * 0.5);
             fx.motionY += getInfo().flakParticlesDiff * Math.abs(rand.nextGaussian());

--- a/src/main/java/mcheli/weapon/MCH_EntityGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityGuidanceSystem.java
@@ -18,43 +18,43 @@ public abstract class MCH_EntityGuidanceSystem implements MCH_IGuidanceSystem {
     public MCH_IEntityLockChecker checker;
 
     /**
-     * 是否为红外弹，会受到热焰弹干扰
+     * Whether this is an IR missile and can be distracted by flares
      */
     public boolean isHeatSeekerMissile = true;
 
     /**
-     * 是否为雷达弹，会受到箔条干扰
+     * Whether this is a radar missile and can be distracted by chaff
      */
     public boolean isRadarMissile = false;
 
     /**
-     * 半主动雷达弹需要持续引导
+     * Semi-active radar missiles need continuous guidance
      */
     public boolean passiveRadar = false;
 
     /**
-     * 半主动雷达弹脱离引导后脱锁计时
+     * Unlock timer after semi-active radar missile loses guidance
      */
     public int passiveRadarLockOutCount = 20;
     /**
-     * 速度门雷达最大角度，超过此角度将脱锁 (也可用于红外弹尾后攻击)
+     * Velocity-gate radar maximum angle; exceeding this angle breaks lock (can also be used for rear-aspect IR attacks)
      */
     public float pdHDNMaxDegree = 1000f;
     /**
-     * 速度门雷达脱锁间隔，超过最大角度后，在该tick后导弹脱锁
+     * Velocity-gate radar unlock interval; after exceeding max angle, missile unlocks after this tick count
      */
     public int pdHDNMaxDegreeLockOutCount = 10;
     /**
-     * 导弹抗干扰时长，-1为不抗干扰
+     * Missile countermeasure resistance duration; -1 means no resistance
      */
     public int antiFlareCount = -1;
 
     /**
-     * 雷达弹多径杂波检测高度，飞机低于这个高度将使雷达弹脱锁
+     * Radar missile multipath clutter detection height; aircraft below this height makes radar missiles lose lock
      */
     public int lockMinHeight = 12;
     /**
-     * 是否可以锁定导弹实体
+     * Whether missile entities can be locked
      */
     public boolean canLockMissile = false;
 

--- a/src/main/java/mcheli/weapon/MCH_EntityTvMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityTvMissile.java
@@ -72,7 +72,7 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
     public void onUpdateMotion() {
         Entity e = super.shootingEntity;
 
-        //拖线制导
+        //Wire guidance
         if (!getInfo().laserGuidance) {
             if (e != null && !e.isDead) {
                 MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(e);
@@ -88,7 +88,7 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
             }
         }
 
-        //激光制导
+        //Laser guidance
         else {
 
             MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(e);
@@ -103,10 +103,10 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
             float pitch;
 
             if (getInfo().hasLaserGuidancePod) {
-                yaw = e.rotationYaw;  // 获取玩家的偏航角度
-                pitch = e.rotationPitch;  // 获取玩家的俯仰角度
+                yaw = e.rotationYaw;  // Gets player yaw angle
+                pitch = e.rotationPitch;  // Gets player pitch angle
             } else {
-//                MCH_EntityBaseVehicle ac = null; //玩家乘坐的实体
+//                MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
 //                if(e.ridingEntity instanceof MCH_EntityBaseVehicle) {
 //                    ac = (MCH_EntityBaseVehicle)e.ridingEntity;
 //                } else if(e.ridingEntity instanceof MCH_EntitySeat) {
@@ -119,18 +119,18 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
                 pitch = shootingAircraft.rotationPitch;
             }
 
-            // 计算目标方向的三维坐标变化量
+            // Calculates 3D coordinate deltas toward target direction
             double targetX = -MathHelper.sin(yaw / 180.0F * (float) Math.PI) * MathHelper.cos(pitch / 180.0F * (float) Math.PI);
             double targetZ = MathHelper.cos(yaw / 180.0F * (float) Math.PI) * MathHelper.cos(pitch / 180.0F * (float) Math.PI);
             double targetY = -MathHelper.sin(pitch / 180.0F * (float) Math.PI);
 
-            // 计算方向的距离
+            // Calculates direction distance
             double dist = MathHelper.sqrt_double(targetX * targetX + targetY * targetY + targetZ * targetZ);
             double maxDist = 1500.0;
-            double segmentLength = 100.0;  // 每段的长度
-            int numSegments = (int) (maxDist / segmentLength);  // 计算需要的段数
+            double segmentLength = 100.0;  // Length of each segment
+            int numSegments = (int) (maxDist / segmentLength);  // Calculates required number of segments
 
-            // 在客户端和服务器端都将目标方向进行归一化处理
+            // Normalizes target direction on both client and server
             targetX = targetX * maxDist / dist;
             targetY = targetY * maxDist / dist;
             targetZ = targetZ * maxDist / dist;
@@ -149,39 +149,39 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
                 posZ = clientTarget().zCoord;
             }
 
-            // 计算发射源
+            // Calculates launch source
             Vec3 src = W_WorldFunc.getWorldVec3(this.worldObj, posX, posY, posZ);
 
-            // 射线检测
+            // Raycast
             MovingObjectPosition hitResult = null;
 
             for (int i = 1; i <= numSegments; i++) {
-                // 计算当前分段的目标点，确保每段都从上一个段的终点开始
+                // Calculates target point of current segment, ensuring each segment starts from previous endpoint
                 Vec3 currentDst = W_WorldFunc.getWorldVec3(this.worldObj,
                         posX + targetX * i / numSegments,
                         posY + targetY * i / numSegments,
                         posZ + targetZ * i / numSegments);
 
-                // 执行射线检测
+                // Performs raycast
                 List<MovingObjectPosition> hitResults = rayTraceAllBlocks(this.worldObj, src, currentDst, false, true, true);
 
                 if (hitResults != null && !hitResults.isEmpty()) {
                     hitResult = hitResults.get(0);
-                    break;  // 找到碰撞结果后，退出循环
+                    break;  // Exits loop after finding collision result
                 }
 
-                // 更新src为当前检测的dst
-                src = currentDst;  // 当前段的dst成为下一段的src
+                // Updates src to the current checked dst
+                src = currentDst;  // Current segment dst becomes next segment src
             }
 
-            // 如果没有检测到碰撞，则返回默认的目标位置
+            // If no collision is detected, returns default target position
             if (hitResult == null) {
-                hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // 使用目标点作为默认值
+                hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // Uses target point as default value
             }
 
-            // 如果射线击中有效方块并且不是水中方块
+            // If raycast hits a valid block and it is not underwater
             if (!this.worldObj.isRemote) {
-                // 设置导弹的目标位置
+                // Sets missile target position
                 targetPosX = hitResult.hitVec.xCoord;
                 targetPosY = hitResult.hitVec.yCoord;
                 targetPosZ = hitResult.hitVec.zCoord;
@@ -198,40 +198,40 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
 
     public void onLaserGuide() {
 
-        // 获取当前导弹目标位置的方块
+        // Gets block at current missile target position
         Block targetBlock = W_WorldFunc.getBlock(super.worldObj, (int) this.targetPosX, (int) this.targetPosY, (int) this.targetPosZ);
 
-        // 如果目标位置有方块且该方块是可碰撞的
+        // If target position has a block and the block is collidable
         if (targetBlock != null && targetBlock.isCollidable()) {
             double heightOffset = 0.0D;
             double deltaX, deltaY, deltaZ, distance;
 
-            // 如果导弹的重力为 0，则执行以下逻辑
+            // If missile gravity is 0, executes the following logic
             if ((double) this.getGravity() == 0.0D) {
-                // 在更新次数少于10次时，给定一个高度偏移量
+                // Applies a height offset while update count is less than 10
                 if (this.getCountOnUpdate() < 10) {
                     //heightOffset = 20.0D;
                     heightOffset = 0.0D;
                 }
 
-                // 计算目标与当前导弹位置的差距
+                // Calculates difference between target and current missile position
                 deltaX = this.targetPosX - super.posX;
                 deltaY = this.targetPosY + heightOffset - super.posY;
                 deltaZ = this.targetPosZ - super.posZ;
 
-                // 计算导弹到目标的距离
+                // Calculates distance from missile to target
                 distance = MathHelper.sqrt_double(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
 
                 double targetMotionX = deltaX * super.acceleration / distance;
                 double targetMotionY = deltaY * super.acceleration / distance;
                 double targetMotionZ = deltaZ * super.acceleration / distance;
-                // 计算导弹的速度分量
+                // Calculates missile velocity components
                 super.motionX += (targetMotionX - super.motionX) * getInfo().turningFactor;
                 super.motionY += (targetMotionY - super.motionY) * getInfo().turningFactor;
                 super.motionZ += (targetMotionZ - super.motionZ) * getInfo().turningFactor;
 
-                // 限制速度上限，防止导弹速度过快
-                double maxSpeed = getInfo().acceleration; // 最大速度值
+                // Limits max speed to prevent missile from moving too fast
+                double maxSpeed = getInfo().acceleration; // Maximum speed value
                 double currentSpeed = Math.sqrt(motionX * motionX + motionY * motionY + motionZ * motionZ);
                 if (currentSpeed > maxSpeed) {
                     double scale = maxSpeed / currentSpeed;
@@ -241,26 +241,26 @@ public class MCH_EntityTvMissile extends MCH_EntityBaseBullet {
                 }
 
             } else {
-                // 如果导弹有重力，则按以下逻辑处理
+                // If missile has gravity, handles with the following logic
                 deltaX = this.targetPosX - super.posX;
                 deltaY = this.targetPosY - super.posY;
-                deltaY *= 0.3D;  // 对垂直方向进行适当的缩放
+                deltaY *= 0.3D;  // Appropriately scales vertical direction
                 deltaZ = this.targetPosZ - super.posZ;
 
-                // 计算导弹与目标的距离
+                // Calculates distance between missile and target
                 distance = MathHelper.sqrt_double(deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ);
 
-                // 计算导弹的速度分量，确保不超过加速度的最大值
+                // Calculates missile velocity components, ensuring they do not exceed max acceleration
                 super.motionX = deltaX * super.acceleration / distance;
                 super.motionZ = deltaZ * super.acceleration / distance;
             }
         }
 
-        // 计算导弹的朝向（水平旋转角度）
+        // Calculates missile orientation (horizontal rotation angle)
         double yawAngle = (float) Math.atan2(super.motionZ, super.motionX);
         super.rotationYaw = (float) (yawAngle * 180.0D / 3.141592653589793D) - 90.0F;
 
-        // 计算导弹的朝向（垂直旋转角度）
+        // Calculates missile orientation (vertical rotation angle)
         double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
         super.rotationPitch = -((float) (Math.atan2(super.motionY, horizontalSpeed) * 180.0D / 3.141592653589793D));
     }

--- a/src/main/java/mcheli/weapon/MCH_LaserGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_LaserGuidanceSystem.java
@@ -55,10 +55,10 @@ public class MCH_LaserGuidanceSystem implements MCH_IGuidanceSystem {
             float pitch;
 
             if (hasLaserGuidancePod) {
-                yaw = user.rotationYaw;  // 获取玩家的偏航角度
-                pitch = user.rotationPitch;  // 获取玩家的俯仰角度
+                yaw = user.rotationYaw;  // Gets player yaw angle
+                pitch = user.rotationPitch;  // Gets player pitch angle
             } else {
-                MCH_EntityBaseVehicle ac = null; //玩家乘坐的实体
+                MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
                 if(user.ridingEntity instanceof MCH_EntityBaseVehicle) {
                     ac = (MCH_EntityBaseVehicle)user.ridingEntity;
                 } else if(user.ridingEntity instanceof MCH_EntitySeat) {
@@ -71,18 +71,18 @@ public class MCH_LaserGuidanceSystem implements MCH_IGuidanceSystem {
                 pitch = ac.rotationPitch;
             }
 
-            // 计算目标方向的三维坐标变化量
+            // Calculates 3D coordinate deltas toward target direction
             double targetX = -MathHelper.sin(yaw / 180.0F * (float) Math.PI) * MathHelper.cos(pitch / 180.0F * (float) Math.PI);
             double targetZ = MathHelper.cos(yaw / 180.0F * (float) Math.PI) * MathHelper.cos(pitch / 180.0F * (float) Math.PI);
             double targetY = -MathHelper.sin(pitch / 180.0F * (float) Math.PI);
 
-            // 计算方向的距离
+            // Calculates direction distance
             double dist = MathHelper.sqrt_double(targetX * targetX + targetY * targetY + targetZ * targetZ);
             double maxDist = 1500.0;
-            double segmentLength = 100.0;  // 每段的长度
-            int numSegments = (int) (maxDist / segmentLength);  // 计算需要的段数
+            double segmentLength = 100.0;  // Length of each segment
+            int numSegments = (int) (maxDist / segmentLength);  // Calculates required number of segments
 
-            // 在客户端和服务器端都将目标方向进行归一化处理
+            // Normalizes target direction on both client and server
             targetX = targetX * maxDist / dist;
             targetY = targetY * maxDist / dist;
             targetZ = targetZ * maxDist / dist;
@@ -95,37 +95,37 @@ public class MCH_LaserGuidanceSystem implements MCH_IGuidanceSystem {
             double posY = RenderManager.renderPosY;
             double posZ = RenderManager.renderPosZ;
 
-            // 计算发射源
+            // Calculates launch source
             Vec3 src = W_WorldFunc.getWorldVec3(this.worldObj, posX, posY, posZ);
 
-            // 射线检测
+            // Raycast
             MovingObjectPosition hitResult = null;
 
             for (int i = 1; i <= numSegments; i++) {
-                // 计算当前分段的目标点，确保每段都从上一个段的终点开始
+                // Calculates target point of current segment, ensuring each segment starts from previous endpoint
                 Vec3 currentDst = W_WorldFunc.getWorldVec3(this.worldObj,
                         posX + targetX * i / numSegments,
                         posY + targetY * i / numSegments,
                         posZ + targetZ * i / numSegments);
 
-                // 执行射线检测
+                // Performs raycast
                 List<MovingObjectPosition> hitResults = rayTraceAllBlocks(this.worldObj, src, currentDst, false, true, true);
 
                 if (hitResults != null && !hitResults.isEmpty()) {
                     hitResult = hitResults.get(0);
-                    break;  // 找到碰撞结果后，退出循环
+                    break;  // Exits loop after finding collision result
                 }
 
-                // 更新src为当前检测的dst
-                src = currentDst;  // 当前段的dst成为下一段的src
+                // Updates src to the current checked dst
+                src = currentDst;  // Current segment dst becomes next segment src
             }
 
-            // 如果没有检测到碰撞，则返回默认的目标位置
+            // If no collision is detected, returns default target position
             if (hitResult == null) {
-                hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // 使用目标点作为默认值
+                hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // Uses target point as default value
             }
 
-            // 设置导弹的目标位置
+            // Sets missile target position
             targetPosX = hitResult.hitVec.xCoord;
             targetPosY = hitResult.hitVec.yCoord;
             targetPosZ = hitResult.hitVec.zCoord;

--- a/src/main/java/mcheli/weapon/MCH_RenderLockBox.java
+++ b/src/main/java/mcheli/weapon/MCH_RenderLockBox.java
@@ -24,7 +24,7 @@ public class MCH_RenderLockBox extends W_Render {
     public static void renderGuidanceHUD() {
         EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
         if(player == null) return;
-        MCH_EntityBaseVehicle ac = null; //玩家乘坐的实体
+        MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
         if(player.ridingEntity instanceof MCH_EntityBaseVehicle) {
             ac = (MCH_EntityBaseVehicle)player.ridingEntity;
         } else if(player.ridingEntity instanceof MCH_EntitySeat) {
@@ -64,23 +64,23 @@ public class MCH_RenderLockBox extends W_Render {
             if(distance > 1000) return;
 
             GL11.glPushMatrix();
-            // 进行位置变换，将目标实体渲染到玩家视角中
+            // Transforms position to render target entity in the player view
             GL11.glTranslatef((float)x, (float)y , (float)z);
             GL11.glNormal3f(0.0F, 1.0F, 0.0F);
             GL11.glRotatef(-rm.playerViewY, 0.0F, 1.0F, 0.0F);
             GL11.glRotatef(rm.playerViewX, 1.0F, 0.0F, 0.0F);
             GL11.glScalef(-0.02666667F, -0.02666667F, 0.02666667F);
-            GL11.glDisable(2896); // 禁用深度测试
-            GL11.glTranslatef(0.0F, 9.374999F, 0.0F); // 上移一些偏移量
-            GL11.glDepthMask(false); // 禁用深度写入
-            GL11.glEnable(3042); // 启用混合
-            GL11.glBlendFunc(770, 771); // 设置混合模式
-            GL11.glDisable(3553); // 禁用纹理
+            GL11.glDisable(2896); // Disables depth testing
+            GL11.glTranslatef(0.0F, 9.374999F, 0.0F); // Moves up by an offset
+            GL11.glDepthMask(false); // Disables depth writes
+            GL11.glEnable(3042); // Enables blending
+            GL11.glBlendFunc(770, 771); // Sets blend mode
+            GL11.glDisable(3553); // Disables textures
             GL11.glDisable(2929 /* GL_DEPTH_TEST */);
 
-            // 获取绘制前的屏幕宽度
+            // Gets screen width before drawing
             int prevWidth = GL11.glGetInteger(2849);
-            // 设置目标实体大小 50-20, 1000-1000
+            // Sets target entity size 50-20, 1000-1000
             float minDistance = 50.0F;
             float size1 = 20.0F;
             float maxDistance = 300.0F;
@@ -89,47 +89,47 @@ public class MCH_RenderLockBox extends W_Render {
             size = Math.max(size1, Math.min(maxSize, size));
 
 
-            // 创建Tessellator对象，用于绘制图形
+            // Creates a Tessellator object for drawing graphics
             Tessellator tessellator = Tessellator.instance;
-            tessellator.startDrawing(2); // 开始绘制线条
-            tessellator.setBrightness(240); // 设置亮度
+            tessellator.startDrawing(2); // Starts drawing lines
+            tessellator.setBrightness(240); // Sets brightness
 
-            GL11.glLineWidth((float) MCH_Gui.scaleFactor * 1.5F); // 设置线宽
-            tessellator.setColorRGBA_F(0.0F, 1.0F, 0.0F, 1.0F); // 绿色
+            GL11.glLineWidth((float) MCH_Gui.scaleFactor * 1.5F); // Sets line width
+            tessellator.setColorRGBA_F(0.0F, 1.0F, 0.0F, 1.0F); // Green
 
-            // 绘制矩形框，表示锁定范围
+            // Draws a rectangle representing the lock range
             tessellator.addVertex(-size - 1.0F, 0.0D, 0.0D);
             tessellator.addVertex(-size - 1.0F, size * 2.0F, 0.0D);
             tessellator.addVertex(size + 1.0F, size * 2.0F, 0.0D);
             tessellator.addVertex(size + 1.0F, 0.0D, 0.0D);
-            tessellator.draw(); // 绘制线条
+            tessellator.draw(); // Draws lines
 
 
             if(distance > 10) {
-                // 获取 FontRenderer 对象并设置颜色为绿色
+                // Gets the FontRenderer object and sets the color to green
                 FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
                 {
                     GL11.glPushMatrix();
-                    GL11.glTranslatef(0.0F, size * 2.0F + 1.0F, 0.0F); // 将文本放置在矩形框的下方
+                    GL11.glTranslatef(0.0F, size * 2.0F + 1.0F, 0.0F); // Places text below the rectangle
                     float fontSize = 5.0F + (float) ((distance - 10.0D) / (300.0D - 10.0D)) * (40.0F - 5.0F);
-                    // 确保字体大小在5和40之间
+                    // Ensures font size is between 5 and 40
                     fontSize = Math.max(5.0F, Math.min(40.0F, fontSize));
                     GL11.glScalef(fontSize, fontSize, fontSize);
-                    String text = String.format("%.1f", distance); // 格式化为一位小数
+                    String text = String.format("%.1f", distance); // Formats with one decimal place
                     fontRenderer.drawString(text, -fontRenderer.getStringWidth(text) / 2, 0, 0x00ff00);
                     GL11.glPopMatrix();
                 }
             }
 
             GL11.glPopMatrix();
-            // 恢复之前的线宽，启用纹理，恢复深度写入和深度测试
+            // Restores previous line width, enables textures, restores depth writes and depth testing
             GL11.glLineWidth((float) prevWidth);
             GL11.glEnable(3553);
             GL11.glDepthMask(true);
             GL11.glEnable(2896);
             GL11.glDisable(3042);
             GL11.glEnable(2929 /* GL_DEPTH_TEST */);
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F); // 恢复默认颜色
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F); // Restores default color
         }
     }
 }

--- a/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
@@ -107,7 +107,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
             super.guidanceSystem.lock(prm.user);
             if(guidanceSystem.isLockComplete()) {
                Entity target = guidanceSystem.lastLockEntity;
-               //获取玩家射击的AA弹
+               //Gets AA missile fired by player
                for (MCH_EntityBaseBullet bullet : getShootBullets(worldObj, prm.user, getInfo().maxLockOnRange)) {
                   bullet.clientSetTargetEntity(target);
                   super.optionParameter1 = W_Entity.getEntityId(target);

--- a/src/main/java/mcheli/weapon/MCH_WeaponASMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponASMissile.java
@@ -15,99 +15,99 @@ import java.util.List;
 
 public class MCH_WeaponASMissile extends MCH_WeaponBase {
 
-   // 构造函数，初始化武器属性
+   // Constructor; initializes weapon attributes
    public MCH_WeaponASMissile(World world, Vec3 position, float yaw, float pitch, String name, MCH_WeaponInfo weaponInfo) {
       super(world, position, yaw, pitch, name, weaponInfo);
-      this.acceleration = 3.0F;  // 加速度
-      this.explosionPower = 9;   // 爆炸威力
-      this.power = 40;           // 武器威力
-      this.interval = -350;      // 射击间隔
+      this.acceleration = 3.0F;  // Acceleration
+      this.explosionPower = 9;   // Explosion power
+      this.power = 40;           // Weapon power
+      this.interval = -350;      // Firing interval
       if (world.isRemote) {
-         this.interval -= 10;     // 如果是客户端，减少射击间隔
+         this.interval -= 10;     // If client side, reduces firing interval
       }
    }
 
-   // 是否计入重新加载时间
+   // Whether to count reload time
    public boolean isCooldownCountReloadTime() {
       return true;
    }
 
-   // 更新函数
+   // Update function
    public void update(int countWait) {
       super.update(countWait);
    }
 
-   // 射击函数
+   // Shot function
    public boolean shot(MCH_WeaponParam params) {
 
-      float yaw = params.user.rotationYaw;  // 获取玩家的偏航角度
-      float pitch = params.user.rotationPitch;  // 获取玩家的俯仰角度
+      float yaw = params.user.rotationYaw;  // Gets player yaw angle
+      float pitch = params.user.rotationPitch;  // Gets player pitch angle
 
-      // 计算目标方向的三维坐标变化量
+      // Calculates 3D coordinate deltas toward target direction
       double targetX = -MathHelper.sin(yaw / 180.0F * (float)Math.PI) * MathHelper.cos(pitch / 180.0F * (float)Math.PI);
       double targetZ = MathHelper.cos(yaw / 180.0F * (float)Math.PI) * MathHelper.cos(pitch / 180.0F * (float)Math.PI);
       double targetY = -MathHelper.sin(pitch / 180.0F * (float)Math.PI);
 
-      // 计算方向的距离
+      // Calculates direction distance
       double dist = MathHelper.sqrt_double(targetX * targetX + targetY * targetY + targetZ * targetZ);
       double maxDist = 1500.0;
-      double segmentLength = 100.0;  // 每段的长度
-      int numSegments = (int) (maxDist / segmentLength);  // 计算需要的段数
+      double segmentLength = 100.0;  // Length of each segment
+      int numSegments = (int) (maxDist / segmentLength);  // Calculates required number of segments
 
-      // 在客户端和服务器端都将目标方向进行归一化处理
+      // Normalizes target direction on both client and server
       targetX = targetX * maxDist / dist;
       targetY = targetY * maxDist / dist;
       targetZ = targetZ * maxDist / dist;
 
-      // 计算发射源
+      // Calculates launch source
       Vec3 src = W_WorldFunc.getWorldVec3(this.worldObj, params.entity.posX, params.entity.posY + params.entity.getEyeHeight(), params.entity.posZ);
 
-      // 射线检测
+      // Raycast
       MovingObjectPosition hitResult = null;
 
       for (int i = 1; i <= numSegments; i++) {
-         // 计算当前分段的目标点，确保每段都从上一个段的终点开始
+         // Calculates target point of current segment, ensuring each segment starts from previous endpoint
          Vec3 currentDst = W_WorldFunc.getWorldVec3(this.worldObj,
                  params.entity.posX + targetX * i / numSegments,
                  params.entity.posY + params.entity.getEyeHeight() + targetY * i / numSegments,
                  params.entity.posZ + targetZ * i / numSegments);
 
-         // 执行射线检测
+         // Performs raycast
          List<MovingObjectPosition> hitResults = rayTraceAllBlocks(this.worldObj, src, currentDst, false, true, true);
 
          if (hitResults != null && !hitResults.isEmpty()) {
             hitResult = hitResults.get(0);
-            break;  // 找到碰撞结果后，退出循环
+            break;  // Exits loop after finding collision result
          }
 
-         // 更新src为当前检测的dst
-         src = currentDst;  // 当前段的dst成为下一段的src
+         // Updates src to the current checked dst
+         src = currentDst;  // Current segment dst becomes next segment src
       }
 
-      // 如果没有检测到碰撞，则返回默认的目标位置
+      // If no collision is detected, returns default target position
       if (hitResult == null) {
-         hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // 使用目标点作为默认值
+         hitResult = new MovingObjectPosition(null, src.addVector(targetX, targetY, targetZ));  // Uses target point as default value
       }
 
-      // 如果射线击中有效方块并且不是水中方块
+      // If raycast hits a valid block and it is not underwater
       if (!this.worldObj.isRemote) {
-         // 创建导弹实体并设置参数
+         // Creates missile entity and sets parameters
          MCH_EntityASMissile missile = new MCH_EntityASMissile(this.worldObj, params.posX, params.posY, params.posZ, targetX, targetY, targetZ, yaw, pitch, this.acceleration);
          missile.setName(this.name);
          missile.setParameterFromWeapon(this, params.entity, params.user);
 
-         // 设置导弹的目标位置
+         // Sets missile target position
          missile.targetPosX = hitResult.hitVec.xCoord;
          missile.targetPosY = hitResult.hitVec.yCoord;
          missile.targetPosZ = hitResult.hitVec.zCoord;
 
-         // 将导弹添加到世界中
+         // Adds missile to world
          this.worldObj.spawnEntityInWorld(missile);
 
-         // 播放武器发射声音
+         // Plays weapon firing sound
          playSound(params.entity);
       }
-      return true;  // 命中并成功发射导弹
+      return true;  // Hit and successfully launched missile
    }
 
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
@@ -124,7 +124,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
             super.guidanceSystem.lock(prm.user);
             if(guidanceSystem.isLockComplete()) {
                Entity target = guidanceSystem.lastLockEntity;
-               //获取玩家射击的AT弹
+               //Gets AT missile fired by player
                for (MCH_EntityBaseBullet bullet : getShootBullets(worldObj, prm.user, getInfo().maxLockOnRange)) {
                   bullet.clientSetTargetEntity(target);
                   super.optionParameter1 = W_Entity.getEntityId(target);

--- a/src/main/java/mcheli/weapon/MCH_WeaponEntitySeeker.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponEntitySeeker.java
@@ -68,7 +68,7 @@ public abstract class MCH_WeaponEntitySeeker extends MCH_WeaponBase {
             if(o != null) {
                MCH_EntityBaseBullet msl = (MCH_EntityBaseBullet) o;
                if(!msl.isDead && msl.getInfo() != null && msl.getInfo().passiveRadar) {
-                  //System.out.println("检测到雷达弹"); //TODO shootingEntity always null in client side
+                  //System.out.println("Detected radar missile"); //TODO shootingEntity always null in client side
                   result.add(msl);
                }
             }

--- a/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
@@ -129,24 +129,24 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
    public boolean lock(Entity user, boolean isLockContinue) {
 
-      // 如果是服务器端，则直接返回
+      // If server side, returns immediately
       if(!this.worldObj.isRemote) {
          return false;
       } else {
 
-         boolean result = false;  // 锁定结果
-         double dz;  // 目标实体在Z轴的距离
+         boolean result = false;  // Lock result
+         double dz;  // Distance to target entity on the Z axis
 
-         if(this.lockCount == 0) {  // 如果还没有锁定实体
-            // 获取范围内的所有实体
+         if(this.lockCount == 0) {  // If no entity has been locked yet
+            // Gets all entities within range
             List canLock = this.worldObj.getEntitiesWithinAABBExcludingEntity(user, user.boundingBox.expand(this.lockRange, this.lockRange, this.lockRange));
-            Entity potentialTarget = null;  // 潜在的锁定目标
-            double dist = this.lockRange * this.lockRange * 2.0D;  // 最大锁定距离
+            Entity potentialTarget = null;  // Potential lock target
+            double dist = this.lockRange * this.lockRange * 2.0D;  // Maximum lock distance
 
-            // 遍历所有实体
+            // Iterates over all entities
             for(int i = 0; i < canLock.size(); ++i) {
                Entity currentEntity = (Entity)canLock.get(i);
-               // 检查实体是否可以锁定
+               // Checks whether entity can be locked
                if(this.canLockEntity(currentEntity) ) { //please fucking work
                   //&& !this.aircraft.isFreeLookMode()
                   //do not fucking do this here god hates this
@@ -159,28 +159,28 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                   Entity entityLocker1 = this.getLockEntity(user);
                   float stealth1 = 1.0F - getEntityStealth(currentEntity);
                   double range1 = this.lockRange;
-                  // 计算锁定角度
+                  // Calculates lock angle
                   float angle = (float)this.lockAngle * (stealth1 / 2.0F + 0.5F);
-                  // 判断实体是否在锁定范围内
+                  // Determines whether entity is within lock range
                   if(distance < range1 * range1 && distance < dist && inLockAngle(entityLocker1, user.rotationYaw, user.rotationPitch, currentEntity, angle)) {
-                     // 检测目标是否可见
+                     // Checks whether target is visible
                      Vec3 v1 = W_WorldFunc.getWorldVec3(this.worldObj, entityLocker1.posX, entityLocker1.posY, entityLocker1.posZ);
                      Vec3 v2 = W_WorldFunc.getWorldVec3(this.worldObj, currentEntity.posX, currentEntity.posY + (double)(currentEntity.height / 2.0F), currentEntity.posZ);
                      MovingObjectPosition m = W_WorldFunc.clip(this.worldObj, v1, v2, false, true, false);
                      if(m == null || W_MovingObjectPosition.isHitTypeEntity(m)) {
-                        potentialTarget = currentEntity;  // 设置锁定目标
+                        potentialTarget = currentEntity;  // Sets lock target
                      }
                   }
                }
             }
 
 
-            this.targetEntity = potentialTarget;  // 将潜在目标设置为当前目标
+            this.targetEntity = potentialTarget;  // Sets potential target as current target
             if(potentialTarget != null) {
-               ++this.lockCount;  // 如果锁定了目标，增加锁定计数
+               ++this.lockCount;  // If target is locked, increments lock count
             }
-         } else if(this.targetEntity != null && !this.targetEntity.isDead) {  // 如果已经有目标并且目标未死亡
-            boolean canLockTarget = true;  // 是否可以继续锁定目标
+         } else if(this.targetEntity != null && !this.targetEntity.isDead) {  // If a target already exists and is not dead
+            boolean canLockTarget = true;  // Whether target can continue to be locked
 
             if(targetEntity instanceof MCH_EntityBaseVehicle) {
                if(isRadarMissile && targetEntity.getEntityData().getBoolean("ChaffUsing")) {
@@ -188,18 +188,18 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                }
             }
 
-            // 检查目标是否在水中，如果不能锁定水中目标，则设为false
+            // Checks whether target is in water; sets false if underwater targets cannot be locked
             if(!this.canLockInWater && this.targetEntity.isInWater()) {
                canLockTarget = false;
             }
 
-            boolean isTargetOnGround = isEntityOnGround(this.targetEntity, lockMinHeight);  // 判断目标是否在地面上
-            // 检查目标是否可以锁定在地面
+            boolean isTargetOnGround = isEntityOnGround(this.targetEntity, lockMinHeight);  // Determines whether target is on ground
+            // Checks whether target can be locked on ground
             if(!this.canLockOnGround && isTargetOnGround) {
                canLockTarget = false;
             }
 
-            // 检查目标是否可以锁定在空中
+            // Checks whether target can be locked in air
             if(!this.canLockInAir && !isTargetOnGround) {
                canLockTarget = false;
             }
@@ -214,7 +214,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
             //no god hates ts
 
-            MCH_EntityBaseVehicle ac = null; //玩家乘坐的实体
+            MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
             if(user.ridingEntity instanceof MCH_EntityBaseVehicle) {
                ac = (MCH_EntityBaseVehicle)user.ridingEntity;
 
@@ -229,26 +229,26 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                ac = ((MCH_EntityUavStation)user.ridingEntity).getControlAircract();
             }
             if(ac instanceof MCP_EntityPlane && targetEntity instanceof MCP_EntityPlane) {
-               Vector3f playerVelocity = new Vector3f(ac.motionX, ac.motionY, ac.motionZ);  // 玩家机体的速度向量
-               Vector3f targetVelocity = new Vector3f(targetEntity.motionX, targetEntity.motionY, targetEntity.motionZ);  // 目标机体的速度向量
+               Vector3f playerVelocity = new Vector3f(ac.motionX, ac.motionY, ac.motionZ);  // Velocity vector of the player aircraft
+               Vector3f targetVelocity = new Vector3f(targetEntity.motionX, targetEntity.motionY, targetEntity.motionZ);  // Velocity vector of the target aircraft
                float angleInDegrees = 0;
                if (playerVelocity.length() > 0.001 && targetVelocity.length() > 0.001) {
-                  // 计算两个向量的点积
+                  // Calculates the dot product of the two vectors
                   float dotProduct = Vector3f.dot(playerVelocity, targetVelocity);
-                  // 计算两个向量的长度
+                  // Calculates lengths of the two vectors
                   float playerSpeed = playerVelocity.length();
                   float targetSpeed = targetVelocity.length();
-                  // 计算夹角的余弦值
+                  // Calculates the cosine of the angle
                   float cosAngle = dotProduct / (playerSpeed * targetSpeed);
-                  // 确保夹角余弦值在合法范围内 [-1, 1]，避免浮动导致的异常值
+                  // Ensures the angle cosine is within the valid range [-1, 1],avoids abnormal values caused by floating-point error
                   cosAngle = Math.max(-1.0f, Math.min(1.0f, cosAngle));
-                  // 计算夹角（弧度）
+                  // Calculates the angle (radians)
                   float angle = (float) Math.acos(cosAngle);
-                  // 如果夹角大于90度，将其转换为锐角（90度以内）
+                  // If the angle is greater than 90 degrees, converts it to an acute angle (within 90 degrees)
                   if (angle > Math.PI / 2) {
-                     angle = (float) (Math.PI - angle);  // 转换为锐角
+                     angle = (float) (Math.PI - angle);  // Converts to an acute angle
                   }
-                  // 将角度转化为度数（可选）
+                  // Converts angle to degrees (optional)
                   angleInDegrees = (float) Math.toDegrees(angle);
                }
                if (angleInDegrees > ac.getCurrentWeapon(user).getCurrentWeapon().getInfo().pdHDNMaxDegree) {
@@ -256,14 +256,14 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                }
             }
 
-            // 如果可以继续锁定
+            // If lock can continue
             if(canLockTarget) {
                double dx = this.targetEntity.posX - user.posX;
                double dy = this.targetEntity.posY - user.posY;
                dz = this.targetEntity.posZ - user.posZ;
                float stealth = 1.0F - getEntityStealth(this.targetEntity);
                double lockRange = this.lockRange * (double)stealth;
-               // 判断目标是否在锁定范围内
+               // Determines whether target is within lock range
                if(dx * dx + dy * dy + dz * dz < lockRange * lockRange) {
                   if(this.worldObj.isRemote && this.lockSoundCount == 1) {
                      //MCH_PacketNotifyLock.send(this.getTargetEntity());
@@ -271,10 +271,10 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
                   this.lockSoundCount = (this.lockSoundCount + 1) % 15;
                   Entity entityLocker = this.getLockEntity(user);
-                  // 判断目标是否处于锁定范围
+                  // Determines whether target is in lock range
                   if(inLockAngle(entityLocker, user.rotationYaw, user.rotationPitch, this.targetEntity, (float)this.lockAngle)) {
                      if(this.lockCount < this.getLockCountMax()) {
-                        ++this.lockCount;  // 增加锁定计数
+                        ++this.lockCount;  // Increments lock count
                      }
                   } else if(this.continueLockCount > 0) {
                      --this.continueLockCount;
@@ -286,7 +286,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                      --this.lockCount;
                   }
 
-                  // 如果达到最大锁定计数，则锁定成功
+                  // If max lock count is reached, lock succeeds
                   if(this.lockCount >= this.getLockCountMax()) {
                      if(this.continueLockCount <= 0) {
                         this.continueLockCount = this.getLockCountMax() / 3;
@@ -295,7 +295,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                         }
                      }
 
-                     result = true;  // 锁定成功
+                     result = true;  // Lock succeeded
                      this.lastLockEntity = this.targetEntity;
                      if(isLockContinue) {
                         this.prevLockCount = this.lockCount - 1;
@@ -304,27 +304,27 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                      }
                   }
                } else {
-                  this.clearLock();  // 如果不在锁定范围内，清除锁定
+                  this.clearLock();  // If not in lock range, clears lock
                }
             } else {
-               this.clearLock();  // 如果不能继续锁定，清除锁定
+               this.clearLock();  // If lock cannot continue, clears lock
             }
          } else {
-            this.clearLock();  // 如果目标为空或已死亡，清除锁定
+            this.clearLock();  // If target is null or dead, clears lock
          }
 
-         result = this.lockCount >= this.getLockCountMax();  // 判断是否锁定成功
+         result = this.lockCount >= this.getLockCountMax();  // Determines whether lock succeeded
 
          if(result) {
             this.lastLockEntity = targetEntity;
-            // 播放锁定成功音效
+            // Plays lock success sound
             this.worldObj.playSoundAtEntity(user, "mcheli:ir_basic_tone", 1.0f, 1.0f);
          } else {
-            // 播放锁定失败音效
+            // Plays lock failure sound
             this.worldObj.playSoundAtEntity(user, "mcheli:ir_lock_tone", 1.0f, 1.0f);
          }
 
-         return result;  // 返回锁定结果
+         return result;  // Returns lock result
       }
    }
 
@@ -352,26 +352,26 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
    }
 
    public boolean canLockEntity(Entity entity) {
-      // 如果不允许锁定玩家，且实体为玩家，则返回false
+      // If locking players is not allowed and entity is a player, returns false
       if(this.ridableOnly && entity instanceof EntityPlayer && entity.ridingEntity == null) {
          return false;
       } else {
-         // 获取实体的类名
+         // Gets entity class name
          String className = entity.getClass().getName();
 
-         // 如果实体是 EntityCamera 类型的，返回false
+         // If entity is EntityCamera type, returns false
          if(className.indexOf("EntityCamera") >= 0) {
             return false;
          }
-         // 红外弹可以锁定热焰弹
+         // IR missiles can lock flares
          if(this.isHeatSeekerMissile && entity instanceof MCH_EntityFlare) {
             return true;
          }
-         // 雷达弹可以锁定箔条
+         // Radar missiles can lock chaff
          if(this.isRadarMissile && entity instanceof MCH_EntityChaff) {
             return true;
          }
-         // 锁定导弹
+         // Locks missiles
          if(this.canLockMissile &&
                  (entity instanceof MCH_EntityAAMissile || entity instanceof MCH_EntityATMissile
                          || entity instanceof MCH_EntityASMissile || entity instanceof MCH_EntityTvMissile)) {
@@ -379,7 +379,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                return true;
             }
          }
-         // 如果实体既不是生物实体，也不是飞机、车辆等特定类型，返回false
+         // If entity is neither a living entity nor a specific type such as aircraft or vehicle, returns false
          if(!W_Lib.isEntityLivingBase(entity)
                  && !(entity instanceof MCH_EntityBaseVehicle)
                  && className.indexOf("EntityVehicle") < 0
@@ -388,19 +388,19 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                  && className.indexOf("EntityAAGun") < 0) {
             return false;
          }
-         // 如果实体在水中，而不能锁定水中的实体，则返回false
+         // If entity is in water and underwater entities cannot be locked, returns false
          else if(!this.canLockInWater && entity.isInWater()) {
             return false;
          }
-         // 如果有自定义的实体锁定检查器，并且检查器返回false，则返回false
+         // If there is a custom entity lock checker and it returns false, returns false
          else if(this.checker != null && !this.checker.canLockEntity(entity)) {
             return false;
          }
 
          else {
-            // 判断实体是否在地面上
+            // Determines whether entity is on ground
             boolean ong = isEntityOnGround(entity, lockMinHeight);
-            // 如果可以锁定地面上的实体或实体不在地面上，且可以锁定空中的实体，则返回true
+            // If ground entities can be locked or entity is not on ground, and airborne entities can be locked, returns true
             return (this.canLockOnGround || !ong) && (this.canLockInAir || ong);
          }
       }


### PR DESCRIPTION
### Motivation
- Make in-repo Chinese comments and config display names readable in English for maintainability and code inspection. 
- Focus changes on user-visible strings and developer comments while leaving runtime semantics unchanged. 
- Avoid touching compiled artifacts and class files and exclude the `mcheliCE`/legacy folder from translations. 

### Description
- Translated `zh_CN` display names in multiple `configreference/planes/*.txt` files (examples: `h6k.txt`, `su57.txt`, `tu160m.txt`, `tu95ms.txt`, etc.).
- Replaced Chinese inline comments and Javadoc in many Java sources under `src/main/java/mcheli/` with English equivalents (notable files: `MCH_BaseVehicleInfo.java`, `MCH_RenderBaseVehicle.java`, `MCH_WeaponGuidanceSystem.java`, `PacketBase.java`, `MCH_PlayerViewHandler.java`, `MCH_RenderRWR.java`, `MCH_RenderBVRLockBox.java`, `MCH_EntityInfoManager.java`, `MCH_EntityTvMissile.java`, and others). 
- Kept code logic intact (no behavioral changes), normalized some whitespace/trailing spaces and punctuation while ensuring no `.class` files were edited and the `McHeliCE-master`/legacy folder was left untouched. 
- Staged and committed the changes as a single change set titled `Translate Chinese text to English` which updates 36 files with largely comment/text-only edits. 

### Testing
- Ran `git diff --check` to surface whitespace/trailing issues and addressed them, which passed with fixes applied. 
- Used `rg`/searches to locate Han characters and verify translation coverage across the modified files. 
- Attempted to run `./gradlew compileJava` but the Gradle wrapper download failed due to an external proxy returning `HTTP 403`, so Java compilation could not be completed in this environment. 
- Committed the translations with `git commit` successfully; no runtime compilation was validated due to the network/proxy limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32057e62148323a51157694e363dd5)