### PR TITLE
Fix MCP_PlaneChaseCamera render ownership and dummy transform flicker

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,10 +165,13 @@ These options are client-side visual/readability settings for pilots flying plan
 | Config key | Default | Purpose |
 | --- | ---: | --- |
 | `EnableNewPlaneThirdPersonCamera` | `true` | Enables the smooth chase camera only for third-person pilot view in new-flight planes. |
-| `NewPlaneCameraDistance` | `9.0` | Camera distance in blocks behind the plane. |
+| `NewPlaneCameraDistance` | `16.0` | Camera distance in blocks behind the plane. |
+| `NewPlaneCameraMinDistance` | `8.0` | Minimum camera distance from the plane focus. |
+| `NewPlaneCameraMaxDistance` | `24.0` | Maximum camera distance from the plane focus. |
 | `NewPlaneCameraDebugDistance` | `0.0` | `DebugFlightControl`-only distance override; set to `20`-`30` to prove the render path is consuming the custom camera, or `0` to disable. |
-| `NewPlaneCameraHeight` | `2.4` | Vertical offset in blocks above the plane. |
+| `NewPlaneCameraHeight` | `4.0` | Vertical offset in blocks above the plane. |
 | `NewPlaneCameraSideOffset` | `0.0` | Optional left/right offset in blocks for off-center chase views. |
+| `NewPlaneCameraSpeedDistanceScale` | `0.08` | Extra chase distance per block/tick of aircraft speed. |
 | `NewPlaneCameraPositionSmoothing` | `0.22` | How quickly the camera position catches up to the desired chase point; higher values are snappier. |
 | `NewPlaneCameraRotationSmoothing` | `0.16` | How quickly camera yaw and pitch recenter behind the aircraft; higher values are snappier. |
 | `NewPlaneCameraRollInfluence` | `0.15` | How much aircraft roll is applied to the camera horizon, from `0.0` stable horizon to `1.0` full roll coupling. |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -585,7 +585,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                   debugFlightControl(var19, simDelta, (float)mouseDeltaX, (float)mouseDeltaY, (float)mouseRollDeltaX, (float)mouseRollDeltaY);
                }
 
-               var19.setupAllRiderRenderPosition(partialTicks, var17);
+               if(!(var19 instanceof MCP_EntityPlane) || !MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)var19, var17)) {
+                  var19.setupAllRiderRenderPosition(partialTicks, var17);
+               }
                double var29 = (double)MathHelper.sqrt_double(mouseRollDeltaX * mouseRollDeltaX + mouseRollDeltaY * mouseRollDeltaY);
                if(!var20 || var29 < getMaxStickLength() * 0.1D) {
                   mouseRollDeltaX = (double)mcheli.aircraft.MCH_FlightModel.decayPerTick((float)mouseRollDeltaX, 0.95F, simDelta);
@@ -601,7 +603,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                }
 
                W_Reflection.setCameraRoll(p);
-               this.correctViewEntityDummy(var17);
+               if(!(var19 instanceof MCP_EntityPlane) || !MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)var19, var17)) {
+                  this.correctViewEntityDummy(var17);
+               }
             } else {
                MCH_EntitySeat var21 = var17.ridingEntity instanceof MCH_EntitySeat?(MCH_EntitySeat)var17.ridingEntity:null;
                if(var21 != null && var21.getParent() != null) {
@@ -652,7 +656,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                      }
                   }
 
-                  var19.setupAllRiderRenderPosition(partialTicks, var17);
+                  if(!(var19 instanceof MCP_EntityPlane) || !MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)var19, var17)) {
+                     var19.setupAllRiderRenderPosition(partialTicks, var17);
+                  }
                   var19.setRotYaw(y);
                   //System.out.println("yaw9");
                   var19.setRotPitch(p);
@@ -669,7 +675,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                   }
 
                   W_Reflection.setCameraRoll(roll + revRoll);
