### PR TITLE
Improve plane chase camera: dummy no-collision, collision-escape, debug & third-person handling

### DIFF
--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -19,6 +19,7 @@ import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.lweapon.MCH_ClientLightWeaponTickHandler;
 import mcheli.multiplay.MCH_GuiTargetMarker;
 import mcheli.particles.MCH_ParticlesUtil;
+import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.tool.rangefinder.MCH_ItemRangeFinder;
 import mcheli.wrapper.W_ClientEventHook;
 import mcheli.wrapper.W_Reflection;
@@ -183,8 +184,10 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
       switch (event.phase) {
          case START:
             smoothing = event.renderTickTime;
+            MCP_PlaneChaseCamera.beginOrientCameraBypass(Minecraft.getMinecraft(), event.renderTickTime);
             break;
          case END:
+            MCP_PlaneChaseCamera.endOrientCameraBypass(Minecraft.getMinecraft());
             break;
       }
    }

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -162,6 +162,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm NewPlaneCameraMinDistance;
    public static MCH_ConfigPrm NewPlaneCameraMaxDistance;
    public static MCH_ConfigPrm NewPlaneCameraDebugDistance;
+   public static MCH_ConfigPrm NewPlaneCameraDebugAbovePlane;
    public static MCH_ConfigPrm NewPlaneCameraHeight;
    public static MCH_ConfigPrm NewPlaneCameraSideOffset;
    public static MCH_ConfigPrm NewPlaneCameraSpeedDistanceScale;
@@ -411,14 +412,16 @@ public class MCH_Config {
       DisplayHUDThirdPerson = new MCH_ConfigPrm("DisplayHUDThirdPerson", false);
       EnableNewPlaneThirdPersonCamera = new MCH_ConfigPrm("EnableNewPlaneThirdPersonCamera", true);
       EnableNewPlaneThirdPersonCamera.desc = ";Client-only visual chase camera for third-person new-flight planes. Does not change flight physics, weapons, or HUD rendering.";
-      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 16.0D);
+      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 18.0D);
       NewPlaneCameraDistance.desc = ";Blocks behind the aircraft for the new third-person plane chase camera.";
-      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 8.0D);
+      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 12.0D);
       NewPlaneCameraMinDistance.desc = ";Minimum blocks behind the aircraft for the new third-person plane chase camera.";
-      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 24.0D);
+      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 35.0D);
       NewPlaneCameraMaxDistance.desc = ";Maximum blocks behind the aircraft for the new third-person plane chase camera.";
-      NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 0.0D);
-      NewPlaneCameraDebugDistance.desc = ";DebugFlightControl-only chase camera distance override. Set 20-30 to verify the render path consumes the custom camera; 0 disables.";
+      NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 40.0D);
+      NewPlaneCameraDebugDistance.desc = ";DebugFlightControl-only chase camera distance override. Set 40 to verify the render path consumes the custom camera; 0 disables.";
+      NewPlaneCameraDebugAbovePlane = new MCH_ConfigPrm("NewPlaneCameraDebugAbovePlane", false);
+      NewPlaneCameraDebugAbovePlane.desc = ";DebugFlightControl-only hard test: places the chase dummy at plane.posY + 20 with third-person distance zeroed.";
       NewPlaneCameraHeight = new MCH_ConfigPrm("NewPlaneCameraHeight", 4.0D);
       NewPlaneCameraHeight.desc = ";Blocks above the aircraft for the new third-person plane chase camera.";
       NewPlaneCameraSideOffset = new MCH_ConfigPrm("NewPlaneCameraSideOffset", 0.0D);
