### PR TITLE
Lock airframe attitude while in freelook mode

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -156,6 +156,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private float pitchAngularVelocity;
    private float rollAngularVelocity;
    private float yawAngularVelocity;
+   /** Holds the airframe attitude stable while pilot mouse input is being used for freelook. */
+   private boolean freelookAttitudeLocked;
+   private float freelookLockedPitch;
+   private float freelookLockedYaw;
+   private float freelookLockedRoll;
    /** Latest approximate fixed-wing load factor. */
    private double currentGForce = 1.0D;
    /** Fractional overspeed damage retained between ticks. */
@@ -201,6 +206,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.rotationRotor = 0.0F;
       this.prevRotationRotor = 0.0F;
       this.engineThrottle = 0.0D;
+      this.freelookAttitudeLocked = false;
+      this.freelookLockedPitch = 0.0F;
+      this.freelookLockedYaw = 0.0F;
+      this.freelookLockedRoll = 0.0F;
       this.lastAerodynamicDrag = 0.0D;
       this.lastKineticEnergy = 0.0D;
       this.lastPotentialEnergy = 0.0D;
@@ -1076,6 +1085,15 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       float ac_yaw = this.getRotYaw();
       float ac_roll = this.getRotRoll();
       if(this.isFreeLookMode()) {
+         if(!this.freelookAttitudeLocked) {
+            this.freelookAttitudeLocked = true;
+            this.freelookLockedPitch = ac_pitch;
+            this.freelookLockedYaw = ac_yaw;
+            this.freelookLockedRoll = ac_roll;
+         }
+         this.setRotPitch(this.freelookLockedPitch);
+         this.setRotYaw(this.freelookLockedYaw);
+         this.setRotRoll(this.freelookLockedRoll);
          this.mouseAimGeneratedYawCommand = 0.0F;
          this.mouseAimGeneratedPitchCommand = 0.0F;
          this.mouseAimGeneratedRollCommand = 0.0F;
@@ -1100,6 +1118,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
+      this.freelookAttitudeLocked = false;
       boolean useMouseAim = this.shouldUseMouseAimControls(player);
       if(useMouseAim) {
          this.updateMouseAimState(deltaX, deltaY, partialTicks);


### PR DESCRIPTION
### Motivation
- Prevent the plane from rotating when the player uses freelook so the vehicle maintains its attitude while the pilot looks around.

### Description
- Add private fields `freelookAttitudeLocked`, `freelookLockedPitch`, `freelookLockedYaw`, and `freelookLockedRoll` to store the locked attitude state.
- Initialize the freelook lock fields in the constructor to a known default state.
- When entering freelook in `setAngles`, capture and hold the current aircraft attitude by setting the entity rotations to the locked values and zeroing out mouse/flight-related generated inputs and angular velocities.
- When leaving freelook mode clear the `freelookAttitudeLocked` flag so normal control resumes.

### Testing
- No automated tests were added for this change and the project build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a361f65c1e8832385995b7215ce1dff)