-                  this.correctViewEntityDummy(var17);
+                  if(!(var19 instanceof MCP_EntityPlane) || !MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)var19, var17)) {
+                     this.correctViewEntityDummy(var17);
+                  }
                } else {
                   if(isRideAircraft) {
                      W_Reflection.setCameraRoll(0.0F);
@@ -695,7 +703,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             }
 
             MCH_ViewEntityDummy var24 = MCH_ViewEntityDummy.getInstance(var17.worldObj);
-            if(var24 != null) {
+            if(var24 != null && (!(var19 instanceof MCP_EntityPlane) || !MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)var19, var17))) {
                var24.rotationYaw = var17.rotationYaw;
                //System.out.println("yaw14");
                var24.prevRotationYaw = var17.prevRotationYaw;
@@ -747,7 +755,8 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       if (this.mc.thePlayer != null) {
          MCH_ClientTickHandlerBase.applyRotLimit((Entity)this.mc.thePlayer);
          MCH_ViewEntityDummy mCH_ViewEntityDummy = MCH_ViewEntityDummy.getInstance(this.mc.thePlayer.worldObj);
-         if (mCH_ViewEntityDummy != null) {
+         MCP_EntityPlane activePlane = this.mc.thePlayer.ridingEntity instanceof MCP_EntityPlane?(MCP_EntityPlane)this.mc.thePlayer.ridingEntity:null;
+         if (mCH_ViewEntityDummy != null && (activePlane == null || !MCP_PlaneChaseCamera.isRenderCameraActiveFor(activePlane, this.mc.thePlayer))) {
             ((Entity)mCH_ViewEntityDummy).rotationPitch = this.mc.thePlayer.rotationPitch;
             ((Entity)mCH_ViewEntityDummy).rotationYaw = this.mc.thePlayer.rotationYaw;
             ((Entity)mCH_ViewEntityDummy).prevRotationPitch = this.mc.thePlayer.prevRotationPitch;

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -159,9 +159,12 @@ public class MCH_Config {
    public static MCH_ConfigPrm DisplayHUDThirdPerson;
    public static MCH_ConfigPrm EnableNewPlaneThirdPersonCamera;
    public static MCH_ConfigPrm NewPlaneCameraDistance;
+   public static MCH_ConfigPrm NewPlaneCameraMinDistance;
+   public static MCH_ConfigPrm NewPlaneCameraMaxDistance;
    public static MCH_ConfigPrm NewPlaneCameraDebugDistance;
    public static MCH_ConfigPrm NewPlaneCameraHeight;
    public static MCH_ConfigPrm NewPlaneCameraSideOffset;
+   public static MCH_ConfigPrm NewPlaneCameraSpeedDistanceScale;
    public static MCH_ConfigPrm NewPlaneCameraPositionSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraRotationSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraRollInfluence;
@@ -408,14 +411,20 @@ public class MCH_Config {
       DisplayHUDThirdPerson = new MCH_ConfigPrm("DisplayHUDThirdPerson", false);
       EnableNewPlaneThirdPersonCamera = new MCH_ConfigPrm("EnableNewPlaneThirdPersonCamera", true);
       EnableNewPlaneThirdPersonCamera.desc = ";Client-only visual chase camera for third-person new-flight planes. Does not change flight physics, weapons, or HUD rendering.";
-      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 9.0D);
+      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 16.0D);
       NewPlaneCameraDistance.desc = ";Blocks behind the aircraft for the new third-person plane chase camera.";
+      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 8.0D);
+      NewPlaneCameraMinDistance.desc = ";Minimum blocks behind the aircraft for the new third-person plane chase camera.";
+      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 24.0D);
+      NewPlaneCameraMaxDistance.desc = ";Maximum blocks behind the aircraft for the new third-person plane chase camera.";
       NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 0.0D);
       NewPlaneCameraDebugDistance.desc = ";DebugFlightControl-only chase camera distance override. Set 20-30 to verify the render path consumes the custom camera; 0 disables.";
-      NewPlaneCameraHeight = new MCH_ConfigPrm("NewPlaneCameraHeight", 2.4D);
+      NewPlaneCameraHeight = new MCH_ConfigPrm("NewPlaneCameraHeight", 4.0D);
       NewPlaneCameraHeight.desc = ";Blocks above the aircraft for the new third-person plane chase camera.";
       NewPlaneCameraSideOffset = new MCH_ConfigPrm("NewPlaneCameraSideOffset", 0.0D);
       NewPlaneCameraSideOffset.desc = ";Optional horizontal side offset for the new third-person plane chase camera.";
+      NewPlaneCameraSpeedDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSpeedDistanceScale", 0.08D);
+      NewPlaneCameraSpeedDistanceScale.desc = ";Additional chase camera distance per block/tick of plane speed.";
       NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.22D);
       NewPlaneCameraPositionSmoothing.desc = ";How quickly the new plane chase camera position follows the desired point. Higher is snappier.";
       NewPlaneCameraRotationSmoothing = new MCH_ConfigPrm("NewPlaneCameraRotationSmoothing", 0.16D);
