### PR TITLE
Fix plane freelook camera input isolation

### DIFF
--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -136,7 +136,7 @@ public class MCP_PlaneChaseCamera {
       lastClientTickComputed = clientTick;
 
       this.wasFreelookActive = this.freelookActive;
-      this.freelookActive = false;
+      this.freelookActive = plane.isFreeLookMode() || this.isHoldFreelookActive();
       this.updateFreelookOrbit();
       Vec3 anchor = this.getCameraFocusPoint(plane);
       Vec3 focus = this.computeHeldLookAheadFocus(plane, anchor);
@@ -573,7 +573,8 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean shouldConsumeFreelookMouse(MCP_EntityPlane plane, EntityPlayer player) {
-      return false;
+      return plane != null && player != null && plane.isPilot(player)
+            && (plane.isFreeLookMode() || (MCH_Config.EnableHoldFreelook.prmBool && MCH_Key.isKeyDown(MCH_Config.KeyFreeLook.prmInt)));
    }
 
    public static void addFreelookMouseDelta(double deltaX, double deltaY) {


### PR DESCRIPTION
### Motivation
- Prevent pilot freelook mouse movement (looking up/down) from being applied to aircraft controls and causing nose-up/down pitch that can lead to crashes while freelooking in the air.

### Description
- In `src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java` enable the chase-camera freelook orbit when the plane `isFreeLookMode()` is active or the hold-freelook key is pressed by setting `this.freelookActive = plane.isFreeLookMode() || this.isHoldFreelookActive();`.
- Make the camera consume pilot freelook mouse input by changing `shouldConsumeFreelookMouse` to return true for the pilot while freelook (or hold-freelook) is active, preventing that input from leaking into normal aircraft control code.

### Testing
- `git diff --check` was executed and reported no check failures.
- `./gradlew compileJava` could not be executed because the wrapper file is not executable in this environment, so a local compile was not run.
- `bash ./gradlew compileJava` attempted to download Gradle but failed due to an external network/proxy blocking the distribution (HTTP 403), so compile could not be completed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a361f65c1e8832385995b7215ce1dff)