### PR TITLE
New stable third-person plane chase camera with FOV override and UI controls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,19 +173,24 @@ Recommended bindings: keep **Free Look** on a comfortable hold key such as Left 
 | Config key | Default | Purpose | Practical range |
 | --- | ---: | --- | --- |
 | `EnableNewPlaneThirdPersonCamera` | `true` | Enables the smooth chase camera only for third-person pilot view in new-flight planes. | `true`/`false` |
-| `EnableNewPlaneCameraSpeedDistance` | `true` | Allows aircraft speed to pull the camera farther back without shifting focus direction. | `true`/`false` |
+| `EnableSpeedBasedCameraDistance` | `false` | Optional speed distance scaling. Disabled by default to prevent zoom breathing with throttle/speed changes. | keep `false`; use only for small capped effects |
 | `EnableNewPlaneCameraCollision` | `true` | Allows block ray tracing to shorten the camera when terrain/buildings/trees/hangars obstruct the view. | `true`/`false` |
 | `EnablePlaneLookAhead` | `true` | Enables held Plane Look Ahead. This is player-initiated only, never automatic velocity/turn prediction. | `true`/`false` |
 | `EnableHoldFreelook` | `true` | Makes new-chase-camera freelook hold-to-use and suppresses toggle freelook state for this path. | `true`/`false` |
 | `EnableNewPlaneCameraRollInfluence` | `true` | Allows limited aircraft roll to affect the camera horizon. | `true`/`false` |
-| `NewPlaneCameraDistance` | `45.0` | Base chase distance in blocks before speed and size scaling. The default is now 45 blocks; 16 blocks is cockpit-range close for many aircraft and should not be used as the new chase default. | fighters `38`-`55`, bombers `50`-`85`, jets `45`-`75`, slow props `32`-`48` |
-| `NewPlaneCameraMinDistance` | `24.0` | Minimum camera distance from the smoothed focus after collision/scale handling. | `10`-`30` |
-| `NewPlaneCameraMaxDistance` | `90.0` | Maximum camera distance after speed/size scaling. | `45`-`100+` |
-| `NewPlaneCameraDebugDistance` | `40.0` | `DebugFlightControl`-only distance override for proof testing; `0` disables. Keep normal tuning in the non-debug keys. | `0` or `30`-`80` |
+| `PlaneChaseBaseDistance` | `15.0` | Stable base chase distance in blocks before aircraft-size bonus and optional speed bonus. | default `15`; tune with wider FOV before large distance swings |
+| `PlaneChaseMinDistance` | `13.0` | Minimum camera distance from the smoothed focus after scale handling, high enough to keep tails framed during slowdown. | `12`-`18` for normal chase |
+| `PlaneChaseMaxDistance` | `21.0` | Maximum normal camera distance after scale and optional speed bonus. The full range is not used unless speed scaling is enabled. | `20`+ if very large aircraft need it |
+| `NewPlaneCameraDebugDistance` | `0.0` | `DebugFlightControl`-only distance override for proof testing; `0` disables. Keep normal tuning in the non-debug keys. | `0` or `30`-`80` |
 | `NewPlaneCameraDebugAbovePlane` | `false` | `DebugFlightControl`-only hard proof mode that places the dummy above the plane. | debug only |
 | `NewPlaneCameraHeight` | `4.0` | Vertical camera offset above the combat focus. | `2`-`8`; large aircraft may prefer `6`-`12` |
 | `NewPlaneCameraSideOffset` | `0.0` | Optional left/right offset for off-center chase views. | `-4`-`4` |
-| `NewPlaneCameraSpeedDistanceScale` | `10.0` | Extra chase distance per block/tick of aircraft speed when speed scaling is enabled. | slow props `4`-`10`, fighters `8`-`16`, jets `12`-`28` |
+| `PlaneChaseSpeedDistanceScale` | `2.0` | Extra chase distance per block/tick of aircraft speed when speed scaling is explicitly enabled. | keep low; pair with `PlaneChaseSpeedDistanceMaxBonus` |
+| `PlaneChaseSpeedDistanceMaxBonus` | `3.0` | Caps optional speed-based extra distance so acceleration cannot cause aggressive zoom. | `2`-`5` |
+| `EnablePlaneChaseFOVOverride` | `true` | Enables the new chase-camera-only FOV override. | `true` |
+| `PlaneChaseFOV` | `95.0` | Target FOV for new-flight third-person plane chase. | `85`-`105` |
+| `PlaneChaseFreelookFOV` | `95.0` | Optional FOV while hold-freelook orbit is active. | usually match `PlaneChaseFOV` |
+| `PlaneChaseFOVSmoothing` | `0.25` | Smoothly blends FOV entering/exiting chase and freelook. | `0.15`-`0.35` |
 | `NewPlaneCameraSizeDistanceScale` | `1.25` | Extra chase distance per block of aircraft bounding-box size so larger aircraft frame comfortably. | fighters `0.5`-`1.5`, bombers `1.5`-`3.0` |
 | `PlaneChaseFocusVerticalOffset` | `2.5` | Raises the chase focus above the aircraft so the aircraft sits below screen center and forward airspace remains visible. | `1`-`5` fighters/props, `3`-`8` large aircraft |
 | `PlaneChaseScreenVerticalBias` | `4.0` | Raises the aim/framing point above the focus, keeping the crosshair/screen center out of the plane model. | `2`-`7`; reduce if the camera feels detached |
@@ -193,22 +198,29 @@ Recommended bindings: keep **Free Look** on a comfortable hold key such as Left 
 | `PlaneLookAheadSmoothing` | `0.35` | How quickly held Plane Look Ahead blends forward. | `0.20`-`0.55` |
 | `PlaneLookAheadReturnSmoothing` | `0.25` | How quickly focus returns to centered chase framing after look-ahead release. | `0.15`-`0.45` |
 | `FreelookReturnSmoothing` | `0.28` | How quickly released hold-freelook orbit offsets return to rear chase view. | `0.18`-`0.45` |
-| `PlaneFreelookOrbitSensitivity` | `0.15` | Mouse sensitivity multiplier for hold-freelook orbit yaw/pitch around the aircraft. | `0.08`-`0.30` |
+| `PlaneFreelookOrbitSensitivity` | `0.15` | Mouse sensitivity multiplier for hold-freelook target orbit yaw/pitch around the aircraft. | `0.08`-`0.30` |
+| `PlaneFreelookYawSmoothing` | `0.28` | Smooths rendered freelook yaw separately from raw mouse target yaw. | `0.25`-`0.35` |
+| `PlaneFreelookPitchSmoothing` | `0.28` | Smooths rendered freelook pitch separately from raw mouse target pitch. | `0.25`-`0.35` |
+| `PlaneFreelookReturnSmoothing` | `0.18` | Smoothly blends raw and rendered orbit offsets back to rear chase after release. | `0.15`-`0.25` |
+| `PlaneFreelookMaxPitchUp` | `75.0` | Clamps upward orbit pitch to prevent flips. | `60`-`80` |
+| `PlaneFreelookMaxPitchDown` | `65.0` | Clamps downward orbit pitch to prevent flips. | `50`-`75` |
 | `NewPlaneCameraPositionSmoothing` | `0.34` | How quickly camera position follows the desired chase point; higher values are snappier. | dogfight `0.28`-`0.50` |
 | `NewPlaneCameraYawSmoothing` | `0.42` | How quickly normal chase yaw follows the aircraft-centered focus when freelook is not active. | `0.30`-`0.60` |
 | `NewPlaneCameraPitchSmoothing` | `0.34` | How quickly normal chase pitch follows climbs/dives. | `0.24`-`0.50` |
 | `NewPlaneCameraDistanceSmoothing` | `0.25` | How quickly speed/size/collision distance changes are restored or shortened. | `0.18`-`0.40` |
 | `NewPlaneCameraFocusSmoothing` | `0.38` | How quickly the focus moves when held Plane Look Ahead is pressed/released. | `0.25`-`0.55` |
 | `NewPlaneCameraPitchInfluenceSmoothing` | `0.30` | Smooths pitch influence so steep climbs/dives are readable without snapping above/below the aircraft. | `0.20`-`0.45` |
-| `NewPlaneCameraRollInfluence` | `0.12` | Conservative camera roll coupling; `0.0` keeps horizon stable and `1.0` fully rolls with the plane. | `0.05`-`0.25` for combat readability |
+| `PlaneChasePitchInfluence` | `0.25` | Conservative pitch inheritance so the horizon feels more stable than the aircraft. | `0.15`-`0.35` |
+| `NewPlaneCameraRollInfluence` | `0.12` | Conservative camera roll coupling; `0.0` keeps horizon stable and `1.0` fully rolls with the plane. | `0.0`-`0.15` for stable horizon |
+| `PlaneChaseHorizonStabilization` | `true` | Documents/enables the stabilized chase-camera attitude profile. | `true` |
 | `NewPlaneCameraCollision` | `true` | Deprecated compatibility alias for collision; leave `true` with `EnableNewPlaneCameraCollision=true`. | `true`/`false` |
 
 Tuning guidance:
 
