### PR TITLE
Add experimental mouse-aim controls for new-flight-model planes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,6 +222,30 @@ Tuning guidance:
 * **Jets:** use a higher max distance (`90`-`130+`), default-or-higher follow distance (`15`-`35`), and moderate held look-ahead (`12`-`24`) for target tracking without automatic drift.
 * **Slow props:** keep distance lower (`12`-`22`), use modest screen bias (`2`-`4`), and keep speed scaling modest so the camera remains responsive while still framing the aircraft.
 
+
+## Experimental new-flight plane mouse aim controls
+
+Mouse aim is an experimental control foundation for fixed-wing planes using `UseNewMobilitySystem = true` only. It is disabled by default and does not affect legacy aircraft. When enabled globally, pilots can toggle it in a qualifying new-flight plane with `KeyPlaneMouseAim`; the mouse moves a separate desired aim yaw/pitch and the aircraft nose chases that aim through the existing new-flight authority, stall, energy, pitch-suppression, damping, and rotation-limit path. HUD and reticle support are intentionally left for a later pass.
+
+This first implementation uses global client config keys. Per-plane mouse-aim overrides are not wired yet, so pack authors should tune conservatively.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `EnableMouseAimControls` | `false` | Master enable for the experimental mode; new-flight-model planes only. |
+| `KeyPlaneMouseAim` | `49` | Toggle key while piloting a qualifying new-flight plane (N by default). |
+| `MouseAimSensitivity` | `0.18` | Scales raw mouse movement into desired aim yaw/pitch changes. |
+| `MouseAimSmoothing` | `0.30` | Smooths desired aim motion to reduce jitter without snapping. |
+| `MouseAimMaxPitchUp` | `70.0` | Nose-up aim clamp in degrees. |
+| `MouseAimMaxPitchDown` | `55.0` | Nose-down aim clamp in degrees. |
+| `MouseAimYawResponse` | `0.85` | Converts yaw error into yaw command before normal authority limits. |
+| `MouseAimPitchResponse` | `0.85` | Converts pitch error into pitch command before normal authority limits. |
+| `MouseAimAutoBankStrength` | `1.10` | Converts lateral aim error into coordinated auto-bank demand. |
+| `MouseAimAutoBankMaxRoll` | `65.0` | Maximum target roll angle for auto-bank. |
+| `MouseAimCenteringStrength` | `0.18` | Roll damping/leveling strength as the aim point returns toward center. |
+| `MouseAimDebug` | `false` | Emits mouse-aim telemetry in the existing flight-control debug line even when `DebugFlightControl` is off. |
+
+Mouse aim never directly sets aircraft rotation. It only generates pitch/yaw/roll commands that continue through the same new-flight control-authority, compressibility, unsupported-climb, stall, and angular-velocity integration code as other plane controls, so slow, stalled, damaged, or authority-limited aircraft may lag or fail to follow the cursor. Manual roll input is added to auto-bank in a predictable way, so roll keys remain available for corrections.
+
 ## Key config defaults
 
 | Option | Default code | Default input |
@@ -246,6 +270,7 @@ Tuning guidance:
 | `KeyCameraDistanceDown` | `209` | Page Down |
 | `KeyFreeLook` | `29` | Left Control |
 | `KeyPlaneLookAhead` | `56` | Left Alt |
+| `KeyPlaneMouseAim` | `49` | N |
 | `KeyGUI` | `19` | R |
 | `KeyGearUpDown` | `48` | B |
 | `KeyPutToRack` | `36` | J |

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -235,6 +235,15 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `NewFlightLowThrottleLiftRetention` | Plane | float[0..1] | 0.700 | new-flight-only lift/support retained at idle |
 | `NewFlightThrottleControlAuthorityScale` | Plane | float[0..1] | 0.10 | new-flight-only idle control-authority penalty |
 | `NewFlightThrottleHudDisplay` | Plane | boolean | true | show `THR 0-100%` for new-flight pilots |