@@ -574,9 +583,12 @@ public class MCH_Config {
               DisplayHUDThirdPerson,
               EnableNewPlaneThirdPersonCamera,
               NewPlaneCameraDistance,
+              NewPlaneCameraMinDistance,
+              NewPlaneCameraMaxDistance,
               NewPlaneCameraDebugDistance,
               NewPlaneCameraHeight,
               NewPlaneCameraSideOffset,
+              NewPlaneCameraSpeedDistanceScale,
               NewPlaneCameraPositionSmoothing,
               NewPlaneCameraRotationSmoothing,
               NewPlaneCameraRollInfluence,
@@ -663,9 +675,12 @@ public class MCH_Config {
       AllPlaneSpeed.prmDouble = MCH_Lib.RNG(AllPlaneSpeed.prmDouble, 0.0D, 1000.0D);
       NewFlightGravity.prmDouble = MCH_Lib.RNG(NewFlightGravity.prmDouble, 0.001D, 0.2D);
       NewPlaneCameraDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistance.prmDouble, 2.0D, 40.0D);
+      NewPlaneCameraMinDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMinDistance.prmDouble, 1.0D, NewPlaneCameraDistance.prmDouble);
+      NewPlaneCameraMaxDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMaxDistance.prmDouble, NewPlaneCameraMinDistance.prmDouble, 40.0D);
       NewPlaneCameraDebugDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDebugDistance.prmDouble, 0.0D, 40.0D);
       NewPlaneCameraHeight.prmDouble = MCH_Lib.RNG(NewPlaneCameraHeight.prmDouble, -2.0D, 15.0D);
       NewPlaneCameraSideOffset.prmDouble = MCH_Lib.RNG(NewPlaneCameraSideOffset.prmDouble, -10.0D, 10.0D);
+      NewPlaneCameraSpeedDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSpeedDistanceScale.prmDouble, 0.0D, 1.0D);
       NewPlaneCameraPositionSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPositionSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraRotationSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraRotationSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraRollInfluence.prmDouble = MCH_Lib.RNG(NewPlaneCameraRollInfluence.prmDouble, 0.0D, 1.0D);

--- a/src/main/java/mcheli/MCH_ViewEntityDummy.java
+++ b/src/main/java/mcheli/MCH_ViewEntityDummy.java
@@ -1,6 +1,7 @@
 package mcheli;
 
 import mcheli.MCH_Camera;
