### PR TITLE
Improve new-plane third-person chase camera: look‑ahead, hold‑freelook, smoothing, and config/UI updates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,22 +160,52 @@ IgnoreBulletHit = flansmod.common.guns.EntityGrenade
 
 ### New-flight plane third-person chase camera
 
-These options are client-side visual/readability settings for pilots flying planes that use the new flight/new mobility system. They do not change flight physics, stall behavior, pitch authority, throttle behavior, weapons, targeting, HUD rendering, or aircraft balance. Legacy aircraft, helicopters, tanks, turrets, ships, passengers, and gunners keep the existing camera path unless the gated plane conditions are met.
+These options are client-side visual/readability settings for pilots flying planes that use the new flight/new mobility system. They do not change flight physics, stall behavior, pitch authority, throttle behavior, weapons, targeting, HUD rendering, or aircraft balance. Legacy aircraft, first-person view, helicopters, tanks, turrets, ships, passengers, and gunners keep the existing camera path unless the gated new-plane third-person pilot conditions are met.
 
-| Config key | Default | Purpose |
-| --- | ---: | --- |
-| `EnableNewPlaneThirdPersonCamera` | `true` | Enables the smooth chase camera only for third-person pilot view in new-flight planes. |
-| `NewPlaneCameraDistance` | `16.0` | Camera distance in blocks behind the plane. |
-| `NewPlaneCameraMinDistance` | `8.0` | Minimum camera distance from the plane focus. |
-| `NewPlaneCameraMaxDistance` | `24.0` | Maximum camera distance from the plane focus. |
-| `NewPlaneCameraDebugDistance` | `0.0` | `DebugFlightControl`-only distance override; set to `20`-`30` to prove the render path is consuming the custom camera, or `0` to disable. |
-| `NewPlaneCameraHeight` | `4.0` | Vertical offset in blocks above the plane. |
-| `NewPlaneCameraSideOffset` | `0.0` | Optional left/right offset in blocks for off-center chase views. |
-| `NewPlaneCameraSpeedDistanceScale` | `0.08` | Extra chase distance per block/tick of aircraft speed. |
-| `NewPlaneCameraPositionSmoothing` | `0.22` | How quickly the camera position catches up to the desired chase point; higher values are snappier. |
-| `NewPlaneCameraRotationSmoothing` | `0.16` | How quickly camera yaw and pitch recenter behind the aircraft; higher values are snappier. |
-| `NewPlaneCameraRollInfluence` | `0.15` | How much aircraft roll is applied to the camera horizon, from `0.0` stable horizon to `1.0` full roll coupling. |
-| `NewPlaneCameraCollision` | `true` | Shortens/moves the chase camera when a block is between the aircraft and desired camera point. |
+The standard chase camera is intentionally stable: it stays centered on the aircraft with configurable distance, aircraft-size scaling, speed distance scaling, collision avoidance, pitch readability, and conservative roll influence. It does **not** automatically move focus based on throttle, steering input, turn rate, sideslip, or velocity direction. Situational camera movement comes from two held player actions:
+
+* **Hold freelook** (`KeyFreeLook`, default Left Control): while held, the camera orientation follows player view independently of aircraft orientation. Aircraft controls continue normally. Releasing the key smoothly returns to normal chase tracking.
+* **Hold Plane Look Ahead** (`KeyPlaneLookAhead`, default Left Alt): while held, the camera focus blends forward along the aircraft facing direction while the camera remains behind the aircraft at normal chase distance. Releasing the key smoothly returns to centered framing.
+* **Interaction:** freelook takes priority over camera rotation. Holding both keeps freelook rotation predictable while look-ahead only changes the smoothed focus point; neither key alters aircraft controls.
+
+Recommended bindings: keep **Free Look** on a comfortable hold key such as Left Control, and bind **Plane Look Ahead** to Left Alt, a thumb mouse button, or another hold key that can be pressed briefly during target tracking.
+
+| Config key | Default | Purpose | Practical range |
+| --- | ---: | --- | --- |
+| `EnableNewPlaneThirdPersonCamera` | `true` | Enables the smooth chase camera only for third-person pilot view in new-flight planes. | `true`/`false` |
+| `EnableNewPlaneCameraSpeedDistance` | `true` | Allows aircraft speed to pull the camera farther back without shifting focus direction. | `true`/`false` |
+| `EnableNewPlaneCameraCollision` | `true` | Allows block ray tracing to shorten the camera when terrain/buildings/trees/hangars obstruct the view. | `true`/`false` |
+| `EnablePlaneLookAhead` | `true` | Enables held Plane Look Ahead. This is player-initiated only, never automatic velocity/turn prediction. | `true`/`false` |
+| `EnableHoldFreelook` | `true` | Makes new-chase-camera freelook hold-to-use and suppresses toggle freelook state for this path. | `true`/`false` |
+| `EnableNewPlaneCameraRollInfluence` | `true` | Allows limited aircraft roll to affect the camera horizon. | `true`/`false` |
+| `NewPlaneCameraDistance` | `36.0` | Base chase distance in blocks before speed and size scaling. 16 blocks may be too close; 30–50+ blocks can be reasonable depending on aircraft scale and speed. | fighters `28`-`42`, bombers `40`-`70`, jets `38`-`60`, slow props `24`-`38` |
+| `NewPlaneCameraMinDistance` | `18.0` | Minimum camera distance from the smoothed focus after collision/scale handling. | `10`-`30` |
+| `NewPlaneCameraMaxDistance` | `70.0` | Maximum camera distance after speed/size scaling. | `45`-`100+` |
+| `NewPlaneCameraDebugDistance` | `40.0` | `DebugFlightControl`-only distance override for proof testing; `0` disables. Keep normal tuning in the non-debug keys. | `0` or `30`-`80` |
+| `NewPlaneCameraDebugAbovePlane` | `false` | `DebugFlightControl`-only hard proof mode that places the dummy above the plane. | debug only |
+| `NewPlaneCameraHeight` | `4.0` | Vertical camera offset above the combat focus. | `2`-`8`; large aircraft may prefer `6`-`12` |
+| `NewPlaneCameraSideOffset` | `0.0` | Optional left/right offset for off-center chase views. | `-4`-`4` |
+| `NewPlaneCameraSpeedDistanceScale` | `10.0` | Extra chase distance per block/tick of aircraft speed when speed scaling is enabled. | slow props `4`-`10`, fighters `8`-`16`, jets `12`-`28` |
+| `NewPlaneCameraSizeDistanceScale` | `1.25` | Extra chase distance per block of aircraft bounding-box size so larger aircraft frame comfortably. | fighters `0.5`-`1.5`, bombers `1.5`-`3.0` |
+| `PlaneLookAheadDistance` | `12.0` | Held look-ahead focus distance along aircraft facing direction. The camera remains behind the aircraft. | `6`-`24` |
+| `PlaneLookAheadSmoothing` | `0.35` | How quickly held Plane Look Ahead blends forward. | `0.20`-`0.55` |
+| `PlaneLookAheadReturnSmoothing` | `0.25` | How quickly focus returns to centered chase framing after look-ahead release. | `0.15`-`0.45` |
+| `FreelookReturnSmoothing` | `0.28` | How quickly released hold-freelook returns to normal chase-camera orientation. | `0.18`-`0.45` |
+| `NewPlaneCameraPositionSmoothing` | `0.34` | How quickly camera position follows the desired chase point; higher values are snappier. | dogfight `0.28`-`0.50` |
+| `NewPlaneCameraYawSmoothing` | `0.42` | How quickly normal chase yaw follows the aircraft-centered focus when freelook is not active. | `0.30`-`0.60` |
+| `NewPlaneCameraPitchSmoothing` | `0.34` | How quickly normal chase pitch follows climbs/dives. | `0.24`-`0.50` |
+| `NewPlaneCameraDistanceSmoothing` | `0.25` | How quickly speed/size/collision distance changes are restored or shortened. | `0.18`-`0.40` |
+| `NewPlaneCameraFocusSmoothing` | `0.38` | How quickly the focus moves when held Plane Look Ahead is pressed/released. | `0.25`-`0.55` |
+| `NewPlaneCameraPitchInfluenceSmoothing` | `0.30` | Smooths pitch influence so steep climbs/dives are readable without snapping above/below the aircraft. | `0.20`-`0.45` |
+| `NewPlaneCameraRollInfluence` | `0.12` | Conservative camera roll coupling; `0.0` keeps horizon stable and `1.0` fully rolls with the plane. | `0.05`-`0.25` for combat readability |
+| `NewPlaneCameraCollision` | `true` | Deprecated compatibility alias for collision; leave `true` with `EnableNewPlaneCameraCollision=true`. | `true`/`false` |
+
+Tuning guidance:
+
+* **Fighters:** start around `NewPlaneCameraDistance=32`-`40`, `NewPlaneCameraSpeedDistanceScale=8`-`16`, `PlaneLookAheadDistance=10`-`16`, and keep roll influence near `0.10`-`0.18`.
+* **Bombers / large aircraft:** use `NewPlaneCameraDistance=45`-`70`, higher `NewPlaneCameraSizeDistanceScale`, and a taller `NewPlaneCameraHeight` so the full aircraft fits on screen.
+* **Jets:** use a higher max distance (`70`-`100+`) and moderate held look-ahead (`12`-`24`) for target tracking without automatic drift.
+* **Slow props:** keep distance lower (`24`-`38`) and speed scaling modest so the camera remains responsive while still framing the aircraft.
 
 ## Key config defaults
 
