### PR TITLE
Add optional Hold Free Look control and decouple freelook from plane chase camera

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,13 +162,13 @@ IgnoreBulletHit = flansmod.common.guns.EntityGrenade
 
 These options are client-side visual/readability settings for pilots flying planes that use the new flight/new mobility system. They do not change flight physics, stall behavior, pitch authority, throttle behavior, weapons, targeting, HUD rendering, or aircraft balance. Legacy aircraft, first-person view, helicopters, tanks, turrets, ships, passengers, and gunners keep the existing camera path unless the gated new-plane third-person pilot conditions are met.
 
-The standard chase camera is intentionally stable: it stays behind the aircraft with configurable distance, aircraft-size scaling, speed distance scaling, collision avoidance, pitch readability, aircraft-below-center framing, and conservative roll influence. It does **not** automatically move focus based on throttle, steering input, turn rate, sideslip, or velocity direction. Situational camera movement comes from two held player actions:
+The standard chase camera is intentionally stable: it stays behind the aircraft with configurable distance, aircraft-size scaling, speed distance scaling, collision avoidance, pitch readability, aircraft-below-center framing, and conservative roll influence. It does **not** automatically move focus based on throttle, steering input, turn rate, sideslip, or velocity direction. Situational camera movement comes from held player actions only when the matching control option is enabled:
 
-* **Hold freelook** (`KeyFreeLook`, default Left Control): while held, mouse movement orbits the third-person camera around the aircraft/focus point, allowing rear, side, front, high, and low views. Aircraft controls continue normally and do not inherit the orbit camera orientation. Releasing the key smoothly returns orbit yaw/pitch offsets to rear chase view.
+* **Free Look** (`KeyFreeLook`, default Left Control): by default this remains the original toggle action, including in regular third person, so the view does not snap back when the key is released. Enabling **Hold Free Look** in the controls menu changes it to a held action that turns off on key release.
 * **Hold Plane Look Ahead** (`KeyPlaneLookAhead`, default Left Alt): while held, the camera focus blends forward along the aircraft facing direction while the camera remains behind the aircraft at normal chase distance. Releasing the key smoothly returns to centered framing.
-* **Interaction:** freelook takes priority over camera rotation. Holding both keeps freelook orbit in control while look-ahead only changes the smoothed focus point; neither key alters aircraft controls.
+* **Interaction:** the new third-person chase camera no longer consumes freelook mouse movement for a custom orbit path, so freelook uses the shared aircraft freelook state instead of injecting camera-orbit deltas into flight controls.
 
-Recommended bindings: keep **Free Look** on a comfortable hold key such as Left Control, and bind **Plane Look Ahead** to Left Alt, a thumb mouse button, or another hold key that can be pressed briefly during target tracking.
+Recommended bindings: keep **Free Look** on a comfortable key such as Left Control, enable **Hold Free Look** only if you prefer hold-to-use behavior, and bind **Plane Look Ahead** to Left Alt, a thumb mouse button, or another hold key that can be pressed briefly during target tracking.
 
 | Config key | Default | Purpose | Practical range |
 | --- | ---: | --- | --- |
@@ -176,7 +176,7 @@ Recommended bindings: keep **Free Look** on a comfortable hold key such as Left 
 | `EnableSpeedBasedCameraDistance` | `false` | Optional speed distance scaling. Disabled by default to prevent zoom breathing with throttle/speed changes. | keep `false`; use only for small capped effects |
 | `EnableNewPlaneCameraCollision` | `true` | Allows block ray tracing to shorten the camera when terrain/buildings/trees/hangars obstruct the view. | `true`/`false` |
 | `EnablePlaneLookAhead` | `true` | Enables held Plane Look Ahead. This is player-initiated only, never automatic velocity/turn prediction. | `true`/`false` |