@@ -586,6 +589,7 @@ public class MCH_Config {
               NewPlaneCameraMinDistance,
               NewPlaneCameraMaxDistance,
               NewPlaneCameraDebugDistance,
+              NewPlaneCameraDebugAbovePlane,
               NewPlaneCameraHeight,
               NewPlaneCameraSideOffset,
               NewPlaneCameraSpeedDistanceScale,

--- a/src/main/java/mcheli/MCH_ViewEntityDummy.java
+++ b/src/main/java/mcheli/MCH_ViewEntityDummy.java
@@ -5,6 +5,8 @@ import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.wrapper.W_Session;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
 
 public class MCH_ViewEntityDummy extends EntityPlayerSP {
@@ -61,6 +63,7 @@ public class MCH_ViewEntityDummy extends EntityPlayerSP {
          super.posX = camera.posX;
          super.posY = camera.posY;
          super.posZ = camera.posZ;
+         this.configureNoCollisionChaseDummy();
       }
    }
 
@@ -76,7 +79,32 @@ public class MCH_ViewEntityDummy extends EntityPlayerSP {
          instance.posX = x;
          instance.posY = y;
          instance.posZ = z;
+         instance.configureNoCollisionChaseDummy();
       }
+   }
+
+   public void configureNoCollisionChaseDummy() {
+      super.noClip = true;
+      super.ridingEntity = null;
+      super.riddenByEntity = null;
+      this.setSize(0.01F, 0.01F);
+      super.boundingBox.setBounds(super.posX - 0.005D, super.posY - 0.005D, super.posZ - 0.005D, super.posX + 0.005D, super.posY + 0.005D, super.posZ + 0.005D);
+   }
+
+   public AxisAlignedBB getCollisionBox(Entity entity) {
+      return null;
+   }
+
+   public AxisAlignedBB getBoundingBox() {
+      return super.boundingBox;
+   }
+
+   public boolean canBePushed() {
+      return false;
+   }
+
+   public boolean canBeCollidedWith() {
+      return false;
    }
 
    public float getFOVMultiplier() {

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -103,7 +103,9 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          boolean hideHand = true;
          if(useChaseCamera) {
             this.chaseCamera.update(super.mc, var7, var8);
-            W_Reflection.setThirdPersonDistance(0.1F);
+            W_Reflection.setThirdPersonDistance(0.0F);
+            W_Reflection.setThirdPersonDistanceTemp(0.0F);
+            super.mc.renderViewEntity = var12;
             MCH_Lib.setRenderViewEntity(var12);
          } else if((!var9 || !var8.isAlwaysCameraView()) && !var8.getIsGunnerMode(var7) && var8.getCameraId() <= 0) {
             MCH_Lib.setRenderViewEntity(var7);

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -3,10 +3,12 @@ package mcheli.plane;
 import mcheli.MCH_Config;
 import mcheli.MCH_Lib;
 import mcheli.MCH_ViewEntityDummy;
+import mcheli.aircraft.MCH_BoundingBox;
 import mcheli.wrapper.W_Reflection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -18,6 +20,9 @@ public class MCP_PlaneChaseCamera {
    private static boolean consumedByRenderHook;
    private static String currentOwner = "NONE";
    private static String lastWriterMethod = "NONE";
+   private static long nextOrientDebugTime;
+   private static int savedThirdPersonView;
+   private static boolean renderTickBypassActive;
    private static int dummyTransformWrites;
    private static boolean allowNextChaseDummyWrite;
    private static double desiredX;
@@ -34,6 +39,8 @@ public class MCP_PlaneChaseCamera {
    private float yaw;
    private float pitch;
    private boolean initialized;
+   private boolean lastCollisionAdjusted;
+   private String lastCollisionHit = "none";
 
    public boolean shouldUse(Minecraft mc, EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
       return mc != null && mc.gameSettings != null && mc.gameSettings.thirdPersonView > 0 && player != null && plane != null
@@ -61,8 +68,15 @@ public class MCP_PlaneChaseCamera {
 
       Vec3 focus = this.getCameraFocusPoint(plane);
       Vec3 desired = this.computeDesiredCameraPosition(plane, focus);
-      if(MCH_Config.NewPlaneCameraCollision.prmBool) {
-         desired = this.adjustForCollision(plane, focus, desired);
+      if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugAbovePlane.prmBool) {
+         desired = Vec3.createVectorHelper(plane.posX, plane.posY + 20.0D, plane.posZ);
+         this.lastCollisionAdjusted = false;
+         this.lastCollisionHit = "debugAbovePlane";
+      } else {
+         if(MCH_Config.NewPlaneCameraCollision.prmBool) {
+            desired = this.adjustForCollision(plane, focus, desired);
+         }
+         desired = this.escapeAircraftCollision(plane, focus, desired);
       }
       activeCamera = this;
       activeRenderPlane = plane;
@@ -88,6 +102,14 @@ public class MCP_PlaneChaseCamera {
       plane.camera.rotationYaw = this.yaw;
       plane.camera.rotationPitch = this.pitch;
       plane.camera.setPosition(this.posX, this.posY, this.posZ);
+      if(mc != null && mc.theWorld != null) {
+         MCH_ViewEntityDummy dummy = MCH_ViewEntityDummy.getInstance(mc.theWorld);
+         if(dummy != null) {
+            activeDummy = dummy;
+            allowNextChaseDummyWrite = true;
+            dummy.update(plane.camera);
+         }
+      }
       this.debugCamera(mc, plane, focus, desired, true);
       W_Reflection.setCameraRoll(plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
    }
@@ -152,15 +174,80 @@ public class MCP_PlaneChaseCamera {
    private Vec3 adjustForCollision(MCP_EntityPlane plane, Vec3 focus, Vec3 desired) {
       Vec3 start = focus.addVector(0.0D, 0.5D, 0.0D);
       MovingObjectPosition hit = plane.worldObj.rayTraceBlocks(start, desired, false);
+      this.lastCollisionAdjusted = false;
+      this.lastCollisionHit = "none";
       if(hit != null && hit.hitVec != null) {
          double hitDistance = this.distance(start, hit.hitVec);
          if(hitDistance > 1.0D) {
             Vec3 away = Vec3.createVectorHelper(start.xCoord - hit.hitVec.xCoord, start.yCoord - hit.hitVec.yCoord, start.zCoord - hit.hitVec.zCoord).normalize();
             Vec3 adjusted = hit.hitVec.addVector(away.xCoord * 0.35D, away.yCoord * 0.35D, away.zCoord * 0.35D);
+            this.lastCollisionAdjusted = true;
+            this.lastCollisionHit = "block@" + hit.blockX + "," + hit.blockY + "," + hit.blockZ;
             return this.enforceMinimumDistance(focus, desired, adjusted);
          }
       }
       return this.enforceMinimumDistance(focus, desired, desired);
+   }
+
+   private Vec3 escapeAircraftCollision(MCP_EntityPlane plane, Vec3 focus, Vec3 desired) {
+      Vec3 escaped = desired;
+      String hit = this.getAircraftCollisionHit(plane, escaped);
+      if(hit.equals("none")) {
+         return escaped;
+      }
+      Vec3 chaseDirection = Vec3.createVectorHelper(desired.xCoord - focus.xCoord, desired.yCoord - focus.yCoord, desired.zCoord - focus.zCoord);
+      if(chaseDirection.lengthVector() < 1.0E-4D) {
+         chaseDirection = MCH_Lib.Rot2Vec3(plane.getRotYaw(), 0.0F);
+      } else {
+         chaseDirection = chaseDirection.normalize();
+      }
+      for(int i = 0; i < 64 && !hit.equals("none"); ++i) {
+         escaped = escaped.addVector(chaseDirection.xCoord, chaseDirection.yCoord, chaseDirection.zCoord);
+         hit = this.getAircraftCollisionHit(plane, escaped);
+      }
+      this.lastCollisionAdjusted = true;
+      this.lastCollisionHit = hit.equals("none")?"aircraftEscape":hit;
+      return this.enforceMinimumDistance(focus, desired, escaped);
+   }
+
+   private String getAircraftCollisionHit(MCP_EntityPlane plane, Vec3 point) {
+      if(this.isPointInsideAabb(point, plane.boundingBox)) {
+         return "planeBB";
+      }
+      MCH_BoundingBox[] boxes = plane.getCalculatedExtraBoundingBoxes();
+      for(int i = 0; i < boxes.length; ++i) {
+         MCH_BoundingBox box = boxes[i];
+         if(box != null && this.isPointInsideAabb(point, box.boundingBox)) {
+            return "partBB#" + i;
+         }
+      }
+      return "none";
+   }
+
+   private boolean isPointInsideAabb(Vec3 point, AxisAlignedBB bb) {
+      return bb != null && point.xCoord >= bb.minX && point.xCoord <= bb.maxX && point.yCoord >= bb.minY && point.yCoord <= bb.maxY && point.zCoord >= bb.minZ && point.zCoord <= bb.maxZ;
+   }
+
+   private double distanceToAabb(Vec3 point, AxisAlignedBB bb) {
+      if(bb == null) {
+         return Double.MAX_VALUE;
+      }
+      double dx = point.xCoord < bb.minX?bb.minX - point.xCoord:(point.xCoord > bb.maxX?point.xCoord - bb.maxX:0.0D);
+      double dy = point.yCoord < bb.minY?bb.minY - point.yCoord:(point.yCoord > bb.maxY?point.yCoord - bb.maxY:0.0D);
+      double dz = point.zCoord < bb.minZ?bb.minZ - point.zCoord:(point.zCoord > bb.maxZ?point.zCoord - bb.maxZ:0.0D);
+      return Math.sqrt(dx * dx + dy * dy + dz * dz);
+   }
+
+   private double nearestAircraftBoxDistance(MCP_EntityPlane plane, Vec3 point) {
+      double nearest = this.distanceToAabb(point, plane.boundingBox);
+      MCH_BoundingBox[] boxes = plane.getCalculatedExtraBoundingBoxes();
+      for(int i = 0; i < boxes.length; ++i) {
+         MCH_BoundingBox box = boxes[i];
+         if(box != null) {
+            nearest = Math.min(nearest, this.distanceToAabb(point, box.boundingBox));
+         }
+      }
+      return nearest;
    }
 
    private float computeLookPitch(Vec3 camera, Vec3 focus) {
@@ -192,13 +279,20 @@ public class MCP_PlaneChaseCamera {
          this.nextDebugTime = System.currentTimeMillis() + 1000L;
          MCH_ViewEntityDummy dummy = mc != null && mc.theWorld != null?MCH_ViewEntityDummy.getInstance(mc.theWorld):null;
          double dist = dummy != null?this.distance(Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ), desired):0.0D;
-         MCH_Lib.Log("[MCHeli][PlaneChaseCamera] owner=%s lastWriter=%s writes=%d dummy=(%.3f, %.3f, %.3f) prev=(%.3f, %.3f, %.3f) lastTick=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) distanceToDesired=%.3f thirdPerson=%d collision=%s",
-               new Object[]{currentOwner, lastWriterMethod, Integer.valueOf(dummyTransformWrites),
+         boolean dummyInsidePlaneBB = dummy != null && this.isPointInsideAabb(Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ), plane.boundingBox);
+         boolean dummyInsidePartBB = dummy != null && !this.getAircraftCollisionHit(plane, Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ)).equals("none") && !dummyInsidePlaneBB;
+         double nearestBoxDistance = this.nearestAircraftBoxDistance(plane, desired);
+         MCH_Lib.Log("CHASE_CAM: focus=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) finalDummy=(%.3f, %.3f, %.3f) renderView=(%.3f, %.3f, %.3f) planeBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyInsidePlaneBB=%s dummyInsidePartBB=%s collisionAdjusted=%s collisionHit=%s nearestAircraftBoxDistance=%.3f thirdPersonViewMasked=%s distanceToFocus=%.3f owner=%s lastWriter=%s writes=%d thirdPerson=%d",
+               new Object[]{Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
+                     Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord),
                      Double.valueOf(dummy != null?dummy.posX:0.0D), Double.valueOf(dummy != null?dummy.posY:0.0D), Double.valueOf(dummy != null?dummy.posZ:0.0D),
-                     Double.valueOf(dummy != null?dummy.prevPosX:0.0D), Double.valueOf(dummy != null?dummy.prevPosY:0.0D), Double.valueOf(dummy != null?dummy.prevPosZ:0.0D),
-                     Double.valueOf(dummy != null?dummy.lastTickPosX:0.0D), Double.valueOf(dummy != null?dummy.lastTickPosY:0.0D), Double.valueOf(dummy != null?dummy.lastTickPosZ:0.0D),
-                     Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord), Double.valueOf(dist),
-                     Integer.valueOf(mc.gameSettings.thirdPersonView), Boolean.valueOf(MCH_Config.NewPlaneCameraCollision.prmBool)});
+                     Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posX:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posY:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posZ:0.0D),
+                     Double.valueOf(plane.boundingBox != null?plane.boundingBox.minX:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minY:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minZ:0.0D),
+                     Double.valueOf(plane.boundingBox != null?plane.boundingBox.maxX:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.maxY:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.maxZ:0.0D),
+                     Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.minX:0.0D), Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.minY:0.0D), Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.minZ:0.0D),
+                     Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.maxX:0.0D), Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.maxY:0.0D), Double.valueOf(dummy != null && dummy.boundingBox != null?dummy.boundingBox.maxZ:0.0D),
+                     Boolean.valueOf(dummyInsidePlaneBB), Boolean.valueOf(dummyInsidePartBB), Boolean.valueOf(this.lastCollisionAdjusted), this.lastCollisionHit, Double.valueOf(nearestBoxDistance), Boolean.valueOf(renderTickBypassActive), Double.valueOf(this.distance(focus, desired)),
+                     currentOwner, lastWriterMethod, Integer.valueOf(dummyTransformWrites), Integer.valueOf(mc.gameSettings.thirdPersonView)});
       }
    }
 
