### PR TITLE
Implement internal energy model for new-flight fixed-wing planes

### DIFF
--- a/configreference/planes/a-10.txt
+++ b/configreference/planes/a-10.txt
@@ -31,6 +31,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.015
 NewFlightCombatFlapControl = 0.150
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 13700
 FlightCeilingRange = 60
 StallSpeed = 0.348

--- a/configreference/planes/a4.txt
+++ b/configreference/planes/a4.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.443

--- a/configreference/planes/a400m.txt
+++ b/configreference/planes/a400m.txt
@@ -35,6 +35,14 @@ AddTexture = a400m_3
 Category = STA/AR/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 3.800

--- a/configreference/planes/a6.txt
+++ b/configreference/planes/a6.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.426

--- a/configreference/planes/a6m2.txt
+++ b/configreference/planes/a6m2.txt
@@ -41,6 +41,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 10000
 FlightCeilingRange = 56
 StallSpeed = 0.214

--- a/configreference/planes/a6m2n.txt
+++ b/configreference/planes/a6m2n.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 9000
 FlightCeilingRange = 56
 StallSpeed = 0.175

--- a/configreference/planes/a7.txt
+++ b/configreference/planes/a7.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.454

--- a/configreference/planes/ac-130.txt
+++ b/configreference/planes/ac-130.txt
@@ -30,6 +30,14 @@ RotorSpeed = 500.0
 Category = GAA/CASG
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.200

--- a/configreference/planes/ac-47.txt
+++ b/configreference/planes/ac-47.txt
@@ -23,6 +23,14 @@ EnableParachuting = false
 Category = GAA/CASG
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.350

--- a/configreference/planes/an2.txt
+++ b/configreference/planes/an2.txt
@@ -27,6 +27,14 @@ AddTexture = an2_5
 Category = C/AUA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.050

--- a/configreference/planes/au23.txt
+++ b/configreference/planes/au23.txt
@@ -32,6 +32,14 @@ MobilityRoll = 1.103
 Category = AG/CI/UT
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/b-1.txt
+++ b/configreference/planes/b-1.txt
@@ -29,6 +29,14 @@ Stealth = 0.2
 Category = SSHB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.100

--- a/configreference/planes/b-1nuclear.txt
+++ b/configreference/planes/b-1nuclear.txt
@@ -29,6 +29,14 @@ Stealth = 0.2
 Category = SSHB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.250

--- a/configreference/planes/b-2a.txt
+++ b/configreference/planes/b-2a.txt
@@ -41,6 +41,14 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/b-2a2.txt
+++ b/configreference/planes/b-2a2.txt
@@ -41,6 +41,14 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/b-2a3.txt
+++ b/configreference/planes/b-2a3.txt
@@ -41,6 +41,14 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/b-2a4.txt
+++ b/configreference/planes/b-2a4.txt
@@ -41,6 +41,14 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/b29.txt
+++ b/configreference/planes/b29.txt
@@ -27,6 +27,14 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.800

--- a/configreference/planes/b29sp.txt
+++ b/configreference/planes/b29sp.txt
@@ -26,6 +26,14 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/HB/NB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.800

--- a/configreference/planes/b52.txt
+++ b/configreference/planes/b52.txt
@@ -23,6 +23,14 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.500

--- a/configreference/planes/b52d.txt
+++ b/configreference/planes/b52d.txt
@@ -20,6 +20,14 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.400

--- a/configreference/planes/b52n.txt
+++ b/configreference/planes/b52n.txt
@@ -23,6 +23,14 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.550

--- a/configreference/planes/bayraktar tb 2.txt
+++ b/configreference/planes/bayraktar tb 2.txt
@@ -27,6 +27,14 @@ AddSeat = 0.0, 0.0, -3
 Category = UCAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.350

--- a/configreference/planes/bf109.txt
+++ b/configreference/planes/bf109.txt
@@ -46,6 +46,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 12000
 FlightCeilingRange = 56
 StallSpeed = 0.257

--- a/configreference/planes/bqm_74e.txt
+++ b/configreference/planes/bqm_74e.txt
@@ -18,6 +18,14 @@ EngineDrag = 0.011
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/bv138.txt
+++ b/configreference/planes/bv138.txt
@@ -25,6 +25,14 @@ MobilityYawOnGround = 1.5
 Category = MP/LRR
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.350

--- a/configreference/planes/c-47.txt
+++ b/configreference/planes/c-47.txt
@@ -22,6 +22,14 @@ MobDropOption  = 0.97, 1.52, -6.48, 2
 Category = MTA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.350

--- a/configreference/planes/c5.txt
+++ b/configreference/planes/c5.txt
@@ -26,6 +26,14 @@ StepHeight = -1.0
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.000

--- a/configreference/planes/c5m.txt
+++ b/configreference/planes/c5m.txt
@@ -25,6 +25,14 @@ MobDropOption  = 0.97, 1.10, -12.91, 2
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.150

--- a/configreference/planes/e767.txt
+++ b/configreference/planes/e767.txt
@@ -28,6 +28,14 @@ CameraZoom = 10
 Category = AWACS
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.200

--- a/configreference/planes/emb314.txt
+++ b/configreference/planes/emb314.txt
@@ -23,6 +23,14 @@ UnmountPosition = 3.0, 2.0, -5.0
 Category = LA/COINA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/eurofighter_typhoon_2.txt
+++ b/configreference/planes/eurofighter_typhoon_2.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 19800
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/eurofighter_typhoon_2_t.txt
+++ b/configreference/planes/eurofighter_typhoon_2_t.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 19800
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/f-104.txt
+++ b/configreference/planes/f-104.txt
@@ -7,6 +7,14 @@ Speed = 3.70
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/f-15e.txt
+++ b/configreference/planes/f-15e.txt
@@ -40,6 +40,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 18200
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/f-15s_mtd.txt
+++ b/configreference/planes/f-15s_mtd.txt
@@ -46,6 +46,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/f-35a.txt
+++ b/configreference/planes/f-35a.txt
@@ -29,6 +29,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 76
 StallSpeed = 0.657

--- a/configreference/planes/f-35b.txt
+++ b/configreference/planes/f-35b.txt
@@ -29,6 +29,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 15200
 FlightCeilingRange = 76
 StallSpeed = 0.639

--- a/configreference/planes/f-35c.txt
+++ b/configreference/planes/f-35c.txt
@@ -29,6 +29,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 76
 StallSpeed = 0.648

