### PR TITLE
Add new-flight third-person chase camera with per-plane focus offsets

### DIFF
--- a/configreference/planes/a-10.txt
+++ b/configreference/planes/a-10.txt
@@ -12,6 +12,9 @@ Speed = 1.45
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.950
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 2.100

--- a/configreference/planes/a4.txt
+++ b/configreference/planes/a4.txt
@@ -25,6 +25,9 @@ enableback = true
 Category = AA/FA/AGA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = -0.000
+NewPlaneCameraFocusOffsetY = 1.850
+NewPlaneCameraFocusOffsetZ = 0.200
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/a400m.txt
+++ b/configreference/planes/a400m.txt
@@ -35,7 +35,9 @@ AddTexture = a400m_3
 Category = STA/AR/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.580
+NewPlaneCameraFocusOffsetY = 4.840
+NewPlaneCameraFocusOffsetZ = 1.750
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/a6.txt
+++ b/configreference/planes/a6.txt
@@ -25,6 +25,9 @@ enableback = true
 Category = AA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = -0.528
+NewPlaneCameraFocusOffsetY = 3.044
+NewPlaneCameraFocusOffsetZ = -0.998
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/a6m2.txt
+++ b/configreference/planes/a6m2.txt
@@ -22,6 +22,9 @@ UnmountPosition = 3.0, 1.0, -2.0
 Category = CCFA/FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.710
+NewPlaneCameraFocusOffsetZ = 0.400
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/a6m2n.txt
+++ b/configreference/planes/a6m2n.txt
@@ -23,6 +23,9 @@ EntityHeight = 0.8
 Category = IF/FBFP
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.650
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/a7.txt
+++ b/configreference/planes/a7.txt
@@ -24,6 +24,9 @@ enableback = true
 Category = AA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.750
+NewPlaneCameraFocusOffsetZ = 1.252
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/ac-130.txt
+++ b/configreference/planes/ac-130.txt
@@ -30,7 +30,9 @@ RotorSpeed = 500.0
 Category = GAA/CASG
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.650
+NewPlaneCameraFocusOffsetY = 2.680
+NewPlaneCameraFocusOffsetZ = 2.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/ac-47.txt
+++ b/configreference/planes/ac-47.txt
@@ -23,7 +23,9 @@ EnableParachuting = false
 Category = GAA/CASG
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.680
+NewPlaneCameraFocusOffsetY = 5.250
+NewPlaneCameraFocusOffsetZ = 1.780
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/an2.txt
+++ b/configreference/planes/an2.txt
@@ -27,7 +27,9 @@ AddTexture = an2_5
 Category = C/AUA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.527
+NewPlaneCameraFocusOffsetY = 2.260
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/au23.txt
+++ b/configreference/planes/au23.txt
@@ -32,7 +32,9 @@ MobilityRoll = 1.103
 Category = AG/CI/UT
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.410
+NewPlaneCameraFocusOffsetY = 1.800
+NewPlaneCameraFocusOffsetZ = -0.730
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-1.txt
+++ b/configreference/planes/b-1.txt
@@ -29,7 +29,9 @@ Stealth = 0.2
 Category = SSHB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.950
+NewPlaneCameraFocusOffsetY = 7.410
+NewPlaneCameraFocusOffsetZ = 3.700
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-1nuclear.txt
+++ b/configreference/planes/b-1nuclear.txt
@@ -29,7 +29,9 @@ Stealth = 0.2
 Category = SSHB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.950
+NewPlaneCameraFocusOffsetY = 7.410
+NewPlaneCameraFocusOffsetZ = 3.700
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-2a.txt
+++ b/configreference/planes/b-2a.txt
@@ -41,7 +41,9 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.800
+NewPlaneCameraFocusOffsetY = 3.450
+NewPlaneCameraFocusOffsetZ = 0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-2a2.txt
+++ b/configreference/planes/b-2a2.txt
@@ -41,7 +41,9 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.800
+NewPlaneCameraFocusOffsetY = 3.450
+NewPlaneCameraFocusOffsetZ = 0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-2a3.txt
+++ b/configreference/planes/b-2a3.txt
@@ -41,7 +41,9 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.800
+NewPlaneCameraFocusOffsetY = 3.450
+NewPlaneCameraFocusOffsetZ = 0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b-2a4.txt
+++ b/configreference/planes/b-2a4.txt
@@ -41,7 +41,9 @@ MaxRotationPitch =  60
 Category = SSHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.800
+NewPlaneCameraFocusOffsetY = 3.450
+NewPlaneCameraFocusOffsetZ = 0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b29.txt
+++ b/configreference/planes/b29.txt
@@ -27,7 +27,9 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.550
+NewPlaneCameraFocusOffsetY = 2.750
+NewPlaneCameraFocusOffsetZ = -0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b29sp.txt
+++ b/configreference/planes/b29sp.txt
@@ -26,7 +26,9 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/HB/NB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.550
+NewPlaneCameraFocusOffsetY = 2.750
+NewPlaneCameraFocusOffsetZ = -0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b52.txt
+++ b/configreference/planes/b52.txt
@@ -23,7 +23,9 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.720
+NewPlaneCameraFocusOffsetY = 4.570
+NewPlaneCameraFocusOffsetZ = 0.210
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b52d.txt
+++ b/configreference/planes/b52d.txt
@@ -20,7 +20,9 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.720
+NewPlaneCameraFocusOffsetY = 4.570
+NewPlaneCameraFocusOffsetZ = 0.210
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/b52n.txt
+++ b/configreference/planes/b52n.txt
@@ -23,7 +23,9 @@ ThirdPersonDist = 68
 Category = SHB/HB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.720
+NewPlaneCameraFocusOffsetY = 4.570
+NewPlaneCameraFocusOffsetZ = 0.210
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/bayraktar tb 2.txt
+++ b/configreference/planes/bayraktar tb 2.txt
@@ -27,7 +27,9 @@ AddSeat = 0.0, 0.0, -3
 Category = UCAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 0.250
+NewPlaneCameraFocusOffsetZ = -3.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/bf109.txt
+++ b/configreference/planes/bf109.txt
@@ -27,6 +27,9 @@ DamageFactor = 0.8
 Category = F
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.150
+NewPlaneCameraFocusOffsetZ = -1.870
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/bqm_74e.txt
+++ b/configreference/planes/bqm_74e.txt
@@ -18,7 +18,9 @@ EngineDrag = 0.011
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.250
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/bv138.txt
+++ b/configreference/planes/bv138.txt
@@ -25,7 +25,9 @@ MobilityYawOnGround = 1.5
 Category = MP/LRR
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.540
+NewPlaneCameraFocusOffsetY = 0.850
+NewPlaneCameraFocusOffsetZ = 2.450
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/c-47.txt
+++ b/configreference/planes/c-47.txt
@@ -22,7 +22,9 @@ MobDropOption  = 0.97, 1.52, -6.48, 2
 Category = MTA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.680