@@ -200,6 +230,7 @@ These options are client-side visual/readability settings for pilots flying plan
 | `KeyCameraDistanceUp` | `201` | Page Up |
 | `KeyCameraDistanceDown` | `209` | Page Down |
 | `KeyFreeLook` | `29` | Left Control |
+| `KeyPlaneLookAhead` | `56` | Left Alt |
 | `KeyGUI` | `19` | R |
 | `KeyGearUpDown` | `48` | B |
 | `KeyPutToRack` | `36` | J |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,7 +85,8 @@ The config stores key codes rather than names. Common defaults:
 | Dismount mob/seat action | `KeyUnmountMob` | Y |
 | Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
 | Extra function | `KeyExtra` | F |
-| Free look | `KeyFreeLook` | Left Control |
+| Hold free look | `KeyFreeLook` | Left Control |
+| Plane look ahead | `KeyPlaneLookAhead` | Left Alt |
 | Open MCHeli GUI | `KeyGUI` | R |
 | Gear | `KeyGearUpDown` | B |
 | Rack up/down | `KeyPutToRack`, `KeyDownFromRack` | J / U |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -64,6 +64,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm KeyCameraDistUp;
    public static MCH_ConfigPrm KeyCameraDistDown;
    public static MCH_ConfigPrm KeyFreeLook;
+   public static MCH_ConfigPrm KeyPlaneLookAhead;
    public static MCH_ConfigPrm KeyGUI;
    public static MCH_ConfigPrm KeyGearUpDown;
    public static MCH_ConfigPrm KeyPutToRack;