--- a/configreference/planes/f-5e.txt
+++ b/configreference/planes/f-5e.txt
@@ -26,6 +26,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17000
 FlightCeilingRange = 72
 StallSpeed = 0.700

--- a/configreference/planes/f-80.txt
+++ b/configreference/planes/f-80.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 13700
 FlightCeilingRange = 60
 StallSpeed = 0.375

--- a/configreference/planes/f-86f.txt
+++ b/configreference/planes/f-86f.txt
@@ -26,6 +26,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 15000
 FlightCeilingRange = 60
 StallSpeed = 0.349

--- a/configreference/planes/f117.txt
+++ b/configreference/planes/f117.txt
@@ -27,6 +27,14 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/f117gbu27.txt
+++ b/configreference/planes/f117gbu27.txt
@@ -27,6 +27,14 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/f117nuc.txt
+++ b/configreference/planes/f117nuc.txt
@@ -27,6 +27,14 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/f14.txt
+++ b/configreference/planes/f14.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17000
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/f14d.txt
+++ b/configreference/planes/f14d.txt
@@ -33,6 +33,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.608

--- a/configreference/planes/f16c.txt
+++ b/configreference/planes/f16c.txt
@@ -28,6 +28,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 15200
 FlightCeilingRange = 72
 StallSpeed = 0.684

--- a/configreference/planes/f1m.txt
+++ b/configreference/planes/f1m.txt
@@ -41,6 +41,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 8500
 FlightCeilingRange = 54
 StallSpeed = 0.161

--- a/configreference/planes/f22a.txt
+++ b/configreference/planes/f22a.txt
@@ -46,6 +46,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 19800
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/f4a.txt
+++ b/configreference/planes/f4a.txt
@@ -37,6 +37,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17000
 FlightCeilingRange = 72
 StallSpeed = 0.823

--- a/configreference/planes/f8f.txt
+++ b/configreference/planes/f8f.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 11800
 FlightCeilingRange = 56
 StallSpeed = 0.272

--- a/configreference/planes/fa18e.txt
+++ b/configreference/planes/fa18e.txt
@@ -28,6 +28,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.657

--- a/configreference/planes/fa18fold.txt
+++ b/configreference/planes/fa18fold.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.657

--- a/configreference/planes/fa50.txt
+++ b/configreference/planes/fa50.txt
@@ -39,6 +39,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.576

--- a/configreference/planes/geran2.txt
+++ b/configreference/planes/geran2.txt
@@ -26,6 +26,14 @@ AddSeat =  0.0, 0.0, 0.0
 Category = OWAD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.350

--- a/configreference/planes/h6k.txt
+++ b/configreference/planes/h6k.txt
@@ -21,6 +21,14 @@ CameraPosition  = 0.0, 2.00, 4.78
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.800

--- a/configreference/planes/h8k.txt
+++ b/configreference/planes/h8k.txt
@@ -18,6 +18,14 @@ ThirdPersonDist = 28
 Category = MPFB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.350

--- a/configreference/planes/harrier.txt
+++ b/configreference/planes/harrier.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.015
 NewFlightCombatFlapControl = 0.150
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.491

--- a/configreference/planes/harrier_en.txt
+++ b/configreference/planes/harrier_en.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.015
 NewFlightCombatFlapControl = 0.150
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.491

--- a/configreference/planes/il28sh.txt
+++ b/configreference/planes/il28sh.txt
@@ -26,6 +26,14 @@ AddTexture = il28_none
 Category = MB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/il76ua.txt
+++ b/configreference/planes/il76ua.txt
@@ -16,6 +16,14 @@ ThirdPersonDist = 68
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.500

--- a/configreference/planes/j11b.txt
+++ b/configreference/planes/j11b.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/j15.txt
+++ b/configreference/planes/j15.txt
@@ -38,6 +38,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/j8.txt
+++ b/configreference/planes/j8.txt
@@ -20,6 +20,14 @@ ThirdPersonDist = 16
 Category = IA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/jas39.txt
+++ b/configreference/planes/jas39.txt
@@ -31,6 +31,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.576

--- a/configreference/planes/ju87.txt
+++ b/configreference/planes/ju87.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 8200
 FlightCeilingRange = 54
 StallSpeed = 0.170

--- a/configreference/planes/kf-21.txt
+++ b/configreference/planes/kf-21.txt
@@ -38,6 +38,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 76
 StallSpeed = 0.689

--- a/configreference/planes/m2000-5.txt
+++ b/configreference/planes/m2000-5.txt
@@ -36,6 +36,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.720

--- a/configreference/planes/m2000c.txt
+++ b/configreference/planes/m2000c.txt
@@ -36,6 +36,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.720

--- a/configreference/planes/mc130.txt
+++ b/configreference/planes/mc130.txt
@@ -24,6 +24,14 @@ ThirdPersonDist = 28
 Category = STOL/SOMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.200

--- a/configreference/planes/mc130j.txt
+++ b/configreference/planes/mc130j.txt
@@ -28,6 +28,14 @@ MobDropOption  = 0.97, 1.10, -12.91, 2
 Category = STOL/SOMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.200

--- a/configreference/planes/md90.txt
+++ b/configreference/planes/md90.txt
@@ -17,6 +17,14 @@ InventorySize = 64
 Category = C/NBJA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 3.100

--- a/configreference/planes/mig-15.txt
+++ b/configreference/planes/mig-15.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 15500
 FlightCeilingRange = 60
 StallSpeed = 0.422

--- a/configreference/planes/mig-19s.txt
+++ b/configreference/planes/mig-19s.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 60
 StallSpeed = 0.570

--- a/configreference/planes/mig-21pf.txt
+++ b/configreference/planes/mig-21pf.txt
@@ -40,6 +40,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 72
 StallSpeed = 0.779

--- a/configreference/planes/mig17f.txt
+++ b/configreference/planes/mig17f.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16600
 FlightCeilingRange = 60
 StallSpeed = 0.449

--- a/configreference/planes/mig21.txt
+++ b/configreference/planes/mig21.txt
@@ -37,6 +37,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 72
 StallSpeed = 0.761

--- a/configreference/planes/mig23.txt
+++ b/configreference/planes/mig23.txt
@@ -42,6 +42,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17000
 FlightCeilingRange = 72
 StallSpeed = 0.823

--- a/configreference/planes/mig25.txt
+++ b/configreference/planes/mig25.txt
@@ -19,6 +19,14 @@ SmoothShading = true
 Category = I/RA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.800

