### PR TITLE
Prevent double third-person offset for plane chase camera

### DIFF
--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -19,6 +19,7 @@ import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.lweapon.MCH_ClientLightWeaponTickHandler;
 import mcheli.multiplay.MCH_GuiTargetMarker;
 import mcheli.particles.MCH_ParticlesUtil;
+import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.tool.rangefinder.MCH_ItemRangeFinder;
 import mcheli.wrapper.W_ClientEventHook;
 import mcheli.wrapper.W_Reflection;
@@ -183,8 +184,10 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
       switch (event.phase) {
          case START:
             smoothing = event.renderTickTime;
+            MCP_PlaneChaseCamera.beginOrientCameraBypass(Minecraft.getMinecraft(), event.renderTickTime);
             break;
          case END:
+            MCP_PlaneChaseCamera.endOrientCameraBypass(Minecraft.getMinecraft());
             break;
       }
    }

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -103,7 +103,9 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          boolean hideHand = true;
          if(useChaseCamera) {
             this.chaseCamera.update(super.mc, var7, var8);
-            W_Reflection.setThirdPersonDistance(0.1F);
+            W_Reflection.setThirdPersonDistance(0.0F);
+            W_Reflection.setThirdPersonDistanceTemp(0.0F);
+            super.mc.renderViewEntity = var12;
             MCH_Lib.setRenderViewEntity(var12);
          } else if((!var9 || !var8.isAlwaysCameraView()) && !var8.getIsGunnerMode(var7) && var8.getCameraId() <= 0) {
             MCH_Lib.setRenderViewEntity(var7);

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -18,6 +18,9 @@ public class MCP_PlaneChaseCamera {
    private static boolean consumedByRenderHook;
    private static String currentOwner = "NONE";
    private static String lastWriterMethod = "NONE";
+   private static long nextOrientDebugTime;
+   private static int savedThirdPersonView;
+   private static boolean renderTickBypassActive;
    private static int dummyTransformWrites;
    private static boolean allowNextChaseDummyWrite;
    private static double desiredX;
@@ -213,8 +216,9 @@ public class MCP_PlaneChaseCamera {
       activeDummy = dummy;
       allowNextChaseDummyWrite = true;
       dummy.update(activeRenderPlane.camera);
-      W_Reflection.setThirdPersonDistance(0.1F);
-      mc.setRenderViewEntity(dummy);
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.renderViewEntity = dummy;
       MCH_Lib.setRenderViewEntity(dummy);
       W_Reflection.setCameraRoll(activeRenderPlane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
       consumedByRenderHook = true;
@@ -264,7 +268,9 @@ public class MCP_PlaneChaseCamera {
       if(mc.renderViewEntity != dummy) {
          MCH_Lib.Log("[MCHeli] WARNING: chase camera lost renderViewEntity ownership to %s", new Object[]{mc.renderViewEntity != null?mc.renderViewEntity.getClass().getName():"null"});
       }
-      mc.setRenderViewEntity(dummy);
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.renderViewEntity = dummy;
       MCH_Lib.setRenderViewEntity(dummy);
       logRenderViewEntityState(mc, dummy, stage);
       checkRenderViewEntityOwnership(mc, dummy);
@@ -295,6 +301,45 @@ public class MCP_PlaneChaseCamera {
                   Double.valueOf(desiredX), Double.valueOf(desiredY), Double.valueOf(desiredZ)});
    }
 
+
+   public static void beginOrientCameraBypass(Minecraft mc, float partialTicks) {
+      if(activeCamera == null || activeRenderPlane == null || activeDummy == null || mc == null || mc.gameSettings == null) {
+         return;
+      }
+      float beforeDistance = W_Reflection.getThirdPersonDistance();
+      float beforeDistanceTemp = W_Reflection.getThirdPersonDistanceTemp();
+      savedThirdPersonView = mc.gameSettings.thirdPersonView;
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.gameSettings.thirdPersonView = 0;
+      renderTickBypassActive = true;
+      logOrientCameraBypass(mc, partialTicks, beforeDistance, beforeDistanceTemp, W_Reflection.getThirdPersonDistance(), W_Reflection.getThirdPersonDistanceTemp(), true);
+   }
+
+   public static void endOrientCameraBypass(Minecraft mc) {
+      if(!renderTickBypassActive || mc == null || mc.gameSettings == null) {
+         return;
+      }
+      mc.gameSettings.thirdPersonView = savedThirdPersonView;
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      renderTickBypassActive = false;
+   }
+
+   private static void logOrientCameraBypass(Minecraft mc, float partialTicks, float beforeDistance, float beforeDistanceTemp, float afterDistance, float afterDistanceTemp, boolean bypassApplied) {
+      if(!MCH_Config.DebugFlightControl.prmBool || System.currentTimeMillis() < nextOrientDebugTime) {
+         return;
+      }
+      nextOrientDebugTime = System.currentTimeMillis() + 1000L;
+      Entity view = mc.renderViewEntity;
+      double camX = view != null?view.prevPosX + (view.posX - view.prevPosX) * (double)partialTicks:0.0D;
+      double camY = view != null?view.prevPosY + (view.posY - view.prevPosY) * (double)partialTicks:0.0D;
+      double camZ = view != null?view.prevPosZ + (view.posZ - view.prevPosZ) * (double)partialTicks:0.0D;
+      MCH_Lib.Log("[MCHeli][PlaneChaseCamera][orientCamera] entered=true thirdPersonView=%d thirdPersonDistanceBefore=%.3f thirdPersonDistanceTempBefore=%.3f thirdPersonDistanceAfter=%.3f thirdPersonDistanceTempAfter=%.3f renderView=%s pos=(%.3f, %.3f, %.3f) cameraWorld=(%.3f, %.3f, %.3f) bypassApplied=%s",
+            new Object[]{Integer.valueOf(savedThirdPersonView), Float.valueOf(beforeDistance), Float.valueOf(beforeDistanceTemp), Float.valueOf(afterDistance), Float.valueOf(afterDistanceTemp),
+                  view != null?view.getClass().getName():"null", Double.valueOf(view != null?view.posX:0.0D), Double.valueOf(view != null?view.posY:0.0D), Double.valueOf(view != null?view.posZ:0.0D),
+                  Double.valueOf(camX), Double.valueOf(camY), Double.valueOf(camZ), Boolean.valueOf(bypassApplied)});
+   }
 
    public static boolean isRenderCameraActiveFor(MCP_EntityPlane plane, EntityPlayer player) {
       return activeCamera != null && activeRenderPlane != null && activeRenderPlane == plane && player != null;

--- a/src/main/java/mcheli/wrapper/W_Reflection.java
+++ b/src/main/java/mcheli/wrapper/W_Reflection.java
@@ -52,14 +52,31 @@ public class W_Reflection {
 	   }
 
 	   public static void setThirdPersonDistance(float dist) {
-	      if((double)dist >= 0.1D) {
-	         try {
-	            Minecraft e = Minecraft.getMinecraft();
-	            ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78490_B", "thirdPersonDistance"});
-	         } catch (Exception var2) {
-	            var2.printStackTrace();
-	         }
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78490_B", "thirdPersonDistance"});
+	      } catch (Exception var2) {
+	         var2.printStackTrace();
+	      }
+	   }
 
+
+	   public static void setThirdPersonDistanceTemp(float dist) {
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78491_C", "thirdPersonDistanceTemp"});
+	      } catch (Exception var2) {
+	         var2.printStackTrace();
+	      }
+	   }
+
+	   public static float getThirdPersonDistanceTemp() {
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         return ((Float)ObfuscationReflectionHelper.getPrivateValue(EntityRenderer.class, e.entityRenderer, new String[]{"field_78491_C", "thirdPersonDistanceTemp"})).floatValue();
+	      } catch (Exception var1) {
+	         var1.printStackTrace();
+	         return getThirdPersonDistance();
 	      }
 	   }
 


### PR DESCRIPTION
### Motivation
- Fix live chase-camera mismatch where vanilla/MCP `orientCamera` applies an extra third-person orbit/offset around the chase dummy, causing live gameplay camera to differ from the pause-menu view.

### Description
- Treat the chase dummy as a true first-person render target by zeroing both `thirdPersonDistance` and `thirdPersonDistanceTemp` via new reflection helpers and assigning `mc.renderViewEntity` directly for MC 1.7.10 instead of relying on a non-zero offset.
- Add `setThirdPersonDistanceTemp` and `getThirdPersonDistanceTemp` helpers and allow `setThirdPersonDistance(0.0F)` in `W_Reflection` so the renderer can be forced to zero distance.
- Introduce `beginOrientCameraBypass` / `endOrientCameraBypass` in `MCP_PlaneChaseCamera` and call them from the render-tick hook to temporarily mask `gameSettings.thirdPersonView` during the render pass, preventing vanilla `orientCamera` from applying a second third-person backtrace.
- Add once-per-second debug logging in the new orient-camera bypass path showing `thirdPersonView`, `thirdPersonDistance`/`thirdPersonDistanceTemp` before and after, `renderViewEntity` class/pos, interpolated camera world position, and whether the bypass was applied.

### Testing
- Ran `git diff --check` to validate the working tree and formatting; the check completed without reported diffs.
- Attempted `./gradlew test` but the wrapper was not executable in this checkout so it did not run.
- Attempted `bash ./gradlew test` but Gradle distribution download was blocked by the environment proxy (HTTP 403), so unit/integration tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334d9077288329abe5dd71542f1978)