+| `EnableMouseAimControls` | Global/client | boolean | false | experimental mouse-follow controls for new-flight planes only; not currently per-plane |
+| `MouseAimSensitivity` | Global/client | float | 0.18 | raw mouse movement to desired aim yaw/pitch scale |
+| `MouseAimSmoothing` | Global/client | float | 0.30 | desired aim smoothing to avoid jitter |
+| `MouseAimMaxPitchUp` / `MouseAimMaxPitchDown` | Global/client | degrees | 70 / 55 | desired aim pitch clamps |
+| `MouseAimYawResponse` / `MouseAimPitchResponse` | Global/client | float | 0.85 / 0.85 | aim error to existing control command response |
+| `MouseAimAutoBankStrength` | Global/client | float | 1.10 | coordinated bank demand from lateral aim error |
+| `MouseAimAutoBankMaxRoll` | Global/client | degrees | 65 | auto-bank target roll clamp |
+| `MouseAimCenteringStrength` | Global/client | float | 0.18 | roll damping/level-out strength near center aim |
+| `MouseAimDebug` | Global/client | boolean | false | includes mouse-aim telemetry in flight-control debug output |
 | `NewFlightCombatFlaps` | Plane | boolean | true | enables new-flight-only combat flaps |
 | `NewFlightCombatFlapLift` | Plane | float[0..1] | 0.120 | flap lift/support contribution |
 | `NewFlightCombatFlapDrag` | Plane | float[0..0.25] | 0.012 | flap drag penalty |

--- a/docs/vehicle-config/planes.md
+++ b/docs/vehicle-config/planes.md
@@ -433,3 +433,11 @@ Use this key only as a takeoff/runway correction after the aircraft's mass, thru
 Combat flaps are intentionally gated by `useNewMobilitySystem = true`; legacy packs are unaffected unless they opt in. With `NewFlightCombatFlaps = true`, the pilot toggles flaps with the Extra key, the HUD appends `FLP`, and the new flight model applies lift/control help plus extra drag and a lower safe overspeed threshold.
 
 Use flaps with low or moderate throttle for landing and low-speed control. High throttle with flaps can improve a short turn, but the extra drag and reduced `MaxSafeSpeed * NewFlightCombatFlapOverspeed` should punish extended high-speed use. Throttle chopping plus flaps helps manage speed but should not be tuned into an instant brake; raise `NewFlightCombatFlapDrag` gradually and keep `NewFlightEngineBrakeDrag` modest.
+
+## Experimental mouse-aim control foundation
+
+New-flight-model planes can opt into an experimental client-side mouse-follow control foundation through the global MCHeli config. This is currently not a per-plane parser feature: `EnableMouseAimControls` must be enabled globally, then pilots toggle the mode with `KeyPlaneMouseAim` while flying a plane with `UseNewMobilitySystem = true`.
+
+The mode keeps a separate desired aim yaw/pitch derived from smoothed mouse movement, clamps pitch to `MouseAimMaxPitchUp`/`MouseAimMaxPitchDown`, converts aim error into pitch/yaw commands, and adds coordinated auto-bank governed by `MouseAimAutoBankStrength`, `MouseAimAutoBankMaxRoll`, and `MouseAimCenteringStrength`. Those commands still flow through the existing new-flight control authority, stall, energy, unsupported climb, compressibility, and angular-velocity integration code. It does not directly set aircraft rotation and does not change legacy aircraft.
+
+This pass intentionally does not add HUD or reticle polish; it only provides the control foundation and debug telemetry (`MouseAimDebug` or `DebugFlightControl`).

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -327,7 +327,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    private static void debugFlightControl(MCH_EntityBaseVehicle ac, float simDelta, float mouseX, float mouseY, float stickX, float stickY) {
-      if(!MCH_Config.DebugFlightControl.prmBool || ac == null || ac.ticksExisted % 20 != 0) {
+      if((!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.MouseAimDebug.prmBool) || ac == null || ac.ticksExisted % 20 != 0) {
          return;
       }
 
@@ -340,7 +340,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             : 0.0D;
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) finalPitchAngularVelocity=%.4f rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,forwardAirspeed=%.3f,horizontalSpeed=%.3f,totalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,pitchInputRequested=%.4f,pitchInputAfterAuthority=%.4f,pitchAuthorityBeforeSuppression=%.2f,pitchAuthorityAfterSuppression=%.2f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,noseDownRecoverySeverity=%.2f,forcedPitchDelta=%.4f,pitchBreakAngularVelocity=%.4f,kineticEnergy=%.4f,potentialEnergy=%.4f,totalEnergy=%.4f,specificEnergy=%.4f,energyDelta=%.4f,excessPower=%.4f,energyDeficitSeverity=%.2f,climbEnergyDemand=%.4f,pitchEnergyDemand=%.4f,energyUnsupportedClimb=%s,energyForcedRecovery=%s)",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) finalPitchAngularVelocity=%.4f rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,forwardAirspeed=%.3f,horizontalSpeed=%.3f,totalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),aoaFromVelocity=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,pitchInputRequested=%.4f,pitchInputAfterAuthority=%.4f,pitchAuthorityBeforeSuppression=%.2f,pitchAuthorityAfterSuppression=%.2f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,noseDownRecoverySeverity=%.2f,forcedPitchDelta=%.4f,pitchBreakAngularVelocity=%.4f,kineticEnergy=%.4f,potentialEnergy=%.4f,totalEnergy=%.4f,specificEnergy=%.4f,energyDelta=%.4f,excessPower=%.4f,energyDeficitSeverity=%.2f,climbEnergyDemand=%.4f,pitchEnergyDemand=%.4f,energyUnsupportedClimb=%s,energyForcedRecovery=%s) %s",
               simDelta,
               mouseX,
               mouseY,