--- a/configreference/planes/mig29.txt
+++ b/configreference/planes/mig29.txt
@@ -39,6 +39,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/mig3.txt
+++ b/configreference/planes/mig3.txt
@@ -41,6 +41,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 12000
 FlightCeilingRange = 56
 StallSpeed = 0.257

--- a/configreference/planes/mig31.txt
+++ b/configreference/planes/mig31.txt
@@ -4,6 +4,14 @@ MaxHp = 100
 Speed = 4.00
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.300

--- a/configreference/planes/mig31k.txt
+++ b/configreference/planes/mig31k.txt
@@ -27,6 +27,14 @@ EntityHeight = 0.8
 Category = IA/SF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.450

--- a/configreference/planes/mirage3e.txt
+++ b/configreference/planes/mirage3e.txt
@@ -25,6 +25,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17000
 FlightCeilingRange = 72
 StallSpeed = 0.823

--- a/configreference/planes/mirageiv.txt
+++ b/configreference/planes/mirageiv.txt
@@ -18,6 +18,14 @@ ThirdPersonDist = 20
 Category = SUSB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/mq-9.txt
+++ b/configreference/planes/mq-9.txt
@@ -30,6 +30,14 @@ RotorSpeed = 200.0
 Category = UCAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.350

--- a/configreference/planes/mqm170.txt
+++ b/configreference/planes/mqm170.txt
@@ -19,6 +19,14 @@ FuelConsumption = 0.111
 Category = UAV/TD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.350

--- a/configreference/planes/mv-22.txt
+++ b/configreference/planes/mv-22.txt
@@ -27,6 +27,14 @@ FuelConsumption = 16.012
 Category = TRMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 3.200

--- a/configreference/planes/n1k1.txt
+++ b/configreference/planes/n1k1.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 10800
 FlightCeilingRange = 56
 StallSpeed = 0.234

--- a/configreference/planes/ov-10a.txt
+++ b/configreference/planes/ov-10a.txt
@@ -17,6 +17,14 @@ RotorSpeed = 200.0
 Category = LA/OA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/p-51d.txt
+++ b/configreference/planes/p-51d.txt
@@ -25,6 +25,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 12800
 FlightCeilingRange = 56
 StallSpeed = 0.249

--- a/configreference/planes/pzl-m18.txt
+++ b/configreference/planes/pzl-m18.txt
@@ -23,6 +23,14 @@ EntityHeight = 0.86
 Category = C/UA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.82
+ClimbEnergyCostMultiplier = 1.35
+PitchEnergyCostMultiplier = 1.25
+VerticalClimbEnergyCostMultiplier = 1.70
+StallRecoveryEnergyThreshold = 1.20
+SustainedClimbEnergyRequirement = 1.35
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/q-5d.txt
+++ b/configreference/planes/q-5d.txt
@@ -44,6 +44,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 12500
 FlightCeilingRange = 60
 StallSpeed = 0.495

--- a/configreference/planes/qf-80.txt
+++ b/configreference/planes/qf-80.txt
@@ -24,6 +24,14 @@ AddRecipe = "ABC", " E ", "   ", A, mcheli:airframe2, B, mcheli:basicmechanicpar
 Category = UAV/TD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/rafalem.txt
+++ b/configreference/planes/rafalem.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16000
 FlightCeilingRange = 72
 StallSpeed = 0.599

--- a/configreference/planes/skylark.txt
+++ b/configreference/planes/skylark.txt
@@ -23,6 +23,14 @@ RotorSpeed = 200.0
 Category = MUAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.350

--- a/configreference/planes/spitfire-mkvb.txt
+++ b/configreference/planes/spitfire-mkvb.txt
@@ -46,6 +46,14 @@ NewFlightCombatFlapLift = 0.145
 NewFlightCombatFlapDrag = 0.016
 NewFlightCombatFlapControl = 0.190
 NewFlightCombatFlapOverspeed = 0.680
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.08
+ClimbEnergyCostMultiplier = 1.05
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.25
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.05
 FlightCeiling = 11200
 FlightCeilingRange = 56
 StallSpeed = 0.238

--- a/configreference/planes/sr71.txt
+++ b/configreference/planes/sr71.txt
@@ -23,6 +23,14 @@ WeightedCenterZ = -7.6
 Category = SRA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.350

--- a/configreference/planes/su-33.txt
+++ b/configreference/planes/su-33.txt
@@ -39,6 +39,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/su24.txt
+++ b/configreference/planes/su24.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.015
 NewFlightCombatFlapControl = 0.150
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 11000
 FlightCeilingRange = 60
 StallSpeed = 0.691

--- a/configreference/planes/su25.txt
+++ b/configreference/planes/su25.txt
@@ -39,6 +39,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.015
 NewFlightCombatFlapControl = 0.150
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 7000
 FlightCeilingRange = 60
 StallSpeed = 0.407

--- a/configreference/planes/su27bru.txt
+++ b/configreference/planes/su27bru.txt
@@ -38,6 +38,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/su34.txt
+++ b/configreference/planes/su34.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.628

--- a/configreference/planes/su34b.txt
+++ b/configreference/planes/su34b.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.628

--- a/configreference/planes/su34n.txt
+++ b/configreference/planes/su34n.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.628

--- a/configreference/planes/su37.txt
+++ b/configreference/planes/su37.txt
@@ -41,6 +41,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 17500
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/su57.txt
+++ b/configreference/planes/su57.txt
@@ -51,6 +51,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 20000
 FlightCeilingRange = 76
 StallSpeed = 0.720

--- a/configreference/planes/tornado-gr4.txt
+++ b/configreference/planes/tornado-gr4.txt
@@ -40,6 +40,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/tornado-ids.txt
+++ b/configreference/planes/tornado-ids.txt
@@ -43,6 +43,14 @@ NewFlightCombatFlapLift = 0.120
 NewFlightCombatFlapDrag = 0.013
 NewFlightCombatFlapControl = 0.130
 NewFlightCombatFlapOverspeed = 0.780
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.10
+ClimbEnergyCostMultiplier = 0.95
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.05
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 0.95
 FlightCeiling = 16500
 FlightCeilingRange = 72
 StallSpeed = 0.760

--- a/configreference/planes/tu142real.txt
+++ b/configreference/planes/tu142real.txt
@@ -22,6 +22,14 @@ AutoPilotRot = 0
 Category = MP/ASWA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.900

--- a/configreference/planes/tu160m.txt
+++ b/configreference/planes/tu160m.txt
@@ -42,6 +42,14 @@ enableback = true
 Category = SSHB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.200