@@ -166,9 +167,23 @@ public class MCH_Config {
    public static MCH_ConfigPrm NewPlaneCameraHeight;
    public static MCH_ConfigPrm NewPlaneCameraSideOffset;
    public static MCH_ConfigPrm NewPlaneCameraSpeedDistanceScale;
+   public static MCH_ConfigPrm NewPlaneCameraSizeDistanceScale;
+   public static MCH_ConfigPrm PlaneLookAheadDistance;
+   public static MCH_ConfigPrm PlaneLookAheadSmoothing;
+   public static MCH_ConfigPrm PlaneLookAheadReturnSmoothing;
+   public static MCH_ConfigPrm FreelookReturnSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraPositionSmoothing;
-   public static MCH_ConfigPrm NewPlaneCameraRotationSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraYawSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraPitchSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraDistanceSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraFocusSmoothing;
+   public static MCH_ConfigPrm NewPlaneCameraPitchInfluenceSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraRollInfluence;
+   public static MCH_ConfigPrm EnableNewPlaneCameraSpeedDistance;
+   public static MCH_ConfigPrm EnableNewPlaneCameraCollision;
+   public static MCH_ConfigPrm EnablePlaneLookAhead;
+   public static MCH_ConfigPrm EnableHoldFreelook;
+   public static MCH_ConfigPrm EnableNewPlaneCameraRollInfluence;
    public static MCH_ConfigPrm NewPlaneCameraCollision;
    public static MCH_ConfigPrm DisableCameraDistChange;
    public static MCH_ConfigPrm EnableReplaceTextureManager;
@@ -290,6 +305,7 @@ public class MCH_Config {
       KeyCameraDistUp = new MCH_ConfigPrm("KeyCameraDistanceUp", 201);
       KeyCameraDistDown = new MCH_ConfigPrm("KeyCameraDistanceDown", 209);
       KeyFreeLook = new MCH_ConfigPrm("KeyFreeLook", 29);
+      KeyPlaneLookAhead = new MCH_ConfigPrm("KeyPlaneLookAhead", 56);
       KeyGUI = new MCH_ConfigPrm("KeyGUI", 19);
       KeyGearUpDown = new MCH_ConfigPrm("KeyGearUpDown", 48);
       KeyPutToRack = new MCH_ConfigPrm("KeyPutToRack", 36);
@@ -316,6 +332,7 @@ public class MCH_Config {
               KeyCameraDistUp,
               KeyCameraDistDown,
               KeyFreeLook,
+              KeyPlaneLookAhead,
               KeyGUI,
               KeyGearUpDown,
               KeyPutToRack,
@@ -412,12 +429,12 @@ public class MCH_Config {
       DisplayHUDThirdPerson = new MCH_ConfigPrm("DisplayHUDThirdPerson", false);
       EnableNewPlaneThirdPersonCamera = new MCH_ConfigPrm("EnableNewPlaneThirdPersonCamera", true);
       EnableNewPlaneThirdPersonCamera.desc = ";Client-only visual chase camera for third-person new-flight planes. Does not change flight physics, weapons, or HUD rendering.";
-      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 18.0D);
-      NewPlaneCameraDistance.desc = ";Blocks behind the aircraft for the new third-person plane chase camera.";
-      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 12.0D);
-      NewPlaneCameraMinDistance.desc = ";Minimum blocks behind the aircraft for the new third-person plane chase camera.";
-      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 35.0D);
-      NewPlaneCameraMaxDistance.desc = ";Maximum blocks behind the aircraft for the new third-person plane chase camera.";
+      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 36.0D);
+      NewPlaneCameraDistance.desc = ";Base chase distance in blocks for new-flight third-person planes. 16 is often too close; 30-50+ can be reasonable by scale/speed.";
+      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 18.0D);
+      NewPlaneCameraMinDistance.desc = ";Minimum chase distance in blocks after speed/size/collision tuning.";
+      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 70.0D);
+      NewPlaneCameraMaxDistance.desc = ";Maximum chase distance in blocks after speed/size tuning.";
       NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 40.0D);
       NewPlaneCameraDebugDistance.desc = ";DebugFlightControl-only chase camera distance override. Set 40 to verify the render path consumes the custom camera; 0 disables.";
       NewPlaneCameraDebugAbovePlane = new MCH_ConfigPrm("NewPlaneCameraDebugAbovePlane", false);
@@ -426,16 +443,39 @@ public class MCH_Config {
       NewPlaneCameraHeight.desc = ";Blocks above the aircraft for the new third-person plane chase camera.";
       NewPlaneCameraSideOffset = new MCH_ConfigPrm("NewPlaneCameraSideOffset", 0.0D);
       NewPlaneCameraSideOffset.desc = ";Optional horizontal side offset for the new third-person plane chase camera.";
-      NewPlaneCameraSpeedDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSpeedDistanceScale", 0.08D);
-      NewPlaneCameraSpeedDistanceScale.desc = ";Additional chase camera distance per block/tick of plane speed.";
-      NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.22D);
-      NewPlaneCameraPositionSmoothing.desc = ";How quickly the new plane chase camera position follows the desired point. Higher is snappier.";
-      NewPlaneCameraRotationSmoothing = new MCH_ConfigPrm("NewPlaneCameraRotationSmoothing", 0.16D);
-      NewPlaneCameraRotationSmoothing.desc = ";How quickly the new plane chase camera yaw and pitch recenter behind the aircraft. Higher is snappier.";
-      NewPlaneCameraRollInfluence = new MCH_ConfigPrm("NewPlaneCameraRollInfluence", 0.15D);
-      NewPlaneCameraRollInfluence.desc = ";0.0 keeps the horizon mostly stable; 1.0 fully rolls the chase camera with the aircraft.";
+      NewPlaneCameraSpeedDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSpeedDistanceScale", 10.0D);
+      NewPlaneCameraSpeedDistanceScale.desc = ";Extra chase distance per block/tick of aircraft speed when speed-based distance is enabled.";
+      NewPlaneCameraSizeDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSizeDistanceScale", 1.25D);
+      NewPlaneCameraSizeDistanceScale.desc = ";Extra chase distance per block of aircraft bounding-box size; helps bombers and large planes frame comfortably.";
+      PlaneLookAheadDistance = new MCH_ConfigPrm("PlaneLookAheadDistance", 12.0D);
+      PlaneLookAheadDistance.desc = ";Held Plane Look Ahead focus distance in blocks along aircraft facing. Does not alter aircraft controls.";
+      PlaneLookAheadSmoothing = new MCH_ConfigPrm("PlaneLookAheadSmoothing", 0.35D);
+      PlaneLookAheadSmoothing.desc = ";How quickly held Plane Look Ahead blends into its forward focus.";
+      PlaneLookAheadReturnSmoothing = new MCH_ConfigPrm("PlaneLookAheadReturnSmoothing", 0.25D);
+      PlaneLookAheadReturnSmoothing.desc = ";How quickly Plane Look Ahead returns to standard centered chase framing after release.";
+      FreelookReturnSmoothing = new MCH_ConfigPrm("FreelookReturnSmoothing", 0.28D);
+      FreelookReturnSmoothing.desc = ";How quickly hold-freelook returns to normal chase-camera orientation after release.";
+      NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.34D);
+      NewPlaneCameraPositionSmoothing.desc = ";How quickly camera position follows the desired point. Higher is snappier.";
+      NewPlaneCameraYawSmoothing = new MCH_ConfigPrm("NewPlaneCameraYawSmoothing", 0.42D);
+      NewPlaneCameraYawSmoothing.desc = ";How quickly chase camera yaw follows the look-ahead focus.";
+      NewPlaneCameraPitchSmoothing = new MCH_ConfigPrm("NewPlaneCameraPitchSmoothing", 0.34D);
+      NewPlaneCameraPitchSmoothing.desc = ";How quickly chase camera pitch follows climbs/dives.";
+      NewPlaneCameraDistanceSmoothing = new MCH_ConfigPrm("NewPlaneCameraDistanceSmoothing", 0.25D);
+      NewPlaneCameraDistanceSmoothing.desc = ";How quickly speed/size/collision distance changes are applied.";
+      NewPlaneCameraFocusSmoothing = new MCH_ConfigPrm("NewPlaneCameraFocusSmoothing", 0.38D);
+      NewPlaneCameraFocusSmoothing.desc = ";How quickly the combat look-ahead focus point moves.";
+      NewPlaneCameraPitchInfluenceSmoothing = new MCH_ConfigPrm("NewPlaneCameraPitchInfluenceSmoothing", 0.30D);
+      NewPlaneCameraPitchInfluenceSmoothing.desc = ";Smoothing for plane pitch influence so steep climbs/dives read without snapping.";
+      NewPlaneCameraRollInfluence = new MCH_ConfigPrm("NewPlaneCameraRollInfluence", 0.12D);
+      NewPlaneCameraRollInfluence.desc = ";0.0 keeps the horizon stable; 1.0 fully rolls the chase camera with the aircraft. Conservative defaults avoid nausea.";
+      EnableNewPlaneCameraSpeedDistance = new MCH_ConfigPrm("EnableNewPlaneCameraSpeedDistance", true);
+      EnableNewPlaneCameraCollision = new MCH_ConfigPrm("EnableNewPlaneCameraCollision", true);
+      EnablePlaneLookAhead = new MCH_ConfigPrm("EnablePlaneLookAhead", true);
+      EnableHoldFreelook = new MCH_ConfigPrm("EnableHoldFreelook", true);
+      EnableNewPlaneCameraRollInfluence = new MCH_ConfigPrm("EnableNewPlaneCameraRollInfluence", true);
       NewPlaneCameraCollision = new MCH_ConfigPrm("NewPlaneCameraCollision", true);
