### PR TITLE
Fix freelook overwriting aircraft rider pitch/yaw

### DIFF
--- a/McHeliCE-master/src/main/java/com/norwood/mcheli/event/MouseInputHandler.java
+++ b/McHeliCE-master/src/main/java/com/norwood/mcheli/event/MouseInputHandler.java
@@ -528,6 +528,11 @@ public class MouseInputHandler {
                 aircraft.prevLastRiderYaw = aircraft.getPrevDetachedWeaponAimYaw();
                 aircraft.lastRiderPitch = aircraft.getDetachedWeaponAimPitch();
                 aircraft.prevLastRiderPitch = aircraft.getPrevDetachedWeaponAimPitch();
+            } else if (aircraft.canSwitchFreeLook() && aircraft.isFreeLookMode() && aircraft.isPilot(player)) {
+                aircraft.lastRiderYaw = aircraft.getYaw();
+                aircraft.prevLastRiderYaw = aircraft.prevRotationYaw;
+                aircraft.lastRiderPitch = aircraft.getPitch();
+                aircraft.prevLastRiderPitch = aircraft.prevRotationPitch;
             } else {
                 aircraft.lastRiderYaw = player.rotationYaw;
                 aircraft.prevLastRiderYaw = player.prevRotationYaw;


### PR DESCRIPTION
### Motivation
- Prevent the pilot's freelook camera rotation from being copied into the aircraft internal rider aim state so freelook no longer makes flight/weapon logic behave as if the plane itself pitched or yawed.

### Description
- Added a freelook-specific branch in `MouseInputHandler.updateRiderLastPositions` that, when `aircraft.canSwitchFreeLook() && aircraft.isFreeLookMode() && aircraft.isPilot(player)`, writes the aircraft's actual `getYaw()`/`getPitch()` (and their previous values) into `lastRiderYaw`/`lastRiderPitch` instead of using the player camera values; the change is in `McHeliCE-master/src/main/java/com/norwood/mcheli/event/MouseInputHandler.java` and is a small 5-line insertion to avoid freelook contaminating internal aircraft aim state.

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity and it reported no issues.
- Attempted `bash ./gradlew compileJava` to compile the project but the Gradle wrapper failed to download due to an external proxy returning `HTTP/1.1 403 Forbidden`, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35dd58e53c83239526753cdff17ca1)