-| `EnableHoldFreelook` | `true` | Makes new-chase-camera freelook hold-to-use and suppresses toggle freelook state for this path. | `true`/`false` |
+| `EnableHoldFreelook` | `false` | Enables hold-to-use Free Look globally; disabled preserves the original toggle behavior. | `true`/`false` |
 | `EnableNewPlaneCameraRollInfluence` | `true` | Allows limited aircraft roll to affect the camera horizon. | `true`/`false` |
 | `PlaneChaseBaseDistance` | `15.0` | Stable base chase distance in blocks before aircraft-size bonus and optional speed bonus. | default `15`; tune with wider FOV before large distance swings |
 | `PlaneChaseMinDistance` | `13.0` | Minimum camera distance from the smoothed focus after scale handling, high enough to keep tails framed during slowdown. | `12`-`18` for normal chase |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -561,7 +561,8 @@ public class MCH_Config {
       EnableNewPlaneCameraSpeedDistance.desc = ";Disabled by default so the new plane chase camera stays near its stable base distance instead of breathing with throttle/speed.";
       EnableNewPlaneCameraCollision = new MCH_ConfigPrm("EnableNewPlaneCameraCollision", true);
       EnablePlaneLookAhead = new MCH_ConfigPrm("EnablePlaneLookAhead", true);
-      EnableHoldFreelook = new MCH_ConfigPrm("EnableHoldFreelook", true);
+      EnableHoldFreelook = new MCH_ConfigPrm("EnableHoldFreelook", false);
+      EnableHoldFreelook.desc = ";When enabled, the Free Look key must be held; when disabled, Free Look toggles on/off with each key press.";
       EnableNewPlaneCameraRollInfluence = new MCH_ConfigPrm("EnableNewPlaneCameraRollInfluence", true);
       NewPlaneCameraCollision = new MCH_ConfigPrm("NewPlaneCameraCollision", true);
       NewPlaneCameraCollision.desc = ";Deprecated alias for EnableNewPlaneCameraCollision; moves the chase camera in front of solid blocks when line-of-sight collision is detected.";

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -201,11 +201,20 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
                pc.switchGear = 2;
                send = true;
             }