@@ -434,7 +434,8 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               plane != null ? plane.getLastClimbEnergyDemand() : 0.0D,
               plane != null ? plane.getLastPitchEnergyDemand() : 0.0D,
               Boolean.valueOf(plane != null && plane.isLastEnergyUnsupportedClimb()),
-              Boolean.valueOf(plane != null && plane.isLastEnergyForcedRecovery())
+              Boolean.valueOf(plane != null && plane.isLastEnergyForcedRecovery()),
+              plane != null ? plane.getMouseAimDebugString() : "mouseAim=(not-plane)"
       ));
 
       if(plane != null && plane.getLastLowHorizontalSpeedWarning().length() > 0) {

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -65,6 +65,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm KeyCameraDistDown;
    public static MCH_ConfigPrm KeyFreeLook;
    public static MCH_ConfigPrm KeyPlaneLookAhead;
+   public static MCH_ConfigPrm KeyPlaneMouseAim;
    public static MCH_ConfigPrm KeyGUI;
    public static MCH_ConfigPrm KeyGearUpDown;
    public static MCH_ConfigPrm KeyPutToRack;
@@ -150,6 +151,17 @@ public class MCH_Config {
    public static MCH_ConfigPrm MouseControlStickModeHeli;
    public static MCH_ConfigPrm MouseControlStickModePlane;
    public static MCH_ConfigPrm MouseControlFlightSimMode;
+   public static MCH_ConfigPrm EnableMouseAimControls;
+   public static MCH_ConfigPrm MouseAimSensitivity;
+   public static MCH_ConfigPrm MouseAimSmoothing;
+   public static MCH_ConfigPrm MouseAimMaxPitchUp;
+   public static MCH_ConfigPrm MouseAimMaxPitchDown;
+   public static MCH_ConfigPrm MouseAimYawResponse;
+   public static MCH_ConfigPrm MouseAimPitchResponse;
+   public static MCH_ConfigPrm MouseAimAutoBankStrength;
+   public static MCH_ConfigPrm MouseAimAutoBankMaxRoll;
+   public static MCH_ConfigPrm MouseAimCenteringStrength;
+   public static MCH_ConfigPrm MouseAimDebug;
    public static MCH_ConfigPrm SwitchWeaponWithMouseWheel;
    public static MCH_ConfigPrm AllPlaneSpeed;
    public static MCH_ConfigPrm NewFlightGravity;
@@ -321,6 +333,7 @@ public class MCH_Config {
       KeyCameraDistDown = new MCH_ConfigPrm("KeyCameraDistanceDown", 209);
       KeyFreeLook = new MCH_ConfigPrm("KeyFreeLook", 29);
       KeyPlaneLookAhead = new MCH_ConfigPrm("KeyPlaneLookAhead", 56);
+      KeyPlaneMouseAim = new MCH_ConfigPrm("KeyPlaneMouseAim", 49);
       KeyGUI = new MCH_ConfigPrm("KeyGUI", 19);
       KeyGearUpDown = new MCH_ConfigPrm("KeyGearUpDown", 48);
       KeyPutToRack = new MCH_ConfigPrm("KeyPutToRack", 36);
@@ -348,6 +361,7 @@ public class MCH_Config {
               KeyCameraDistDown,
               KeyFreeLook,
               KeyPlaneLookAhead,
+              KeyPlaneMouseAim,
               KeyGUI,
               KeyGearUpDown,
               KeyPutToRack,
@@ -433,6 +447,18 @@ public class MCH_Config {
       MouseControlStickModePlane = new MCH_ConfigPrm("MouseControlStickModePlane", false);
       MouseControlFlightSimMode = new MCH_ConfigPrm("MouseControlFlightSimMode", true);
       MouseControlFlightSimMode.desc = ";MouseControlFlightSimMode = true ( Yaw:key, Roll=mouse )";
+      EnableMouseAimControls = new MCH_ConfigPrm("EnableMouseAimControls", false);
+      EnableMouseAimControls.desc = ";Experimental client-side mouse-follow controls for new-flight-model planes only. KeyPlaneMouseAim toggles this mode while riding a qualifying plane.";
+      MouseAimSensitivity = new MCH_ConfigPrm("MouseAimSensitivity", 0.18D);
+      MouseAimSmoothing = new MCH_ConfigPrm("MouseAimSmoothing", 0.30D);
+      MouseAimMaxPitchUp = new MCH_ConfigPrm("MouseAimMaxPitchUp", 70.0D);
+      MouseAimMaxPitchDown = new MCH_ConfigPrm("MouseAimMaxPitchDown", 55.0D);
+      MouseAimYawResponse = new MCH_ConfigPrm("MouseAimYawResponse", 0.85D);
+      MouseAimPitchResponse = new MCH_ConfigPrm("MouseAimPitchResponse", 0.85D);
+      MouseAimAutoBankStrength = new MCH_ConfigPrm("MouseAimAutoBankStrength", 1.10D);
+      MouseAimAutoBankMaxRoll = new MCH_ConfigPrm("MouseAimAutoBankMaxRoll", 65.0D);
+      MouseAimCenteringStrength = new MCH_ConfigPrm("MouseAimCenteringStrength", 0.18D);
+      MouseAimDebug = new MCH_ConfigPrm("MouseAimDebug", false);
       SwitchWeaponWithMouseWheel = new MCH_ConfigPrm("SwitchWeaponWithMouseWheel", true);
       AllHeliSpeed = new MCH_ConfigPrm("AllHeliSpeed", 1.5D);
       AllPlaneSpeed = new MCH_ConfigPrm("AllPlaneSpeed", 1000.00D);
@@ -638,6 +664,17 @@ public class MCH_Config {
               MouseControlStickModeHeli,
               MouseControlStickModePlane,
               MouseControlFlightSimMode,
+              EnableMouseAimControls,
+              MouseAimSensitivity,
+              MouseAimSmoothing,
+              MouseAimMaxPitchUp,
+              MouseAimMaxPitchDown,
+              MouseAimYawResponse,
+              MouseAimPitchResponse,
+              MouseAimAutoBankStrength,
+              MouseAimAutoBankMaxRoll,
+              MouseAimCenteringStrength,
+              MouseAimDebug,
               AutoThrottleDownHeli,
               AutoThrottleDownPlane,
               AutoThrottleDownShip,

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -21,6 +21,7 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
    public MCH_Key KeySwitchMode;
    public MCH_Key KeyEjectSeat;
    public MCH_Key KeyZoom;
+   public MCH_Key KeyMouseAim;
    public MCH_Key[] Keys;
    private final MCP_PlaneChaseCamera chaseCamera = new MCP_PlaneChaseCamera();
    private boolean wasUsingChaseCamera = false;
@@ -36,7 +37,8 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.KeySwitchMode = new MCH_Key(MCH_Config.KeySwitchMode.prmInt);
       this.KeyEjectSeat = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.KeyMouseAim = new MCH_Key(MCH_Config.KeyPlaneMouseAim.prmInt);
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCP_EntityPlane plane) {
@@ -231,6 +233,16 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          } else {
             plane.zoomCamera();
             playSound("zoom", 0.5F, 1.0F);
+         }
+      }
+
+      if(isPilot && this.KeyMouseAim.isKeyDown()) {
+         if(plane.isNewFlightModelEnabled() && MCH_Config.EnableMouseAimControls.prmBool) {
+            plane.toggleMouseAimControls();
+            send = true;
+            playSoundOK();
+         } else {
+            playSoundNG();
          }
       }
 

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -49,6 +49,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public float rotationRotor;
    public float prevRotationRotor;
    public float addkeyRotValue;
+   private boolean mouseAimControlsEnabled;
+   private boolean mouseAimInitialized;
+   private float mouseAimDesiredYaw;
+   private float mouseAimDesiredPitch;
+   private float mouseAimSmoothedYaw;
+   private float mouseAimSmoothedPitch;
+   private float mouseAimYawError;
+   private float mouseAimPitchError;
+   private float mouseAimGeneratedYawCommand;
+   private float mouseAimGeneratedPitchCommand;
+   private float mouseAimGeneratedRollCommand;
+   private float mouseAimAutoBankTargetRoll;
+   private boolean mouseAimManualRollActive;
    /** Smoothed engine output; commanded throttle remains unchanged for controls and networking. */
    private double engineThrottle;
    /** Last total drag fraction applied by the fixed-wing energy model, exposed for debug output. */
@@ -610,6 +623,95 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return this.pitchBreakActive;
    }
 
+   public void toggleMouseAimControls() {
+      if(!this.isNewFlightModelEnabled() || !MCH_Config.EnableMouseAimControls.prmBool) {
+         this.mouseAimControlsEnabled = false;
+         this.mouseAimInitialized = false;
+         return;
+      }
+
+      this.mouseAimControlsEnabled = !this.mouseAimControlsEnabled;
+      this.initializeMouseAimFromAircraft();
+   }
+
+   private void initializeMouseAimFromAircraft() {
+      this.mouseAimDesiredYaw = this.getRotYaw();
+      this.mouseAimSmoothedYaw = this.mouseAimDesiredYaw;
+      this.mouseAimDesiredPitch = this.clampMouseAimPitch(this.getRotPitch());
+      this.mouseAimSmoothedPitch = this.mouseAimDesiredPitch;
+      this.mouseAimYawError = 0.0F;
+      this.mouseAimPitchError = 0.0F;
+      this.mouseAimGeneratedYawCommand = 0.0F;
+      this.mouseAimGeneratedPitchCommand = 0.0F;
+      this.mouseAimGeneratedRollCommand = 0.0F;
+      this.mouseAimAutoBankTargetRoll = 0.0F;
+      this.mouseAimManualRollActive = false;
+      this.mouseAimInitialized = true;
+   }
+
+   private boolean shouldUseMouseAimControls(Entity player) {
+      return player != null && this.isNewFlightModelEnabled() && MCH_Config.EnableMouseAimControls.prmBool
+            && this.mouseAimControlsEnabled && !this.isFreeLookMode() && !super.isGunnerMode;
+   }
+
+   private float clampMouseAimPitch(float pitch) {
+      float maxUp = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimMaxPitchUp.prmDouble, 0.0D, 89.0D);
+      float maxDown = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimMaxPitchDown.prmDouble, 0.0D, 89.0D);
+      return MCH_Lib.RNG(pitch, -maxUp, maxDown);
+   }
+
+   private float smoothMouseAimAngle(float current, float target, float smoothing, float partialTicks) {
+      float alpha = (float)MCH_FlightModel.clamp(1.0D - Math.pow(1.0D - (double)smoothing, (double)partialTicks), 0.0D, 1.0D);
+      return current + MathHelper.wrapAngleTo180_float(target - current) * alpha;
+   }
+
+   private void updateMouseAimState(float deltaX, float deltaY, float partialTicks) {
+      if(!this.mouseAimInitialized) {
+         this.initializeMouseAimFromAircraft();
+      }
+
+      float sensitivity = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimSensitivity.prmDouble, 0.01D, 5.0D);
+      this.mouseAimDesiredYaw = MathHelper.wrapAngleTo180_float(this.mouseAimDesiredYaw + deltaX * sensitivity);
+      this.mouseAimDesiredPitch = this.clampMouseAimPitch(this.mouseAimDesiredPitch + deltaY * sensitivity);
+
+      float smoothing = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimSmoothing.prmDouble, 0.0D, 1.0D);
+      this.mouseAimSmoothedYaw = MathHelper.wrapAngleTo180_float(this.smoothMouseAimAngle(this.mouseAimSmoothedYaw, this.mouseAimDesiredYaw, smoothing, partialTicks));
+      this.mouseAimSmoothedPitch = this.smoothMouseAimAngle(this.mouseAimSmoothedPitch, this.mouseAimDesiredPitch, smoothing, partialTicks);
+
+      this.mouseAimYawError = MathHelper.wrapAngleTo180_float(this.mouseAimSmoothedYaw - this.getRotYaw());
+      this.mouseAimPitchError = MathHelper.wrapAngleTo180_float(this.mouseAimSmoothedPitch - this.getRotPitch());
+   }
+
+   private float getMouseAimYawCommand(double limit) {
+      float response = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimYawResponse.prmDouble, 0.0D, 5.0D);
+      this.mouseAimGeneratedYawCommand = (float)MCH_FlightModel.clamp((double)(this.mouseAimYawError * response), -limit, limit);
+      return this.mouseAimGeneratedYawCommand;
+   }
+
+   private float getMouseAimPitchCommand(double limit) {
+      float response = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimPitchResponse.prmDouble, 0.0D, 5.0D);
+      this.mouseAimGeneratedPitchCommand = (float)MCH_FlightModel.clamp((double)(-this.mouseAimPitchError * response), -limit, limit);
+      return this.mouseAimGeneratedPitchCommand;
+   }
+
+   private float getMouseAimRollCommand(float manualRoll, double limit) {
+      this.mouseAimAutoBankTargetRoll = (float)MCH_FlightModel.clamp((double)(this.mouseAimYawError * MCH_Config.MouseAimAutoBankStrength.prmDouble),
+            -MCH_Config.MouseAimAutoBankMaxRoll.prmDouble, MCH_Config.MouseAimAutoBankMaxRoll.prmDouble);
+      float centering = (float)MCH_FlightModel.clamp(MCH_Config.MouseAimCenteringStrength.prmDouble, 0.0D, 5.0D);
+      float autoBank = (this.mouseAimAutoBankTargetRoll - this.getRotRoll()) * centering;
+      this.mouseAimManualRollActive = MathHelper.abs(manualRoll) > 0.001F;
+      this.mouseAimGeneratedRollCommand = (float)MCH_FlightModel.clamp((double)(autoBank + manualRoll), -limit, limit);
+      return this.mouseAimGeneratedRollCommand;
+   }
+
+   public String getMouseAimDebugString() {
+      return String.format("mouseAim=(enabled=%s,desiredYaw=%.2f,desiredPitch=%.2f,yawError=%.2f,pitchError=%.2f,pitchCmd=%.4f,yawCmd=%.4f,rollCmd=%.4f,autoBankTargetRoll=%.2f,manualRoll=%s)",
+            Boolean.valueOf(this.mouseAimControlsEnabled), Float.valueOf(this.mouseAimSmoothedYaw), Float.valueOf(this.mouseAimSmoothedPitch),
+            Float.valueOf(this.mouseAimYawError), Float.valueOf(this.mouseAimPitchError), Float.valueOf(this.mouseAimGeneratedPitchCommand),
+            Float.valueOf(this.mouseAimGeneratedYawCommand), Float.valueOf(this.mouseAimGeneratedRollCommand),
+            Float.valueOf(this.mouseAimAutoBankTargetRoll), Boolean.valueOf(this.mouseAimManualRollActive));
+   }
+
    public double getLastAerodynamicDrag() {
       return this.lastAerodynamicDrag;
    }