+NewPlaneCameraFocusOffsetY = 5.250
+NewPlaneCameraFocusOffsetZ = 1.780
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/c5.txt
+++ b/configreference/planes/c5.txt
@@ -26,7 +26,9 @@ StepHeight = -1.0
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.620
+NewPlaneCameraFocusOffsetY = 7.050
+NewPlaneCameraFocusOffsetZ = 2.400
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/c5m.txt
+++ b/configreference/planes/c5m.txt
@@ -25,7 +25,9 @@ MobDropOption  = 0.97, 1.10, -12.91, 2
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.620
+NewPlaneCameraFocusOffsetY = 7.050
+NewPlaneCameraFocusOffsetZ = 2.400
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/e767.txt
+++ b/configreference/planes/e767.txt
@@ -28,7 +28,9 @@ CameraZoom = 10
 Category = AWACS
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.700
+NewPlaneCameraFocusOffsetY = 3.650
+NewPlaneCameraFocusOffsetZ = -0.250
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/emb314.txt
+++ b/configreference/planes/emb314.txt
@@ -23,7 +23,9 @@ UnmountPosition = 3.0, 2.0, -5.0
 Category = LA/COINA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.570
+NewPlaneCameraFocusOffsetZ = -1.700
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/eurofighter_typhoon_2.txt
+++ b/configreference/planes/eurofighter_typhoon_2.txt
@@ -23,6 +23,9 @@ Sound = euro
 Category = ASF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.000
+NewPlaneCameraFocusOffsetZ = 0.036
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.320

--- a/configreference/planes/eurofighter_typhoon_2_t.txt
+++ b/configreference/planes/eurofighter_typhoon_2_t.txt
@@ -26,6 +26,9 @@ Sound = euro
 Category = ASF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.000
+NewPlaneCameraFocusOffsetZ = 0.036
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.350

--- a/configreference/planes/f-104.txt
+++ b/configreference/planes/f-104.txt
@@ -7,7 +7,9 @@ Speed = 3.70
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.520
+NewPlaneCameraFocusOffsetZ = 1.980
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/f-15e.txt
+++ b/configreference/planes/f-15e.txt
@@ -21,6 +21,9 @@ DamageFactor = 0.8
 Speed = 4.0
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.680
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/f-15s_mtd.txt
+++ b/configreference/planes/f-15s_mtd.txt
@@ -27,6 +27,9 @@ Sound = ffifteen
 Category = ASF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.680
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/f-35a.txt
+++ b/configreference/planes/f-35a.txt
@@ -10,6 +10,9 @@ sound = fthirtyfive
 Speed = 3.65
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.170
+NewPlaneCameraFocusOffsetZ = 0.320
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/f-35b.txt
+++ b/configreference/planes/f-35b.txt
@@ -10,6 +10,9 @@ sound = fthirtyfive
 Speed = 3.55
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.170
+NewPlaneCameraFocusOffsetZ = 0.320
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.550

--- a/configreference/planes/f-35c.txt
+++ b/configreference/planes/f-35c.txt
@@ -10,6 +10,9 @@ sound = fthirtyfive
 Speed = 3.60
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.170
+NewPlaneCameraFocusOffsetZ = 0.320
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/f-5e.txt
+++ b/configreference/planes/f-5e.txt
@@ -7,6 +7,9 @@ Speed = 3.40
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.580
+NewPlaneCameraFocusOffsetZ = 1.067
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/f-80.txt
+++ b/configreference/planes/f-80.txt
@@ -23,6 +23,9 @@ ThirdPersonDist = 12
 Category = JF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.920
+NewPlaneCameraFocusOffsetZ = 0.630
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/f-86f.txt
+++ b/configreference/planes/f-86f.txt
@@ -7,6 +7,9 @@ Speed = 1.55
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.850
+NewPlaneCameraFocusOffsetZ = 1.378
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/f117.txt
+++ b/configreference/planes/f117.txt
@@ -27,7 +27,9 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.770
+NewPlaneCameraFocusOffsetZ = 4.011
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/f117gbu27.txt
+++ b/configreference/planes/f117gbu27.txt
@@ -27,7 +27,9 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.770
+NewPlaneCameraFocusOffsetZ = 4.011
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/f117nuc.txt
+++ b/configreference/planes/f117nuc.txt
@@ -27,7 +27,9 @@ DamageFactor = 0.8
 Category = SAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.770
+NewPlaneCameraFocusOffsetZ = 4.011
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/f14.txt
+++ b/configreference/planes/f14.txt
@@ -26,6 +26,9 @@ EnableSeaSurfaceParticle = true
 Category = IA/AS/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.850
+NewPlaneCameraFocusOffsetZ = 0.490
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.780

--- a/configreference/planes/f14d.txt
+++ b/configreference/planes/f14d.txt
@@ -14,6 +14,9 @@ EnableEjectionSeat = true
 Speed = 3.20
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.990
+NewPlaneCameraFocusOffsetZ = 0.150
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/f16c.txt
+++ b/configreference/planes/f16c.txt
@@ -9,6 +9,9 @@ EnableEjectionSeat = true
 Speed = 3.80
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.814
+NewPlaneCameraFocusOffsetZ = 1.762
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.180

--- a/configreference/planes/f1m.txt
+++ b/configreference/planes/f1m.txt
@@ -22,6 +22,9 @@ RotorSpeed = 2000.0
 Category = RFLP
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.880
+NewPlaneCameraFocusOffsetZ = -0.090
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/f22a.txt
+++ b/configreference/planes/f22a.txt
@@ -27,6 +27,9 @@ sound = ftwentytwo
 Category = ASF/SF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.260
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.550

--- a/configreference/planes/f4a.txt
+++ b/configreference/planes/f4a.txt
@@ -18,6 +18,9 @@ CameraZoom = 2
 Category = IB/FB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.430
+NewPlaneCameraFocusOffsetZ = 0.037
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/f8f.txt
+++ b/configreference/planes/f8f.txt
@@ -23,6 +23,9 @@ enableback = true
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.570
+NewPlaneCameraFocusOffsetZ = -1.808
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/fa18e.txt
+++ b/configreference/planes/fa18e.txt
@@ -9,6 +9,9 @@ EnableEjectionSeat = true
 Speed = 3.65
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.200
+NewPlaneCameraFocusOffsetZ = 2.200
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/fa18fold.txt
+++ b/configreference/planes/fa18fold.txt
@@ -23,6 +23,9 @@ EntityHeight = 0.75
 Category = CBMF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.200
+NewPlaneCameraFocusOffsetZ = 2.200
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/fa50.txt
+++ b/configreference/planes/fa50.txt
@@ -20,6 +20,9 @@ Sound = faeighteen
 Category = LCA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.094