-      NewPlaneCameraCollision.desc = ";Moves the new plane chase camera in front of solid blocks when line-of-sight collision is detected.";
+      NewPlaneCameraCollision.desc = ";Deprecated alias for EnableNewPlaneCameraCollision; moves the chase camera in front of solid blocks when line-of-sight collision is detected.";
       DisableCameraDistChange = new MCH_ConfigPrm("DisableThirdPersonCameraDistChange", false);
       EnableReplaceTextureManager = new MCH_ConfigPrm("EnableReplaceTextureManager", true);
       DisplayEntityMarker = new MCH_ConfigPrm("DisplayEntityMarker", true);
@@ -593,9 +633,23 @@ public class MCH_Config {
               NewPlaneCameraHeight,
               NewPlaneCameraSideOffset,
               NewPlaneCameraSpeedDistanceScale,
+              NewPlaneCameraSizeDistanceScale,
+              PlaneLookAheadDistance,
+              PlaneLookAheadSmoothing,
+              PlaneLookAheadReturnSmoothing,
+              FreelookReturnSmoothing,
               NewPlaneCameraPositionSmoothing,
-              NewPlaneCameraRotationSmoothing,
+              NewPlaneCameraYawSmoothing,
+              NewPlaneCameraPitchSmoothing,
+              NewPlaneCameraDistanceSmoothing,
+              NewPlaneCameraFocusSmoothing,
+              NewPlaneCameraPitchInfluenceSmoothing,
               NewPlaneCameraRollInfluence,
+              EnableNewPlaneCameraSpeedDistance,
+              EnableNewPlaneCameraCollision,
+              EnablePlaneLookAhead,
+              EnableHoldFreelook,
+              EnableNewPlaneCameraRollInfluence,
               NewPlaneCameraCollision,
               DisableCameraDistChange,
               EnableReplaceTextureManager,
@@ -678,15 +732,24 @@ public class MCH_Config {
       AllHeliSpeed.prmDouble = MCH_Lib.RNG(AllHeliSpeed.prmDouble, 0.0D, 1000.0D);
       AllPlaneSpeed.prmDouble = MCH_Lib.RNG(AllPlaneSpeed.prmDouble, 0.0D, 1000.0D);
       NewFlightGravity.prmDouble = MCH_Lib.RNG(NewFlightGravity.prmDouble, 0.001D, 0.2D);
-      NewPlaneCameraDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistance.prmDouble, 2.0D, 40.0D);
-      NewPlaneCameraMinDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMinDistance.prmDouble, 1.0D, NewPlaneCameraDistance.prmDouble);
-      NewPlaneCameraMaxDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMaxDistance.prmDouble, NewPlaneCameraMinDistance.prmDouble, 40.0D);
-      NewPlaneCameraDebugDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDebugDistance.prmDouble, 0.0D, 40.0D);
-      NewPlaneCameraHeight.prmDouble = MCH_Lib.RNG(NewPlaneCameraHeight.prmDouble, -2.0D, 15.0D);
-      NewPlaneCameraSideOffset.prmDouble = MCH_Lib.RNG(NewPlaneCameraSideOffset.prmDouble, -10.0D, 10.0D);
-      NewPlaneCameraSpeedDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSpeedDistanceScale.prmDouble, 0.0D, 1.0D);
+      NewPlaneCameraDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistance.prmDouble, 8.0D, 90.0D);
+      NewPlaneCameraMinDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMinDistance.prmDouble, 4.0D, NewPlaneCameraDistance.prmDouble);
+      NewPlaneCameraMaxDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMaxDistance.prmDouble, NewPlaneCameraMinDistance.prmDouble, 120.0D);
+      NewPlaneCameraDebugDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDebugDistance.prmDouble, 0.0D, 120.0D);
+      NewPlaneCameraHeight.prmDouble = MCH_Lib.RNG(NewPlaneCameraHeight.prmDouble, -4.0D, 30.0D);
+      NewPlaneCameraSideOffset.prmDouble = MCH_Lib.RNG(NewPlaneCameraSideOffset.prmDouble, -20.0D, 20.0D);
+      NewPlaneCameraSpeedDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSpeedDistanceScale.prmDouble, 0.0D, 80.0D);
+      NewPlaneCameraSizeDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSizeDistanceScale.prmDouble, 0.0D, 5.0D);
+      PlaneLookAheadDistance.prmDouble = MCH_Lib.RNG(PlaneLookAheadDistance.prmDouble, 0.0D, 80.0D);
+      PlaneLookAheadSmoothing.prmDouble = MCH_Lib.RNG(PlaneLookAheadSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneLookAheadReturnSmoothing.prmDouble = MCH_Lib.RNG(PlaneLookAheadReturnSmoothing.prmDouble, 0.01D, 1.0D);
+      FreelookReturnSmoothing.prmDouble = MCH_Lib.RNG(FreelookReturnSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraPositionSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPositionSmoothing.prmDouble, 0.01D, 1.0D);
-      NewPlaneCameraRotationSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraRotationSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraYawSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraYawSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraPitchSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPitchSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraDistanceSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistanceSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraFocusSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraFocusSmoothing.prmDouble, 0.01D, 1.0D);
+      NewPlaneCameraPitchInfluenceSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPitchInfluenceSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraRollInfluence.prmDouble = MCH_Lib.RNG(NewPlaneCameraRollInfluence.prmDouble, 0.0D, 1.0D);
       AllTankSpeed.prmDouble = MCH_Lib.RNG(AllTankSpeed.prmDouble, 0.0D, 1000.0D);
       AllShipSpeed.prmDouble = MCH_Lib.RNG(AllShipSpeed.prmDouble, 0.0D, 1000.0D);

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -174,7 +174,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.listKeyBindingButtons.add(new W_GuiButton(54, x1 + 90, y + 175, 60, 20, "Reset All"));
       boolean var13 = true;
       boolean var14 = true;
