### PR TITLE
Fix held freelook and remove third-person orbit jank

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -201,11 +201,20 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
                pc.switchGear = 2;
                send = true;
             }
-         if (this.KeyFreeLook.isKeyDown())
-            if (ac.canSwitchFreeLook()) {
+         if (ac.canSwitchFreeLook()) {
+            if (MCH_Config.EnableHoldFreelook.prmBool) {
+               if (this.KeyFreeLook.isKeyDown() && !ac.isFreeLookMode()) {
+                  pc.switchFreeLook = 1;
+                  send = true;
+               } else if (this.KeyFreeLook.isKeyUp() && ac.isFreeLookMode()) {
+                  pc.switchFreeLook = 2;
+                  send = true;
+               }
+            } else if (this.KeyFreeLook.isKeyDown()) {
                pc.switchFreeLook = (byte)(ac.isFreeLookMode() ? 2 : 1);
                send = true;
             }
+         }
          if (this.KeyGUI.isKeyDown()) {
             pc.openGui = true;
             send = true;

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -146,17 +146,10 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.commonPlayerControlInGUI(player, plane, isPilot, new MCP_PlanePacketPlayerControl());
    }
 
-   private boolean isNewChaseHoldFreelookPath(MCP_EntityPlane plane, boolean isPilot) {
-      return isPilot && MCH_Config.EnableHoldFreelook.prmBool && plane != null && plane.isNewFlightModelEnabled() && MCH_Config.EnableNewPlaneThirdPersonCamera.prmBool && super.mc != null && super.mc.gameSettings != null && super.mc.gameSettings.thirdPersonView > 0;
-   }
-
    protected void playerControl(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
       MCP_PlanePacketPlayerControl pc = new MCP_PlanePacketPlayerControl();
       boolean send = false;
       send = this.commonPlayerControl(player, plane, isPilot, pc);
-      if(this.isNewChaseHoldFreelookPath(plane, isPilot)) {
-         pc.switchFreeLook = 0;
-      }
       boolean isUav;
       if(isPilot) {
          if(this.KeySwitchMode.isKeyDown()) {

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -136,7 +136,7 @@ public class MCP_PlaneChaseCamera {
       lastClientTickComputed = clientTick;
 
       this.wasFreelookActive = this.freelookActive;
-      this.freelookActive = this.isHoldFreelookActive();
+      this.freelookActive = false;
       this.updateFreelookOrbit();
       Vec3 anchor = this.getCameraFocusPoint(plane);
       Vec3 focus = this.computeHeldLookAheadFocus(plane, anchor);
@@ -573,7 +573,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean shouldConsumeFreelookMouse(MCP_EntityPlane plane, EntityPlayer player) {
-      return activeCamera != null && activeRenderPlane == plane && player != null && activeCamera.isHoldFreelookActive();
+      return false;
    }
 
    public static void addFreelookMouseDelta(double deltaX, double deltaY) {


### PR DESCRIPTION
### Motivation
- Users reported that freelook in third-person was adjusting aircraft roll/pitch and behaving erratically, so freelook should be a held action when configured and third-person freelook-specific mouse handling should not modify flight orientation.
- Maintain the original first-person freelook semantics and ensure the plane chase camera path does not bypass the shared freelook state.

### Description
- Implement press/release semantics for `EnableHoldFreelook`: when enabled, pressing the freelook key sends freelook-on and releasing sends freelook-off, while leaving toggle behavior intact when the setting is disabled (`src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java`).
- Remove the plane-specific suppression of freelook packets in the new chase-camera path so planes use the common freelook state (`src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java`).
- Disable the chase-camera’s freelook consumption path by forcing the chase camera to ignore hold-freelook state and by making `shouldConsumeFreelookMouse` return `false`, preventing third-person mouse-orbit deltas from being applied to the aircraft orientation (`src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java`).
- Remove the now-unnecessary helper that masked freelook packet forwarding for the chase-camera path.

### Testing
- Ran `git diff --check` with no reported issues.
- Attempted `./gradlew test` but the Gradle wrapper failed to download the distribution due to a proxy HTTP 403, so automated test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c2f96cbc8323b847dd213e2e02ad)