+NewPlaneCameraFocusOffsetZ = 2.570
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/geran2.txt
+++ b/configreference/planes/geran2.txt
@@ -26,7 +26,9 @@ AddSeat =  0.0, 0.0, 0.0
 Category = OWAD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 0.250
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/h6k.txt
+++ b/configreference/planes/h6k.txt
@@ -21,7 +21,9 @@ CameraPosition  = 0.0, 2.00, 4.78
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.500
+NewPlaneCameraFocusOffsetY = 3.250
+NewPlaneCameraFocusOffsetZ = 3.550
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/h8k.txt
+++ b/configreference/planes/h8k.txt
@@ -18,7 +18,9 @@ ThirdPersonDist = 28
 Category = MPFB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.700
+NewPlaneCameraFocusOffsetY = 2.050
+NewPlaneCameraFocusOffsetZ = 0.100
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/harrier.txt
+++ b/configreference/planes/harrier.txt
@@ -25,6 +25,9 @@ ThrottleUpDown = 0.3
 Category = V/STOL/GAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.820
+NewPlaneCameraFocusOffsetZ = 0.220
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/harrier_en.txt
+++ b/configreference/planes/harrier_en.txt
@@ -23,6 +23,9 @@ ThrottleUpDown = 0.3
 Category = V/STOL/SA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.820
+NewPlaneCameraFocusOffsetZ = 0.220
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/il28sh.txt
+++ b/configreference/planes/il28sh.txt
@@ -26,7 +26,9 @@ AddTexture = il28_none
 Category = MB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.960
+NewPlaneCameraFocusOffsetZ = -2.100
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/il76ua.txt
+++ b/configreference/planes/il76ua.txt
@@ -16,7 +16,9 @@ ThirdPersonDist = 68
 Category = SA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.754
+NewPlaneCameraFocusOffsetY = 6.042
+NewPlaneCameraFocusOffsetZ = 3.935
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/j11b.txt
+++ b/configreference/planes/j11b.txt
@@ -25,6 +25,9 @@ AddRecipe = "ABC", "DEF", "GGG", A, mcheli:airframe2, B, mcheli:advancedmechanic
 Category = ASF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.490
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/j15.txt
+++ b/configreference/planes/j15.txt
@@ -19,6 +19,9 @@ Sound = sutwentyseven
 Category = CBMF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.490
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/j8.txt
+++ b/configreference/planes/j8.txt
@@ -20,7 +20,9 @@ ThirdPersonDist = 16
 Category = IA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.830
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/jas39.txt
+++ b/configreference/planes/jas39.txt
@@ -12,6 +12,9 @@ MobilityPitch = 1.603
 
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.550
+NewPlaneCameraFocusOffsetZ = -0.600
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/ju87.txt
+++ b/configreference/planes/ju87.txt
@@ -26,6 +26,9 @@ RotorSpeed = 2000.0
 Category = DB/GAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = -0.040
+NewPlaneCameraFocusOffsetY = 3.147
+NewPlaneCameraFocusOffsetZ = -2.584
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.200

--- a/configreference/planes/kf-21.txt
+++ b/configreference/planes/kf-21.txt
@@ -19,6 +19,9 @@ Stealth = 0.55
 Category = SSF/MCA/ASF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.080
+NewPlaneCameraFocusOffsetZ = 1.378
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/m2000-5.txt
+++ b/configreference/planes/m2000-5.txt
@@ -17,6 +17,9 @@ ThirdPersonDist = 20
 Category = MFA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.000
+NewPlaneCameraFocusOffsetZ = 0.600
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/m2000c.txt
+++ b/configreference/planes/m2000c.txt
@@ -17,6 +17,9 @@ ThirdPersonDist = 20
 Category = MFA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.000
+NewPlaneCameraFocusOffsetZ = 0.500
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/mc130.txt
+++ b/configreference/planes/mc130.txt
@@ -24,7 +24,9 @@ ThirdPersonDist = 28
 Category = STOL/SOMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.650
+NewPlaneCameraFocusOffsetY = 2.680
+NewPlaneCameraFocusOffsetZ = 2.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mc130j.txt
+++ b/configreference/planes/mc130j.txt
@@ -28,7 +28,9 @@ MobDropOption  = 0.97, 1.10, -12.91, 2
 Category = STOL/SOMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.650
+NewPlaneCameraFocusOffsetY = 2.680
+NewPlaneCameraFocusOffsetZ = 2.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/md90.txt
+++ b/configreference/planes/md90.txt
@@ -17,7 +17,9 @@ InventorySize = 64
 Category = C/NBJA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.800
+NewPlaneCameraFocusOffsetY = 3.350
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mig-15.txt
+++ b/configreference/planes/mig-15.txt
@@ -25,6 +25,9 @@ ThirdPersonDist = 12
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.970
+NewPlaneCameraFocusOffsetZ = 2.650
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/mig-19s.txt
+++ b/configreference/planes/mig-19s.txt
@@ -23,6 +23,9 @@ ThirdPersonDist = 17
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.745
+NewPlaneCameraFocusOffsetZ = 1.250
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/mig-21pf.txt
+++ b/configreference/planes/mig-21pf.txt
@@ -21,6 +21,9 @@ ThirdPersonDist = 17
 Category = F/IA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.750
+NewPlaneCameraFocusOffsetZ = 1.400
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/mig17f.txt
+++ b/configreference/planes/mig17f.txt
@@ -23,6 +23,9 @@ ThrottleUpDown = 0.3
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.700
+NewPlaneCameraFocusOffsetZ = -0.154
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/mig21.txt
+++ b/configreference/planes/mig21.txt
@@ -18,6 +18,9 @@ SmoothShading = true
 Category = F/IA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.850
+NewPlaneCameraFocusOffsetZ = 0.500
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/mig23.txt
+++ b/configreference/planes/mig23.txt
@@ -23,6 +23,9 @@ ThrottleUpDown = 0.3
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.684
+NewPlaneCameraFocusOffsetZ = -0.400
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/mig25.txt
+++ b/configreference/planes/mig25.txt
@@ -19,7 +19,9 @@ SmoothShading = true
 Category = I/RA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.020
+NewPlaneCameraFocusOffsetY = 2.450
+NewPlaneCameraFocusOffsetZ = 5.600
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mig29.txt
+++ b/configreference/planes/mig29.txt
@@ -20,6 +20,9 @@ Sound = migtwentynine
 Category = ASF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.250
+NewPlaneCameraFocusOffsetZ = -0.500
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/mig3.txt
+++ b/configreference/planes/mig3.txt
@@ -22,6 +22,9 @@ RotorSpeed = 2000.0
 Category = FA/IA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.900
+NewPlaneCameraFocusOffsetZ = -1.170
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/mig31.txt
+++ b/configreference/planes/mig31.txt
@@ -4,7 +4,9 @@ MaxHp = 100
 Speed = 4.00
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.050
+NewPlaneCameraFocusOffsetZ = 0.450
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mig31k.txt
+++ b/configreference/planes/mig31k.txt
@@ -27,7 +27,9 @@ EntityHeight = 0.8
 Category = IA/SF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.030