-         if (this.KeyFreeLook.isKeyDown())
-            if (ac.canSwitchFreeLook()) {
+         if (ac.canSwitchFreeLook()) {
+            if (MCH_Config.EnableHoldFreelook.prmBool) {
+               if (this.KeyFreeLook.isKeyDown() && !ac.isFreeLookMode()) {
+                  pc.switchFreeLook = 1;
+                  send = true;
+               } else if (this.KeyFreeLook.isKeyUp() && ac.isFreeLookMode()) {
+                  pc.switchFreeLook = 2;
+                  send = true;
+               }
+            } else if (this.KeyFreeLook.isKeyDown()) {
                pc.switchFreeLook = (byte)(ac.isFreeLookMode() ? 2 : 1);
                send = true;
             }
+         }
          if (this.KeyGUI.isKeyDown()) {
             pc.openGui = true;
             send = true;

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -69,6 +69,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
    private MCH_GuiOnOffButton buttonThrottleShip;
    private MCH_GuiOnOffButton buttonThrottleTank;
    private MCH_GuiOnOffButton buttonFlightSimMode;
+   private MCH_GuiOnOffButton buttonHoldFreelook;
    private MCH_GuiOnOffButton buttonSwitchWeaponWheel;
    private W_GuiButton buttonReloadAircraftInfo;
    private W_GuiButton buttonReloadWeaponInfo;
@@ -124,11 +125,12 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.buttonMouseInv = new MCH_GuiOnOffButton(0, x1, y + 25, 150, 20, "Invert Mouse : ");
       this.sliderSensitivity = new MCH_GuiSlider(0, x1, y + 50, 150, 20, "Sensitivity : %.1f", 0.0F, 0.0F, 30.0F, 0.1F);
       this.buttonFlightSimMode = new MCH_GuiOnOffButton(0, x1, y + 75, 150, 20, "Mouse Flight Sim Mode : ");
-      this.buttonSwitchWeaponWheel = new MCH_GuiOnOffButton(0, x1, y + 100, 150, 20, "Switch Weapon Wheel : ");
-      this.listControlButtons.add(new W_GuiButton(50, x1, y + 125, 150, 20, "Render Settings >>"));
-      this.listControlButtons.add(new W_GuiButton(51, x1, y + 150, 150, 20, "Key Binding >>"));
+      this.buttonHoldFreelook = new MCH_GuiOnOffButton(0, x1, y + 100, 150, 20, "Hold Free Look : ");
+      this.buttonSwitchWeaponWheel = new MCH_GuiOnOffButton(0, x1, y + 125, 150, 20, "Switch Weapon Wheel : ");
+      this.listControlButtons.add(new W_GuiButton(50, x1, y + 150, 150, 20, "Render Settings >>"));
+      this.listControlButtons.add(new W_GuiButton(51, x1, y + 175, 150, 20, "Key Binding >>"));
       this.listControlButtons.add(new W_GuiButton(55, x2, y + 150, 150, 20, "Development >>"));
-      this.buttonTestMode = new MCH_GuiOnOffButton(0, x1, y + 175, 150, 20, "Test Mode : ");
+      this.buttonTestMode = new MCH_GuiOnOffButton(0, x2, y + 175, 150, 20, "Test Mode : ");
       this.buttonStickModeHeli = new MCH_GuiOnOffButton(0, x2, y + 25, 150, 20, "Stick Mode Heli : ");
       this.buttonStickModePlane = new MCH_GuiOnOffButton(0, x2, y + 50, 150, 20, "Stick Mode Plane : ");
       this.buttonThrottleHeli = new MCH_GuiOnOffButton(0, x2, y + 75, 150, 20, "Throttle Down Heli : ");
@@ -145,6 +147,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.listControlButtons.add(this.buttonThrottleTank);
       this.listControlButtons.add(this.buttonTestMode);
       this.listControlButtons.add(this.buttonFlightSimMode);
+      this.listControlButtons.add(this.buttonHoldFreelook);
       this.listControlButtons.add(this.buttonSwitchWeaponWheel);
       Iterator id = this.listControlButtons.iterator();
 
@@ -431,6 +434,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
 
       this.buttonTestMode.setOnOff(config.TestMode.prmBool);
       this.buttonFlightSimMode.setOnOff(config.MouseControlFlightSimMode.prmBool);
+      this.buttonHoldFreelook.setOnOff(config.EnableHoldFreelook.prmBool);
       this.buttonSwitchWeaponWheel.setOnOff(config.SwitchWeaponWithMouseWheel.prmBool);
 
       this.buttonPlaneChaseCamera.setOnOff(config.EnableNewPlaneThirdPersonCamera.prmBool);
@@ -459,6 +463,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       config.MouseControlStickModeHeli.setPrm(buttonStickModeHeli.getOnOff());
       config.MouseControlStickModePlane.setPrm(buttonStickModePlane.getOnOff());
       config.MouseControlFlightSimMode.setPrm(buttonFlightSimMode.getOnOff());
+      config.EnableHoldFreelook.setPrm(buttonHoldFreelook.getOnOff());
       config.SwitchWeaponWithMouseWheel.setPrm(buttonSwitchWeaponWheel.getOnOff());
 
       config.MouseSensitivity.setPrm(sliderSensitivity.getSliderValueInt(1));

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -146,17 +146,10 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.commonPlayerControlInGUI(player, plane, isPilot, new MCP_PlanePacketPlayerControl());
    }
 
-   private boolean isNewChaseHoldFreelookPath(MCP_EntityPlane plane, boolean isPilot) {
-      return isPilot && MCH_Config.EnableHoldFreelook.prmBool && plane != null && plane.isNewFlightModelEnabled() && MCH_Config.EnableNewPlaneThirdPersonCamera.prmBool && super.mc != null && super.mc.gameSettings != null && super.mc.gameSettings.thirdPersonView > 0;
-   }
-
    protected void playerControl(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
       MCP_PlanePacketPlayerControl pc = new MCP_PlanePacketPlayerControl();
       boolean send = false;
       send = this.commonPlayerControl(player, plane, isPilot, pc);
-      if(this.isNewChaseHoldFreelookPath(plane, isPilot)) {
-         pc.switchFreeLook = 0;
-      }
       boolean isUav;
       if(isPilot) {
          if(this.KeySwitchMode.isKeyDown()) {

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -136,7 +136,7 @@ public class MCP_PlaneChaseCamera {
       lastClientTickComputed = clientTick;
 
       this.wasFreelookActive = this.freelookActive;
-      this.freelookActive = this.isHoldFreelookActive();
+      this.freelookActive = false;
       this.updateFreelookOrbit();
       Vec3 anchor = this.getCameraFocusPoint(plane);
       Vec3 focus = this.computeHeldLookAheadFocus(plane, anchor);
@@ -573,7 +573,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean shouldConsumeFreelookMouse(MCP_EntityPlane plane, EntityPlayer player) {
-      return activeCamera != null && activeRenderPlane == plane && player != null && activeCamera.isHoldFreelookActive();
+      return false;
    }
 
    public static void addFreelookMouseDelta(double deltaX, double deltaY) {


### PR DESCRIPTION
### Motivation

- Introduce a configurable "Hold Free Look" behavior so players can choose hold-to-use or toggle freelook globally and avoid the chase camera consuming freelook input. 

### Description

- Change default `EnableHoldFreelook` to `false` and add a descriptive `desc` entry in `MCH_Config` so the global freelook mode is configurable. 
- Add a new control in the config GUI (`buttonHoldFreelook`) and persist its state in `saveAndApplyConfig`. 
- Update `MCH_BaseVehicleClientTickHandler` to handle hold-versus-toggle freelook behavior at input time, sending separate switch codes for key down/up when hold mode is enabled. 
- Remove the chase-camera special-case freelook path and stop the plane chase camera from consuming freelook mouse deltas (`MCP_PlaneChaseCamera`), effectively decoupling freelook orbit from the new third-person chase camera; update docs in `docs/configuration.md` to reflect the new behavior and defaults. 

### Testing

- Built the project with `./gradlew build` and the build completed successfully. 
- Ran the test suite with `./gradlew test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35c2f96cbc8323b847dd213e2e02ad)