### PR TITLE
Reset plane control state during free-look and ignore input yaw/roll while free-looking

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1076,8 +1076,28 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       float ac_yaw = this.getRotYaw();
       float ac_roll = this.getRotRoll();
       if(this.isFreeLookMode()) {
-         y = 0.0F;
-         x = 0.0F;
+         this.mouseAimGeneratedYawCommand = 0.0F;
+         this.mouseAimGeneratedPitchCommand = 0.0F;
+         this.mouseAimGeneratedRollCommand = 0.0F;
+         this.pitchAngularVelocity = 0.0D;
+         this.rollAngularVelocity = 0.0D;
+         this.yawAngularVelocity = 0.0D;
+         this.lastFinalPitchAngularVelocity = 0.0D;
+         this.lastRequestedPitchInput = 0.0F;
+         this.lastPitchInputAfterAuthority = 0.0F;
+         this.lastControlAuthority = this.getControlAuthorityFactor();
+         this.lastPitchAuthority = 1.0D;
+         this.lastPitchAuthorityAfterSuppression = 1.0D;
+         this.lastNoseUpPitchSuppression = 0.0D;
+         this.addkeyRotValue = 0.0F;
+         this.prevRotationRoll = this.getRotRoll();
+         super.prevRotationPitch = this.getRotPitch();
+         if(this.getRidingEntity() == null) {
+            super.prevRotationYaw = this.getRotYaw();
+         }
+
+         player.setAngles(deltaX, deltaY);
+         return;
       }
 
       boolean useMouseAim = this.shouldUseMouseAimControls(player);
@@ -1742,11 +1762,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                }
             }
 
-            if(super.moveLeft && !super.moveRight) {
+            if(!this.isFreeLookMode() && super.moveLeft && !super.moveRight) {
                this.setRotYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
             }
 
-            if(super.moveRight && !super.moveLeft) {
+            if(!this.isFreeLookMode() && super.moveRight && !super.moveLeft) {
                this.setRotYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
             }
          }


### PR DESCRIPTION
### Motivation

- Prevent player free-look from inadvertently altering plane control state or leaving stale input/velocity values that cause unintended motion. 
- Ensure mouse-aim and keyboard yaw inputs do not change aircraft attitude while in free-look mode.

### Description

- When `isFreeLookMode()` is true the code now clears generated mouse-aim commands, angular velocities, authority/last-input fields, `addkeyRotValue`, and caches previous rotations, then calls `player.setAngles(deltaX, deltaY)` and returns early. 
- `prevRotationPitch` and `prevRotationYaw` are updated during free-look to avoid large interpolation jumps on return from free-look. 
- Left/right key yaw adjustments are now skipped while in free-look by guarding `moveLeft`/`moveRight` handling with `!this.isFreeLookMode()`. 
- Keeps existing mouse-aim initialization and control flow for non-free-look modes unchanged.

### Testing

- Built the project with `./gradlew build` and the build completed successfully. 
- Ran the project's automated tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3619092fc48323b6f3685fbcc31df1)