+NewPlaneCameraFocusOffsetZ = 0.020
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mirage3e.txt
+++ b/configreference/planes/mirage3e.txt
@@ -6,6 +6,9 @@ MaxHp = 100
 Speed = 4.0
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.970
+NewPlaneCameraFocusOffsetZ = 1.500
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/mirageiv.txt
+++ b/configreference/planes/mirageiv.txt
@@ -18,7 +18,9 @@ ThirdPersonDist = 20
 Category = SUSB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.450
+NewPlaneCameraFocusOffsetZ = 2.600
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mq-9.txt
+++ b/configreference/planes/mq-9.txt
@@ -30,7 +30,9 @@ RotorSpeed = 200.0
 Category = UCAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.150
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mqm170.txt
+++ b/configreference/planes/mqm170.txt
@@ -19,7 +19,9 @@ FuelConsumption = 0.111
 Category = UAV/TD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.250
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/mv-22.txt
+++ b/configreference/planes/mv-22.txt
@@ -27,7 +27,9 @@ FuelConsumption = 16.012
 Category = TRMTA/TA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.700
+NewPlaneCameraFocusOffsetY = 1.450
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/n1k1.txt
+++ b/configreference/planes/n1k1.txt
@@ -25,6 +25,9 @@ DamageFactor = 0.8
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.590
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/ov-10a.txt
+++ b/configreference/planes/ov-10a.txt
@@ -17,7 +17,9 @@ RotorSpeed = 200.0
 Category = LA/OA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.550
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/p-51d.txt
+++ b/configreference/planes/p-51d.txt
@@ -6,6 +6,9 @@ MaxHp = 100
 Speed = 1.08
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.250
+NewPlaneCameraFocusOffsetZ = -1.820
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/pzl-m18.txt
+++ b/configreference/planes/pzl-m18.txt
@@ -23,7 +23,9 @@ EntityHeight = 0.86
 Category = C/UA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.720
+NewPlaneCameraFocusOffsetZ = -2.950
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/q-5d.txt
+++ b/configreference/planes/q-5d.txt
@@ -25,6 +25,9 @@ ThirdPersonDist = 18
 Category = GAA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.680
+NewPlaneCameraFocusOffsetZ = 2.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/qf-80.txt
+++ b/configreference/planes/qf-80.txt
@@ -24,7 +24,9 @@ AddRecipe = "ABC", " E ", "   ", A, mcheli:airframe2, B, mcheli:basicmechanicpar
 Category = UAV/TD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.250
+NewPlaneCameraFocusOffsetZ = 0.000
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/rafalem.txt
+++ b/configreference/planes/rafalem.txt
@@ -24,6 +24,9 @@ AddRecipe = "ABC", "DEF", "G  ", A, mcheli:airframe2, B, mcheli:advancedmechanic
 Category = MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.850
+NewPlaneCameraFocusOffsetZ = 0.400
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.250

--- a/configreference/planes/skylark.txt
+++ b/configreference/planes/skylark.txt
@@ -23,7 +23,9 @@ RotorSpeed = 200.0
 Category = MUAV
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 0.650
+NewPlaneCameraFocusOffsetZ = 0.340
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/spitfire-mkvb.txt
+++ b/configreference/planes/spitfire-mkvb.txt
@@ -27,6 +27,9 @@ AddTexture = spitfire-mkvb_skalski
 Category = FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.250
+NewPlaneCameraFocusOffsetZ = -2.270
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 0.950

--- a/configreference/planes/sr71.txt
+++ b/configreference/planes/sr71.txt
@@ -23,7 +23,9 @@ WeightedCenterZ = -7.6
 Category = SRA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.464
+NewPlaneCameraFocusOffsetZ = 3.180
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/su-33.txt
+++ b/configreference/planes/su-33.txt
@@ -20,6 +20,9 @@ Sound = sutwentyseven
 Category = CBASF/MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.360
+NewPlaneCameraFocusOffsetZ = 7.210
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/su24.txt
+++ b/configreference/planes/su24.txt
@@ -26,6 +26,9 @@ enableback = true
 Category = AWTB/ID
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.310
+NewPlaneCameraFocusOffsetY = 3.250
+NewPlaneCameraFocusOffsetZ = 7.370
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/su25.txt
+++ b/configreference/planes/su25.txt
@@ -20,6 +20,9 @@ SmoothShading = true
 Category = AA/CAS
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.580
+NewPlaneCameraFocusOffsetZ = 3.480
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/su27bru.txt
+++ b/configreference/planes/su27bru.txt
@@ -19,6 +19,9 @@ SweepWingSpeed = 0.85
 Category = MF/ASF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 2.526
+NewPlaneCameraFocusOffsetZ = 2.829
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/su34.txt
+++ b/configreference/planes/su34.txt
@@ -24,6 +24,9 @@ DamageFactor = 0.8
 Category = SF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.394
+NewPlaneCameraFocusOffsetY = 2.778
+NewPlaneCameraFocusOffsetZ = 7.670
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/su34b.txt
+++ b/configreference/planes/su34b.txt
@@ -24,6 +24,9 @@ DamageFactor = 0.8
 Category = FB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.394
+NewPlaneCameraFocusOffsetY = 2.778
+NewPlaneCameraFocusOffsetZ = 7.670
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/su34n.txt
+++ b/configreference/planes/su34n.txt
@@ -24,6 +24,9 @@ DamageFactor = 0.8
 Category = SF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.394
+NewPlaneCameraFocusOffsetY = 2.778
+NewPlaneCameraFocusOffsetZ = 7.670
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/su37.txt
+++ b/configreference/planes/su37.txt
@@ -22,6 +22,9 @@ sound = sutwentyseven
 Category = MF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.040
+NewPlaneCameraFocusOffsetZ = 4.190
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.450

--- a/configreference/planes/su57.txt
+++ b/configreference/planes/su57.txt
@@ -32,6 +32,9 @@ AddTexture = su57_tgm
 Category = SMF
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 3.061
+NewPlaneCameraFocusOffsetZ = 0.000
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.550

--- a/configreference/planes/tornado-gr4.txt
+++ b/configreference/planes/tornado-gr4.txt
@@ -21,6 +21,9 @@ FuelConsumption = 13.419
 Category = MA/SA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.900
+NewPlaneCameraFocusOffsetZ = 0.340
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/tornado-ids.txt
+++ b/configreference/planes/tornado-ids.txt
@@ -24,6 +24,9 @@ FuelConsumption = 13.419
 Category = MA/SA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.900
+NewPlaneCameraFocusOffsetZ = 0.340
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.650

--- a/configreference/planes/tu142real.txt
+++ b/configreference/planes/tu142real.txt
@@ -22,7 +22,9 @@ AutoPilotRot = 0
 Category = MP/ASWA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.400
+NewPlaneCameraFocusOffsetY = 4.359
+NewPlaneCameraFocusOffsetZ = 1.200
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu160m.txt
+++ b/configreference/planes/tu160m.txt
@@ -42,7 +42,9 @@ enableback = true
 Category = SSHB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.660