@@ -928,13 +1030,23 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          x = 0.0F;
       }
 
+      boolean useMouseAim = this.shouldUseMouseAimControls(player);
+      if(useMouseAim) {
+         this.updateMouseAimState(deltaX, deltaY, partialTicks);
+         x = 0.0F;
+         y = 0.0F;
+      } else if(this.mouseAimControlsEnabled && (!this.isNewFlightModelEnabled() || !MCH_Config.EnableMouseAimControls.prmBool)) {
+         this.mouseAimControlsEnabled = false;
+         this.mouseAimInitialized = false;
+      }
+
       float yaw = 0.0F;
       float pitch = 0.0F;
       float roll = 0.0F;
       double m_add;
       if(this.canUpdateYaw(player)) {
          m_add = this.getAddRotationYawLimit();
-         yaw = this.getControlRotYaw(x, y, partialTicks);
+         yaw = useMouseAim ? this.getMouseAimYawCommand(m_add) : this.getControlRotYaw(x, y, partialTicks);
          if((double)yaw < -m_add) {
             yaw = (float)(-m_add);
          }
@@ -948,7 +1060,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       if(this.canUpdatePitch(player)) {
          m_add = this.getAddRotationPitchLimit();
-         pitch = this.getControlRotPitch(x, y, partialTicks);
+         pitch = useMouseAim ? this.getMouseAimPitchCommand(m_add) : this.getControlRotPitch(x, y, partialTicks);
          if((double)pitch < -m_add) {
             pitch = (float)(-m_add);
          }
@@ -963,6 +1075,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if(this.canUpdateRoll(player)) {
          m_add = this.getAddRotationRollLimit();
          roll = this.getControlRotRoll(x, y, partialTicks);
+         if(useMouseAim) {
+            roll = this.getMouseAimRollCommand(roll, m_add);
+         }
          if((double)roll < -m_add) {
             roll = (float)(-m_add);
          }


### PR DESCRIPTION
### Motivation

- Provide a War Thunder-style mouse-follow control mode for fixed-wing aircraft that use the new flight/mobility system so the mouse represents a desired aim direction while preserving the existing flight model authority and limits. 
- Keep legacy controls unchanged and implement the feature as an opt-in, client-side control foundation that feeds into the existing control path rather than directly setting rotations.

### Description

- Added a client-side mouse-aim state on planes with smoothing, yaw wrap, pitch clamping, and conversion of aim error into pitch/yaw commands and an auto-bank roll contribution; state and logic live in `MCP_EntityPlane` (new helpers: `toggleMouseAimControls`, `updateMouseAimState`, `getMouseAim*Command`, debug string). 
- Integrated mouse-aim output into the existing control path by routing generated yaw/pitch/roll commands through `setAngles` so all new-flight authority, stall/energy/unsupported-climb, compressibility, and angular-rate damping still apply. 
- Added keybind and toggle support via `KeyPlaneMouseAim` and a client toggle in `MCP_ClientPlaneTickHandler`, and added global config keys and defaults in `MCH_Config` for enabling/tuning (`EnableMouseAimControls`, `MouseAimSensitivity`, `MouseAimSmoothing`, `MouseAimMaxPitchUp`, `MouseAimMaxPitchDown`, `MouseAimYawResponse`, `MouseAimPitchResponse`, `MouseAimAutoBankStrength`, `MouseAimAutoBankMaxRoll`, `MouseAimCenteringStrength`, `MouseAimDebug`). 
- Exposed debug telemetry by adding mouse-aim telemetry to the existing `debugFlightControl` output (gated by `DebugFlightControl` or `MouseAimDebug`) and updated docs (`docs/configuration.md`, `docs/vehicle-config-reference.md`, `docs/vehicle-config/planes.md`) to describe the new experimental keys and behavior.

### Testing

- Ran `git diff --check` to ensure no whitespace/patch issues and it passed. 
- Sanity-checked debug output and config wiring by running repository text searches (`rg`) and verifying the new telemetry is included in the `debugFlightControl` line; no runtime/compile steps were executed per instructions. 
- Committed changes (branch `b70736e`); no `.class` files were compiled or added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346df6aca883298c9cd7148d0d4c24)