@@ -213,8 +307,9 @@ public class MCP_PlaneChaseCamera {
       activeDummy = dummy;
       allowNextChaseDummyWrite = true;
       dummy.update(activeRenderPlane.camera);
-      W_Reflection.setThirdPersonDistance(0.1F);
-      mc.setRenderViewEntity(dummy);
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.renderViewEntity = dummy;
       MCH_Lib.setRenderViewEntity(dummy);
       W_Reflection.setCameraRoll(activeRenderPlane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
       consumedByRenderHook = true;
@@ -264,7 +359,9 @@ public class MCP_PlaneChaseCamera {
       if(mc.renderViewEntity != dummy) {
          MCH_Lib.Log("[MCHeli] WARNING: chase camera lost renderViewEntity ownership to %s", new Object[]{mc.renderViewEntity != null?mc.renderViewEntity.getClass().getName():"null"});
       }
-      mc.setRenderViewEntity(dummy);
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.renderViewEntity = dummy;
       MCH_Lib.setRenderViewEntity(dummy);
       logRenderViewEntityState(mc, dummy, stage);
       checkRenderViewEntityOwnership(mc, dummy);
@@ -295,6 +392,45 @@ public class MCP_PlaneChaseCamera {
                   Double.valueOf(desiredX), Double.valueOf(desiredY), Double.valueOf(desiredZ)});
    }
 
+
+   public static void beginOrientCameraBypass(Minecraft mc, float partialTicks) {
+      if(activeCamera == null || activeRenderPlane == null || activeDummy == null || mc == null || mc.gameSettings == null) {
+         return;
+      }
+      float beforeDistance = W_Reflection.getThirdPersonDistance();
+      float beforeDistanceTemp = W_Reflection.getThirdPersonDistanceTemp();
+      savedThirdPersonView = mc.gameSettings.thirdPersonView;
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      mc.gameSettings.thirdPersonView = 0;
+      renderTickBypassActive = true;
+      logOrientCameraBypass(mc, partialTicks, beforeDistance, beforeDistanceTemp, W_Reflection.getThirdPersonDistance(), W_Reflection.getThirdPersonDistanceTemp(), true);
+   }
+
+   public static void endOrientCameraBypass(Minecraft mc) {
+      if(!renderTickBypassActive || mc == null || mc.gameSettings == null) {
+         return;
+      }
+      mc.gameSettings.thirdPersonView = savedThirdPersonView;
+      W_Reflection.setThirdPersonDistance(0.0F);
+      W_Reflection.setThirdPersonDistanceTemp(0.0F);
+      renderTickBypassActive = false;
+   }
+
+   private static void logOrientCameraBypass(Minecraft mc, float partialTicks, float beforeDistance, float beforeDistanceTemp, float afterDistance, float afterDistanceTemp, boolean bypassApplied) {
+      if(!MCH_Config.DebugFlightControl.prmBool || System.currentTimeMillis() < nextOrientDebugTime) {
+         return;
+      }
+      nextOrientDebugTime = System.currentTimeMillis() + 1000L;
+      Entity view = mc.renderViewEntity;
+      double camX = view != null?view.prevPosX + (view.posX - view.prevPosX) * (double)partialTicks:0.0D;
+      double camY = view != null?view.prevPosY + (view.posY - view.prevPosY) * (double)partialTicks:0.0D;
+      double camZ = view != null?view.prevPosZ + (view.posZ - view.prevPosZ) * (double)partialTicks:0.0D;
+      MCH_Lib.Log("[MCHeli][PlaneChaseCamera][orientCamera] entered=true thirdPersonView=%d thirdPersonDistanceBefore=%.3f thirdPersonDistanceTempBefore=%.3f thirdPersonDistanceAfter=%.3f thirdPersonDistanceTempAfter=%.3f renderView=%s pos=(%.3f, %.3f, %.3f) cameraWorld=(%.3f, %.3f, %.3f) bypassApplied=%s",
+            new Object[]{Integer.valueOf(savedThirdPersonView), Float.valueOf(beforeDistance), Float.valueOf(beforeDistanceTemp), Float.valueOf(afterDistance), Float.valueOf(afterDistanceTemp),
+                  view != null?view.getClass().getName():"null", Double.valueOf(view != null?view.posX:0.0D), Double.valueOf(view != null?view.posY:0.0D), Double.valueOf(view != null?view.posZ:0.0D),
+                  Double.valueOf(camX), Double.valueOf(camY), Double.valueOf(camZ), Boolean.valueOf(bypassApplied)});
+   }
 
    public static boolean isRenderCameraActiveFor(MCP_EntityPlane plane, EntityPlayer player) {
       return activeCamera != null && activeRenderPlane != null && activeRenderPlane == plane && player != null;

--- a/src/main/java/mcheli/wrapper/W_Reflection.java
+++ b/src/main/java/mcheli/wrapper/W_Reflection.java
@@ -52,14 +52,31 @@ public class W_Reflection {
 	   }
 
 	   public static void setThirdPersonDistance(float dist) {
-	      if((double)dist >= 0.1D) {
-	         try {
-	            Minecraft e = Minecraft.getMinecraft();
-	            ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78490_B", "thirdPersonDistance"});
-	         } catch (Exception var2) {
-	            var2.printStackTrace();
-	         }
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78490_B", "thirdPersonDistance"});
+	      } catch (Exception var2) {
+	         var2.printStackTrace();
+	      }
+	   }
 
+
+	   public static void setThirdPersonDistanceTemp(float dist) {
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         ObfuscationReflectionHelper.setPrivateValue(EntityRenderer.class, e.entityRenderer, Float.valueOf(dist), new String[]{"field_78491_C", "thirdPersonDistanceTemp"});
+	      } catch (Exception var2) {
+	         var2.printStackTrace();
+	      }
+	   }
+
+	   public static float getThirdPersonDistanceTemp() {
+	      try {
+	         Minecraft e = Minecraft.getMinecraft();
+	         return ((Float)ObfuscationReflectionHelper.getPrivateValue(EntityRenderer.class, e.entityRenderer, new String[]{"field_78491_C", "thirdPersonDistanceTemp"})).floatValue();
+	      } catch (Exception var1) {
+	         var1.printStackTrace();
+	         return getThirdPersonDistance();
 	      }
 	   }
 


### PR DESCRIPTION
### Motivation
- Make the new third-person plane chase camera more robust by preventing the chase dummy from colliding with the world or the aircraft and by avoiding camera clipping into aircraft geometry. 
- Provide additional debug hooks and a safe render-tick bypass to ensure the chase camera can temporarily force first-person orientation during render setup. 
- Centralize third-person distance handling and expose a temporary distance slot to reliably mask engine-driven distance changes during chase-camera operation. 

### Description
- Added a new config `NewPlaneCameraDebugAbovePlane` and adjusted chase camera defaults (`NewPlaneCameraDistance`, `NewPlaneCameraMinDistance`, `NewPlaneCameraMaxDistance`, `NewPlaneCameraDebugDistance`) to tune chase distances. 
- Enhanced `MCP_PlaneChaseCamera` with collision-escape logic that tests aircraft bounding boxes and extra part boxes, enforces minimum distances, records rich debug state, and exposes `beginOrientCameraBypass`/`endOrientCameraBypass` to temporarily force first-person view and zero third-person distances during render orientation. 
- Updated `MCP_ClientPlaneTickHandler` and camera application paths to use zeroed third-person distance and a chase dummy as `renderViewEntity`, and ensure `renderViewEntity` is set consistently when the chase camera is active. 
- Modified `MCH_ViewEntityDummy` to become a near-zero-size, no-clip, non-colliding chase dummy by setting `noClip`, clearing rider fields, shrinking the bounding box, and overriding collision methods to return no collision. 
- Added temporary third-person distance getter/setter `setThirdPersonDistanceTemp` and `getThirdPersonDistanceTemp` to `W_Reflection`, and removed the previous minimum-distance guard to allow explicit zeroing of the distance. 
- Hooked the render tick in `MCH_ClientEventHook` to call `MCP_PlaneChaseCamera.beginOrientCameraBypass` and `endOrientCameraBypass` at `RenderTickEvent` START/END to mask game settings while orienting the chase camera. 

### Testing
- Performed an automated project build using `./gradlew build`, which completed successfully without compile errors. 
- No automated unit tests are present for the mod-specific camera logic, so no test-suite runs were executed against the new camera code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a334d9077288329abe5dd71542f1978)