+NewPlaneCameraFocusOffsetY = 5.650
+NewPlaneCameraFocusOffsetZ = 5.760
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu160mmsl.txt
+++ b/configreference/planes/tu160mmsl.txt
@@ -42,7 +42,9 @@ enableback = true
 Category = SSHB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.660
+NewPlaneCameraFocusOffsetY = 5.650
+NewPlaneCameraFocusOffsetZ = 5.760
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu22m3.txt
+++ b/configreference/planes/tu22m3.txt
@@ -35,7 +35,9 @@ MaxRotationPitch =  60
 Category = SB/MS
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.473
+NewPlaneCameraFocusOffsetY = 2.950
+NewPlaneCameraFocusOffsetZ = 1.119
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu4.txt
+++ b/configreference/planes/tu4.txt
@@ -28,7 +28,9 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB/NB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.550
+NewPlaneCameraFocusOffsetY = 2.750
+NewPlaneCameraFocusOffsetZ = -0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu4light.txt
+++ b/configreference/planes/tu4light.txt
@@ -25,7 +25,9 @@ UnmountPosition = 3.0, 2.0, -4.0
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = -0.550
+NewPlaneCameraFocusOffsetY = 2.750
+NewPlaneCameraFocusOffsetZ = -0.280
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu95k22.txt
+++ b/configreference/planes/tu95k22.txt
@@ -23,7 +23,9 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.400
+NewPlaneCameraFocusOffsetY = 4.359
+NewPlaneCameraFocusOffsetZ = 1.200
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu95ms.txt
+++ b/configreference/planes/tu95ms.txt
@@ -22,7 +22,9 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.400
+NewPlaneCameraFocusOffsetY = 4.359
+NewPlaneCameraFocusOffsetZ = 1.200
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/tu95org.txt
+++ b/configreference/planes/tu95org.txt
@@ -22,7 +22,9 @@ AutoPilotRot = 0
 Category = SHNB/SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.400
+NewPlaneCameraFocusOffsetY = 4.359
+NewPlaneCameraFocusOffsetZ = 1.200
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/victor_b2.txt
+++ b/configreference/planes/victor_b2.txt
@@ -48,7 +48,9 @@ AddBlade = 1,0,   3.631,  2.416,  -2.367,   0, 0, -1
 Category = SB
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.428
+NewPlaneCameraFocusOffsetY = 2.550
+NewPlaneCameraFocusOffsetZ = 2.411
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/x-47b.txt
+++ b/configreference/planes/x-47b.txt
@@ -25,7 +25,9 @@ Stealth = 0.35
 Category = UCAV/TECD
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
-
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.950
+NewPlaneCameraFocusOffsetZ = 5.200
 # New-flight internal energy model tuning
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.

--- a/configreference/planes/yak38.txt
+++ b/configreference/planes/yak38.txt
@@ -26,6 +26,9 @@ MobilityRoll = 1.307
 Category = VTOL/FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.340
+NewPlaneCameraFocusOffsetZ = -0.060
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/yak38_r60.txt
+++ b/configreference/planes/yak38_r60.txt
@@ -26,6 +26,9 @@ MobilityRoll = 1.307
 Category = VTOL/FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.340
+NewPlaneCameraFocusOffsetZ = -0.060
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/yak38_upk.txt
+++ b/configreference/planes/yak38_upk.txt
@@ -26,6 +26,9 @@ MobilityRoll = 1.307
 Category = VTOL/FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.340
+NewPlaneCameraFocusOffsetZ = -0.060
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/configreference/planes/yak38_x23.txt
+++ b/configreference/planes/yak38_x23.txt
@@ -26,6 +26,9 @@ MobilityRoll = 1.307
 Category = VTOL/FA
 EnableRealisticFlightModel = true
 UseNewMobilitySystem = true
+NewPlaneCameraFocusOffsetX = 0.000
+NewPlaneCameraFocusOffsetY = 1.340
+NewPlaneCameraFocusOffsetZ = -0.060
 # PhysicalMass is translational aircraft weight/momentum for the new flight model.
 # EngineThrust is physical engine force; InertiaMultiplier remains rotational response only.
 PhysicalMass = 1.750

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -157,6 +157,22 @@ IgnoreBulletHit = flansmod.common.guns.EntityBullet
 IgnoreBulletHit = flansmod.common.guns.EntityGrenade
 ```
 
+
+### New-flight plane third-person chase camera
+
+These options are client-side visual/readability settings for pilots flying planes that use the new flight/new mobility system. They do not change flight physics, stall behavior, pitch authority, throttle behavior, weapons, targeting, HUD rendering, or aircraft balance. Legacy aircraft, helicopters, tanks, turrets, ships, passengers, and gunners keep the existing camera path unless the gated plane conditions are met.
+
+| Config key | Default | Purpose |
+| --- | ---: | --- |
+| `EnableNewPlaneThirdPersonCamera` | `true` | Enables the smooth chase camera only for third-person pilot view in new-flight planes. |
+| `NewPlaneCameraDistance` | `9.0` | Camera distance in blocks behind the plane. |
+| `NewPlaneCameraHeight` | `2.4` | Vertical offset in blocks above the plane. |
+| `NewPlaneCameraSideOffset` | `0.0` | Optional left/right offset in blocks for off-center chase views. |
+| `NewPlaneCameraPositionSmoothing` | `0.22` | How quickly the camera position catches up to the desired chase point; higher values are snappier. |
+| `NewPlaneCameraRotationSmoothing` | `0.16` | How quickly camera yaw and pitch recenter behind the aircraft; higher values are snappier. |
+| `NewPlaneCameraRollInfluence` | `0.15` | How much aircraft roll is applied to the camera horizon, from `0.0` stable horizon to `1.0` full roll coupling. |
+| `NewPlaneCameraCollision` | `true` | Shortens/moves the chase camera when a block is between the aircraft and desired camera point. |
+
 ## Key config defaults
 
 | Option | Default code | Default input |

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -66,6 +66,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `CameraRotationSpeed` | All | float | 1000.0 | camera part rotation speed |
 | `DefaultFreelook` | All | boolean | false | default pilot freelook |
 | `ThirdPersonDist` | All | float | 4.0 | third-person distance |
+| `NewPlaneCameraFocusOffsetX/Y/Z` | Plane | local blocks | `0,1,0` | new-flight third-person chase-camera focus anchor; visual/client readability only |
 | `UnmountPosition` | All | vec3 | normal unmount | custom dismount point |
 | `Width` | All | float | 2.0 | collision/body width |
 | `Height` | All | float | 0.7 | collision/body height |

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -69,6 +69,7 @@ With the default `AllPlaneSpeed = 1000`, a 500 mph plane therefore uses `Speed 0
 | `NewFlightCombatFlapDrag` | normalized drag coefficient [0..0.05] | 0.014 | **New flight model only.** Extra drag while combat flaps are deployed. |
 | `NewFlightCombatFlapControl` | normalized authority bonus [0..0.40] | 0.14 | **New flight model only.** Control-authority boost while combat flaps are deployed. |
 | `NewFlightCombatFlapOverspeed` | normalized multiplier [0.50..1] | 0.72 | **New flight model only.** Multiplier applied to `MaxSafeSpeed` while flaps are deployed; lower values punish high-speed flap use earlier. |