-* **Fighters:** start around `NewPlaneCameraDistance=40`-`55`, `PlaneChaseFocusVerticalOffset=2`-`4`, `PlaneChaseScreenVerticalBias=3`-`5`, `NewPlaneCameraSpeedDistanceScale=8`-`16`, `PlaneLookAheadDistance=10`-`16`, and keep roll influence near `0.10`-`0.18`.
-* **Bombers / large aircraft:** use `NewPlaneCameraDistance=55`-`85`, higher `NewPlaneCameraSizeDistanceScale`, a taller `NewPlaneCameraHeight`, and `PlaneChaseFocusVerticalOffset=4`-`8` so the full aircraft fits below center.
-* **Jets:** use a higher max distance (`90`-`130+`), default-or-higher follow distance (`45`-`75`), and moderate held look-ahead (`12`-`24`) for target tracking without automatic drift.
-* **Slow props:** keep distance lower (`32`-`48`), use modest screen bias (`2`-`4`), and keep speed scaling modest so the camera remains responsive while still framing the aircraft.
+* **Fighters:** start around `PlaneChaseBaseDistance=14`-`24`, `PlaneChaseFocusVerticalOffset=2`-`4`, `PlaneChaseScreenVerticalBias=3`-`5`, `PlaneChaseSpeedDistanceScale=8`-`16`, `PlaneLookAheadDistance=10`-`16`, and keep roll influence near `0.10`-`0.18`.
+* **Bombers / large aircraft:** use `PlaneChaseBaseDistance=24`-`45`, higher `NewPlaneCameraSizeDistanceScale`, a taller `NewPlaneCameraHeight`, and `PlaneChaseFocusVerticalOffset=4`-`8` so the full aircraft fits below center.
+* **Jets:** use a higher max distance (`90`-`130+`), default-or-higher follow distance (`15`-`35`), and moderate held look-ahead (`12`-`24`) for target tracking without automatic drift.
+* **Slow props:** keep distance lower (`12`-`22`), use modest screen bias (`2`-`4`), and keep speed scaling modest so the camera remains responsive while still framing the aircraft.
 
 ## Key config defaults
 
@@ -252,3 +264,13 @@ Tuning guidance:
 ## Item and block IDs
 
 The source still initializes legacy numeric IDs for core items/blocks, including fuel, GLTD, chain, parachute, container, UAV stations, drafting table, wrench, rangefinder, Stinger/Javelin/RPG shared IDs, and Drafting Table block IDs. In modern Forge 1.7.10 modpacks, prefer resolving conflicts through generated config and registry names rather than hand-editing unless you know your pack's ID map.
+
+## New plane third-person chase camera defaults
+
+The new-flight-model plane chase camera is tuned around a stable follow distance instead of aggressive speed zoom. Its default base distance is 15 blocks, with the normal distance range held near 13-21 blocks before aircraft-size and collision handling. Speed-based distance scaling is disabled by default (`EnableSpeedBasedCameraDistance = false`); if enabled, keep `PlaneChaseSpeedDistanceScale` low and cap `PlaneChaseSpeedDistanceMaxBonus` around 2-5 blocks.
+
+Plane camera tuning is exposed in the in-game MCHeli options opened from the aircraft `R` key menu: choose **MOD Options**, then **Render Settings**, then **Plane Camera** to adjust distance, FOV, speed bonus, freelook smoothing, and pitch/roll influence without restarting.
+
+For awareness, prefer stable distance plus a wider FOV rather than large dynamic distance swings. `EnablePlaneChaseFOVOverride` is enabled by default for the new-flight third-person plane chase camera only, with `PlaneChaseFOV = 95`. Recommended chase FOV values are 85-105. `PlaneChaseFreelookFOV` defaults to the same value, and `PlaneChaseFOVSmoothing` blends the override when entering, freelooking, or leaving the camera.
+
+Hold-freelook is hold-to-orbit: mouse input changes raw orbit yaw/pitch targets, while `PlaneFreelookYawSmoothing` and `PlaneFreelookPitchSmoothing` smooth the rendered orbit. `PlaneFreelookReturnSmoothing` controls the blend back to rear chase after release. Recommended starting values are sensitivity 0.15, yaw/pitch smoothing around 0.18-0.28, return smoothing around 0.12-0.22, max pitch up around 75 degrees, and max pitch down around 65 degrees. Freelook should feel smooth and camera-like, not raw or jittery.

--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderLivingEvent.Specials.Post;
@@ -177,6 +178,13 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
          MCH_ParticlesUtil.clearMarkPoint();
       }
 