--- a/configreference/planes/tu160mmsl.txt
+++ b/configreference/planes/tu160mmsl.txt
@@ -42,6 +42,14 @@ enableback = true
 Category = SSHB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 5.350

--- a/configreference/planes/tu22m3.txt
+++ b/configreference/planes/tu22m3.txt
@@ -35,6 +35,14 @@ MaxRotationPitch =  60
 Category = SB/MS
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.700

--- a/configreference/planes/tu4.txt
+++ b/configreference/planes/tu4.txt
@@ -28,6 +28,14 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/NB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.800

--- a/configreference/planes/tu4light.txt
+++ b/configreference/planes/tu4light.txt
@@ -25,6 +25,14 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.800

--- a/configreference/planes/tu95k22.txt
+++ b/configreference/planes/tu95k22.txt
@@ -23,6 +23,14 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.950

--- a/configreference/planes/tu95ms.txt
+++ b/configreference/planes/tu95ms.txt
@@ -22,6 +22,14 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.800

--- a/configreference/planes/tu95org.txt
+++ b/configreference/planes/tu95org.txt
@@ -22,6 +22,14 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 0.90
+ClimbEnergyCostMultiplier = 1.25
+PitchEnergyCostMultiplier = 1.20
+VerticalClimbEnergyCostMultiplier = 1.55
+StallRecoveryEnergyThreshold = 1.15
+SustainedClimbEnergyRequirement = 1.25
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.700

--- a/configreference/planes/victor_b2.txt
+++ b/configreference/planes/victor_b2.txt
@@ -48,6 +48,14 @@ AddBlade = 1,0,   3.631,  2.416,  -2.367,   0, 0, -1
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/x-47b.txt
+++ b/configreference/planes/x-47b.txt
@@ -25,6 +25,14 @@ Stealth = 0.35
 Category = UCAV/TECD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 4.400

--- a/configreference/planes/yak38.txt
+++ b/configreference/planes/yak38.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 11000
 FlightCeilingRange = 60
 StallSpeed = 0.524

--- a/configreference/planes/yak38_r60.txt
+++ b/configreference/planes/yak38_r60.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 11000
 FlightCeilingRange = 60
 StallSpeed = 0.524

--- a/configreference/planes/yak38_upk.txt
+++ b/configreference/planes/yak38_upk.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 11000
 FlightCeilingRange = 60
 StallSpeed = 0.524

--- a/configreference/planes/yak38_x23.txt
+++ b/configreference/planes/yak38_x23.txt
@@ -45,6 +45,14 @@ NewFlightCombatFlapLift = 0.105
 NewFlightCombatFlapDrag = 0.014
 NewFlightCombatFlapControl = 0.140
 NewFlightCombatFlapOverspeed = 0.720
+
+# New-flight internal energy model tuning
+EnergyRetentionMultiplier = 1.05
+ClimbEnergyCostMultiplier = 1.00
+PitchEnergyCostMultiplier = 1.00
+VerticalClimbEnergyCostMultiplier = 1.15
+StallRecoveryEnergyThreshold = 1.00
+SustainedClimbEnergyRequirement = 1.00
 FlightCeiling = 11000
 FlightCeilingRange = 60
 StallSpeed = 0.524

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -63,6 +63,12 @@ With the default `AllPlaneSpeed = 1000`, a 500 mph plane therefore uses `Speed 0
 | `NewFlightCombatFlapDrag` | float[0..0.25] | 0.012 | **New flight model only.** Extra drag while combat flaps are deployed. |
 | `NewFlightCombatFlapControl` | float[0..1] | 0.12 | **New flight model only.** Control-authority boost while combat flaps are deployed. |
 | `NewFlightCombatFlapOverspeed` | float[0.1..1] | 0.78 | **New flight model only.** Multiplier applied to `MaxSafeSpeed` while flaps are deployed; lower values punish high-speed flap use earlier. |
+| `EnergyRetentionMultiplier` | float[0.1..3] | 1.0 | **New flight model only.** Scales how much stored kinetic energy is usable for brief zoom climbs and high-pitch manoeuvres. |
+| `ClimbEnergyCostMultiplier` | float[0.1..5] | 1.0 | **New flight model only.** Scales energy demand from positive vertical speed. |
+| `PitchEnergyCostMultiplier` | float[0.1..5] | 1.0 | **New flight model only.** Scales energy demand from nose-up/high-AoA pitch manoeuvres. |
+| `VerticalClimbEnergyCostMultiplier` | float[0.1..8] | 1.0 | **New flight model only.** Scales extra demand for steep nose-up climb attempts. Raise this to prevent hover-climb behavior. |
+| `StallRecoveryEnergyThreshold` | float[0.1..3] | 1.0 | **New flight model only.** Specific-energy fraction of stall recovery speed required before forced energy recovery fades. |
+| `SustainedClimbEnergyRequirement` | float[0.1..3] | 1.0 | **New flight model only.** Specific-energy fraction of climb sustain speed required for supported sustained climb. |
 | `StallSpeed` | float[0..10] | 0 | Absolute stall threshold; if 0, uses `max(0.05, topSpeed * StallSpeedFactor)`. |
 | `CriticalAoA` | float[1..90] | 14.00 | AoA in degrees where stall demand begins. |
 | `StallLiftLoss` | float[0..1] | 0.820 | Fraction of lift removed at full stall. |
@@ -165,6 +171,40 @@ targetHorizontalSpeed = horizontalSpeed * (1 - drag)
                       - climb * ClimbEnergyLoss
 ```
 