+| `NewPlaneCameraFocusOffsetX`, `NewPlaneCameraFocusOffsetY`, `NewPlaneCameraFocusOffsetZ` | local blocks | `0, 1, 0` | **New third-person camera/new flight model only.** Local-space visual focus point for the smooth chase camera, yaw-rotated from the aircraft entity origin so the camera follows the cockpit/center-of-mass area instead of model pivots such as propellers, noses, or tails. These values are visual only and do not change physics or balance. |
 | `StallSpeed` | internal speed [0..2] | 0 | Absolute stall threshold; if 0, uses `max(0.05, topSpeed * StallSpeedFactor)`. |
 | `CriticalAoA` | degrees [5..30] | 14.40 | AoA in degrees where stall demand begins. |
 | `StallLiftLoss` | float[0..1] | 0.820 | Fraction of lift removed at full stall. |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -157,6 +157,14 @@ public class MCH_Config {
    public static MCH_ConfigPrm AllTankSpeed;
    public static MCH_ConfigPrm HurtResistantTime;
    public static MCH_ConfigPrm DisplayHUDThirdPerson;
+   public static MCH_ConfigPrm EnableNewPlaneThirdPersonCamera;
+   public static MCH_ConfigPrm NewPlaneCameraDistance;
+   public static MCH_ConfigPrm NewPlaneCameraHeight;
+   public static MCH_ConfigPrm NewPlaneCameraSideOffset;
+   public static MCH_ConfigPrm NewPlaneCameraPositionSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraRotationSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraRollInfluence;
+   public static MCH_ConfigPrm NewPlaneCameraCollision;
    public static MCH_ConfigPrm DisableCameraDistChange;
    public static MCH_ConfigPrm EnableReplaceTextureManager;
    public static MCH_ConfigPrm DisplayEntityMarker;
@@ -397,6 +405,22 @@ public class MCH_Config {
       AllTankSpeed = new MCH_ConfigPrm("AllTankSpeed", 1.0D);
       HurtResistantTime = new MCH_ConfigPrm("HurtResistantTime", 0.0D);
       DisplayHUDThirdPerson = new MCH_ConfigPrm("DisplayHUDThirdPerson", false);
+      EnableNewPlaneThirdPersonCamera = new MCH_ConfigPrm("EnableNewPlaneThirdPersonCamera", true);
+      EnableNewPlaneThirdPersonCamera.desc = ";Client-only visual chase camera for third-person new-flight planes. Does not change flight physics, weapons, or HUD rendering.";
+      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 9.0D);
+      NewPlaneCameraDistance.desc = ";Blocks behind the aircraft for the new third-person plane chase camera.";
+      NewPlaneCameraHeight = new MCH_ConfigPrm("NewPlaneCameraHeight", 2.4D);
+      NewPlaneCameraHeight.desc = ";Blocks above the aircraft for the new third-person plane chase camera.";
+      NewPlaneCameraSideOffset = new MCH_ConfigPrm("NewPlaneCameraSideOffset", 0.0D);
+      NewPlaneCameraSideOffset.desc = ";Optional horizontal side offset for the new third-person plane chase camera.";
+      NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.22D);
+      NewPlaneCameraPositionSmoothing.desc = ";How quickly the new plane chase camera position follows the desired point. Higher is snappier.";
+      NewPlaneCameraRotationSmoothing = new MCH_ConfigPrm("NewPlaneCameraRotationSmoothing", 0.16D);
+      NewPlaneCameraRotationSmoothing.desc = ";How quickly the new plane chase camera yaw and pitch recenter behind the aircraft. Higher is snappier.";
+      NewPlaneCameraRollInfluence = new MCH_ConfigPrm("NewPlaneCameraRollInfluence", 0.15D);
+      NewPlaneCameraRollInfluence.desc = ";0.0 keeps the horizon mostly stable; 1.0 fully rolls the chase camera with the aircraft.";
+      NewPlaneCameraCollision = new MCH_ConfigPrm("NewPlaneCameraCollision", true);
+      NewPlaneCameraCollision.desc = ";Moves the new plane chase camera in front of solid blocks when line-of-sight collision is detected.";
       DisableCameraDistChange = new MCH_ConfigPrm("DisableThirdPersonCameraDistChange", false);
       EnableReplaceTextureManager = new MCH_ConfigPrm("EnableReplaceTextureManager", true);
       DisplayEntityMarker = new MCH_ConfigPrm("DisplayEntityMarker", true);