+   }
+
+   @SubscribeEvent
+   public void onFovUpdate(FOVUpdateEvent event) {
+      if(event != null && MCP_PlaneChaseCamera.isFovOverrideActive()) {
+         event.newfov = MCP_PlaneChaseCamera.applyFovOverride(event.newfov);
+      }
    }
 
    @SubscribeEvent

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -166,7 +166,12 @@ public class MCH_Config {
    public static MCH_ConfigPrm NewPlaneCameraDebugAbovePlane;
    public static MCH_ConfigPrm NewPlaneCameraHeight;
    public static MCH_ConfigPrm NewPlaneCameraSideOffset;
-   public static MCH_ConfigPrm NewPlaneCameraSpeedDistanceScale;
+   public static MCH_ConfigPrm PlaneChaseSpeedDistanceScale;
+   public static MCH_ConfigPrm PlaneChaseSpeedDistanceMaxBonus;
+   public static MCH_ConfigPrm EnablePlaneChaseFOVOverride;
+   public static MCH_ConfigPrm PlaneChaseFOV;
+   public static MCH_ConfigPrm PlaneChaseFreelookFOV;
+   public static MCH_ConfigPrm PlaneChaseFOVSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraSizeDistanceScale;
    public static MCH_ConfigPrm PlaneChaseFocusVerticalOffset;
    public static MCH_ConfigPrm PlaneChaseScreenVerticalBias;
@@ -175,13 +180,20 @@ public class MCH_Config {
    public static MCH_ConfigPrm PlaneLookAheadReturnSmoothing;
    public static MCH_ConfigPrm FreelookReturnSmoothing;
    public static MCH_ConfigPrm PlaneFreelookOrbitSensitivity;
+   public static MCH_ConfigPrm PlaneFreelookYawSmoothing;
+   public static MCH_ConfigPrm PlaneFreelookPitchSmoothing;
+   public static MCH_ConfigPrm PlaneFreelookReturnSmoothing;
+   public static MCH_ConfigPrm PlaneFreelookMaxPitchUp;
+   public static MCH_ConfigPrm PlaneFreelookMaxPitchDown;
    public static MCH_ConfigPrm NewPlaneCameraPositionSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraYawSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraPitchSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraDistanceSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraFocusSmoothing;
    public static MCH_ConfigPrm NewPlaneCameraPitchInfluenceSmoothing;
+   public static MCH_ConfigPrm PlaneChasePitchInfluence;
    public static MCH_ConfigPrm NewPlaneCameraRollInfluence;
+   public static MCH_ConfigPrm PlaneChaseHorizonStabilization;
    public static MCH_ConfigPrm EnableNewPlaneCameraSpeedDistance;
    public static MCH_ConfigPrm EnableNewPlaneCameraCollision;
    public static MCH_ConfigPrm EnablePlaneLookAhead;
@@ -432,13 +444,13 @@ public class MCH_Config {
       DisplayHUDThirdPerson = new MCH_ConfigPrm("DisplayHUDThirdPerson", false);
       EnableNewPlaneThirdPersonCamera = new MCH_ConfigPrm("EnableNewPlaneThirdPersonCamera", true);
       EnableNewPlaneThirdPersonCamera.desc = ";Client-only visual chase camera for third-person new-flight planes. Does not change flight physics, weapons, or HUD rendering.";
-      NewPlaneCameraDistance = new MCH_ConfigPrm("NewPlaneCameraDistance", 45.0D);
-      NewPlaneCameraDistance.desc = ";Base chase distance in blocks for new-flight third-person planes. default is 45; 16 is often too close and 45-80+ can be reasonable by scale/speed.";
-      NewPlaneCameraMinDistance = new MCH_ConfigPrm("NewPlaneCameraMinDistance", 24.0D);
-      NewPlaneCameraMinDistance.desc = ";Minimum chase distance in blocks after speed/size/collision tuning.";
-      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("NewPlaneCameraMaxDistance", 90.0D);
-      NewPlaneCameraMaxDistance.desc = ";Maximum chase distance in blocks after speed/size tuning.";
-      NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 40.0D);
+      NewPlaneCameraDistance = new MCH_ConfigPrm("PlaneChaseBaseDistance", 15.0D);
+      NewPlaneCameraDistance.desc = ";Base chase distance in blocks for new-flight third-person planes. default is 15; 16 is often too close and 45-80+ can be reasonable by scale/speed.";
+      NewPlaneCameraMinDistance = new MCH_ConfigPrm("PlaneChaseMinDistance", 13.0D);
+      NewPlaneCameraMinDistance.desc = ";Minimum chase distance in blocks after size and optional speed tuning; default 13 keeps aircraft framed when slowing down.";
+      NewPlaneCameraMaxDistance = new MCH_ConfigPrm("PlaneChaseMaxDistance", 21.0D);
+      NewPlaneCameraMaxDistance.desc = ";Maximum chase distance in blocks after size and optional speed tuning; default 21 avoids aggressive zoom breathing.";
+      NewPlaneCameraDebugDistance = new MCH_ConfigPrm("NewPlaneCameraDebugDistance", 0.0D);
       NewPlaneCameraDebugDistance.desc = ";DebugFlightControl-only chase camera distance override. Set 40 to verify the render path consumes the custom camera; 0 disables.";
       NewPlaneCameraDebugAbovePlane = new MCH_ConfigPrm("NewPlaneCameraDebugAbovePlane", false);
       NewPlaneCameraDebugAbovePlane.desc = ";DebugFlightControl-only hard test: places the chase dummy at plane.posY + 20 with third-person distance zeroed.";
@@ -446,8 +458,18 @@ public class MCH_Config {
       NewPlaneCameraHeight.desc = ";Blocks above the aircraft for the new third-person plane chase camera.";
       NewPlaneCameraSideOffset = new MCH_ConfigPrm("NewPlaneCameraSideOffset", 0.0D);
       NewPlaneCameraSideOffset.desc = ";Optional horizontal side offset for the new third-person plane chase camera.";
-      NewPlaneCameraSpeedDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSpeedDistanceScale", 10.0D);
-      NewPlaneCameraSpeedDistanceScale.desc = ";Extra chase distance per block/tick of aircraft speed when speed-based distance is enabled.";
+      PlaneChaseSpeedDistanceScale = new MCH_ConfigPrm("PlaneChaseSpeedDistanceScale", 2.0D);
+      PlaneChaseSpeedDistanceScale.desc = ";Extra chase distance per block/tick of aircraft speed when speed-based distance is explicitly enabled; kept low to avoid zoom breathing.";
+      PlaneChaseSpeedDistanceMaxBonus = new MCH_ConfigPrm("PlaneChaseSpeedDistanceMaxBonus", 3.0D);
+      PlaneChaseSpeedDistanceMaxBonus.desc = ";Maximum extra blocks optional speed-based distance may add; default small for stable framing.";
+      EnablePlaneChaseFOVOverride = new MCH_ConfigPrm("EnablePlaneChaseFOVOverride", true);
+      EnablePlaneChaseFOVOverride.desc = ";Overrides FOV only for the new-flight third-person plane chase camera; does not affect first person, legacy aircraft cameras, or normal Minecraft third person.";
+      PlaneChaseFOV = new MCH_ConfigPrm("PlaneChaseFOV", 95.0D);
+      PlaneChaseFOV.desc = ";Target new plane chase camera FOV. Recommended range is 85-105; wider FOV improves awareness without excessive camera distance.";
+      PlaneChaseFreelookFOV = new MCH_ConfigPrm("PlaneChaseFreelookFOV", 95.0D);
+      PlaneChaseFreelookFOV.desc = ";Optional FOV while hold-freelook orbit is active; defaults to match PlaneChaseFOV.";
+      PlaneChaseFOVSmoothing = new MCH_ConfigPrm("PlaneChaseFOVSmoothing", 0.25D);
+      PlaneChaseFOVSmoothing.desc = ";How quickly the chase FOV override blends in, changes for freelook, and restores when leaving chase camera.";
       NewPlaneCameraSizeDistanceScale = new MCH_ConfigPrm("NewPlaneCameraSizeDistanceScale", 1.25D);
       NewPlaneCameraSizeDistanceScale.desc = ";Extra chase distance per block of aircraft bounding-box size; helps bombers and large planes frame comfortably.";
       PlaneChaseFocusVerticalOffset = new MCH_ConfigPrm("PlaneChaseFocusVerticalOffset", 2.5D);
@@ -463,22 +485,32 @@ public class MCH_Config {
       FreelookReturnSmoothing = new MCH_ConfigPrm("FreelookReturnSmoothing", 0.28D);
       FreelookReturnSmoothing.desc = ";How quickly hold-freelook returns to normal chase-camera orientation after release.";
       PlaneFreelookOrbitSensitivity = new MCH_ConfigPrm("PlaneFreelookOrbitSensitivity", 0.15D);
-      PlaneFreelookOrbitSensitivity.desc = ";Mouse sensitivity multiplier for new chase-camera hold freelook orbit yaw/pitch.";
-      NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.34D);
+      PlaneFreelookOrbitSensitivity.desc = ";Mouse sensitivity multiplier for new chase-camera hold freelook target orbit yaw/pitch.";
+      PlaneFreelookYawSmoothing = new MCH_ConfigPrm("PlaneFreelookYawSmoothing", 0.20D);
+      PlaneFreelookPitchSmoothing = new MCH_ConfigPrm("PlaneFreelookPitchSmoothing", 0.20D);
+      PlaneFreelookReturnSmoothing = new MCH_ConfigPrm("PlaneFreelookReturnSmoothing", 0.14D);
+      PlaneFreelookMaxPitchUp = new MCH_ConfigPrm("PlaneFreelookMaxPitchUp", 75.0D);
+      PlaneFreelookMaxPitchDown = new MCH_ConfigPrm("PlaneFreelookMaxPitchDown", 65.0D);
+      NewPlaneCameraPositionSmoothing = new MCH_ConfigPrm("NewPlaneCameraPositionSmoothing", 0.22D);
       NewPlaneCameraPositionSmoothing.desc = ";How quickly camera position follows the desired point. Higher is snappier.";
-      NewPlaneCameraYawSmoothing = new MCH_ConfigPrm("NewPlaneCameraYawSmoothing", 0.42D);
+      NewPlaneCameraYawSmoothing = new MCH_ConfigPrm("NewPlaneCameraYawSmoothing", 0.26D);
       NewPlaneCameraYawSmoothing.desc = ";How quickly normal chase camera yaw follows the raised aim focus.";
-      NewPlaneCameraPitchSmoothing = new MCH_ConfigPrm("NewPlaneCameraPitchSmoothing", 0.34D);
+      NewPlaneCameraPitchSmoothing = new MCH_ConfigPrm("NewPlaneCameraPitchSmoothing", 0.22D);
       NewPlaneCameraPitchSmoothing.desc = ";How quickly chase camera pitch follows climbs/dives.";
-      NewPlaneCameraDistanceSmoothing = new MCH_ConfigPrm("NewPlaneCameraDistanceSmoothing", 0.25D);
+      NewPlaneCameraDistanceSmoothing = new MCH_ConfigPrm("NewPlaneCameraDistanceSmoothing", 0.16D);
       NewPlaneCameraDistanceSmoothing.desc = ";How quickly speed/size/collision distance changes are applied.";
-      NewPlaneCameraFocusSmoothing = new MCH_ConfigPrm("NewPlaneCameraFocusSmoothing", 0.38D);
+      NewPlaneCameraFocusSmoothing = new MCH_ConfigPrm("NewPlaneCameraFocusSmoothing", 0.24D);
       NewPlaneCameraFocusSmoothing.desc = ";How quickly the chase focus moves when held look-ahead or framing offsets change.";
       NewPlaneCameraPitchInfluenceSmoothing = new MCH_ConfigPrm("NewPlaneCameraPitchInfluenceSmoothing", 0.30D);
       NewPlaneCameraPitchInfluenceSmoothing.desc = ";Smoothing for plane pitch influence so steep climbs/dives read without snapping.";
+      PlaneChasePitchInfluence = new MCH_ConfigPrm("PlaneChasePitchInfluence", 0.25D);
+      PlaneChasePitchInfluence.desc = ";How much aircraft pitch affects the new chase camera direction; conservative defaults keep the camera observational instead of glued to the plane.";
       NewPlaneCameraRollInfluence = new MCH_ConfigPrm("NewPlaneCameraRollInfluence", 0.12D);
       NewPlaneCameraRollInfluence.desc = ";0.0 keeps the horizon stable; 1.0 fully rolls the chase camera with the aircraft. Conservative defaults avoid nausea.";
-      EnableNewPlaneCameraSpeedDistance = new MCH_ConfigPrm("EnableNewPlaneCameraSpeedDistance", true);
+      PlaneChaseHorizonStabilization = new MCH_ConfigPrm("PlaneChaseHorizonStabilization", true);
+      PlaneChaseHorizonStabilization.desc = ";Keeps the new chase camera horizon more stable than the aircraft by applying conservative roll and pitch inheritance.";
+      EnableNewPlaneCameraSpeedDistance = new MCH_ConfigPrm("EnableSpeedBasedCameraDistance", false);
+      EnableNewPlaneCameraSpeedDistance.desc = ";Disabled by default so the new plane chase camera stays near its stable base distance instead of breathing with throttle/speed.";
       EnableNewPlaneCameraCollision = new MCH_ConfigPrm("EnableNewPlaneCameraCollision", true);
       EnablePlaneLookAhead = new MCH_ConfigPrm("EnablePlaneLookAhead", true);
       EnableHoldFreelook = new MCH_ConfigPrm("EnableHoldFreelook", true);
@@ -641,7 +673,12 @@ public class MCH_Config {
               NewPlaneCameraDebugAbovePlane,
               NewPlaneCameraHeight,
               NewPlaneCameraSideOffset,
-              NewPlaneCameraSpeedDistanceScale,
+              PlaneChaseSpeedDistanceScale,
+              PlaneChaseSpeedDistanceMaxBonus,
+              EnablePlaneChaseFOVOverride,
+              PlaneChaseFOV,
+              PlaneChaseFreelookFOV,
+              PlaneChaseFOVSmoothing,
               NewPlaneCameraSizeDistanceScale,
               PlaneChaseFocusVerticalOffset,
               PlaneChaseScreenVerticalBias,
@@ -650,13 +687,20 @@ public class MCH_Config {
               PlaneLookAheadReturnSmoothing,
               FreelookReturnSmoothing,
               PlaneFreelookOrbitSensitivity,
+              PlaneFreelookYawSmoothing,
+              PlaneFreelookPitchSmoothing,
+              PlaneFreelookReturnSmoothing,
+              PlaneFreelookMaxPitchUp,
+              PlaneFreelookMaxPitchDown,
               NewPlaneCameraPositionSmoothing,
               NewPlaneCameraYawSmoothing,
               NewPlaneCameraPitchSmoothing,
               NewPlaneCameraDistanceSmoothing,
               NewPlaneCameraFocusSmoothing,
               NewPlaneCameraPitchInfluenceSmoothing,
+              PlaneChasePitchInfluence,
               NewPlaneCameraRollInfluence,
+              PlaneChaseHorizonStabilization,
               EnableNewPlaneCameraSpeedDistance,
               EnableNewPlaneCameraCollision,
               EnablePlaneLookAhead,
@@ -744,14 +788,14 @@ public class MCH_Config {
       AllHeliSpeed.prmDouble = MCH_Lib.RNG(AllHeliSpeed.prmDouble, 0.0D, 1000.0D);
       AllPlaneSpeed.prmDouble = MCH_Lib.RNG(AllPlaneSpeed.prmDouble, 0.0D, 1000.0D);
       NewFlightGravity.prmDouble = MCH_Lib.RNG(NewFlightGravity.prmDouble, 0.001D, 0.2D);
-      if(Math.abs(NewPlaneCameraDistance.prmDouble - 36.0D) < 0.001D) {
-         NewPlaneCameraDistance.prmDouble = 45.0D;
+      if(Math.abs(NewPlaneCameraDistance.prmDouble - 36.0D) < 0.001D || Math.abs(NewPlaneCameraDistance.prmDouble - 45.0D) < 0.001D || Math.abs(NewPlaneCameraDistance.prmDouble - 30.0D) < 0.001D) {
+         NewPlaneCameraDistance.prmDouble = 15.0D;
       }
-      if(Math.abs(NewPlaneCameraMinDistance.prmDouble - 18.0D) < 0.001D) {
-         NewPlaneCameraMinDistance.prmDouble = 24.0D;
+      if(Math.abs(NewPlaneCameraMinDistance.prmDouble - 18.0D) < 0.001D || Math.abs(NewPlaneCameraMinDistance.prmDouble - 24.0D) < 0.001D || Math.abs(NewPlaneCameraMinDistance.prmDouble - 40.0D) < 0.001D || Math.abs(NewPlaneCameraMinDistance.prmDouble - 26.0D) < 0.001D) {
+         NewPlaneCameraMinDistance.prmDouble = 13.0D;
       }
-      if(Math.abs(NewPlaneCameraMaxDistance.prmDouble - 70.0D) < 0.001D) {
-         NewPlaneCameraMaxDistance.prmDouble = 90.0D;
+      if(Math.abs(NewPlaneCameraMaxDistance.prmDouble - 70.0D) < 0.001D || Math.abs(NewPlaneCameraMaxDistance.prmDouble - 90.0D) < 0.001D || Math.abs(NewPlaneCameraMaxDistance.prmDouble - 55.0D) < 0.001D || Math.abs(NewPlaneCameraMaxDistance.prmDouble - 42.0D) < 0.001D) {
+         NewPlaneCameraMaxDistance.prmDouble = 21.0D;
       }
       NewPlaneCameraDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistance.prmDouble, 8.0D, 120.0D);
       NewPlaneCameraMinDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraMinDistance.prmDouble, 4.0D, NewPlaneCameraDistance.prmDouble);
@@ -759,7 +803,7 @@ public class MCH_Config {
       NewPlaneCameraDebugDistance.prmDouble = MCH_Lib.RNG(NewPlaneCameraDebugDistance.prmDouble, 0.0D, 120.0D);
       NewPlaneCameraHeight.prmDouble = MCH_Lib.RNG(NewPlaneCameraHeight.prmDouble, -4.0D, 30.0D);
       NewPlaneCameraSideOffset.prmDouble = MCH_Lib.RNG(NewPlaneCameraSideOffset.prmDouble, -20.0D, 20.0D);
-      NewPlaneCameraSpeedDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSpeedDistanceScale.prmDouble, 0.0D, 80.0D);
+      PlaneChaseSpeedDistanceScale.prmDouble = MCH_Lib.RNG(PlaneChaseSpeedDistanceScale.prmDouble, 0.0D, 80.0D);
       NewPlaneCameraSizeDistanceScale.prmDouble = MCH_Lib.RNG(NewPlaneCameraSizeDistanceScale.prmDouble, 0.0D, 5.0D);
       PlaneChaseFocusVerticalOffset.prmDouble = MCH_Lib.RNG(PlaneChaseFocusVerticalOffset.prmDouble, -10.0D, 30.0D);
       PlaneChaseScreenVerticalBias.prmDouble = MCH_Lib.RNG(PlaneChaseScreenVerticalBias.prmDouble, -10.0D, 30.0D);
@@ -774,6 +818,16 @@ public class MCH_Config {
       NewPlaneCameraDistanceSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraDistanceSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraFocusSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraFocusSmoothing.prmDouble, 0.01D, 1.0D);
       NewPlaneCameraPitchInfluenceSmoothing.prmDouble = MCH_Lib.RNG(NewPlaneCameraPitchInfluenceSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneChasePitchInfluence.prmDouble = MCH_Lib.RNG(PlaneChasePitchInfluence.prmDouble, 0.0D, 1.0D);
+      PlaneChaseSpeedDistanceMaxBonus.prmDouble = MCH_Lib.RNG(PlaneChaseSpeedDistanceMaxBonus.prmDouble, 0.0D, 20.0D);
+      PlaneChaseFOV.prmDouble = MCH_Lib.RNG(PlaneChaseFOV.prmDouble, 30.0D, 120.0D);
+      PlaneChaseFreelookFOV.prmDouble = MCH_Lib.RNG(PlaneChaseFreelookFOV.prmDouble, 30.0D, 120.0D);
+      PlaneChaseFOVSmoothing.prmDouble = MCH_Lib.RNG(PlaneChaseFOVSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneFreelookYawSmoothing.prmDouble = MCH_Lib.RNG(PlaneFreelookYawSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneFreelookPitchSmoothing.prmDouble = MCH_Lib.RNG(PlaneFreelookPitchSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneFreelookReturnSmoothing.prmDouble = MCH_Lib.RNG(PlaneFreelookReturnSmoothing.prmDouble, 0.01D, 1.0D);
+      PlaneFreelookMaxPitchUp.prmDouble = MCH_Lib.RNG(PlaneFreelookMaxPitchUp.prmDouble, 0.0D, 89.0D);
+      PlaneFreelookMaxPitchDown.prmDouble = MCH_Lib.RNG(PlaneFreelookMaxPitchDown.prmDouble, 0.0D, 89.0D);
       NewPlaneCameraRollInfluence.prmDouble = MCH_Lib.RNG(NewPlaneCameraRollInfluence.prmDouble, 0.0D, 1.0D);
       AllTankSpeed.prmDouble = MCH_Lib.RNG(AllTankSpeed.prmDouble, 0.0D, 1000.0D);
       AllShipSpeed.prmDouble = MCH_Lib.RNG(AllShipSpeed.prmDouble, 0.0D, 1000.0D);

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -43,6 +43,22 @@ public class MCH_ConfigGui extends W_GuiContainer {
    private MCH_GuiOnOffButton buttonMarkThroughWall;
    private MCH_GuiOnOffButton buttonReplaceCamera;
    private MCH_GuiOnOffButton buttonNewExplosion;
+   private MCH_GuiOnOffButton buttonPlaneChaseCamera;
+   private MCH_GuiOnOffButton buttonPlaneChaseSpeedDistance;
+   private MCH_GuiOnOffButton buttonPlaneChaseFovOverride;
+   private MCH_GuiSlider sliderPlaneChaseBaseDistance;
+   private MCH_GuiSlider sliderPlaneChaseMinDistance;
+   private MCH_GuiSlider sliderPlaneChaseMaxDistance;
+   private MCH_GuiSlider sliderPlaneChaseSpeedScale;
+   private MCH_GuiSlider sliderPlaneChaseSpeedMaxBonus;
+   private MCH_GuiSlider sliderPlaneChaseFov;
+   private MCH_GuiSlider sliderPlaneChaseFreelookFov;
+   private MCH_GuiSlider sliderPlaneFreelookSensitivity;
+   private MCH_GuiSlider sliderPlaneFreelookYawSmoothing;
+   private MCH_GuiSlider sliderPlaneFreelookPitchSmoothing;
+   private MCH_GuiSlider sliderPlaneFreelookReturnSmoothing;
+   private MCH_GuiSlider sliderPlaneChasePitchInfluence;
+   private MCH_GuiSlider sliderPlaneChaseRollInfluence;
    private MCH_GuiSlider sliderEntityMarkerSize;
    private MCH_GuiSlider sliderBlockMarkerSize;
    private MCH_GuiSlider sliderSensitivity;
@@ -59,6 +75,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
    private W_GuiButton buttonReloadAllHUD;
    public List listControlButtons;
    public List listRenderButtons;
+   public List listPlaneCameraButtons;
    public List listKeyBindingButtons;
    public List listDevelopButtons;
    public MCH_GuiList keyBindingList;
@@ -68,6 +85,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
    public static final int BUTTON_KEY_BINDING = 51;
    public static final int BUTTON_PREV_CONTROL = 52;
    public static final int BUTTON_DEVELOP = 55;
+   public static final int BUTTON_PLANE_CAMERA = 56;
    public static final int BUTTON_KEY_LIST = 53;
    public static final int BUTTON_KEY_RESET_ALL = 54;
    public static final int BUTTON_KEY_LIST_BASE = 200;
@@ -77,19 +95,21 @@ public class MCH_ConfigGui extends W_GuiContainer {
    public static final int BUTTON_DEV_RELOAD_HUD = 402;
    public static final int BUTTON_SAVE_CLOSE = 100;
    public static final int BUTTON_CANCEL = 101;
+   public static final int BUTTON_APPLY = 102;
    public int currentScreenId = 0;
    public static final int SCREEN_CONTROLS = 0;
    public static final int SCREEN_RENDER = 1;
    public static final int SCREEN_KEY_BIND = 2;
    public static final int SCREEN_DEVELOP = 3;
+   public static final int SCREEN_PLANE_CAMERA = 4;
    private int ignoreButtonCounter = 0;
 
 
    public MCH_ConfigGui(EntityPlayer player) {
       super(new MCH_ConfigGuiContainer(player));
       this.thePlayer = player;
-      super.xSize = 330;
-      super.ySize = 200;
+      super.xSize = 480;
+      super.ySize = 250;
    }
 
    public void initGui() {
@@ -97,6 +117,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       super.buttonList.clear();
       int x1 = super.guiLeft + 10;
       int x2 = super.guiLeft + 10 + 150 + 10;
+      int x3 = x2 + 150 + 10;
       int y = super.guiTop;
       boolean DY = true;
       this.listControlButtons = new ArrayList();
@@ -139,6 +160,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.sliderHitMark = new MCH_GuiSlider[]{new MCH_GuiSlider(0, x1 + 0, y + 125, 75, 20, "Alpha:%.0f", 0.0F, 0.0F, 255.0F, 16.0F), new MCH_GuiSlider(0, x1 + 75, y + 75, 75, 20, "Red:%.0f", 0.0F, 0.0F, 255.0F, 16.0F), new MCH_GuiSlider(0, x1 + 75, y + 100, 75, 20, "Green:%.0f", 0.0F, 0.0F, 255.0F, 16.0F), new MCH_GuiSlider(0, x1 + 75, y + 125, 75, 20, "Blue:%.0f", 0.0F, 0.0F, 255.0F, 16.0F)};
       this.buttonReplaceCamera = new MCH_GuiOnOffButton(0, x1, y + 150, 150, 20, "Change Camera Pos : ");
       this.listRenderButtons.add(new W_GuiButton(52, x1, y + 175, 90, 20, "Controls <<"));
+      this.listRenderButtons.add(new W_GuiButton(56, x1 + 95, y + 175, 110, 20, "Plane Camera >>"));
       this.buttonSmoothShading = new MCH_GuiOnOffButton(0, x2, y + 25, 150, 20, "Smooth Shading : ");
       this.buttonShowEntityMarker = new MCH_GuiOnOffButton(0, x2, y + 50, 150, 20, "Show Entity Maker : ");
       this.sliderEntityMarkerSize = new MCH_GuiSlider(0, x2 + 30, y + 75, 120, 20, "Entity Marker Size:%.0f", 10.0F, 0.0F, 30.0F, 1.0F);
@@ -165,13 +187,54 @@ public class MCH_ConfigGui extends W_GuiContainer {
          super.buttonList.add(idr);
       }
 
+      this.listPlaneCameraButtons = new ArrayList<W_GuiButton>();
+      this.buttonPlaneChaseCamera = new MCH_GuiOnOffButton(0, x1, y + 25, 150, 20, "New Chase Cam : ");
+      this.sliderPlaneChaseBaseDistance = new MCH_GuiSlider(0, x1, y + 50, 150, 20, "Base Dist:%.0f", 15.0F, 8.0F, 80.0F, 1.0F);
+      this.sliderPlaneChaseMinDistance = new MCH_GuiSlider(0, x1, y + 75, 150, 20, "Min Dist:%.0f", 13.0F, 6.0F, 80.0F, 1.0F);
+      this.sliderPlaneChaseMaxDistance = new MCH_GuiSlider(0, x1, y + 100, 150, 20, "Max Dist:%.0f", 21.0F, 8.0F, 120.0F, 1.0F);
+      this.buttonPlaneChaseSpeedDistance = new MCH_GuiOnOffButton(0, x1, y + 125, 150, 20, "Speed Distance : ");
+      this.sliderPlaneChaseSpeedScale = new MCH_GuiSlider(0, x1, y + 150, 150, 20, "Speed Scale:%.1f", 2.0F, 0.0F, 20.0F, 0.5F);
+      this.sliderPlaneChaseSpeedMaxBonus = new MCH_GuiSlider(0, x1, y + 175, 150, 20, "Speed Bonus:%.0f", 3.0F, 0.0F, 20.0F, 1.0F);
+      this.sliderPlaneChasePitchInfluence = new MCH_GuiSlider(0, x3, y + 25, 150, 20, "Pitch Inf:%.2f", 0.25F, 0.0F, 1.0F, 0.05F);
+      this.buttonPlaneChaseFovOverride = new MCH_GuiOnOffButton(0, x2, y + 25, 150, 20, "Chase FOV : ");
+      this.sliderPlaneChaseFov = new MCH_GuiSlider(0, x2, y + 50, 150, 20, "FOV:%.0f", 95.0F, 60.0F, 120.0F, 1.0F);
+      this.sliderPlaneChaseFreelookFov = new MCH_GuiSlider(0, x2, y + 75, 150, 20, "Free FOV:%.0f", 95.0F, 60.0F, 120.0F, 1.0F);
+      this.sliderPlaneFreelookSensitivity = new MCH_GuiSlider(0, x2, y + 100, 150, 20, "Free Sens:%.2f", 0.15F, 0.01F, 1.0F, 0.01F);
+      this.sliderPlaneFreelookYawSmoothing = new MCH_GuiSlider(0, x2, y + 125, 150, 20, "Free Yaw:%.2f", 0.28F, 0.01F, 1.0F, 0.01F);
+      this.sliderPlaneFreelookPitchSmoothing = new MCH_GuiSlider(0, x2, y + 150, 150, 20, "Free Pitch:%.2f", 0.28F, 0.01F, 1.0F, 0.01F);
+      this.sliderPlaneFreelookReturnSmoothing = new MCH_GuiSlider(0, x2, y + 175, 150, 20, "Free Return:%.2f", 0.18F, 0.01F, 1.0F, 0.01F);
+      this.sliderPlaneChaseRollInfluence = new MCH_GuiSlider(0, x3, y + 50, 150, 20, "Roll Inf:%.2f", 0.12F, 0.0F, 1.0F, 0.05F);
+      this.listPlaneCameraButtons.add(this.buttonPlaneChaseCamera);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseBaseDistance);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseMinDistance);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseMaxDistance);
+      this.listPlaneCameraButtons.add(this.buttonPlaneChaseSpeedDistance);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseSpeedScale);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseSpeedMaxBonus);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChasePitchInfluence);
+      this.listPlaneCameraButtons.add(this.buttonPlaneChaseFovOverride);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseFov);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseFreelookFov);
+      this.listPlaneCameraButtons.add(this.sliderPlaneFreelookSensitivity);
+      this.listPlaneCameraButtons.add(this.sliderPlaneFreelookYawSmoothing);
+      this.listPlaneCameraButtons.add(this.sliderPlaneFreelookPitchSmoothing);
+      this.listPlaneCameraButtons.add(this.sliderPlaneFreelookReturnSmoothing);
+      this.listPlaneCameraButtons.add(this.sliderPlaneChaseRollInfluence);
+      this.listPlaneCameraButtons.add(new W_GuiButton(50, x1, y + 220, 90, 20, "Render <<"));
+      id = this.listPlaneCameraButtons.iterator();
+
+      while(id.hasNext()) {
+         idr = (W_GuiButton)id.next();
+         super.buttonList.add(idr);
+      }
+
       this.listKeyBindingButtons = new ArrayList();
       this.waitKeyButtonId = 0;
       this.waitKeyAcceptCount = 0;
       this.keyBindingList = new MCH_GuiList(53, 7, x1, y + 25 - 2, 310, 150, "");
       this.listKeyBindingButtons.add(this.keyBindingList);
-      this.listKeyBindingButtons.add(new W_GuiButton(52, x1, y + 175, 90, 20, "Controls <<"));
-      this.listKeyBindingButtons.add(new W_GuiButton(54, x1 + 90, y + 175, 60, 20, "Reset All"));
+      this.listKeyBindingButtons.add(new W_GuiButton(52, x1, y + 220, 90, 20, "Controls <<"));
+      this.listKeyBindingButtons.add(new W_GuiButton(54, x1 + 90, y + 220, 60, 20, "Reset All"));
       boolean var13 = true;
       boolean var14 = true;
       MCH_GuiListItemKeyBind[] var10000 = new MCH_GuiListItemKeyBind[30];
@@ -313,7 +376,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
          this.listDevelopButtons.add(this.buttonReloadAllHUD);
       }
 
-      this.listDevelopButtons.add(new W_GuiButton(52, x1, y + 175, 90, 20, "Controls <<"));
+      this.listDevelopButtons.add(new W_GuiButton(52, x1, y + 220, 90, 20, "Controls <<"));
       var15 = this.listDevelopButtons.iterator();
 
       while(var15.hasNext()) {
@@ -321,8 +384,9 @@ public class MCH_ConfigGui extends W_GuiContainer {
          super.buttonList.add(var16);
       }
 
-      super.buttonList.add(new GuiButton(100, x2, y + 175, 80, 20, "Save & Close"));
-      super.buttonList.add(new GuiButton(101, x2 + 90, y + 175, 60, 20, "Cancel"));
+      super.buttonList.add(new GuiButton(102, x2, y + 220, 80, 20, "Apply"));
+      super.buttonList.add(new GuiButton(100, x2 + 90, y + 220, 80, 20, "Save & Close"));
+      super.buttonList.add(new GuiButton(101, x2 + 180, y + 220, 60, 20, "Cancel"));
       this.switchScreen(0);
       this.applySwitchScreen();
       this.getAllStatusFromConfig();
@@ -368,6 +432,23 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.buttonTestMode.setOnOff(config.TestMode.prmBool);
       this.buttonFlightSimMode.setOnOff(config.MouseControlFlightSimMode.prmBool);
       this.buttonSwitchWeaponWheel.setOnOff(config.SwitchWeaponWithMouseWheel.prmBool);
+
+      this.buttonPlaneChaseCamera.setOnOff(config.EnableNewPlaneThirdPersonCamera.prmBool);
+      this.buttonPlaneChaseSpeedDistance.setOnOff(config.EnableNewPlaneCameraSpeedDistance.prmBool);
+      this.buttonPlaneChaseFovOverride.setOnOff(config.EnablePlaneChaseFOVOverride.prmBool);
+      this.sliderPlaneChaseBaseDistance.setSliderValue((float)config.NewPlaneCameraDistance.prmDouble);
+      this.sliderPlaneChaseMinDistance.setSliderValue((float)config.NewPlaneCameraMinDistance.prmDouble);
+      this.sliderPlaneChaseMaxDistance.setSliderValue((float)config.NewPlaneCameraMaxDistance.prmDouble);
+      this.sliderPlaneChaseSpeedScale.setSliderValue((float)config.PlaneChaseSpeedDistanceScale.prmDouble);
+      this.sliderPlaneChaseSpeedMaxBonus.setSliderValue((float)config.PlaneChaseSpeedDistanceMaxBonus.prmDouble);
+      this.sliderPlaneChaseFov.setSliderValue((float)config.PlaneChaseFOV.prmDouble);
+      this.sliderPlaneChaseFreelookFov.setSliderValue((float)config.PlaneChaseFreelookFOV.prmDouble);
+      this.sliderPlaneFreelookSensitivity.setSliderValue((float)config.PlaneFreelookOrbitSensitivity.prmDouble);
+      this.sliderPlaneFreelookYawSmoothing.setSliderValue((float)config.PlaneFreelookYawSmoothing.prmDouble);
+      this.sliderPlaneFreelookPitchSmoothing.setSliderValue((float)config.PlaneFreelookPitchSmoothing.prmDouble);
+      this.sliderPlaneFreelookReturnSmoothing.setSliderValue((float)config.PlaneFreelookReturnSmoothing.prmDouble);
+      this.sliderPlaneChasePitchInfluence.setSliderValue((float)config.PlaneChasePitchInfluence.prmDouble);
+      this.sliderPlaneChaseRollInfluence.setSliderValue((float)config.NewPlaneCameraRollInfluence.prmDouble);
    }
 
    public void saveAndApplyConfig() {
@@ -418,6 +499,26 @@ public class MCH_ConfigGui extends W_GuiContainer {
          sendClientSettings();
       }
 
+      config.EnableNewPlaneThirdPersonCamera.setPrm(buttonPlaneChaseCamera.getOnOff());
+      config.EnableNewPlaneCameraSpeedDistance.setPrm(buttonPlaneChaseSpeedDistance.getOnOff());
+      config.EnablePlaneChaseFOVOverride.setPrm(buttonPlaneChaseFovOverride.getOnOff());
+      float chaseBaseDistance = sliderPlaneChaseBaseDistance.getSliderValueInt(1);
+      float chaseMinDistance = Math.min(sliderPlaneChaseMinDistance.getSliderValueInt(1), chaseBaseDistance);
+      float chaseMaxDistance = Math.max(sliderPlaneChaseMaxDistance.getSliderValueInt(1), chaseMinDistance);
+      config.NewPlaneCameraDistance.setPrm(chaseBaseDistance);
+      config.NewPlaneCameraMinDistance.setPrm(chaseMinDistance);
+      config.NewPlaneCameraMaxDistance.setPrm(chaseMaxDistance);
+      config.PlaneChaseSpeedDistanceScale.setPrm(sliderPlaneChaseSpeedScale.getSliderValueInt(1));
+      config.PlaneChaseSpeedDistanceMaxBonus.setPrm(sliderPlaneChaseSpeedMaxBonus.getSliderValueInt(1));
+      config.PlaneChaseFOV.setPrm(sliderPlaneChaseFov.getSliderValueInt(1));
+      config.PlaneChaseFreelookFOV.setPrm(sliderPlaneChaseFreelookFov.getSliderValueInt(1));
+      config.PlaneFreelookOrbitSensitivity.setPrm(sliderPlaneFreelookSensitivity.getSliderValueInt(2));
+      config.PlaneFreelookYawSmoothing.setPrm(sliderPlaneFreelookYawSmoothing.getSliderValueInt(2));
+      config.PlaneFreelookPitchSmoothing.setPrm(sliderPlaneFreelookPitchSmoothing.getSliderValueInt(2));
+      config.PlaneFreelookReturnSmoothing.setPrm(sliderPlaneFreelookReturnSmoothing.getSliderValueInt(2));
+      config.PlaneChasePitchInfluence.setPrm(sliderPlaneChasePitchInfluence.getSliderValueInt(2));
+      config.NewPlaneCameraRollInfluence.setPrm(sliderPlaneChaseRollInfluence.getSliderValueInt(2));
+
       // Apply key codes
       for (int i = 0; i < keyBindingList.getItemNum(); i++) {
          ((MCH_GuiListItemKeyBind) keyBindingList.getItem(i)).applyKeycode();
@@ -441,6 +542,13 @@ public class MCH_ConfigGui extends W_GuiContainer {
       }
 
       i$ = this.listRenderButtons.iterator();
+
+      while(i$.hasNext()) {
+         b = (W_GuiButton)i$.next();
+         b.setVisible(false);
+      }
+
+      i$ = this.listPlaneCameraButtons.iterator();
 
       while(i$.hasNext()) {
          b = (W_GuiButton)i$.next();
@@ -480,6 +588,15 @@ public class MCH_ConfigGui extends W_GuiContainer {
          return;
       case 1:
          i$ = this.listRenderButtons.iterator();
+
+         while(i$.hasNext()) {
+            b = (W_GuiButton)i$.next();
+            b.setVisible(true);
+         }
+
+         return;
+      case 4:
+         i$ = this.listPlaneCameraButtons.iterator();
 
          while(i$.hasNext()) {
             b = (W_GuiButton)i$.next();
@@ -639,12 +756,18 @@ public class MCH_ConfigGui extends W_GuiContainer {
          case 55:
             this.switchScreen(3);
             break;
+         case 56:
+            this.switchScreen(4);
+            break;
          case 100:
             this.saveAndApplyConfig();
             super.mc.thePlayer.closeScreen();
             break;
          case 101:
             super.mc.thePlayer.closeScreen();
+            break;
+         case 102:
+            this.saveAndApplyConfig();
             break;
          case 401:
             //reloads the vehicle assets
@@ -738,7 +861,10 @@ public class MCH_ConfigGui extends W_GuiContainer {
          GL11.glPopMatrix();
       } else {
          int var12;
-         if(this.currentScreenId == 2) {
+         if(this.currentScreenId == 4) {
+            this.drawString("< Plane Camera >", 170, 10, 16777215);
+            this.drawString("Stable distance + FOV; Apply works in-flight", 10, 212, 16777215);
+         } else if(this.currentScreenId == 2) {
             this.drawString("< Key Binding >", 170, 10, 16777215);
             if(this.waitKeyButtonId != 0) {
                drawRect(30, 30, super.xSize - 30, super.ySize - 30, -533712848);

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -60,10 +60,19 @@ public class MCP_PlaneChaseCamera {
    private boolean wasFreelookActive;
    private float orbitYawOffset;
    private float orbitPitchOffset;
+   private float smoothedOrbitYawOffset;
+   private float smoothedOrbitPitchOffset;
    private double orbitDirX;
    private double orbitDirY;
    private double orbitDirZ;
    private double lastFinalChaseDistance;
+   private double lastBaseChaseDistance;
+   private double lastSizeDistanceBonus;
+   private double lastSpeedDistanceBonus;
+   private double lastDesiredDistance;
+   private double lastCollisionAdjustedDistance;
+   private float smoothedFov = -1.0F;
+   private float lastFovTarget;
    private double lastDesiredX;
    private double lastDesiredY;
    private double lastDesiredZ;
@@ -103,6 +112,8 @@ public class MCP_PlaneChaseCamera {
       this.wasFreelookActive = false;
       this.orbitYawOffset = 0.0F;
       this.orbitPitchOffset = 0.0F;
+      this.smoothedOrbitYawOffset = 0.0F;
+      this.smoothedOrbitPitchOffset = 0.0F;
       W_Reflection.setCameraRoll(0.0F);
       if(activeCamera == this) {
          activeCamera = null;
@@ -150,6 +161,7 @@ public class MCP_PlaneChaseCamera {
          desired = this.escapeAircraftCollision(plane, focus, desired);
       }
       this.lastDistanceAfterCollision = this.distance(focus, desired);
+      this.lastCollisionAdjustedDistance = this.lastDistanceAfterCollision;
       this.lastFinalChaseDistance = this.lastDistanceAfterCollision;
       this.lastDesiredX = desired.xCoord;
       this.lastDesiredY = desired.yCoord;
@@ -282,10 +294,15 @@ public class MCP_PlaneChaseCamera {
       double dy = plane.posY - plane.prevPosY;
       double dz = plane.posZ - plane.prevPosZ;
       double speed = Math.sqrt(dx * dx + dy * dy + dz * dz);
-      double target = MCH_Config.NewPlaneCameraDistance.prmDouble + this.getAircraftSize(plane) * MCH_Config.NewPlaneCameraSizeDistanceScale.prmDouble;
+      this.lastBaseChaseDistance = MCH_Config.NewPlaneCameraDistance.prmDouble;
+      this.lastSizeDistanceBonus = this.getAircraftSize(plane) * MCH_Config.NewPlaneCameraSizeDistanceScale.prmDouble;
+      this.lastSpeedDistanceBonus = 0.0D;
+      double target = this.lastBaseChaseDistance + this.lastSizeDistanceBonus;
       if(MCH_Config.EnableNewPlaneCameraSpeedDistance.prmBool) {
-         target += speed * MCH_Config.NewPlaneCameraSpeedDistanceScale.prmDouble;
+         this.lastSpeedDistanceBonus = Math.min(speed * MCH_Config.PlaneChaseSpeedDistanceScale.prmDouble, MCH_Config.PlaneChaseSpeedDistanceMaxBonus.prmDouble);
+         target += this.lastSpeedDistanceBonus;
       }
+      this.lastDesiredDistance = target;
       target = MCH_Lib.RNG(target, MCH_Config.NewPlaneCameraMinDistance.prmDouble, MCH_Config.NewPlaneCameraMaxDistance.prmDouble);
       if(this.smoothedDistance <= 0.0D) {
          this.smoothedDistance = target;
@@ -313,8 +330,9 @@ public class MCP_PlaneChaseCamera {
    }
 
    private Vec3 getOrbitDirection(MCP_EntityPlane plane) {
-      float yaw = plane.getRotYaw() + this.orbitYawOffset;
-      float pitch = this.smoothedPitchInfluence * 0.35F + this.orbitPitchOffset;
+      float yaw = plane.getRotYaw() + this.smoothedOrbitYawOffset;
+      float pitchInfluence = this.freelookActive || Math.abs(this.smoothedOrbitYawOffset) > 0.01F || Math.abs(this.smoothedOrbitPitchOffset) > 0.01F?0.0F:this.smoothedPitchInfluence * (float)MCH_Config.PlaneChasePitchInfluence.prmDouble;
+      float pitch = pitchInfluence + this.smoothedOrbitPitchOffset;
       Vec3 dir = MCH_Lib.Rot2Vec3(yaw, pitch);
       this.orbitDirX = dir.xCoord;
       this.orbitDirY = dir.yCoord;
@@ -327,12 +345,12 @@ public class MCP_PlaneChaseCamera {
          double sensitivity = MCH_Config.PlaneFreelookOrbitSensitivity.prmDouble;
          this.orbitYawOffset += (float)(pendingFreelookMouseX * sensitivity);
          this.orbitPitchOffset += (float)(pendingFreelookMouseY * sensitivity);
-         this.orbitPitchOffset = MathHelper.clamp_float(this.orbitPitchOffset, -80.0F, 80.0F);
+         this.orbitPitchOffset = MathHelper.clamp_float(this.orbitPitchOffset, -(float)MCH_Config.PlaneFreelookMaxPitchDown.prmDouble, (float)MCH_Config.PlaneFreelookMaxPitchUp.prmDouble);
          pendingFreelookMouseX = 0.0D;
          pendingFreelookMouseY = 0.0D;
       } else {
-         this.orbitYawOffset = this.smoothAngle(this.orbitYawOffset, 0.0F, MCH_Config.FreelookReturnSmoothing.prmDouble);
-         this.orbitPitchOffset = this.smoothAngle(this.orbitPitchOffset, 0.0F, MCH_Config.FreelookReturnSmoothing.prmDouble);
+         this.orbitYawOffset = this.smoothAngle(this.orbitYawOffset, 0.0F, MCH_Config.PlaneFreelookReturnSmoothing.prmDouble);
+         this.orbitPitchOffset = this.smoothAngle(this.orbitPitchOffset, 0.0F, MCH_Config.PlaneFreelookReturnSmoothing.prmDouble);
          if(Math.abs(this.orbitYawOffset) < 0.01F) {
             this.orbitYawOffset = 0.0F;
          }
@@ -340,6 +358,10 @@ public class MCP_PlaneChaseCamera {
             this.orbitPitchOffset = 0.0F;
          }
       }
+      double yawSmoothing = this.freelookActive?MCH_Config.PlaneFreelookYawSmoothing.prmDouble:MCH_Config.PlaneFreelookReturnSmoothing.prmDouble;
+      double pitchSmoothing = this.freelookActive?MCH_Config.PlaneFreelookPitchSmoothing.prmDouble:MCH_Config.PlaneFreelookReturnSmoothing.prmDouble;
+      this.smoothedOrbitYawOffset = this.smoothAngle(this.smoothedOrbitYawOffset, this.orbitYawOffset, yawSmoothing);
+      this.smoothedOrbitPitchOffset = this.smoothAngle(this.smoothedOrbitPitchOffset, this.orbitPitchOffset, pitchSmoothing);
    }
 
    private Vec3 computeHeldLookAheadFocus(MCP_EntityPlane plane, Vec3 anchor) {
@@ -514,10 +536,10 @@ public class MCP_PlaneChaseCamera {
          boolean dummyInsidePlaneBB = dummy != null && this.isPointInsideAabb(Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ), plane.boundingBox);
          boolean dummyInsidePartBB = dummy != null && !this.getAircraftCollisionHit(plane, Vec3.createVectorHelper(dummy.posX, dummy.posY, dummy.posZ)).equals("none") && !dummyInsidePlaneBB;
          double nearestBoxDistance = this.nearestAircraftBoxDistance(plane, desired);
-         MCH_Lib.Log("CHASE_CAM: phase=CLIENT_TICK focus=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) smoothed=(%.3f, %.3f, %.3f) distBeforeCollision=%.3f distAfterCollision=%.3f yaw=%.2f pitch=%.2f rollInfluence=%.2f lookAheadBlend=%.2f freelook=%s baseDistance=%.2f finalDistance=%.2f focusYOffset=%.2f screenBias=%.2f orbitYawOffset=%.2f orbitPitchOffset=%.2f orbitDir=(%.3f,%.3f,%.3f) finalDummy=(%.3f, %.3f, %.3f) renderView=(%.3f, %.3f, %.3f) planeBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyInsidePlaneBB=%s dummyInsidePartBB=%s collisionAdjusted=%s collisionHit=%s nearestAircraftBoxDistance=%.3f thirdPersonViewMasked=%s distanceToFocus=%.3f owner=%s lastWriter=%s writes=%d thirdPerson=%d",
-               new Object[]{Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
+         MCH_Lib.Log("CHASE_CAM: phase=CLIENT_TICK fovOverride=%s fovTarget=%.2f smoothedFov=%.2f baseDistance=%.2f sizeBonus=%.2f speedBonus=%.2f desiredDistance=%.2f smoothedDistance=%.2f collisionAdjustedDistance=%.2f freelook=%s freelookRaw=(%.2f,%.2f) freelookSmoothed=(%.2f,%.2f) freelookReturning=%s rollInfluence=%.2f pitchInfluence=%.2f focus=(%.3f, %.3f, %.3f) desired=(%.3f, %.3f, %.3f) smoothed=(%.3f, %.3f, %.3f) distBeforeCollision=%.3f distAfterCollision=%.3f yaw=%.2f pitch=%.2f lookAheadBlend=%.2f focusYOffset=%.2f screenBias=%.2f orbitDir=(%.3f,%.3f,%.3f) finalDummy=(%.3f, %.3f, %.3f) renderView=(%.3f, %.3f, %.3f) planeBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyBB=(%.3f, %.3f, %.3f -> %.3f, %.3f, %.3f) dummyInsidePlaneBB=%s dummyInsidePartBB=%s collisionAdjusted=%s collisionHit=%s nearestAircraftBoxDistance=%.3f thirdPersonViewMasked=%s distanceToFocus=%.3f owner=%s lastWriter=%s writes=%d thirdPerson=%d",
+               new Object[]{Boolean.valueOf(isFovOverrideActive()), Float.valueOf(this.lastFovTarget), Float.valueOf(this.smoothedFov), Double.valueOf(this.lastBaseChaseDistance), Double.valueOf(this.lastSizeDistanceBonus), Double.valueOf(this.lastSpeedDistanceBonus), Double.valueOf(this.lastDesiredDistance), Double.valueOf(this.smoothedDistance), Double.valueOf(this.lastCollisionAdjustedDistance), Boolean.valueOf(this.freelookActive), Float.valueOf(this.orbitYawOffset), Float.valueOf(this.orbitPitchOffset), Float.valueOf(this.smoothedOrbitYawOffset), Float.valueOf(this.smoothedOrbitPitchOffset), Boolean.valueOf(!this.freelookActive && (Math.abs(this.orbitYawOffset) > 0.01F || Math.abs(this.orbitPitchOffset) > 0.01F)), Float.valueOf(this.getRollInfluence(plane)), Float.valueOf(this.smoothedPitchInfluence * (float)MCH_Config.PlaneChasePitchInfluence.prmDouble), Double.valueOf(focus.xCoord), Double.valueOf(focus.yCoord), Double.valueOf(focus.zCoord),
                      Double.valueOf(this.lastDesiredX), Double.valueOf(this.lastDesiredY), Double.valueOf(this.lastDesiredZ),
-                     Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ), Double.valueOf(this.lastDistanceBeforeCollision), Double.valueOf(this.lastDistanceAfterCollision), Float.valueOf(this.yaw), Float.valueOf(this.pitch), Float.valueOf(this.getRollInfluence(plane)), Double.valueOf(this.lookAheadBlend), Boolean.valueOf(this.freelookActive), Double.valueOf(MCH_Config.NewPlaneCameraDistance.prmDouble), Double.valueOf(this.lastFinalChaseDistance), Double.valueOf(MCH_Config.PlaneChaseFocusVerticalOffset.prmDouble), Double.valueOf(MCH_Config.PlaneChaseScreenVerticalBias.prmDouble), Float.valueOf(this.orbitYawOffset), Float.valueOf(this.orbitPitchOffset), Double.valueOf(this.orbitDirX), Double.valueOf(this.orbitDirY), Double.valueOf(this.orbitDirZ),
+                     Double.valueOf(this.posX), Double.valueOf(this.posY), Double.valueOf(this.posZ), Double.valueOf(this.lastDistanceBeforeCollision), Double.valueOf(this.lastDistanceAfterCollision), Float.valueOf(this.yaw), Float.valueOf(this.pitch), Double.valueOf(this.lookAheadBlend), Double.valueOf(MCH_Config.PlaneChaseFocusVerticalOffset.prmDouble), Double.valueOf(MCH_Config.PlaneChaseScreenVerticalBias.prmDouble), Double.valueOf(this.orbitDirX), Double.valueOf(this.orbitDirY), Double.valueOf(this.orbitDirZ),
                      Double.valueOf(dummy != null?dummy.posX:0.0D), Double.valueOf(dummy != null?dummy.posY:0.0D), Double.valueOf(dummy != null?dummy.posZ:0.0D),
                      Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posX:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posY:0.0D), Double.valueOf(mc.renderViewEntity != null?mc.renderViewEntity.posZ:0.0D),
                      Double.valueOf(plane.boundingBox != null?plane.boundingBox.minX:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minY:0.0D), Double.valueOf(plane.boundingBox != null?plane.boundingBox.minZ:0.0D),
@@ -529,11 +551,38 @@ public class MCP_PlaneChaseCamera {
       }
    }
 
+   public static boolean isFovOverrideActive() {
+      return activeCamera != null && activeRenderPlane != null && MCH_Config.EnablePlaneChaseFOVOverride.prmBool;
+   }
+
+   public static float applyFovOverride(float currentFov) {
+      if(!isFovOverrideActive()) {
+         return currentFov;
+      }
+      return activeCamera.updateFov(currentFov);
+   }
+
+   private float updateFov(float currentFov) {
+      float target = (float)(this.freelookActive?MCH_Config.PlaneChaseFreelookFOV.prmDouble:MCH_Config.PlaneChaseFOV.prmDouble);
+      this.lastFovTarget = target;
+      if(this.smoothedFov < 0.0F) {
+         this.smoothedFov = currentFov;
+      }
+      this.smoothedFov += (target - this.smoothedFov) * (float)MCH_Config.PlaneChaseFOVSmoothing.prmDouble;
+      return this.smoothedFov;
+   }
+
    public static boolean shouldConsumeFreelookMouse(MCP_EntityPlane plane, EntityPlayer player) {
       return activeCamera != null && activeRenderPlane == plane && player != null && activeCamera.isHoldFreelookActive();
    }
 
    public static void addFreelookMouseDelta(double deltaX, double deltaY) {
+      if(Math.abs(deltaX) < 0.01D) {
+         deltaX = 0.0D;
+      }
+      if(Math.abs(deltaY) < 0.01D) {
+         deltaY = 0.0D;
+      }
       pendingFreelookMouseX += deltaX;
       pendingFreelookMouseY += deltaY;
    }


### PR DESCRIPTION
### Motivation
- Provide a stable, readable third-person chase camera for new-flight planes that reduces aggressive speed-based zooming and improves pilot situational awareness.
- Expose tuning for chase distance, speed-scaling, freelook orbit, and FOV via config and in-game GUI so users can adjust camera behavior without editing files.
- Add an FOV override applied only to the new chase camera path so wider FOV can be used instead of large dynamic distance swings.

### Description
- Documentation: updated `docs/configuration.md` with the new plane chase camera section and renamed/defaulted keys and tuning guidance.
- Configuration: added and renamed multiple `MCH_Config` parameters (e.g. `PlaneChaseBaseDistance` / `PlaneChaseMinDistance` / `PlaneChaseMaxDistance`, `PlaneChaseSpeedDistanceScale`, `PlaneChaseSpeedDistanceMaxBonus`, `EnablePlaneChaseFOVOverride`, `PlaneChaseFOV`, freelook smoothing and limits, `PlaneChasePitchInfluence`, `PlaneChaseHorizonStabilization`, and others), adjusted defaults, and updated `correctionParameter()` ranges and migration logic for legacy values.
- GUI: added a new Plane Camera settings screen to `MCH_ConfigGui` with toggles and sliders for base/min/max distance, optional speed scaling and cap, chase/ freelook FOV, freelook sensitivity/smoothing/limits, pitch/roll influence, an `Apply` button, and wiring to load/save the new config fields.
- Camera logic: refactored `MCP_PlaneChaseCamera` to implement smoothed freelook orbit (separate raw target and smoothed render offsets), capped speed-distance bonus, pitch/roll influence tuning, smoothed FOV target blending and debug/state tracking, reduced freelook jitter thresholds, and improved debug logging; added public helpers `isFovOverrideActive()` and `applyFovOverride()` and integrated FOV smoothing per-frame.
- Client event: added an `FOVUpdateEvent` handler in `MCH_ClientEventHook` to apply the chase-camera-only FOV override when active.

### Testing
- Automated project build (`compile`) was run and succeeded in the development environment.
- No automated unit tests were modified or added for camera behavior in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34626c533883298983f0e056759f6e)