-      MCH_GuiListItemKeyBind[] var10000 = new MCH_GuiListItemKeyBind[29];
+      MCH_GuiListItemKeyBind[] var10000 = new MCH_GuiListItemKeyBind[30];
       MCH_GuiListItemKeyBind var10003 = new MCH_GuiListItemKeyBind(200, 300, x1, "Up", MCH_Config.KeyUp);
       MCH_Config var10009 = MCH_MOD.config;
       var10000[0] = var10003;
@@ -266,6 +266,9 @@ public class MCH_ConfigGui extends W_GuiContainer {
       var10003 = new MCH_GuiListItemKeyBind(228, 328, x1, "Submarine Descend", MCH_Config.KeySubmarineDescend);
       var10009 = MCH_MOD.config;
       var10000[28] = var10003;
+      var10003 = new MCH_GuiListItemKeyBind(229, 329, x1, "Plane Look Ahead", MCH_Config.KeyPlaneLookAhead);
+      var10009 = MCH_MOD.config;
+      var10000[29] = var10003;
       //var10003 = new MCH_GuiListItemKeyBind(227, 327, x1, "Use Weapon Vehicle", MCH_Config.KeyUseWeapon);
       //var10009 = MCH_MOD.config;
       //var10000[26] = var10003;

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -144,10 +144,17 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.commonPlayerControlInGUI(player, plane, isPilot, new MCP_PlanePacketPlayerControl());
    }
 