+
+### Internal energy model for new-flight fixed-wing planes
+
+Planes with `useNewMobilitySystem = true` now run an internal per-tick energy check in addition to lift, AoA, drag, and stall logic. Legacy planes do not use these calculations. The model records kinetic energy from `PhysicalMass` and full 3D velocity, potential energy from `PhysicalMass`, resolved new-flight gravity, and altitude, total energy, specific energy, tick-to-tick energy delta, and an approximate excess-power value. It then compares usable retained kinetic energy plus current thrust contribution against climb and pitch demands.
+
+```text
+kineticEnergy = 0.5 * PhysicalMass * (motionX^2 + motionY^2 + motionZ^2)
+potentialEnergy = PhysicalMass * resolvedGravity * max(0, altitude)
+totalEnergy = kineticEnergy + potentialEnergy
+specificEnergy = totalEnergy / PhysicalMass
+energyDelta = totalEnergy - previousTotalEnergy
+excessPower ~= energyDelta per tick
+
+climbEnergyDemand = positiveVerticalSpeed * PhysicalMass * resolvedGravity
+                  * ClimbEnergyCostMultiplier
+                + steepNoseUpVerticalDemand * VerticalClimbEnergyCostMultiplier
+pitchEnergyDemand = noseUpDemand * stall/aoa/body-rate demand
+                  * PitchEnergyCostMultiplier
+usableEnergy = kineticEnergy * EnergyRetentionMultiplier + thrustEnergy + positiveEnergyDelta
+energyDeficitSeverity = clamp(shortfall and specific-energy deficit, 0, 1)
+```
+
+`energyDeficitSeverity` is not a Y-motion clamp. When it rises, the aircraft loses nose-up pitch authority, receives extra energy/induced drag, can trigger pitch-break recovery, and biases the nose downward through the normal angular-velocity path. This preserves brief zoom climbs when the aircraft enters with enough airspeed/energy, but a low-speed or low-throttle aircraft at 80-90 degrees nose-up will bleed energy, stall, and rotate down instead of hovering upward. Low horizontal speed is handled by using full 3D airspeed and the existing low-speed/AoA stall state, so a plane cannot avoid the energy check just because `motionX`/`motionZ` are near zero.
+
+Tuning guidance:
+
+* Light fighters: keep `EnergyRetentionMultiplier` near or slightly above `1.0`, moderate `ClimbEnergyCostMultiplier`, and avoid excessive `VerticalClimbEnergyCostMultiplier` so they can dogfight and zoom climb without hovering.
+* Heavy fighters: use similar retention but slightly higher pitch/climb costs so mass and pitch demand matter.
+* Jets: may use slightly better retention or lower sustained-climb requirement only when `EngineThrust`, drag, mass, and gravity already justify strong climb performance.
+* Bombers/transports: lower retention and raise climb, pitch, recovery, and vertical-climb requirements so they recover poorly from steep nose-up flight.
+* Poor-energy aircraft, UAVs, and utility planes: use the bomber-style direction with even higher vertical-climb costs.
+
+Do not use these keys to fake impossible vertical performance. First tune real inputs (`PhysicalMass`, `EngineThrust`, gravity override, `BaseDrag`, `InducedDrag`, `ClimbEnergyLoss`, `StallSpeed`, `CriticalAoA`, and `StallRecoverySpeed`); use the energy multipliers only to shape how that physical/tuned energy is retained or spent.
+
 ### Stall, AoA, lift loss, and recovery
 
 ```text
@@ -229,7 +269,7 @@ Pilot nose-up input is also suppressed when the aircraft lacks energy or lift to
 
 ```text
 unsupportedClimb = nose-up attitude while climbing * max(0, 1 - thrustToWeight)