@@ -545,6 +569,14 @@ public class MCH_Config {
               EnableModEntityRender,
               DisableRenderLivingSpecials,
               DisplayHUDThirdPerson,
+              EnableNewPlaneThirdPersonCamera,
+              NewPlaneCameraDistance,
+              NewPlaneCameraHeight,
+              NewPlaneCameraSideOffset,
+              NewPlaneCameraPositionSmoothing,
+              NewPlaneCameraRotationSmoothing,
+              NewPlaneCameraRollInfluence,
+              NewPlaneCameraCollision,
               DisableCameraDistChange,
               EnableReplaceTextureManager,
               DisplayEntityMarker,
@@ -626,6 +658,12 @@ public class MCH_Config {
       AllHeliSpeed.prmDouble = MCH_Lib.RNG(AllHeliSpeed.prmDouble, 0.0D, 1000.0D);
       AllPlaneSpeed.prmDouble = MCH_Lib.RNG(AllPlaneSpeed.prmDouble, 0.0D, 1000.0D);
       NewFlightGravity.prmDouble = MCH_Lib.RNG(NewFlightGravity.prmDouble, 0.001D, 0.2D);
+      NewPlaneCameraDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistance.prmDouble, 2.0D, 40.0D);
+      NewPlaneCameraHeight.prmDouble = MCH_Lib.RNG(NewPlaneCameraHeight.prmDouble, -2.0D, 15.0D);
+      NewPlaneCameraSideOffset.prmDouble = MCH_Lib.RNG(NewPlaneCameraSideOffset.prmDouble, -10.0D, 10.0D);
+      NewPlaneCameraPositionSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPositionSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraRotationSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraRotationSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraRollInfluence.prmDouble = MCH_Lib.RNG(NewPlaneCameraRollInfluence.prmDouble, 0.0D, 1.0D);
       AllTankSpeed.prmDouble = MCH_Lib.RNG(AllTankSpeed.prmDouble, 0.0D, 1000.0D);
       AllShipSpeed.prmDouble = MCH_Lib.RNG(AllShipSpeed.prmDouble, 0.0D, 1000.0D);
       this.setBlockListFromString(bulletBreakableBlocks, BulletBreakableBlock.prmString);

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -22,6 +22,8 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
    public MCH_Key KeyEjectSeat;
    public MCH_Key KeyZoom;
    public MCH_Key[] Keys;
+   private final MCP_PlaneChaseCamera chaseCamera = new MCP_PlaneChaseCamera();
+   private boolean wasUsingChaseCamera = false;
 
 
    public MCP_ClientPlaneTickHandler(Minecraft minecraft, MCH_Config config) {
@@ -92,7 +94,17 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          }
 
          boolean hideHand = true;
-         if((!var9 || !var8.isAlwaysCameraView()) && !var8.getIsGunnerMode(var7) && var8.getCameraId() <= 0) {
+         boolean useChaseCamera = this.chaseCamera.shouldUse(super.mc, var7, var8, var9);
+         if(useChaseCamera) {
+            this.chaseCamera.update(super.mc, var7, var8);
+            var12.update(var8.camera);
+            W_Reflection.setThirdPersonDistance(0.1F);
+            MCH_Lib.setRenderViewEntity(var12);
+         } else if((!var9 || !var8.isAlwaysCameraView()) && !var8.getIsGunnerMode(var7) && var8.getCameraId() <= 0) {
+            if(this.wasUsingChaseCamera) {
+               this.chaseCamera.reset();
+               W_Reflection.setThirdPersonDistance(var8.thirdPersonDist);
+            }
             MCH_Lib.setRenderViewEntity(var7);
             if(!var9 && var8.getCurrentWeaponID(var7) < 0) {
                hideHand = false;
@@ -105,8 +117,13 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
             MCH_Lib.disableFirstPersonItemRender(var7.getCurrentEquippedItem());
          }
 
+         this.wasUsingChaseCamera = useChaseCamera;
          super.isRiding = true;
       } else {
+         if(this.wasUsingChaseCamera) {
+            this.chaseCamera.reset();
+            this.wasUsingChaseCamera = false;
+         }
          super.isRiding = false;
       }
 
@@ -118,6 +135,8 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          MCH_Lib.enableFirstPersonItemRender();
          MCH_Lib.setRenderViewEntity(var7);
          W_Reflection.setCameraRoll(0.0F);
+         this.chaseCamera.reset();
+         this.wasUsingChaseCamera = false;
       }
 
    }

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -1,0 +1,145 @@
+package mcheli.plane;
+
+import mcheli.MCH_Config;
+import mcheli.MCH_Lib;
+import mcheli.wrapper.W_Reflection;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MathHelper;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+
+public class MCP_PlaneChaseCamera {
+
+   private MCP_EntityPlane activePlane;
+   private int activeView = -1;
+   private double posX;
+   private double posY;
+   private double posZ;
+   private float yaw;
+   private float pitch;
+   private boolean initialized;
+
+   public boolean shouldUse(Minecraft mc, EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
+      return mc != null && mc.gameSettings != null && mc.gameSettings.thirdPersonView > 0 && player != null && plane != null
+            && isPilot && MCH_Config.EnableNewPlaneThirdPersonCamera.prmBool && plane.isNewFlightModelEnabled()
+            && !plane.getIsGunnerMode(player) && plane.getCameraId() <= 0 && !plane.isDestroyed();
+   }
+
+   public void reset() {
+      this.activePlane = null;
+      this.activeView = -1;
+      this.initialized = false;
+      W_Reflection.setCameraRoll(0.0F);
+   }
+
+   public void update(Minecraft mc, EntityPlayer player, MCP_EntityPlane plane) {
+      if(!this.initialized || this.activePlane != plane || this.activeView != mc.gameSettings.thirdPersonView) {
+         this.initialize(plane);
+      }
+
+      Vec3 focus = this.getCameraFocusPoint(plane);
+      Vec3 desired = this.computeDesiredCameraPosition(plane, focus);
+      if(MCH_Config.NewPlaneCameraCollision.prmBool) {
+         desired = this.adjustForCollision(plane, focus, desired);
+      }
+      this.debugCamera(plane, focus, desired);
+
+      float targetYaw = plane.getRotYaw();
+      float targetPitch = this.computeLookPitch(desired, focus);
+      this.yaw = this.smoothAngle(this.yaw, targetYaw, (float)MCH_Config.NewPlaneCameraRotationSmoothing.prmDouble);
+      this.pitch = this.smoothAngle(this.pitch, targetPitch, (float)MCH_Config.NewPlaneCameraRotationSmoothing.prmDouble);
+
+      double posSmoothing = MCH_Config.NewPlaneCameraPositionSmoothing.prmDouble;
+      this.posX = this.smooth(this.posX, desired.xCoord, posSmoothing);
+      this.posY = this.smooth(this.posY, desired.yCoord, posSmoothing);
+      this.posZ = this.smooth(this.posZ, desired.zCoord, posSmoothing);
+
+      plane.camera.prevRotationYaw = plane.camera.rotationYaw;
+      plane.camera.prevRotationPitch = plane.camera.rotationPitch;
+      plane.camera.rotationYaw = this.yaw;
+      plane.camera.rotationPitch = this.pitch;
+      plane.camera.setPosition(this.posX, this.posY, this.posZ);
+      W_Reflection.setCameraRoll(plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
+   }
+
+   private void initialize(MCP_EntityPlane plane) {
+      Vec3 focus = this.getCameraFocusPoint(plane);
+      Vec3 desired = this.computeDesiredCameraPosition(plane, focus);
+      this.posX = desired.xCoord;
+      this.posY = desired.yCoord;
+      this.posZ = desired.zCoord;
+      this.yaw = plane.getRotYaw();
+      this.pitch = this.computeLookPitch(desired, focus);
+      this.activePlane = plane;
+      this.activeView = Minecraft.getMinecraft().gameSettings.thirdPersonView;
+      this.initialized = true;
+   }
+
+   private Vec3 getCameraFocusPoint(MCP_EntityPlane plane) {
+      MCP_PlaneInfo info = plane.getPlaneInfo();
+      double ox = info != null?(double)info.newPlaneCameraFocusOffsetX:0.0D;
+      double oy = info != null?(double)info.newPlaneCameraFocusOffsetY:1.0D;
+      double oz = info != null?(double)info.newPlaneCameraFocusOffsetZ:0.0D;
+      float yawRad = plane.getRotYaw() * 0.017453292F;
+      double sin = (double)MathHelper.sin(yawRad);
+      double cos = (double)MathHelper.cos(yawRad);
+      double worldX = plane.posX + ox * cos - oz * sin;
+      double worldY = plane.posY + oy;
+      double worldZ = plane.posZ + ox * sin + oz * cos;
+      return Vec3.createVectorHelper(worldX, worldY, worldZ);
+   }
+
+   private Vec3 computeDesiredCameraPosition(MCP_EntityPlane plane, Vec3 focus) {
+      double distance = MCH_Config.NewPlaneCameraDistance.prmDouble;
+      double height = MCH_Config.NewPlaneCameraHeight.prmDouble;
+      double side = MCH_Config.NewPlaneCameraSideOffset.prmDouble;
+      Vec3 forward = MCH_Lib.Rot2Vec3(plane.getRotYaw(), 0.0F);
+      Vec3 right = MCH_Lib.Rot2Vec3(plane.getRotYaw() + 90.0F, 0.0F);
+      double x = focus.xCoord - forward.xCoord * distance + right.xCoord * side;
+      double y = focus.yCoord + height;
+      double z = focus.zCoord - forward.zCoord * distance + right.zCoord * side;
+      return Vec3.createVectorHelper(x, y, z);
+   }
+
+   private Vec3 adjustForCollision(MCP_EntityPlane plane, Vec3 focus, Vec3 desired) {
+      Vec3 start = focus.addVector(0.0D, 0.5D, 0.0D);
+      MovingObjectPosition hit = plane.worldObj.rayTraceBlocks(start, desired, false);
+      if(hit != null && hit.hitVec != null) {
+         Vec3 away = Vec3.createVectorHelper(start.xCoord - hit.hitVec.xCoord, start.yCoord - hit.hitVec.yCoord, start.zCoord - hit.hitVec.zCoord).normalize();
+         return hit.hitVec.addVector(away.xCoord * 0.35D, away.yCoord * 0.35D, away.zCoord * 0.35D);
+      }
+      return desired;
+   }
+
+   private float computeLookPitch(Vec3 camera, Vec3 focus) {
+      double dx = focus.xCoord - camera.xCoord;
+      double dy = focus.yCoord - camera.yCoord;
+      double dz = focus.zCoord - camera.zCoord;
+      double horizontal = Math.sqrt(dx * dx + dz * dz);
+      return MathHelper.clamp_float((float)(-Math.atan2(dy, horizontal) * 57.29577951308232D), -35.0F, 35.0F);
+   }
+
+   private void debugCamera(MCP_EntityPlane plane, Vec3 focus, Vec3 desired) {
+      if(MCH_Config.DebugFlightControl.prmBool) {
+         MCP_PlaneInfo info = plane.getPlaneInfo();
+         float ox = info != null?info.newPlaneCameraFocusOffsetX:0.0F;
+         float oy = info != null?info.newPlaneCameraFocusOffsetY:1.0F;
+         float oz = info != null?info.newPlaneCameraFocusOffsetZ:0.0F;
+         MCH_Lib.Log("[MCHeli][PlaneChaseCamera] entity=(%.3f, %.3f, %.3f) focus=(%.3f, %.3f, %.3f) offset=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f)",
+               new Object[]{Double.valueOf(plane.posX), Double.valueOf(plane.posY), Double.valueOf(plane.posZ),
+                     Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
+                     Float.valueOf(ox), Float.valueOf(oy), Float.valueOf(oz),
+                     Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord)});
+      }
+   }
+
+   private float smoothAngle(float current, float target, float smoothing) {
+      float delta = MathHelper.wrapAngleTo180_float(target - current);
+      return current + delta * MathHelper.clamp_float(smoothing, 0.01F, 1.0F);
+   }
+
+   private double smooth(double current, double target, double smoothing) {
+      return current + (target - current) * MCH_Lib.RNG(smoothing, 0.01D, 1.0D);
+   }
+}

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -77,6 +77,10 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
    public float newFlightCombatFlapDrag = 0.014F;
    public float newFlightCombatFlapControl = 0.14F;
    public float newFlightCombatFlapOverspeed = 0.72F;