+   private boolean isNewChaseHoldFreelookPath(MCP_EntityPlane plane, boolean isPilot) {
+      return isPilot && MCH_Config.EnableHoldFreelook.prmBool && plane != null && plane.isNewFlightModelEnabled() && MCH_Config.EnableNewPlaneThirdPersonCamera.prmBool && super.mc != null && super.mc.gameSettings != null && super.mc.gameSettings.thirdPersonView > 0;
+   }
+
    protected void playerControl(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
       MCP_PlanePacketPlayerControl pc = new MCP_PlanePacketPlayerControl();
       boolean send = false;
       send = this.commonPlayerControl(player, plane, isPilot, pc);
+      if(this.isNewChaseHoldFreelookPath(plane, isPilot)) {
+         pc.switchFreeLook = 0;
+      }
       boolean isUav;
       if(isPilot) {
          if(this.KeySwitchMode.isKeyDown()) {

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -2,6 +2,7 @@ package mcheli.plane;
 
 import mcheli.MCH_Config;
 import mcheli.MCH_Lib;
+import mcheli.MCH_Key;
 import mcheli.MCH_ViewEntityDummy;
 import mcheli.aircraft.MCH_BoundingBox;
 import mcheli.wrapper.W_Reflection;
@@ -47,6 +48,14 @@ public class MCP_PlaneChaseCamera {
    private boolean initialized;
    private boolean lastCollisionAdjusted;
    private String lastCollisionHit = "none";
+   private Vec3 smoothedFocus;
+   private double smoothedDistance;
+   private double lastDistanceBeforeCollision;
+   private double lastDistanceAfterCollision;
+   private float smoothedPitchInfluence;
+   private double lookAheadBlend;
+   private boolean freelookActive;
+   private boolean wasFreelookActive;
    private double renderPosX;
    private double renderPosY;
    private double renderPosZ;
@@ -78,6 +87,9 @@ public class MCP_PlaneChaseCamera {
       this.activeView = -1;
       this.initialized = false;
       this.hasRenderTransform = false;
+      this.lookAheadBlend = 0.0D;
+      this.freelookActive = false;
+      this.wasFreelookActive = false;
       W_Reflection.setCameraRoll(0.0F);
       if(activeCamera == this) {
          activeCamera = null;
@@ -99,18 +111,31 @@ public class MCP_PlaneChaseCamera {
       }
       lastClientTickComputed = clientTick;
 
-      Vec3 focus = this.getCameraFocusPoint(plane);
+      this.wasFreelookActive = this.freelookActive;
+      this.freelookActive = this.isHoldFreelookActive();
+      Vec3 anchor = this.getCameraFocusPoint(plane);
+      Vec3 focus = this.computeHeldLookAheadFocus(plane, anchor);
+      this.smoothedFocus = this.smoothVec(this.smoothedFocus, focus, MCH_Config.NewPlaneCameraFocusSmoothing.prmDouble);
+      if(this.smoothedFocus != null) {
+         focus = this.smoothedFocus;
+      }
       Vec3 desired = this.computeDesiredCameraPosition(plane, focus);
+      this.lastDistanceBeforeCollision = this.distance(focus, desired);
       if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugAbovePlane.prmBool) {
          desired = Vec3.createVectorHelper(plane.posX, plane.posY + 20.0D, plane.posZ);
          this.lastCollisionAdjusted = false;
          this.lastCollisionHit = "debugAbovePlane";
       } else {
-         if(MCH_Config.NewPlaneCameraCollision.prmBool) {
+         if(MCH_Config.EnableNewPlaneCameraCollision.prmBool && MCH_Config.NewPlaneCameraCollision.prmBool) {
             desired = this.adjustForCollision(plane, focus, desired);
+         } else {
+            this.lastCollisionAdjusted = false;
+            this.lastCollisionHit = "disabled";
          }
          desired = this.escapeAircraftCollision(plane, focus, desired);
       }
+      this.lastDistanceAfterCollision = this.distance(focus, desired);
+      desired = this.smoothVec(Vec3.createVectorHelper(this.posX, this.posY, this.posZ), desired, MCH_Config.NewPlaneCameraPositionSmoothing.prmDouble);
       activeCamera = this;
       activeRenderPlane = plane;
       desiredX = desired.xCoord;
@@ -120,8 +145,12 @@ public class MCP_PlaneChaseCamera {
       dummyTransformWrites = 0;
       consumedByRenderHook = false;
 
-      this.yaw = plane.getRotYaw();
-      this.pitch = 45.0F;
+      float targetYaw = this.freelookActive && player != null?player.rotationYaw:this.computeLookYaw(desired, focus);
+      float targetPitch = this.freelookActive && player != null?player.rotationPitch:this.computeLookPitch(desired, focus);
+      double yawSmooth = this.freelookActive?1.0D:(this.wasFreelookActive?MCH_Config.FreelookReturnSmoothing.prmDouble:MCH_Config.NewPlaneCameraYawSmoothing.prmDouble);
+      double pitchSmooth = this.freelookActive?1.0D:(this.wasFreelookActive?MCH_Config.FreelookReturnSmoothing.prmDouble:MCH_Config.NewPlaneCameraPitchSmoothing.prmDouble);
+      this.yaw = this.smoothAngle(this.yaw, targetYaw, yawSmooth);
+      this.pitch = this.smoothAngle(this.pitch, targetPitch, pitchSmooth);
       this.posX = desired.xCoord;
       this.posY = desired.yCoord;
       this.posZ = desired.zCoord;
@@ -130,11 +159,11 @@ public class MCP_PlaneChaseCamera {
       this.mirrorRenderTransformToPlaneCamera(plane);
       logPhase("CLIENT_TICK", mc, activeDummy, false, false);
       this.debugCamera(mc, plane, focus, desired, true);
-      W_Reflection.setCameraRoll(plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble);
+      W_Reflection.setCameraRoll(this.getRollInfluence(plane));
    }
 
    private static void logShouldUseProof(Minecraft mc, MCP_EntityPlane plane, boolean result, boolean thirdPerson, boolean hasPlayer, boolean hasPlane, boolean isPilot, boolean enabled, boolean newFlight, boolean notGunner, boolean cameraOk, boolean notDestroyed) {
-      if(System.currentTimeMillis() < nextProofLogTime) {
+      if(!MCH_Config.DebugFlightControl.prmBool || System.currentTimeMillis() < nextProofLogTime) {
          return;
       }
       nextProofLogTime = System.currentTimeMillis() + 1000L;
@@ -145,7 +174,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    private static void logStageProof(Minecraft mc, String label, MCP_EntityPlane plane, boolean shouldUse) {
-      if(System.currentTimeMillis() < nextStageProofLogTime) {
+      if(!MCH_Config.DebugFlightControl.prmBool || System.currentTimeMillis() < nextStageProofLogTime) {
          return;
       }
       nextStageProofLogTime = System.currentTimeMillis() + 1000L;
@@ -156,7 +185,7 @@ public class MCP_PlaneChaseCamera {
 
    public static void logCameraWrite(String methodName, String stage) {
       Minecraft mc = Minecraft.getMinecraft();
-      if((activeCamera != null || (MCH_Config.DebugFlightControl != null && MCH_Config.DebugFlightControl.prmBool)) && System.currentTimeMillis() >= nextWriteLogTime) {
+      if(MCH_Config.DebugFlightControl != null && MCH_Config.DebugFlightControl.prmBool && System.currentTimeMillis() >= nextWriteLogTime) {
          nextWriteLogTime = System.currentTimeMillis() + 1000L;
          String renderView = mc != null && mc.renderViewEntity != null?mc.renderViewEntity.getClass().getName():"null";
          MCH_Lib.Log("[MCHeli][PlaneChaseCamera][WRITE] method=%s stage=%s active=%s renderView=%s thirdPersonDistance=%.3f thirdPersonDistanceTemp=%.3f",
@@ -172,6 +201,9 @@ public class MCP_PlaneChaseCamera {
       this.posZ = desired.zCoord;
       this.yaw = plane.getRotYaw();
       this.pitch = this.computeLookPitch(desired, focus);
+      this.smoothedFocus = focus;
+      this.smoothedDistance = this.distance(focus, desired);
+      this.smoothedPitchInfluence = plane.getRotPitch();
       this.activePlane = plane;
       this.activeView = Minecraft.getMinecraft().gameSettings.thirdPersonView;
       this.initialized = true;
@@ -192,7 +224,7 @@ public class MCP_PlaneChaseCamera {
       this.renderPosZ = this.posZ;
       this.renderYaw = this.yaw;
       this.renderPitch = this.pitch;
-      this.renderRoll = plane != null?plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble:0.0F;
+      this.renderRoll = plane != null?this.getRollInfluence(plane):0.0F;
       this.renderZoom = plane != null && plane.camera != null?plane.camera.getCameraZoom():1.0F;
       this.hasRenderTransform = true;
    }
@@ -223,13 +255,6 @@ public class MCP_PlaneChaseCamera {
       return Vec3.createVectorHelper(worldX, worldY, worldZ);
    }
 
-   private double getCameraDistance() {
-      if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugDistance.prmDouble > 0.0D) {
-         return MCH_Config.NewPlaneCameraDebugDistance.prmDouble;
-      }
-      return MCH_Lib.RNG(MCH_Config.NewPlaneCameraDistance.prmDouble, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
-   }
-
    private double getCameraDistance(MCP_EntityPlane plane) {
       if(MCH_Config.DebugFlightControl.prmBool && MCH_Config.NewPlaneCameraDebugDistance.prmDouble > 0.0D) {
          return MCH_Config.NewPlaneCameraDebugDistance.prmDouble;
@@ -238,19 +263,44 @@ public class MCP_PlaneChaseCamera {
       double dy = plane.posY - plane.prevPosY;
       double dz = plane.posZ - plane.prevPosZ;
       double speed = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      return MCH_Lib.RNG(MCH_Config.NewPlaneCameraDistance.prmDouble + speed * MCH_Config.NewPlaneCameraSpeedDistanceScale.prmDouble, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
+      double target = MCH_Config.NewPlaneCameraDistance.prmDouble + this.getAircraftSize(plane) * MCH_Config.NewPlaneCameraSizeDistanceScale.prmDouble;
+      if(MCH_Config.EnableNewPlaneCameraSpeedDistance.prmBool) {
+         target += speed * MCH_Config.NewPlaneCameraSpeedDistanceScale.prmDouble;
+      }
+      target = MCH_Lib.RNG(target, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
+      if(this.smoothedDistance <= 0.0D) {
+         this.smoothedDistance = target;
+      } else {
+         this.smoothedDistance += (target - this.smoothedDistance) * MCH_Config.NewPlaneCameraDistanceSmoothing.prmDouble;
+      }
+      return this.smoothedDistance;
    }
 
    private Vec3 computeDesiredCameraPosition(MCP_EntityPlane plane, Vec3 focus) {
       double distance = this.getCameraDistance(plane);
       double height = MCH_Config.NewPlaneCameraHeight.prmDouble;
       double side = MCH_Config.NewPlaneCameraSideOffset.prmDouble;
-      Vec3 forward = MCH_Lib.Rot2Vec3(plane.getRotYaw(), 0.0F);
+      this.smoothedPitchInfluence += (plane.getRotPitch() - this.smoothedPitchInfluence) * (float)MCH_Config.NewPlaneCameraPitchInfluenceSmoothing.prmDouble;
+      Vec3 forward = MCH_Lib.Rot2Vec3(plane.getRotYaw(), this.smoothedPitchInfluence * 0.35F);
       Vec3 right = MCH_Lib.Rot2Vec3(plane.getRotYaw() + 90.0F, 0.0F);
       double x = focus.xCoord - forward.xCoord * distance + right.xCoord * side;
       double y = focus.yCoord + height;
       double z = focus.zCoord - forward.zCoord * distance + right.zCoord * side;
       return Vec3.createVectorHelper(x, y, z);
+   }
+
+   private Vec3 computeHeldLookAheadFocus(MCP_EntityPlane plane, Vec3 anchor) {
+      boolean held = MCH_Config.EnablePlaneLookAhead.prmBool && MCH_Key.isKeyDown(MCH_Config.KeyPlaneLookAhead.prmInt);
+      double smoothing = held?MCH_Config.PlaneLookAheadSmoothing.prmDouble:MCH_Config.PlaneLookAheadReturnSmoothing.prmDouble;
+      double target = held?1.0D:0.0D;
+      this.lookAheadBlend += (target - this.lookAheadBlend) * MCH_Lib.RNG(smoothing, 0.01D, 1.0D);
+      if(this.lookAheadBlend < 1.0E-3D) {
+         this.lookAheadBlend = 0.0D;
+         return anchor;
+      }
+      Vec3 forward = MCH_Lib.Rot2Vec3(plane.getRotYaw(), plane.getRotPitch() * 0.35F);
+      double distance = MCH_Config.PlaneLookAheadDistance.prmDouble * this.lookAheadBlend;
+      return anchor.addVector(forward.xCoord * distance, forward.yCoord * distance, forward.zCoord * distance);
    }
 
    private Vec3 adjustForCollision(MCP_EntityPlane plane, Vec3 focus, Vec3 desired) {
@@ -332,6 +382,32 @@ public class MCP_PlaneChaseCamera {
       return nearest;
    }
 
+   private double getAircraftSize(MCP_EntityPlane plane) {
+      AxisAlignedBB bb = plane.boundingBox;
+      if(bb == null) {
+         return 0.0D;
+      }
+      double sx = bb.maxX - bb.minX;
+      double sy = bb.maxY - bb.minY;
+      double sz = bb.maxZ - bb.minZ;
+      MCH_BoundingBox[] boxes = plane.getCalculatedExtraBoundingBoxes();
+      for(int i = 0; i < boxes.length; ++i) {
+         if(boxes[i] != null && boxes[i].boundingBox != null) {
+            AxisAlignedBB b = boxes[i].boundingBox;
+            sx = Math.max(sx, b.maxX - b.minX);
+            sy = Math.max(sy, b.maxY - b.minY);
+            sz = Math.max(sz, b.maxZ - b.minZ);
+         }
+      }
+      return Math.max(sx, Math.max(sy, sz));
+   }
+
+   private float computeLookYaw(Vec3 camera, Vec3 focus) {
+      double dx = focus.xCoord - camera.xCoord;
+      double dz = focus.zCoord - camera.zCoord;
+      return (float)(Math.atan2(dz, dx) * 57.29577951308232D) - 90.0F;
+   }
+
    private float computeLookPitch(Vec3 camera, Vec3 focus) {
       double dx = focus.xCoord - camera.xCoord;
       double dy = focus.yCoord - camera.yCoord;
@@ -349,6 +425,27 @@ public class MCP_PlaneChaseCamera {
       return focus.addVector(direction.xCoord * minDistance, direction.yCoord * minDistance, direction.zCoord * minDistance);
    }
 
+   private Vec3 smoothVec(Vec3 from, Vec3 to, double amount) {
+      if(from == null || to == null) {
+         return to;
+      }
+      amount = MCH_Lib.RNG(amount, 0.01D, 1.0D);
+      return Vec3.createVectorHelper(from.xCoord + (to.xCoord - from.xCoord) * amount, from.yCoord + (to.yCoord - from.yCoord) * amount, from.zCoord + (to.zCoord - from.zCoord) * amount);
+   }
+
+   private float smoothAngle(float from, float to, double amount) {
+      amount = MCH_Lib.RNG(amount, 0.01D, 1.0D);
+      return from + MathHelper.wrapAngleTo180_float(to - from) * (float)amount;
+   }
+
+   private float getRollInfluence(MCP_EntityPlane plane) {
+      return MCH_Config.EnableNewPlaneCameraRollInfluence.prmBool?plane.getRotRoll() * (float)MCH_Config.NewPlaneCameraRollInfluence.prmDouble:0.0F;
+   }
+
+   private boolean isHoldFreelookActive() {
+      return MCH_Config.EnableHoldFreelook.prmBool && MCH_Key.isKeyDown(MCH_Config.KeyFreeLook.prmInt);
+   }
+
    private double distance(Vec3 a, Vec3 b) {
       double dx = a.xCoord - b.xCoord;
       double dy = a.yCoord - b.yCoord;
@@ -364,9 +461,10 @@ public class MCP_PlaneChaseCamera {
          boolean dummyInsidePlaneBB = dummy != null && this.isPointInsideAabb(Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ), plane.boundingBox);
          boolean dummyInsidePartBB = dummy != null && !this.getAircraftCollisionHit(plane, Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ)).equals("none") && !dummyInsidePlaneBB;
          double nearestBoxDistance = this.nearestAircraftBoxDistance(plane, desired);
-         MCH_Lib.Log("CHASE_CAM: focus=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) finalDummy=(%.3f, %.3f, %.3f) renderView=(%.3f, %.3f, %.3f) planeBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyInsidePlaneBB=%s dummyInsidePartBB=%s collisionAdjusted=%s collisionHit=%s nearestAircraftBoxDistance=%.3f thirdPersonViewMasked=%s distanceToFocus=%.3f owner=%s lastWriter=%s writes=%d thirdPerson=%d",
+         MCH_Lib.Log("CHASE_CAM: phase=CLIENT_TICK focus=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) smoothed=(%.3f, %.3f, %.3f) distBeforeCollision=%.3f distAfterCollision=%.3f yaw=%.2f pitch=%.2f rollInfluence=%.2f lookAheadBlend=%.2f freelook=%s finalDummy=(%.3f, %.3f, %.3f) renderView=(%.3f, %.3f, %.3f) planeBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyInsidePlaneBB=%s dummyInsidePartBB=%s collisionAdjusted=%s collisionHit=%s nearestAircraftBoxDistance=%.3f thirdPersonViewMasked=%s distanceToFocus=%.3f owner=%s lastWriter=%s writes=%d thirdPerson=%d",
                new Object[]{Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
                      Double.valueOf(desired.xCoord), Double.valueOf(desired.yCoord), Double.valueOf(desired.zCoord),
+                     Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ), Double.valueOf(this.lastDistanceBeforeCollision), Double.valueOf(this.lastDistanceAfterCollision), Float.valueOf(this.yaw), Float.valueOf(this.pitch), Float.valueOf(this.getRollInfluence(plane)), Double.valueOf(this.lookAheadBlend), Boolean.valueOf(this.freelookActive),
                      Double.valueOf(dummy != null?dummy.posX:0.0D), Double.valueOf(dummy != null?dummy.posY:0.0D), Double.valueOf(dummy != null?dummy.posZ:0.0D),
                      Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posX:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posY:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posZ:0.0D),
                      Double.valueOf(plane.boundingBox != null?plane.boundingBox.minX:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minY:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minZ:0.0D),
@@ -394,7 +492,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static void logPhase(String phase, Minecraft mc, MCH_ViewEntityDummy dummy, boolean transformApplied, boolean beforeOrientCamera) {
-      if(System.currentTimeMillis() < nextPhaseLogTime) {
+      if(!MCH_Config.DebugFlightControl.prmBool || System.currentTimeMillis() < nextPhaseLogTime) {
          return;
       }
       nextPhaseLogTime = System.currentTimeMillis() + 1000L;


### PR DESCRIPTION
### Motivation

- Provide a more readable, predictable third-person chase camera for planes that use the new flight model by adding optional held interactions and finer tuning controls.
- Avoid automatic velocity/turn-based camera drifting while still allowing pilots to temporarily preview forward-facing direction and freelook without altering aircraft controls.

### Description

- Added a suite of new camera configuration parameters (speed/size scaling, multiple smoothing parameters, look-ahead distances, freelook return smoothing, rollout-safe collision toggles, and roll influence toggles) and adjusted several default values for a more practical out-of-the-box camera (`MCH_Config` changes and `configuration.md` updates).
- Implemented held Plane Look Ahead and hold-to-freelook behaviors in the chase camera (`MCP_PlaneChaseCamera`) including smoothing of focus/position/distance, aircraft-size-based distance scaling, collision handling improvements, and conservative roll influence control; introduced `MCH_Key` usage for held-key checks.
- Exposed a new keybind `KeyPlaneLookAhead` (default Left Alt) and added it to the config GUI (`MCH_ConfigGui`) and docs (`getting-started.md`) and added `KeyPlaneLookAhead` to the `KeyConfig` array.
- Minor integration/tick handler change (`MCP_ClientPlaneTickHandler`) to avoid toggling freelook state when using the new chase camera hold path; updated debug/log gating to respect `DebugFlightControl`.

### Testing

- Performed a full project build with `./gradlew build` and executed the automated test suite with `./gradlew test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34524fb2008329bfb5ab8bf614b1ae)