-energyDeficit = max(stallSeverity, aoaSeverity, speedSeverity, liftDeficit, unsupportedClimb)
+energyDeficit = max(stallSeverity, aoaSeverity, speedSeverity, liftDeficit, unsupportedClimb, energyDeficitSeverity)
 noseUpPitchInput *= 1 - clamp(energyDeficit * (0.35 + 0.65 * noseUpAttitude), 0, 1)
 ```
 
@@ -399,4 +439,4 @@ Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy pa
 
 Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
 
-Debug flight logging (`DebugFlightControl`) includes commanded throttle percent, smoothed engine output percent, effective curved/idle throttle percent, propulsive throttle percent, flap state, pitch, airspeed, forward speed, vertical speed, physical mass, weight force, engine thrust force (`EngineThrust * propulsiveThrottle`, with idle propulsion suppressed while parked at 0% commanded throttle), lift force, lift before stall loss, lift after stall loss, lift-to-weight ratio, thrust-to-weight ratio, net forward acceleration, `TakeoffDistanceMultiplier`, base/effective takeoff thresholds, whether takeoff threshold scaling is active, `validTakeoff`, `validClimb`, whether stall suppressed takeoff/climb headroom, applied gravity acceleration, resolved global/override gravity, placement motion-lock state, current motion/cached velocity, lift acceleration, net vertical acceleration, airborne state, velocity-derived `aoaFromVelocity`, `criticalAoA`, `stallDemand`, `speedSeverity`, `aoaSeverity`, smoothed stall severity, stall state, throttle-deficit pitch-down moment, lift loss, drag, control authority, pitch-break state, applied pitch-break angular velocity, and overspeed state for new-flight tuning.
+Debug flight logging (`DebugFlightControl`) includes energy telemetry (`kineticEnergy`, `potentialEnergy`, `totalEnergy`, `specificEnergy`, `energyDelta`, `excessPower`, `energyDeficitSeverity`, `climbEnergyDemand`, `pitchEnergyDemand`, `energyUnsupportedClimb`, and `energyForcedRecovery`) plus commanded throttle percent, smoothed engine output percent, effective curved/idle throttle percent, propulsive throttle percent, flap state, pitch, airspeed, forward speed, vertical speed, physical mass, weight force, engine thrust force (`EngineThrust * propulsiveThrottle`, with idle propulsion suppressed while parked at 0% commanded throttle), lift force, lift before stall loss, lift after stall loss, lift-to-weight ratio, thrust-to-weight ratio, net forward acceleration, `TakeoffDistanceMultiplier`, base/effective takeoff thresholds, whether takeoff threshold scaling is active, `validTakeoff`, `validClimb`, whether stall suppressed takeoff/climb headroom, applied gravity acceleration, resolved global/override gravity, placement motion-lock state, current motion/cached velocity, lift acceleration, net vertical acceleration, airborne state, velocity-derived `aoaFromVelocity`, `criticalAoA`, `stallDemand`, `speedSeverity`, `aoaSeverity`, smoothed stall severity, stall state, throttle-deficit pitch-down moment, lift loss, drag, control authority, pitch-break state, applied pitch-break angular velocity, and overspeed state for new-flight tuning.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -339,7 +339,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             : 0.0D;
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,horizontalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,pitchAuthority=%.2f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,pitchBreakAngularVelocity=%.4f)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,horizontalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,pitchAuthority=%.2f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,pitchBreakAngularVelocity=%.4f,kineticEnergy=%.4f,potentialEnergy=%.4f,totalEnergy=%.4f,specificEnergy=%.4f,energyDelta=%.4f,excessPower=%.4f,energyDeficitSeverity=%.2f,climbEnergyDemand=%.4f,pitchEnergyDemand=%.4f,energyUnsupportedClimb=%s,energyForcedRecovery=%s)",
               simDelta,
               mouseX,
               mouseY,
@@ -414,7 +414,18 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               ac.getLastIdleThrottleWarning(),
               ac.getLastLowHorizontalSpeedWarning(),
               Boolean.valueOf(ac.isPitchBreakActive()),
-              plane != null ? plane.getLastPitchBreakAngularVelocity() : 0.0D
+              plane != null ? plane.getLastPitchBreakAngularVelocity() : 0.0D,
+              plane != null ? plane.getLastKineticEnergy() : 0.0D,
+              plane != null ? plane.getLastPotentialEnergy() : 0.0D,
+              plane != null ? plane.getLastTotalEnergy() : 0.0D,
+              plane != null ? plane.getLastSpecificEnergy() : 0.0D,
+              plane != null ? plane.getLastEnergyDelta() : 0.0D,
+              plane != null ? plane.getLastExcessPower() : 0.0D,
+              plane != null ? plane.getLastEnergyDeficitSeverity() : 0.0D,
+              plane != null ? plane.getLastClimbEnergyDemand() : 0.0D,
+              plane != null ? plane.getLastPitchEnergyDemand() : 0.0D,
+              Boolean.valueOf(plane != null && plane.isLastEnergyUnsupportedClimb()),
+              Boolean.valueOf(plane != null && plane.isLastEnergyForcedRecovery())
       ));
 
       if(plane != null && plane.getLastLowHorizontalSpeedWarning().length() > 0) {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -53,6 +53,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double engineThrottle;
    /** Last total drag fraction applied by the fixed-wing energy model, exposed for debug output. */
    private double lastAerodynamicDrag;
+   private double lastKineticEnergy;
+   private double lastPotentialEnergy;
+   private double lastTotalEnergy;
+   private double previousTotalEnergy;
+   private double lastSpecificEnergy;
+   private double lastEnergyDelta;
+   private double lastExcessPower;
+   private double lastEnergyDeficitSeverity;
+   private double lastClimbEnergyDemand;
+   private double lastPitchEnergyDemand;
+   private boolean lastEnergyUnsupportedClimb;
+   private boolean lastEnergyForcedRecovery;
    /** Last stall lift-loss fraction applied to vertical motion, exposed for debug output. */
    private double lastLiftLoss;
    /** Last downward gravity acceleration applied by the new fixed-wing model. */
@@ -158,6 +170,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.prevRotationRotor = 0.0F;
       this.engineThrottle = 0.0D;
       this.lastAerodynamicDrag = 0.0D;
+      this.lastKineticEnergy = 0.0D;
+      this.lastPotentialEnergy = 0.0D;
+      this.lastTotalEnergy = 0.0D;
+      this.previousTotalEnergy = Double.NaN;
+      this.lastSpecificEnergy = 0.0D;
+      this.lastEnergyDelta = 0.0D;
+      this.lastExcessPower = 0.0D;
+      this.lastEnergyDeficitSeverity = 0.0D;
+      this.lastClimbEnergyDemand = 0.0D;
+      this.lastPitchEnergyDemand = 0.0D;
+      this.lastEnergyUnsupportedClimb = false;
+      this.lastEnergyForcedRecovery = false;
       this.lastLiftLoss = 0.0D;
       this.lastGravityAcceleration = 0.0D;
       this.lastLiftAcceleration = 0.0D;
@@ -462,6 +486,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double climbDemand = MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D);
       double supportDeficit = Math.max(Math.max(thrustDeficit, liftDeficit),
             Math.max(climbSpeedDeficit, Math.max(this.stallSeverity, Math.max(this.speedStallSeverity, this.aoaStallSeverity))));
+      supportDeficit = Math.max(supportDeficit, this.lastEnergyDeficitSeverity);
       double unsupportedClimb = noseUpAttitude * climbDemand * supportDeficit;
       if(this.isIdleUnsupportedClimb(noseUpAttitude, stallSpeed)) {
          unsupportedClimb = Math.max(unsupportedClimb, 0.35D + 0.65D * noseUpAttitude);
@@ -516,7 +541,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
       double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
             Math.max(this.speedStallSeverity, liftDeficit));
-      double energyDeficit = Math.max(aerodynamicDeficit, this.getUnsupportedClimbSeverity());
+      double energyDeficit = Math.max(Math.max(aerodynamicDeficit, this.lastEnergyDeficitSeverity), this.getUnsupportedClimbSeverity());
       return MCH_FlightModel.clamp(energyDeficit * (0.35D + 0.65D * noseUpAttitude), 0.0D, 1.0D);
    }
 
@@ -705,6 +730,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public double getLastControlAuthority() {
       return this.lastControlAuthority;
    }
+
+   public double getLastKineticEnergy() { return this.lastKineticEnergy; }
+   public double getLastPotentialEnergy() { return this.lastPotentialEnergy; }
+   public double getLastTotalEnergy() { return this.lastTotalEnergy; }
+   public double getLastSpecificEnergy() { return this.lastSpecificEnergy; }
+   public double getLastEnergyDelta() { return this.lastEnergyDelta; }
+   public double getLastExcessPower() { return this.lastExcessPower; }
+   public double getLastEnergyDeficitSeverity() { return this.lastEnergyDeficitSeverity; }
+   public double getLastClimbEnergyDemand() { return this.lastClimbEnergyDemand; }
+   public double getLastPitchEnergyDemand() { return this.lastPitchEnergyDemand; }
+   public boolean isLastEnergyUnsupportedClimb() { return this.lastEnergyUnsupportedClimb; }
+   public boolean isLastEnergyForcedRecovery() { return this.lastEnergyForcedRecovery; }
 
 
    public boolean isLastAirborne() {
@@ -1216,7 +1253,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             this.speedStallSeverity);
       double liftDeficit = MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D);
       double energyDeficit = Math.max(Math.max(this.stallSeverity, Math.max(this.aoaStallSeverity, this.speedStallSeverity)),
-            Math.max(thrustDeficit * climbDemand, liftDeficit));
+            Math.max(this.lastEnergyDeficitSeverity, Math.max(thrustDeficit * climbDemand, liftDeficit)));
       double legacyStrengthScale = MCH_FlightModel.clamp((double)this.getPlaneInfo().stallStrength / 0.6D, 0.0D, 4.0D);
       double pitchMoment = energyDeficit * noseUpAttitude * (0.35D + 0.65D * climbDemand)
             * (double)this.getPlaneInfo().stallPitchRecoveryStrength * legacyStrengthScale * 0.45D;
@@ -1232,6 +1269,51 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastThrustPitchDownMoment = appliedPitchDownVelocity;
    }
 
+   private double updateNewFlightEnergyState(double mass, double gravityAccel, double horizontalSpeed, double drag) {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      double vx = super.motionX;
+      double vy = super.motionY;
+      double vz = super.motionZ;
+      double speedSq = vx * vx + vy * vy + vz * vz;
+      this.lastKineticEnergy = 0.5D * mass * speedSq;
+      this.lastPotentialEnergy = mass * gravityAccel * Math.max(0.0D, super.posY);
+      this.lastTotalEnergy = this.lastKineticEnergy + this.lastPotentialEnergy;
+      this.lastSpecificEnergy = this.lastTotalEnergy / Math.max(1.0E-6D, mass);
+      this.lastEnergyDelta = Double.isNaN(this.previousTotalEnergy) ? 0.0D : this.lastTotalEnergy - this.previousTotalEnergy;
+      this.previousTotalEnergy = this.lastTotalEnergy;
+      this.lastExcessPower = this.lastEnergyDelta;
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor);
+      double recoverySpeed = info.stallRecoverySpeed > 0.0F ? (double)info.stallRecoverySpeed : stallSpeed * 1.2D;
+      double climbSustainSpeed = Math.max(recoverySpeed, stallSpeed * 1.35D);
+      double noseUp = MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 72.0D, 0.0D, 1.0D);
+      double climbDemand = Math.max(0.0D, super.motionY) * mass * gravityAccel * info.climbEnergyCostMultiplier;
+      double pitchDemand = noseUp * (0.5D * mass * climbSustainSpeed * climbSustainSpeed)
+            * (Math.max(this.aoaStallSeverity, this.speedStallSeverity) + 0.35D * MCH_FlightModel.clamp(Math.abs(this.pitchAngularVelocity) / 2.0D, 0.0D, 1.0D))
+            * info.pitchEnergyCostMultiplier;
+      double verticalDemand = noseUp * noseUp * Math.max(0.0D, super.motionY) * mass * gravityAccel
+            * info.verticalClimbEnergyCostMultiplier;
+      this.lastClimbEnergyDemand = climbDemand + verticalDemand;
+      this.lastPitchEnergyDemand = pitchDemand;
+
+      double retainedEnergy = this.lastKineticEnergy * info.energyRetentionMultiplier;
+      double thrustEnergy = Math.max(0.0D, this.lastEngineThrustForce * Math.max(0.0D, horizontalSpeed + Math.max(0.0D, super.motionY)));
+      double requiredSpecificEnergy = 0.5D * climbSustainSpeed * climbSustainSpeed * info.sustainedClimbEnergyRequirement;
+      double recoverySpecificEnergy = 0.5D * recoverySpeed * recoverySpeed * info.stallRecoveryEnergyThreshold;
+      double energyShortfall = (this.lastClimbEnergyDemand + this.lastPitchEnergyDemand) - (retainedEnergy + thrustEnergy + Math.max(0.0D, this.lastEnergyDelta));
+      double demandScale = Math.max(1.0E-6D, this.lastClimbEnergyDemand + this.lastPitchEnergyDemand);
+      double maneuverDeficit = MCH_FlightModel.clamp(energyShortfall / demandScale, 0.0D, 1.0D);
+      double specificDeficit = noseUp > 0.0D ? MCH_FlightModel.clamp((requiredSpecificEnergy - 0.5D * speedSq) / Math.max(0.05D, requiredSpecificEnergy), 0.0D, 1.0D) : 0.0D;
+      double powerDeficit = this.lastExcessPower < 0.0D && (noseUp > 0.0D || super.motionY > 0.0D)
+            ? MCH_FlightModel.clamp(-this.lastExcessPower / Math.max(demandScale, mass * gravityAccel * 0.05D), 0.0D, 1.0D) : 0.0D;
+      this.lastEnergyDeficitSeverity = MCH_FlightModel.clamp(Math.max(maneuverDeficit, Math.max(specificDeficit, powerDeficit))
+            * Math.max(noseUp, MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D)), 0.0D, 1.0D);
+      this.lastEnergyUnsupportedClimb = this.lastEnergyDeficitSeverity > 0.15D && (noseUp > 0.10D || super.motionY > 0.02D);
+      this.lastEnergyForcedRecovery = this.lastEnergyDeficitSeverity > 0.65D
+            || (noseUp > 0.35D && 0.5D * speedSq < recoverySpecificEnergy && this.getPropulsiveEngineThrottle() < 0.25D);
+      return MCH_FlightModel.clamp(drag + this.lastEnergyDeficitSeverity * (0.045D + 0.10D * noseUp), 0.0D, 0.5D);
+   }
+
    public void resetNewFlightPlacementMotion() {
       if(this.getPlaneInfo() == null || !this.getPlaneInfo().useNewMobilitySystem) {
          return;
@@ -1240,6 +1322,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.velocityX = this.velocityY = this.velocityZ = 0.0D;
       this.engineThrottle = 0.0D;
       this.lastAerodynamicDrag = 0.0D;
+      this.lastKineticEnergy = 0.0D;
+      this.lastPotentialEnergy = 0.0D;
+      this.lastTotalEnergy = 0.0D;
+      this.previousTotalEnergy = Double.NaN;
+      this.lastSpecificEnergy = 0.0D;
+      this.lastEnergyDelta = 0.0D;
+      this.lastExcessPower = 0.0D;
+      this.lastEnergyDeficitSeverity = 0.0D;
+      this.lastClimbEnergyDemand = 0.0D;
+      this.lastPitchEnergyDemand = 0.0D;
+      this.lastEnergyUnsupportedClimb = false;
+      this.lastEnergyForcedRecovery = false;
       this.lastLiftLoss = 0.0D;
       this.lastGravityAcceleration = 0.0D;
       this.lastLiftAcceleration = 0.0D;
@@ -2066,6 +2160,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             double idleDragBoost = this.lastIdleUnsupportedClimb ? 0.12D : 0.0D;
             drag += this.lastUnsupportedClimbSeverity * (0.08D + idleDragBoost + 0.22D * Math.max(this.stallSeverity, this.aoaStallSeverity));
             this.lastStallSuppressedLiftHeadroom = true;
+         }
+         double gravityAccel = Math.max(1.0E-6D, this.resolveNewFlightGravity());
+         drag = this.updateNewFlightEnergyState(mass, gravityAccel, horizontalSpeed, drag);
+         if(this.lastEnergyForcedRecovery) {
+            this.pitchBreakActive = true;
+            double energyPitchBreak = MCH_FlightModel.clamp(this.lastEnergyDeficitSeverity * noseHighPitch * 0.55D, 0.0D, 0.75D);
+            this.pitchAngularVelocity += (float)energyPitchBreak;
+            this.lastPitchBreakAngularVelocity = Math.max(this.lastPitchBreakAngularVelocity, energyPitchBreak);
+            if(this.pitchAngularVelocity < 0.0F) {
+               this.pitchAngularVelocity *= (float)(1.0D - MCH_FlightModel.clamp(this.lastEnergyDeficitSeverity * 0.55D, 0.0D, 0.55D));
+            }
          }
          drag = MCH_FlightModel.clamp(drag, 0.0D, 0.5D);
          this.lastAerodynamicDrag = drag;

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -85,6 +85,18 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float newFlightCombatFlapDrag = 0.012F;
    public float newFlightCombatFlapControl = 0.12F;
    public float newFlightCombatFlapOverspeed = 0.78F;
+   /** Multiplies usable stored energy retained for unsupported climb/pitch manoeuvres. */
+   public float energyRetentionMultiplier = 1.0F;
+   /** Multiplies energy demand from positive climb rate. */
+   public float climbEnergyCostMultiplier = 1.0F;
+   /** Multiplies energy demand from nose-up/high-AoA pitch manoeuvres. */
+   public float pitchEnergyCostMultiplier = 1.0F;
+   /** Multiplies energy demand from near-vertical nose-up climb attempts. */
+   public float verticalClimbEnergyCostMultiplier = 1.0F;
+   /** Specific-energy fraction of stall recovery speed required before forced recovery fades. */
+   public float stallRecoveryEnergyThreshold = 1.0F;
+   /** Specific-energy fraction of climb sustain speed required for supported climbs. */
+   public float sustainedClimbEnergyRequirement = 1.0F;
    /** Absolute airspeed below which a fixed-wing plane can enter a stall. Zero derives it from StallSpeedFactor. */
    public float stallSpeed = 0.0F;
    /** Angle between the plane forward vector and velocity vector at which airflow separates. */
@@ -376,6 +388,18 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.newFlightCombatFlapControl = this.toFloat(data, 0.0F, 1.0F);
          } else if(item.equalsIgnoreCase("NewFlightCombatFlapOverspeed")) {
             this.newFlightCombatFlapOverspeed = this.toFloat(data, 0.1F, 1.0F);
+         } else if(item.equalsIgnoreCase("EnergyRetentionMultiplier")) {
+            this.energyRetentionMultiplier = this.toFloat(data, 0.1F, 3.0F);
+         } else if(item.equalsIgnoreCase("ClimbEnergyCostMultiplier")) {
+            this.climbEnergyCostMultiplier = this.toFloat(data, 0.1F, 5.0F);
+         } else if(item.equalsIgnoreCase("PitchEnergyCostMultiplier")) {
+            this.pitchEnergyCostMultiplier = this.toFloat(data, 0.1F, 5.0F);
+         } else if(item.equalsIgnoreCase("VerticalClimbEnergyCostMultiplier")) {
+            this.verticalClimbEnergyCostMultiplier = this.toFloat(data, 0.1F, 8.0F);
+         } else if(item.equalsIgnoreCase("StallRecoveryEnergyThreshold")) {
+            this.stallRecoveryEnergyThreshold = this.toFloat(data, 0.1F, 3.0F);
+         } else if(item.equalsIgnoreCase("SustainedClimbEnergyRequirement")) {
+            this.sustainedClimbEnergyRequirement = this.toFloat(data, 0.1F, 3.0F);
          } else if(item.equalsIgnoreCase("StallSpeedKmh")) {
             this.stallSpeed = this.toInternalSpeedFromKmh(data, 0.0F, 720.0F);
          } else if(item.equalsIgnoreCase("StallSpeed")) {


### PR DESCRIPTION
### Motivation

- Replace ad-hoc vertical-climb / stall prevention with an energy-based check that prevents indefinite nose-up/vertical hover climbs while preserving brief zoom climbs. 
- Limit the change to aircraft that opt into the new mobility system (`useNewMobilitySystem = true`) and reuse existing physical tuning values where available. 
- Provide data and telemetry to let pack authors tune energy behaviour rather than hard-clamping vertical motion. 

### Description

- Added new per-vehicle tuning keys (`EnergyRetentionMultiplier`, `ClimbEnergyCostMultiplier`, `PitchEnergyCostMultiplier`, `VerticalClimbEnergyCostMultiplier`, `StallRecoveryEnergyThreshold`, and `SustainedClimbEnergyRequirement`) and parser handling in `MCP_PlaneInfo` so new-flight planes can be tuned. 
- Implemented per-tick energy bookkeeping and deficit estimation in `MCP_EntityPlane`: kinetic/potential/total/specific energy, tick `energyDelta`, simple `excessPower` estimate, climb/pitch/vertical climb demand computations, and a bounded `energyDeficitSeverity` that ranges 0.0–1.0. 
- Integrated deficit into flight behavior without direct Y-motion clamping by adding energy-influenced drag, feeding `energyDeficitSeverity` into existing unsupported-climb and pitch-suppression logic, and by triggering pitch-break nose-down angular velocity for severe deficits; brief zoom climbs remain possible when stored kinetic energy and thrust justify them. 
- Kept existing stall/AoA/speed checks and used existing config keys (`PhysicalMass`, `EngineThrust`, gravity overrides, `criticalAoA`, stall speeds, drag, etc.) rather than inventing replacement physical values. 
- Exposed telemetry getters and extended debug logging in `MCH_ClientCommonTickHandler` to include `kineticEnergy`, `potentialEnergy`, `totalEnergy`, `specificEnergy`, `energyDelta`, `excessPower`, `energyDeficitSeverity`, `climbEnergyDemand`, `pitchEnergyDemand`, `energyUnsupportedClimb`, and `energyForcedRecovery`. 
- Documented the model and new keys in `docs/vehicle-config/planes.md` and injected a per-plane energy-tuning block into all `configreference/planes/*` files that opt into `UseNewMobilitySystem = true` with balance-guided defaults for fighters, jets, bombers, and poor-energy aircraft. 

### Testing

- Ran repository sanity check (`diff --check`) and static checks against the modified files, which reported no problems. 
- Executed a Python validation script that scanned every `configreference/planes` entry with `UseNewMobilitySystem = true` and confirmed all six energy keys are present, which succeeded. 
- Verified no compiled `.class` artifacts were produced or included by checking for class files in the workspace, which returned none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3327d9d0988329be2912206a126e73)