### PR TITLE
Refactor plane mouse-aim overlay into dedicated renderer with robustness and debug improvements

### DIFF
--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -20,13 +20,12 @@ import mcheli.lweapon.MCH_ClientLightWeaponTickHandler;
 import mcheli.multiplay.MCH_GuiTargetMarker;
 import mcheli.particles.MCH_ParticlesUtil;
 import mcheli.plane.MCP_PlaneChaseCamera;
-import mcheli.plane.MCP_EntityPlane;
+import mcheli.plane.client.MCP_NewPlaneOverlayRenderer;
 import mcheli.tool.rangefinder.MCH_ItemRangeFinder;
 import mcheli.wrapper.W_ClientEventHook;
 import mcheli.wrapper.W_Reflection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
-import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -51,9 +50,7 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
    private static boolean cancelRender = true;
 
    public static float smoothing;
-   private static long nextPlaneMouseAimReticleDebugTime;
-   private static final ResourceLocation PLANE_MOUSE_AIM_RETICLE_TEXTURE =
-         new ResourceLocation("mcheli", "textures/gui/plane_crosshair.png");
+   private final MCP_NewPlaneOverlayRenderer newPlaneOverlayRenderer = new MCP_NewPlaneOverlayRenderer();
 
    public void renderLivingEventSpecialsPre(Pre event) {
       MCH_Config var10000 = MCH_MOD.config;
@@ -187,194 +184,12 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
 
    @SubscribeEvent
    public void onRenderOverlayPre(RenderGameOverlayEvent.Pre event) {
-      if(event == null || event.type != RenderGameOverlayEvent.ElementType.CROSSHAIRS) {
-         return;
-      }
-
-      EntityClientPlayerMP player = Minecraft.getMinecraft().thePlayer;
-      if(player == null) {
-         return;
-      }
-      MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
-      if(ac instanceof MCP_EntityPlane && ((MCP_EntityPlane)ac).shouldSuppressVanillaCrosshair(player)) {
-         event.setCanceled(true);
-      }
+      this.newPlaneOverlayRenderer.onRenderOverlayPre(event);
    }
 
    @SubscribeEvent
    public void onRenderOverlayPost(RenderGameOverlayEvent.Post event) {
-      if(event == null || event.type != RenderGameOverlayEvent.ElementType.ALL) {
-         return;
-      }
-
-      Minecraft mc = Minecraft.getMinecraft();
-      EntityClientPlayerMP player = mc.thePlayer;
-      ReticleState state = this.getPlaneMouseAimReticleState(mc, player);
-      boolean debug = MCH_Config.DebugFlightControl.prmBool || MCH_Config.PlaneMouseAimReticleDebug.prmBool;
-      if(!state.shouldDraw) {
-         if(debug) {
-            this.logPlaneMouseAimReticleDebug(mc, state, false);
-         }
-         return;
-      }
-
-      ScaledResolution scaled = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
-      int width = scaled.getScaledWidth();
-      int height = scaled.getScaledHeight();
-      double centerX = (double)width / 2.0D;
-      double centerY = (double)height / 2.0D;
-      double safeRadius = Math.max(12.0D, Math.min((double)Math.min(width, height) * MCH_Config.PlaneMouseAimMaxScreenRadius.prmDouble,
-            (double)Math.min(width, height) * 0.50D));
-      double yawRange = Math.max(1.0D, MCH_Config.PlaneMouseAimYawVisualRange.prmDouble);
-      double pitchRange = Math.max(1.0D, Math.max(MCH_Config.MouseAimMaxPitchUp.prmDouble, MCH_Config.MouseAimMaxPitchDown.prmDouble));
-      double aimX = centerX + (double)state.plane.getMouseAimYawError() / yawRange * safeRadius;
-      double aimY = centerY - (double)state.plane.getMouseAimPitchError() / pitchRange * safeRadius;
-      double dx = aimX - centerX;
-      double dy = aimY - centerY;
-      double dist = Math.sqrt(dx * dx + dy * dy);
-      if(dist > safeRadius && dist > 1.0E-4D) {
-         aimX = centerX + dx / dist * safeRadius;
-         aimY = centerY + dy / dist * safeRadius;
-      }
-
-      this.drawPlaneMouseAimOverlay(mc, aimX, aimY, centerX, centerY);
-      state.mouseX = aimX;
-      state.mouseY = aimY;
-      state.noseX = centerX;
-      state.noseY = centerY;
-      if(debug) {
-         String text = this.getPlaneMouseAimReticleDebugText(state, true);
-         mc.fontRenderer.drawStringWithShadow(text, 6, height / 2 + 64, 0x55FF66);
-      }
-      this.logPlaneMouseAimReticleDebug(mc, state, true);
-   }
-
-   private ReticleState getPlaneMouseAimReticleState(Minecraft mc, EntityClientPlayerMP player) {
-      ReticleState state = new ReticleState();
-      if(mc != null && mc.gameSettings != null && mc.gameSettings.hideGUI) {
-         state.reason = "hud_hidden";
-         return state;
-      }
-      if(player == null) {
-         state.reason = "no_player";
-         return state;
-      }
-
-      MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
-      if(!(ac instanceof MCP_EntityPlane)) {
-         state.reason = "not_plane";
-         return state;
-      }
-
-      MCP_EntityPlane plane = (MCP_EntityPlane)ac;
-      state.plane = plane;
-      if(!plane.isPilot(player)) {
-         state.reason = "not_pilot";
-      } else if(!plane.isNewFlightModelEnabled()) {
-         state.reason = "not_new_flight";
-      } else if(!plane.isMouseAimControlsEnabled()) {
-         state.reason = "mouse_aim_disabled";
-      } else if(!MCH_Config.EnablePlaneMouseAimReticle.prmBool) {
-         state.reason = "reticle_config_disabled";
-      } else {
-         state.reason = "draw";
-         state.shouldDraw = true;
-      }
-      return state;
-   }
-
-   private void drawPlaneMouseAimOverlay(Minecraft mc, double mouseX, double mouseY, double noseX, double noseY) {
-      GL11.glPushMatrix();
-      GL11.glDisable(2929);
-      GL11.glEnable(3042);
-      GL11.glBlendFunc(770, 771);
-      GL11.glEnable(3553);
-      GL11.glColor4f(0.25F, 1.0F, 0.35F, (float)Math.max(0.0D, Math.min(1.0D, MCH_Config.PlaneMouseAimReticleOpacity.prmDouble)));
-      mc.renderEngine.bindTexture(getPlaneMouseAimReticleTexture());
-      double mouseSize = 96.0D * Math.max(0.25D, Math.min(4.0D, MCH_Config.PlaneMouseAimReticleScale.prmDouble));
-      this.drawTexturedOverlayQuad(mouseX - mouseSize / 2.0D, mouseY - mouseSize / 2.0D, mouseSize, mouseSize, 1024.0D, 1024.0D);
-      GL11.glDisable(3553);
-      this.drawOverlayLineReticle(mouseX, mouseY, mouseSize * 0.35D, 0xEE55FF66);
-      double noseSize = 10.0D * Math.max(0.25D, Math.min(4.0D, MCH_Config.PlaneNoseReticleScale.prmDouble));
-      int noseAlpha = ((int)(Math.max(0.0D, Math.min(1.0D, MCH_Config.PlaneNoseReticleOpacity.prmDouble)) * 255.0D) & 255) << 24;
-      this.drawOverlayLineReticle(noseX, noseY, noseSize, noseAlpha | 0x00FFFFFF);
-      GL11.glEnable(3553);
-      GL11.glDisable(3042);
-      GL11.glEnable(2929);
-      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-      GL11.glPopMatrix();
-   }
-
-   private static ResourceLocation getPlaneMouseAimReticleTexture() {
-      String path = MCH_Config.PlaneMouseAimReticleTexture != null ? MCH_Config.PlaneMouseAimReticleTexture.prmString : "";
-      if(path == null || path.trim().length() <= 0) {
-         return PLANE_MOUSE_AIM_RETICLE_TEXTURE;
-      }
-      path = path.trim();
-      int domainSep = path.indexOf(':');
-      if(domainSep >= 0) {
-         return new ResourceLocation(path.substring(0, domainSep), path.substring(domainSep + 1));
-      }
-      if(path.startsWith("assets/mcheli/")) {
-         path = path.substring("assets/mcheli/".length());
-      }
-      return new ResourceLocation("mcheli", path);
-   }
-
-   private void drawTexturedOverlayQuad(double x, double y, double width, double height, double texWidth, double texHeight) {
-      Tessellator tess = Tessellator.instance;
-      tess.startDrawingQuads();
-      tess.addVertexWithUV(x, y + height, -90.0D, 0.0D, texHeight / texHeight);
-      tess.addVertexWithUV(x + width, y + height, -90.0D, texWidth / texWidth, texHeight / texHeight);
-      tess.addVertexWithUV(x + width, y, -90.0D, texWidth / texWidth, 0.0D);
-      tess.addVertexWithUV(x, y, -90.0D, 0.0D, 0.0D);
-      tess.draw();
-   }
-
-   private void drawOverlayLineReticle(double x, double y, double radius, int color) {
-      GL11.glColor4ub((byte)(color >> 16 & 255), (byte)(color >> 8 & 255), (byte)(color & 255), (byte)(color >> 24 & 255));
-      Tessellator tess = Tessellator.instance;
-      tess.startDrawing(1);
-      tess.addVertex(x - radius, y, -89.0D);
-      tess.addVertex(x - radius * 0.35D, y, -89.0D);
-      tess.addVertex(x + radius * 0.35D, y, -89.0D);
-      tess.addVertex(x + radius, y, -89.0D);
-      tess.addVertex(x, y - radius, -89.0D);
-      tess.addVertex(x, y - radius * 0.35D, -89.0D);
-      tess.addVertex(x, y + radius * 0.35D, -89.0D);
-      tess.addVertex(x, y + radius, -89.0D);
-      tess.draw();
-   }
-
-   private void logPlaneMouseAimReticleDebug(Minecraft mc, ReticleState state, boolean rendered) {
-      if(System.currentTimeMillis() < nextPlaneMouseAimReticleDebugTime) {
-         return;
-      }
-      nextPlaneMouseAimReticleDebugTime = System.currentTimeMillis() + 1000L;
-      String text = this.getPlaneMouseAimReticleDebugText(state, rendered);
-      MCH_Lib.Log("[MCHeli][PlaneMouseAimReticle] %s", new Object[]{text});
-   }
-
-   private String getPlaneMouseAimReticleDebugText(ReticleState state, boolean rendered) {
-      MCP_EntityPlane plane = state.plane;
-      return String.format("rendered=%s reason=%s mouse=(%.1f,%.1f) nose=(%.1f,%.1f) desired=(%.2f,%.2f) error=(%.2f,%.2f) crosshairSuppressed=%s",
-            Boolean.valueOf(rendered), state.reason, Double.valueOf(state.mouseX), Double.valueOf(state.mouseY),
-            Double.valueOf(state.noseX), Double.valueOf(state.noseY),
-            Float.valueOf(plane != null ? plane.getMouseAimDesiredYaw() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimDesiredPitch() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimYawError() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimPitchError() : 0.0F),
-            Boolean.valueOf(plane != null && plane.wasMouseAimVanillaCrosshairSuppressed()));
-   }
-
-   private static class ReticleState {
-      MCP_EntityPlane plane;
-      boolean shouldDraw;
-      String reason = "unknown";
-      double mouseX;
-      double mouseY;
-      double noseX;
-      double noseY;
+      this.newPlaneOverlayRenderer.onRenderOverlayPost(event);
    }
 
    @SubscribeEvent

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -43,7 +43,6 @@ import mcheli.plane.MCP_EntityPlane;
 import mcheli.plane.MCP_PlaneInfo;
 import mcheli.plane.MCP_PlaneInfoManager;
 import mcheli.plane.MCP_RenderPlane;
-import mcheli.plane.client.MCP_NewPlaneOverlayRenderer;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.ship.MCH_RenderShip;
 import mcheli.ship.MCH_ShipInfo;
@@ -611,7 +610,6 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
    public void init() {
       MinecraftForge.EVENT_BUS.register(new MCH_ParticlesUtil());
       MinecraftForge.EVENT_BUS.register(new MCH_ClientEventHook());
-      MinecraftForge.EVENT_BUS.register(new MCP_NewPlaneOverlayRenderer());
       MinecraftForge.EVENT_BUS.register(new MCH_RenderBVRLockBox());
       MinecraftForge.EVENT_BUS.register(new MCH_RenderRWR());
    }

--- a/src/main/java/mcheli/plane/client/MCP_NewPlaneOverlayRenderer.java
+++ b/src/main/java/mcheli/plane/client/MCP_NewPlaneOverlayRenderer.java
@@ -11,7 +11,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.MathHelper;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Vec3;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import org.lwjgl.opengl.GL11;
 
@@ -20,10 +23,14 @@ public class MCP_NewPlaneOverlayRenderer {
 
    private static final ResourceLocation PLANE_MOUSE_AIM_RETICLE_TEXTURE = new ResourceLocation("mcheli", "textures/gui/plane_crosshair.png");
    private static long nextDebugLogTime;
+   private static long nextEventLogTime;
+   private static boolean reticleTextureChecked;
+   private static boolean reticleTextureAvailable = true;
    private boolean registeredLogged;
+   private boolean postEnteredLogged;
 
    public MCP_NewPlaneOverlayRenderer() {
-      MCH_Lib.Log("[MCHeli][NewPlaneOverlay] registered renderer instance", new Object[0]);
+      MCH_Lib.Log("[MCHeli][NewPlaneOverlay] created renderer helper driven by MCH_ClientEventHook", new Object[0]);
    }
 
    @SubscribeEvent
@@ -32,7 +39,7 @@ public class MCP_NewPlaneOverlayRenderer {
          return;
       }
 
-      OverlayState state = this.getOverlayState(Minecraft.getMinecraft());
+      OverlayState state = this.getOverlayState(Minecraft.getMinecraft(), event.type, "pre_crosshairs");
       if(state.shouldSuppressCrosshair()) {
          state.crosshairSuppressed = true;
          if(state.plane != null) {
@@ -46,42 +53,57 @@ public class MCP_NewPlaneOverlayRenderer {
 
    @SubscribeEvent
    public void onRenderOverlayPost(RenderGameOverlayEvent.Post event) {
-      if(event == null || event.type != RenderGameOverlayEvent.ElementType.ALL) {
+      if(event == null) {
+         return;
+      }
+      if(!this.postEnteredLogged || (this.isDebugEnabled() && event.type == RenderGameOverlayEvent.ElementType.ALL && System.currentTimeMillis() >= nextEventLogTime)) {
+         this.postEnteredLogged = true;
+         nextEventLogTime = System.currentTimeMillis() + 1000L;
+         MCH_Lib.Log("[MCHeli][NewPlaneOverlay] post event entered type=%s", new Object[]{event.type});
+      }
+      if(event.type != RenderGameOverlayEvent.ElementType.ALL) {
          return;
       }
 
       Minecraft mc = Minecraft.getMinecraft();
-      OverlayState state = this.getOverlayState(mc);
-      if(!state.hasPlane) {
-         return;
+      OverlayState state = this.getOverlayState(mc, event.type, "post_all");
+      this.populateScreen(mc, state);
+      this.populateStageDecisions(state);
+
+      if(state.proofShouldDraw) {
+         this.drawProofOverlay(mc, state);
+         state.proofDrawn = true;
       }
 
-      ScaledResolution scaled = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
-      state.width = scaled.getScaledWidth();
-      state.height = scaled.getScaledHeight();
-      state.noseX = (double)state.width / 2.0D;
-      state.noseY = (double)state.height / 2.0D;
-      this.drawProofOverlay(mc, state);
-
-      if(state.shouldDrawReticle()) {
-         this.updateAimScreenPosition(state);
-         this.drawMouseAimReticles(mc, state);
+      if(state.overlayActive) {
+         this.updateAimScreenPosition(mc, state);
       } else {
-         state.mouseX = state.noseX;
-         state.mouseY = state.noseY;
+         state.mouseX = state.centerX;
+         state.mouseY = state.centerY;
+         state.noseX = state.centerX;
+         state.noseY = state.centerY;
       }
 
-      if(MCH_Config.PlaneMouseAimReticleDebug.prmBool || MCH_Config.DebugFlightControl.prmBool) {
+      if(state.cursorShouldDraw) {
+         this.drawMouseAimCursor(mc, state);
+         state.cursorDrawn = true;
+      }
+      if(state.noseShouldDraw) {
+         this.drawNoseReticle(state);
+         state.noseDrawn = true;
+      }
+      if(state.debugEnabled && state.hasPlane) {
          this.drawDebugText(mc, state);
       }
-      if(state.shouldDrawReticle()) {
-         this.logDebugOncePerSecond(state);
-      }
+      this.logDebugOncePerSecond(state);
    }
 
-   private OverlayState getOverlayState(Minecraft mc) {
+   private OverlayState getOverlayState(Minecraft mc, RenderGameOverlayEvent.ElementType eventType, String eventStage) {
       OverlayState state = new OverlayState();
       state.rendererRegistered = true;
+      state.eventStage = eventStage;
+      state.eventType = eventType != null?eventType.name():"null";
+      state.debugEnabled = this.isDebugEnabled();
       if(!this.registeredLogged) {
          this.registeredLogged = true;
          MCH_Lib.Log("[MCHeli][NewPlaneOverlay] first overlay state query reached", new Object[0]);
@@ -90,87 +112,212 @@ public class MCP_NewPlaneOverlayRenderer {
          state.skipReason = "no_minecraft";
          return state;
       }
+      state.renderViewEntityClass = mc.renderViewEntity != null?mc.renderViewEntity.getClass().getName():"null";
       EntityClientPlayerMP player = mc.thePlayer;
       if(player == null) {
          state.skipReason = "no_player";
          return state;
       }
+      state.player = player;
+      state.playerEntityClass = player.getClass().getName();
       MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
+      state.ridingEntityClass = ac != null?ac.getClass().getName():(player.ridingEntity != null?player.ridingEntity.getClass().getName():"null");
       if(!(ac instanceof MCP_EntityPlane)) {
          state.skipReason = "not_plane";
          return state;
       }
       state.hasPlane = true;
-      state.player = player;
       state.plane = (MCP_EntityPlane)ac;
+      state.newFlight = state.plane.isNewFlightModelEnabled();
+      state.mouseAimEnabled = state.plane.isMouseAimControlsActive();
       if(!state.plane.isPilot(player)) {
          state.skipReason = "not_pilot";
-      } else if(!state.plane.isNewFlightModelEnabled()) {
+      } else if(!state.newFlight) {
          state.skipReason = "not_new_flight";
-      } else if(!state.plane.isMouseAimControlsActive()) {
-         state.skipReason = "mouse_aim_disabled";
-      } else if(!MCH_Config.EnablePlaneMouseAimReticle.prmBool) {
-         state.skipReason = "reticle_config_disabled";
       } else {
-         state.skipReason = "draw";
+         state.skipReason = "qualifying_plane";
          state.qualifies = true;
       }
       state.crosshairSuppressed = state.plane.wasMouseAimVanillaCrosshairSuppressed();
       return state;
    }
 
-   private void updateAimScreenPosition(OverlayState state) {
+   private void populateScreen(Minecraft mc, OverlayState state) {
+      if(mc == null) {
+         state.width = 0;
+         state.height = 0;
+      } else {
+         ScaledResolution scaled = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+         state.width = scaled.getScaledWidth();
+         state.height = scaled.getScaledHeight();
+      }
+      state.centerX = (double)state.width / 2.0D;
+      state.centerY = (double)state.height / 2.0D;
+      state.mouseX = state.centerX;
+      state.mouseY = state.centerY;
+      state.noseX = state.centerX;
+      state.noseY = state.centerY;
+   }
+
+   private void populateStageDecisions(OverlayState state) {
+      state.overlayActive = state.qualifies && (state.mouseAimEnabled || state.debugEnabled);
+      state.proofShouldDraw = state.debugEnabled && state.qualifies;
+      state.cursorShouldDraw = state.qualifies && (state.mouseAimEnabled || state.debugEnabled);
+      state.noseShouldDraw = state.overlayActive || (state.debugEnabled && state.qualifies);
+      state.proofSkipReason = state.proofShouldDraw?"draw":"debug_or_plane_gate";
+      state.cursorSkipReason = state.cursorShouldDraw?"draw":"mouse_aim_or_debug_gate";
+      state.noseSkipReason = state.noseShouldDraw?"draw":"overlay_gate";
+   }
+
+   private void updateAimScreenPosition(Minecraft mc, OverlayState state) {
+      Entity camera = mc != null && mc.renderViewEntity != null?mc.renderViewEntity:state.player;
+      state.cameraYaw = camera != null?camera.rotationYaw:0.0D;
+      state.cameraPitch = camera != null?camera.rotationPitch:0.0D;
+      state.desiredAimYaw = state.plane != null?state.plane.getMouseAimDesiredYaw():state.cameraYaw;
+      state.desiredAimPitch = state.plane != null?state.plane.getMouseAimDesiredPitch():state.cameraPitch;
+      state.cursorYawDelta = MathHelper.wrapAngleTo180_float((float)(state.desiredAimYaw - state.cameraYaw));
+      state.cursorPitchDelta = MathHelper.wrapAngleTo180_float((float)(state.desiredAimPitch - state.cameraPitch));
       double safeRadius = Math.max(12.0D, Math.min((double)Math.min(state.width, state.height) * MCH_Config.PlaneMouseAimMaxScreenRadius.prmDouble,
             (double)Math.min(state.width, state.height) * 0.50D));
       double yawRange = Math.max(1.0D, MCH_Config.PlaneMouseAimYawVisualRange.prmDouble);
       double pitchRange = Math.max(1.0D, Math.max(MCH_Config.MouseAimMaxPitchUp.prmDouble, MCH_Config.MouseAimMaxPitchDown.prmDouble));
-      state.mouseX = state.noseX + (double)state.plane.getMouseAimYawError() / yawRange * safeRadius;
-      state.mouseY = state.noseY - (double)state.plane.getMouseAimPitchError() / pitchRange * safeRadius;
-      double dx = state.mouseX - state.noseX;
-      double dy = state.mouseY - state.noseY;
+      state.mouseX = state.centerX + state.cursorYawDelta / yawRange * safeRadius;
+      state.mouseY = state.centerY + state.cursorPitchDelta / pitchRange * safeRadius;
+      if(!this.validNumbers(state.cameraYaw, state.cameraPitch, state.desiredAimYaw, state.desiredAimPitch, state.cursorYawDelta, state.cursorPitchDelta, state.mouseX, state.mouseY)) {
+         state.cursorBadMath = true;
+         state.cursorSkipReason = "bad_math_center_fallback";
+         MCH_Lib.Log("[MCHeli][NewPlaneOverlay] bad cursor math camera=(%.3f,%.3f) desired=(%.3f,%.3f) delta=(%.3f,%.3f) screen=(%.3f,%.3f)",
+               new Object[]{Double.valueOf(state.cameraYaw), Double.valueOf(state.cameraPitch), Double.valueOf(state.desiredAimYaw), Double.valueOf(state.desiredAimPitch), Double.valueOf(state.cursorYawDelta), Double.valueOf(state.cursorPitchDelta), Double.valueOf(state.mouseX), Double.valueOf(state.mouseY)});
+         state.mouseX = state.centerX;
+         state.mouseY = state.centerY;
+      }
+      this.clampToSafeRadius(state, true, safeRadius);
+
+      Vec3 noseForward = state.plane != null?MCH_Lib.Rot2Vec3(state.plane.getRotYaw(), state.plane.getRotPitch()):Vec3.createVectorHelper(0.0D, 0.0D, 1.0D);
+      double noseYaw = Math.atan2(-noseForward.xCoord, noseForward.zCoord) * 180.0D / Math.PI;
+      double nosePitch = Math.asin(-noseForward.yCoord) * 180.0D / Math.PI;
+      state.noseYawDelta = MathHelper.wrapAngleTo180_float((float)(noseYaw - state.cameraYaw));
+      state.nosePitchDelta = MathHelper.wrapAngleTo180_float((float)(nosePitch - state.cameraPitch));
+      state.noseX = state.centerX + state.noseYawDelta / yawRange * safeRadius;
+      state.noseY = state.centerY + state.nosePitchDelta / pitchRange * safeRadius;
+      if(!this.validNumbers(noseYaw, nosePitch, state.noseYawDelta, state.nosePitchDelta, state.noseX, state.noseY)) {
+         state.noseBadMath = true;
+         state.noseSkipReason = "bad_math_center_fallback";
+         MCH_Lib.Log("[MCHeli][NewPlaneOverlay] bad nose math nose=(%.3f,%.3f) delta=(%.3f,%.3f) screen=(%.3f,%.3f)",
+               new Object[]{Double.valueOf(noseYaw), Double.valueOf(nosePitch), Double.valueOf(state.noseYawDelta), Double.valueOf(state.nosePitchDelta), Double.valueOf(state.noseX), Double.valueOf(state.noseY)});
+         state.noseX = state.centerX;
+         state.noseY = state.centerY;
+      }
+      this.clampToSafeRadius(state, false, safeRadius);
+   }
+
+   private void clampToSafeRadius(OverlayState state, boolean mouse, double safeRadius) {
+      double x = mouse?state.mouseX:state.noseX;
+      double y = mouse?state.mouseY:state.noseY;
+      double dx = x - state.centerX;
+      double dy = y - state.centerY;
       double dist = Math.sqrt(dx * dx + dy * dy);
-      if(dist > safeRadius && dist > 1.0E-4D) {
-         state.mouseX = state.noseX + dx / dist * safeRadius;
-         state.mouseY = state.noseY + dy / dist * safeRadius;
+      if(!this.validNumbers(x, y, dx, dy, dist)) {
+         x = state.centerX;
+         y = state.centerY;
+      } else if(dist > safeRadius && dist > 1.0E-4D) {
+         x = state.centerX + dx / dist * safeRadius;
+         y = state.centerY + dy / dist * safeRadius;
+         if(mouse) {
+            state.mouseClamped = true;
+         } else {
+            state.noseClamped = true;
+         }
+      }
+      if(mouse) {
+         state.mouseX = x;
+         state.mouseY = y;
+      } else {
+         state.noseX = x;
+         state.noseY = y;
       }
    }
 
    private void drawProofOverlay(Minecraft mc, OverlayState state) {
-      GL11.glPushMatrix();
-      GL11.glDisable(2929);
-      GL11.glEnable(3042);
-      GL11.glBlendFunc(770, 771);
+      this.beginOverlayGl();
       GL11.glDisable(3553);
-      this.drawLineCross(state.noseX, state.noseY, 28.0D, 0xAA00FF00);
+      GL11.glColor4f(1.0F, 1.0F, 0.0F, 1.0F);
+      this.drawLineCross(state.centerX, state.centerY, 34.0D, 0xFFFFFF00);
       GL11.glEnable(3553);
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-      mc.fontRenderer.drawStringWithShadow("NEW PLANE OVERLAY ACTIVE", 6, 6, 0x55FF66);
-      GL11.glDisable(3042);
-      GL11.glEnable(2929);
-      GL11.glPopMatrix();
+      if(mc != null && mc.fontRenderer != null) {
+         mc.fontRenderer.drawStringWithShadow("NEW PLANE OVERLAY ACTIVE", 6, 6, 0xFFFF00);
+      }
+      this.endOverlayGl();
    }
 
-   private void drawMouseAimReticles(Minecraft mc, OverlayState state) {
+   private void drawMouseAimCursor(Minecraft mc, OverlayState state) {
+      this.beginOverlayGl();
+      double mouseSize = 128.0D * this.clamp(MCH_Config.PlaneMouseAimReticleScale.prmDouble, 0.25D, 4.0D);
+      boolean textureBound = this.bindPlaneMouseAimReticleTexture(mc);
+      if(textureBound) {
+         GL11.glEnable(3553);
+         GL11.glColor4f(0.25F, 1.0F, 0.35F, (float)this.clamp(MCH_Config.PlaneMouseAimReticleOpacity.prmDouble, 0.0D, 1.0D));
+         this.drawTexturedQuad(state.mouseX - mouseSize / 2.0D, state.mouseY - mouseSize / 2.0D, mouseSize, mouseSize);
+      }
+      GL11.glDisable(3553);
+      if(!textureBound || state.debugEnabled) {
+         this.drawLineCross(state.mouseX, state.mouseY, mouseSize * 0.35D, textureBound?0xAA55FF66:0xEE55FF66);
+      }
+      state.textureAvailable = textureBound;
+      this.endOverlayGl();
+   }
+
+   private void drawNoseReticle(OverlayState state) {
+      this.beginOverlayGl();
+      GL11.glDisable(3553);
+      double noseSize = 11.0D * this.clamp(MCH_Config.PlaneNoseReticleScale.prmDouble, 0.25D, 4.0D);
+      double noseOpacity = this.clamp(MCH_Config.PlaneNoseReticleOpacity.prmDouble, 0.0D, 1.0D) * (state.noseClamped?0.45D:1.0D);
+      int noseAlpha = ((int)(noseOpacity * 255.0D) & 255) << 24;
+      this.drawLineCross(state.noseX, state.noseY, noseSize, noseAlpha | 0x00FFFFFF);
+      this.drawLineBox(state.noseX, state.noseY, noseSize * 0.65D, noseAlpha | 0x00FFFFFF);
+      this.endOverlayGl();
+   }
+
+   private void beginOverlayGl() {
+      GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
       GL11.glPushMatrix();
       GL11.glDisable(2929);
       GL11.glEnable(3042);
       GL11.glBlendFunc(770, 771);
-      GL11.glEnable(3553);
-      GL11.glColor4f(0.25F, 1.0F, 0.35F, (float)this.clamp(MCH_Config.PlaneMouseAimReticleOpacity.prmDouble, 0.0D, 1.0D));
-      mc.renderEngine.bindTexture(PLANE_MOUSE_AIM_RETICLE_TEXTURE);
-      double mouseSize = 96.0D * this.clamp(MCH_Config.PlaneMouseAimReticleScale.prmDouble, 0.25D, 4.0D);
-      this.drawTexturedQuad(state.mouseX - mouseSize / 2.0D, state.mouseY - mouseSize / 2.0D, mouseSize, mouseSize);
-      GL11.glDisable(3553);
-      this.drawLineCross(state.mouseX, state.mouseY, mouseSize * 0.35D, 0xEE55FF66);
-      double noseSize = 11.0D * this.clamp(MCH_Config.PlaneNoseReticleScale.prmDouble, 0.25D, 4.0D);
-      int noseAlpha = ((int)(this.clamp(MCH_Config.PlaneNoseReticleOpacity.prmDouble, 0.0D, 1.0D) * 255.0D) & 255) << 24;
-      this.drawLineCross(state.noseX, state.noseY, noseSize, noseAlpha | 0x00FFFFFF);
-      this.drawLineBox(state.noseX, state.noseY, noseSize * 0.65D, noseAlpha | 0x00FFFFFF);
-      GL11.glEnable(3553);
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-      GL11.glDisable(3042);
-      GL11.glEnable(2929);
+   }
+
+   private void endOverlayGl() {
+      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
       GL11.glPopMatrix();
+      GL11.glPopAttrib();
+   }
+
+   private boolean bindPlaneMouseAimReticleTexture(Minecraft mc) {
+      if(mc == null) {
+         reticleTextureAvailable = false;
+         return false;
+      }
+      if(!reticleTextureChecked) {
+         reticleTextureChecked = true;
+         try {
+            mc.getResourceManager().getResource(PLANE_MOUSE_AIM_RETICLE_TEXTURE);
+            reticleTextureAvailable = true;
+         } catch(Exception e) {
+            reticleTextureAvailable = false;
+            MCH_Lib.Log("[MCHeli][NewPlaneOverlay] failed to find reticle texture: %s", new Object[]{PLANE_MOUSE_AIM_RETICLE_TEXTURE});
+         }
+      }
+      if(reticleTextureAvailable) {
+         try {
+            mc.getTextureManager().bindTexture(PLANE_MOUSE_AIM_RETICLE_TEXTURE);
+         } catch(Exception e) {
+            reticleTextureAvailable = false;
+            MCH_Lib.Log("[MCHeli][NewPlaneOverlay] failed to bind reticle texture: %s", new Object[]{PLANE_MOUSE_AIM_RETICLE_TEXTURE});
+         }
+      }
+      return reticleTextureAvailable;
    }
 
    private void drawTexturedQuad(double x, double y, double width, double height) {
@@ -206,16 +353,20 @@ public class MCP_NewPlaneOverlayRenderer {
    }
 
    private void drawDebugText(Minecraft mc, OverlayState state) {
-      String debug = this.formatDebug(state);
-      GL11.glPushMatrix();
-      GL11.glEnable(3042);
+      if(mc == null || mc.fontRenderer == null) {
+         return;
+      }
+      this.beginOverlayGl();
       GL11.glEnable(3553);
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-      mc.fontRenderer.drawStringWithShadow(debug, 6, 20, 0x55FF66);
-      GL11.glPopMatrix();
+      mc.fontRenderer.drawStringWithShadow(this.formatDebug(state), 6, 20, 0x55FF66);
+      this.endOverlayGl();
    }
 
    private void logDebugOncePerSecond(OverlayState state) {
+      if(!state.debugEnabled && !state.overlayActive) {
+         return;
+      }
       if(System.currentTimeMillis() < nextDebugLogTime) {
          return;
       }
@@ -224,14 +375,35 @@ public class MCP_NewPlaneOverlayRenderer {
    }
 
    private String formatDebug(OverlayState state) {
-      MCP_EntityPlane plane = state.plane;
-      return String.format("registered=%s reason=%s crosshairSuppressed=%s aim=(%.1f,%.1f) nose=(%.1f,%.1f) desired=(%.2f,%.2f) error=(%.2f,%.2f)",
-            Boolean.valueOf(state.rendererRegistered), state.skipReason, Boolean.valueOf(state.crosshairSuppressed),
+      return String.format("eventEntered=true stage=%s type=%s player=%s riding=%s planeQualifies=%s reason=%s renderView=%s mouseAim=%s debugReticle=%s debugFlight=%s size=%dx%d texture=%s proof=%s(%s) cursor=%s(%s) nose=%s(%s) crosshairSuppressed=%s desiredAimYaw/Pitch=(%.2f,%.2f) cameraYaw/Pitch=(%.2f,%.2f) cursorYawDelta/PitchDelta=(%.2f,%.2f) screenX/Y=(%.1f,%.1f) noseXY=(%.1f,%.1f) noseDelta=(%.2f,%.2f)",
+            state.eventStage, state.eventType, state.playerEntityClass, state.ridingEntityClass, Boolean.valueOf(state.qualifies), state.skipReason,
+            state.renderViewEntityClass, Boolean.valueOf(state.mouseAimEnabled), Boolean.valueOf(MCH_Config.PlaneMouseAimReticleDebug.prmBool), Boolean.valueOf(MCH_Config.DebugFlightControl.prmBool),
+            Integer.valueOf(state.width), Integer.valueOf(state.height), Boolean.valueOf(reticleTextureAvailable), Boolean.valueOf(state.proofDrawn), state.proofSkipReason,
+            Boolean.valueOf(state.cursorDrawn), state.cursorSkipReason, Boolean.valueOf(state.noseDrawn), state.noseSkipReason,
+            Boolean.valueOf(state.crosshairSuppressed), Double.valueOf(state.desiredAimYaw), Double.valueOf(state.desiredAimPitch),
+            Double.valueOf(state.cameraYaw), Double.valueOf(state.cameraPitch), Double.valueOf(state.cursorYawDelta), Double.valueOf(state.cursorPitchDelta),
             Double.valueOf(state.mouseX), Double.valueOf(state.mouseY), Double.valueOf(state.noseX), Double.valueOf(state.noseY),
-            Float.valueOf(plane != null ? plane.getMouseAimDesiredYaw() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimDesiredPitch() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimYawError() : 0.0F),
-            Float.valueOf(plane != null ? plane.getMouseAimPitchError() : 0.0F));
+            Double.valueOf(state.noseYawDelta), Double.valueOf(state.nosePitchDelta));
+   }
+
+   private boolean isDebugEnabled() {
+      return MCH_Config.PlaneMouseAimReticleDebug.prmBool || MCH_Config.DebugFlightControl.prmBool;
+   }
+
+   private boolean validNumbers(double a) {
+      return !Double.isNaN(a) && !Double.isInfinite(a);
+   }
+
+   private boolean validNumbers(double a, double b, double c, double d, double e) {
+      return this.validNumbers(a) && this.validNumbers(b) && this.validNumbers(c) && this.validNumbers(d) && this.validNumbers(e);
+   }
+
+   private boolean validNumbers(double a, double b, double c, double d, double e, double f) {
+      return this.validNumbers(a) && this.validNumbers(b) && this.validNumbers(c) && this.validNumbers(d) && this.validNumbers(e) && this.validNumbers(f);
+   }
+
+   private boolean validNumbers(double a, double b, double c, double d, double e, double f, double g, double h) {
+      return this.validNumbers(a) && this.validNumbers(b) && this.validNumbers(c) && this.validNumbers(d) && this.validNumbers(e) && this.validNumbers(f) && this.validNumbers(g) && this.validNumbers(h);
    }
 
    private double clamp(double value, double min, double max) {
@@ -244,21 +416,50 @@ public class MCP_NewPlaneOverlayRenderer {
       boolean rendererRegistered;
       boolean hasPlane;
       boolean qualifies;
+      boolean newFlight;
+      boolean mouseAimEnabled;
+      boolean debugEnabled;
+      boolean overlayActive;
       boolean crosshairSuppressed;
       String skipReason = "not_plane";
+      String eventStage = "unknown";
+      String eventType = "unknown";
+      String playerEntityClass = "null";
+      String ridingEntityClass = "null";
+      String renderViewEntityClass = "null";
       int width;
       int height;
       double mouseX;
       double mouseY;
       double noseX;
       double noseY;
-
-      boolean shouldDrawReticle() {
-         return this.qualifies;
-      }
+      double centerX;
+      double centerY;
+      double desiredAimYaw;
+      double desiredAimPitch;
+      double cameraYaw;
+      double cameraPitch;
+      double cursorYawDelta;
+      double cursorPitchDelta;
+      double noseYawDelta;
+      double nosePitchDelta;
+      boolean mouseClamped;
+      boolean noseClamped;
+      boolean cursorBadMath;
+      boolean noseBadMath;
+      boolean textureAvailable = true;
+      boolean proofShouldDraw;
+      boolean proofDrawn;
+      String proofSkipReason = "not_evaluated";
+      boolean cursorShouldDraw;
+      boolean cursorDrawn;
+      String cursorSkipReason = "not_evaluated";
+      boolean noseShouldDraw;
+      boolean noseDrawn;
+      String noseSkipReason = "not_evaluated";
 
       boolean shouldSuppressCrosshair() {
-         return this.qualifies && MCH_Config.HideVanillaCrosshairInPlaneMouseAim.prmBool;
+         return this.qualifies && this.mouseAimEnabled && MCH_Config.HideVanillaCrosshairInPlaneMouseAim.prmBool;
       }
    }
 }


### PR DESCRIPTION
### Motivation

- Move the plane mouse-aim overlay logic out of `MCH_ClientEventHook` into a focused renderer helper to simplify event handling and reduce coupling. 
- Improve robustness for rendering (GL state handling, texture availability) and add richer debug / diagnostic output to help troubleshoot overlay behavior. 

### Description

- Introduces a new helper class `MCP_NewPlaneOverlayRenderer` that encapsulates overlay state, pre/post event handling, drawing, validation, clamping and debug formatting for the plane mouse-aim reticle and nose indicator. 
- Removes the previous inline reticle code from `MCH_ClientEventHook` and delegates `onRenderOverlayPre` and `onRenderOverlayPost` calls to an instance of `MCP_NewPlaneOverlayRenderer`. 
- Stops registering `MCP_NewPlaneOverlayRenderer` directly in `MCH_ClientProxy` and instead uses the renderer instance owned by `MCH_ClientEventHook`. 
- Adds safe GL state push/pop via `beginOverlayGl`/`endOverlayGl`, texture existence checks and bind fallback in `bindPlaneMouseAimReticleTexture`, math validation helpers (`validNumbers`), screen/population and stage-decision separation, clamping logic, and much more detailed debug/log output in `formatDebug`. 

### Testing

- Built the project with Gradle using `./gradlew build` (including running the test task) and the build completed successfully. 
- No automated unit tests were added or modified in this change and the existing build/test suite passed during the build run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34a379836c83299e2fce2614990c60)