+import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.wrapper.W_Session;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
@@ -50,9 +51,13 @@ public class MCH_ViewEntityDummy extends EntityPlayerSP {
          super.prevRotationPitch = super.rotationPitch;
          super.rotationYaw = camera.rotationYaw;
          super.rotationPitch = camera.rotationPitch;
+         MCP_PlaneChaseCamera.recordDummyTransformWrite("MCH_ViewEntityDummy.update", false);
          super.prevPosX = camera.posX;
          super.prevPosY = camera.posY;
          super.prevPosZ = camera.posZ;
+         super.lastTickPosX = camera.posX;
+         super.lastTickPosY = camera.posY;
+         super.lastTickPosZ = camera.posZ;
          super.posX = camera.posX;
          super.posY = camera.posY;
          super.posZ = camera.posZ;
@@ -61,6 +66,7 @@ public class MCH_ViewEntityDummy extends EntityPlayerSP {
 
    public static void setCameraPosition(double x, double y, double z) {
       if(instance != null) {
+         MCP_PlaneChaseCamera.recordDummyTransformWrite("MCH_ViewEntityDummy.setCameraPosition", false);
          instance.prevPosX = x;
          instance.prevPosY = y;
          instance.prevPosZ = z;

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5148,7 +5148,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          }
       }
 
-      if(this instanceof MCP_EntityPlane && MCP_PlaneChaseCamera.applyActiveRiderCamera((MCP_EntityPlane)this)) {
+      if(this instanceof MCP_EntityPlane && MCP_PlaneChaseCamera.isRenderCameraActiveFor((MCP_EntityPlane)this, player)) {
          return;
       }
 

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -83,8 +83,15 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
 
       if(var8 != null && var8.getAcInfo() != null) {
          this.update(var7, var8);
+         boolean useChaseCamera = this.chaseCamera.shouldUse(super.mc, var7, var8, var9);
+         if(!useChaseCamera && this.wasUsingChaseCamera) {
+            this.chaseCamera.reset();
+            W_Reflection.setThirdPersonDistance(var8.thirdPersonDist);
+         }
          MCH_ViewEntityDummy var12 = MCH_ViewEntityDummy.getInstance(super.mc.theWorld);
-         var12.update(var8.camera);
+         if(!useChaseCamera) {
+            var12.update(var8.camera);
+         }
          if(!inGUI) {
             if(!var8.isDestroyed()) {
                this.playerControl(var7, var8, var9);
@@ -94,17 +101,11 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          }
 
          boolean hideHand = true;
-         boolean useChaseCamera = this.chaseCamera.shouldUse(super.mc, var7, var8, var9);
          if(useChaseCamera) {
             this.chaseCamera.update(super.mc, var7, var8);
-            var12.update(var8.camera);
             W_Reflection.setThirdPersonDistance(0.1F);
             MCH_Lib.setRenderViewEntity(var12);
          } else if((!var9 || !var8.isAlwaysCameraView()) && !var8.getIsGunnerMode(var7) && var8.getCameraId() <= 0) {
-            if(this.wasUsingChaseCamera) {
-               this.chaseCamera.reset();
-               W_Reflection.setThirdPersonDistance(var8.thirdPersonDist);
-            }
             MCH_Lib.setRenderViewEntity(var7);
             if(!var9 && var8.getCurrentWeaponID(var7) < 0) {
                hideHand = false;

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -16,6 +16,13 @@ public class MCP_PlaneChaseCamera {
    private static MCP_PlaneChaseCamera activeCamera;
    private static MCP_EntityPlane activeRenderPlane;
    private static boolean consumedByRenderHook;
+   private static String currentOwner = "NONE";
+   private static String lastWriterMethod = "NONE";
+   private static int dummyTransformWrites;
+   private static boolean allowNextChaseDummyWrite;
+   private static double desiredX;
+   private static double desiredY;
+   private static double desiredZ;
    private long nextDebugTime;
 
    private MCP_EntityPlane activePlane;
@@ -57,7 +64,11 @@ public class MCP_PlaneChaseCamera {
       }
       activeCamera = this;
       activeRenderPlane = plane;
-      this.debugCamera(mc, plane, focus, desired, true);
+      desiredX = desired.xCoord;
+      desiredY = desired.yCoord;
+      desiredZ = desired.zCoord;
+      currentOwner = "CHASE";
+      dummyTransformWrites = 0;
       consumedByRenderHook = false;
 
       float targetYaw = plane.getRotYaw();
@@ -75,6 +86,7 @@ public class MCP_PlaneChaseCamera {
       plane.camera.rotationYaw = this.yaw;
       plane.camera.rotationPitch = this.pitch;
       plane.camera.setPosition(this.posX, this.posY, this.posZ);
+      this.debugCamera(mc, plane, focus, desired, true);
       W_Reflection.setCameraRoll(plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
    }
 
@@ -109,11 +121,22 @@ public class MCP_PlaneChaseCamera {
       if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugDistance.prmDouble > 0.0D) {
          return MCH_Config.NewPlaneCameraDebugDistance.prmDouble;
       }
-      return MCH_Config.NewPlaneCameraDistance.prmDouble;
+      return MCH_Lib.RNG(MCH_Config.NewPlaneCameraDistance.prmDouble, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
+   }
+
+   private double getCameraDistance(MCP_EntityPlane plane) {
+      if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugDistance.prmDouble > 0.0D) {
+         return MCH_Config.NewPlaneCameraDebugDistance.prmDouble;
+      }
+      double dx = plane.posX - plane.prevPosX;
+      double dy = plane.posY - plane.prevPosY;
+      double dz = plane.posZ - plane.prevPosZ;
+      double speed = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      return MCH_Lib.RNG(MCH_Config.NewPlaneCameraDistance.prmDouble + speed * MCH_Config.NewPlaneCameraSpeedDistanceScale.prmDouble, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
    }
 
    private Vec3 computeDesiredCameraPosition(MCP_EntityPlane plane, Vec3 focus) {
-      double distance = this.getCameraDistance();
+      double distance = this.getCameraDistance(plane);
       double height = MCH_Config.NewPlaneCameraHeight.prmDouble;
       double side = MCH_Config.NewPlaneCameraSideOffset.prmDouble;
       Vec3 forward = MCH_Lib.Rot2Vec3(plane.getRotYaw(), 0.0F);
@@ -147,7 +170,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    private Vec3 enforceMinimumDistance(Vec3 focus, Vec3 desired, Vec3 camera) {
-      double minDistance = Math.min(5.0D, Math.max(3.0D, this.getCameraDistance() * 0.35D));
+      double minDistance = MCH_Config.NewPlaneCameraMinDistance.prmDouble;
       if(this.distance(focus, camera) >= minDistance) {
          return camera;
       }
@@ -165,24 +188,15 @@ public class MCP_PlaneChaseCamera {
    private void debugCamera(Minecraft mc, MCP_EntityPlane plane, Vec3 focus, Vec3 desired, boolean shouldUse) {
       if(MCH_Config.DebugFlightControl.prmBool && System.currentTimeMillis() >= this.nextDebugTime) {
          this.nextDebugTime = System.currentTimeMillis() + 1000L;
-         MCP_PlaneInfo info = plane.getPlaneInfo();
-         Entity view = mc.renderViewEntity;
-         float ox = info != null?info.newPlaneCameraFocusOffsetX:0.0F;
-         float oy = info != null?info.newPlaneCameraFocusOffsetY:1.0F;
-         float oz = info != null?info.newPlaneCameraFocusOffsetZ:0.0F;
-         MCH_Lib.Log("[MCHeli][PlaneChaseCamera] desired=(%.3f, %.3f, %.3f) planeCamera=(%.3f, %.3f, %.3f yaw=%.2f pitch=%.2f) view=(%s %.3f, %.3f, %.3f) thirdPerson=%d cameraId=%d shouldUse=%s consumedLastFrame=%s config(distance=%.2f debugDistance=%.2f effectiveDistance=%.2f height=%.2f side=%.2f posSmooth=%.2f rotSmooth=%.2f collision=%s) entity=(%.3f, %.3f, %.3f) focus=(%.3f, %.3f, %.3f) offset=(%.3f, %.3f, %.3f)",
-               new Object[]{Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord),
-                     Double.valueOf(plane.camera.posX), Double.valueOf(plane.camera.posY), Double.valueOf(plane.camera.posZ),
-                     Float.valueOf(plane.camera.rotationYaw), Float.valueOf(plane.camera.rotationPitch),
-                     view != null?view.getClass().getSimpleName():"null",
-                     Double.valueOf(view != null?view.posX:0.0D), Double.valueOf(view != null?view.posY:0.0D), Double.valueOf(view != null?view.posZ:0.0D),
-                     Integer.valueOf(mc.gameSettings.thirdPersonView), Integer.valueOf(plane.getCameraId()), Boolean.valueOf(shouldUse), Boolean.valueOf(consumedByRenderHook),
-                     Double.valueOf(MCH_Config.NewPlaneCameraDistance.prmDouble), Double.valueOf(MCH_Config.NewPlaneCameraDebugDistance.prmDouble), Double.valueOf(this.getCameraDistance()),
-                     Double.valueOf(MCH_Config.NewPlaneCameraHeight.prmDouble), Double.valueOf(MCH_Config.NewPlaneCameraSideOffset.prmDouble),
-                     Double.valueOf(MCH_Config.NewPlaneCameraPositionSmoothing.prmDouble), Double.valueOf(MCH_Config.NewPlaneCameraRotationSmoothing.prmDouble), Boolean.valueOf(MCH_Config.NewPlaneCameraCollision.prmBool),
-                     Double.valueOf(plane.posX), Double.valueOf(plane.posY), Double.valueOf(plane.posZ),
-                     Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
-                     Float.valueOf(ox), Float.valueOf(oy), Float.valueOf(oz)});
+         MCH_ViewEntityDummy dummy = mc != null && mc.theWorld != null?MCH_ViewEntityDummy.getInstance(mc.theWorld):null;
+         double dist = dummy != null?this.distance(Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ), desired):0.0D;
+         MCH_Lib.Log("[MCHeli][PlaneChaseCamera] owner=%s lastWriter=%s writes=%d dummy=(%.3f, %.3f, %.3f) prev=(%.3f, %.3f, %.3f) lastTick=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) distanceToDesired=%.3f thirdPerson=%d collision=%s",
+               new Object[]{currentOwner, lastWriterMethod, Integer.valueOf(dummyTransformWrites),
+                     Double.valueOf(dummy != null?dummy.posX:0.0D), Double.valueOf(dummy != null?dummy.posY:0.0D), Double.valueOf(dummy != null?dummy.posZ:0.0D),
+                     Double.valueOf(dummy != null?dummy.prevPosX:0.0D), Double.valueOf(dummy != null?dummy.prevPosY:0.0D), Double.valueOf(dummy != null?dummy.prevPosZ:0.0D),
+                     Double.valueOf(dummy != null?dummy.lastTickPosX:0.0D), Double.valueOf(dummy != null?dummy.lastTickPosY:0.0D), Double.valueOf(dummy != null?dummy.lastTickPosZ:0.0D),
+                     Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord), Double.valueOf(dist),
+                     Integer.valueOf(mc.gameSettings.thirdPersonView), Boolean.valueOf(MCH_Config.NewPlaneCameraCollision.prmBool)});
       }
    }
 
@@ -194,6 +208,7 @@ public class MCP_PlaneChaseCamera {
       if(dummy == null) {
          return false;
       }
+      allowNextChaseDummyWrite = true;
       dummy.update(activeRenderPlane.camera);
       W_Reflection.setThirdPersonDistance(0.1F);
       MCH_Lib.setRenderViewEntity(dummy);
@@ -210,9 +225,34 @@ public class MCP_PlaneChaseCamera {
       if(dummy == null) {
          return false;
       }
+      allowNextChaseDummyWrite = true;
       dummy.update(plane.camera);
       consumedByRenderHook = true;
       return true;
+   }
+
+
+   public static boolean isRenderCameraActiveFor(MCP_EntityPlane plane, EntityPlayer player) {
+      return activeCamera != null && activeRenderPlane != null && activeRenderPlane == plane && player != null;
+   }
+
+   public static void recordDummyTransformWrite(String methodName, boolean chaseWriter) {
+      if(allowNextChaseDummyWrite) {
+         allowNextChaseDummyWrite = false;
+         chaseWriter = true;
+         methodName = methodName + "[CHASE]";
+      }
+      lastWriterMethod = methodName;
+      ++dummyTransformWrites;
+      if(chaseWriter) {
+         currentOwner = "CHASE";
+      }
+      if(activeCamera != null && !chaseWriter) {
+         currentOwner = methodName.indexOf("Gunner") >= 0?"GUNNER":"LEGACY_SEAT";
+         if(MCH_Config.DebugFlightControl.prmBool) {
+            MCH_Lib.Log("[MCHeli] WARNING: non-chase camera writer while chase camera active: %s", new Object[]{methodName});
+         }
+      }
    }
 
    private float smoothAngle(float current, float target, float smoothing) {


### PR DESCRIPTION
### Motivation
- The chase camera was flickering because more than one render/tick path could write `MCH_ViewEntityDummy` / the active render view in the same frame, and interpolation fields could remain inconsistent causing visual smear. 
- The intent is to make the chase camera the single owner of dummy render transforms while active and to add diagnostics to prove ownership and catch non-chase writers. 

### Description
- Add ownership/tracking to `MCP_PlaneChaseCamera`: `currentOwner`, `lastWriterMethod`, `dummyTransformWrites`, `allowNextChaseDummyWrite`, plus `isRenderCameraActiveFor(...)` and `recordDummyTransformWrite(...)` for centralized guard and logging. 
- Ensure chase camera is the only writer by setting `allowNextChaseDummyWrite` when the chase camera path applies the dummy and short-circuiting legacy seat/rider camera paths using `isRenderCameraActiveFor(...)` in `MCH_ClientCommonTickHandler`, `MCH_EntityBaseVehicle.setupAllRiderRenderPosition(...)`, and `MCP_ClientPlaneTickHandler`. 
- Make dummy writes consistent by updating `MCH_ViewEntityDummy.update(...)` and `MCH_ViewEntityDummy.setCameraPosition(...)` to set `posX/Y/Z`, `prevPosX/Y/Z`, and `lastTickPosX/Y/Z` together and call `recordDummyTransformWrite(...)`. 
- Add debug diagnostics printed once per second under `DebugFlightControl` showing `owner`, `lastWriter`, `writes` count, dummy current/prev/lastTick positions, desired chase position, and distance to desired, and emit a strict warning whenever a non-chase writer writes while chase is active. 
- Adjust chase camera defaults and controls: increase `NewPlaneCameraDistance` to `16.0`, `NewPlaneCameraHeight` to `4.0`, add `NewPlaneCameraMinDistance`=`8.0`, `NewPlaneCameraMaxDistance`=`24.0`, and add `NewPlaneCameraSpeedDistanceScale`=`0.08` with documentation updates. 

### Testing
- Ran `git diff --check` to verify whitespace and trivial diff issues, which succeeded. 
- Ran `find . -name '*.class' -print | head -5` to confirm no compiled artifacts were added, which succeeded. 
- No Java/Gradle compilation was performed per instructions (so runtime behavior not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3346b058608329985e3b38b9d18513)