+   /** Local-space focus point for the new third-person chase camera; yaw-rotated on the client. */
+   public float newPlaneCameraFocusOffsetX = 0.0F;
+   public float newPlaneCameraFocusOffsetY = 1.0F;
+   public float newPlaneCameraFocusOffsetZ = 0.0F;
    /** Absolute airspeed below which a fixed-wing plane can enter a stall. Zero derives it from StallSpeedFactor. */
    public float stallSpeed = 0.0F;
    /** Angle between the plane forward vector and velocity vector at which airflow separates. */
@@ -363,6 +367,12 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.newFlightCombatFlapControl = this.parseNewFlightFloat("NewFlightCombatFlapControl", data, 0.0F, 0.40F);
          } else if(item.equalsIgnoreCase("NewFlightCombatFlapOverspeed")) {
             this.newFlightCombatFlapOverspeed = this.parseNewFlightFloat("NewFlightCombatFlapOverspeed", data, 0.50F, 1.0F);
+         } else if(item.equalsIgnoreCase("NewPlaneCameraFocusOffsetX")) {
+            this.newPlaneCameraFocusOffsetX = this.parseNewFlightFloat("NewPlaneCameraFocusOffsetX", data, -50.0F, 50.0F);
+         } else if(item.equalsIgnoreCase("NewPlaneCameraFocusOffsetY")) {
+            this.newPlaneCameraFocusOffsetY = this.parseNewFlightFloat("NewPlaneCameraFocusOffsetY", data, -10.0F, 30.0F);
+         } else if(item.equalsIgnoreCase("NewPlaneCameraFocusOffsetZ")) {
+            this.newPlaneCameraFocusOffsetZ = this.parseNewFlightFloat("NewPlaneCameraFocusOffsetZ", data, -80.0F, 80.0F);
          } else if(item.equalsIgnoreCase("StallSpeed")) {
             this.stallSpeed = this.parseNewFlightFloat("StallSpeed", data, 0.0F, 2.0F);
          } else if(item.equalsIgnoreCase("CriticalAoA")) {


### PR DESCRIPTION
### Motivation

- Provide a smooth, configurable third-person chase camera for planes using the new flight/new mobility system and allow per-plane tuning of the camera focus point so the chase view follows a cockpit/centre-of-mass point instead of model pivots. 
- Expose client-side camera tuning options so server packs and players can adjust chase distance, height, smoothing, roll influence and collision behavior without changing flight physics or balance.

### Description

- Added a client-only chase camera implementation `MCP_PlaneChaseCamera` and integrated it into `MCP_ClientPlaneTickHandler` so it is used when `EnableNewPlaneThirdPersonCamera` is enabled and the plane opts into the new flight model. 
- Introduced global config parameters in `MCH_Config` (`EnableNewPlaneThirdPersonCamera`, `NewPlaneCameraDistance`, `NewPlaneCameraHeight`, `NewPlaneCameraSideOffset`, `NewPlaneCameraPositionSmoothing`, `NewPlaneCameraRotationSmoothing`, `NewPlaneCameraRollInfluence`, `NewPlaneCameraCollision`) with defaults and value clamping. 
- Added per-plane focus offsets `NewPlaneCameraFocusOffsetX/Y/Z` to `MCP_PlaneInfo` and parsing logic so pack plane text files can specify a local-space focus anchor; updated many plane config files to include sensible offsets. 
- Updated documentation (`docs/configuration.md`, `docs/vehicle-config-reference.md`, `docs/vehicle-config/planes.md`) to document the new camera settings and the per-plane focus keys and clarify the camera is visual-only and does not affect physics. 

### Testing

- Built the project with `./gradlew build` to validate compilation with the new classes and config entries, and the build completed successfully. 
- No additional automated unit tests were present or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a333ad770a48329bc70546954724db0)