### PR TITLE
Fix plane hold-freelook altitude loss by treating hold-freelook as camera-only for chase camera

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -6,6 +6,8 @@ import mcheli.MCH_Key;
 import mcheli.MCH_Lib;
 import mcheli.MCH_PacketIndOpenScreen;
 import mcheli.network.packets.PacketLockTarget;
+import mcheli.plane.MCP_EntityPlane;
+import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.wrapper.W_Network;
 import mcheli.wrapper.W_PacketBase;
 import net.minecraft.client.Minecraft;
@@ -203,10 +205,17 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
             }
          if (ac.canSwitchFreeLook()) {
             if (MCH_Config.EnableHoldFreelook.prmBool) {
-               if (this.KeyFreeLook.isKeyDown() && !ac.isFreeLookMode()) {
-                  pc.switchFreeLook = 1;
-                  send = true;
-               } else if (this.KeyFreeLook.isKeyUp() && ac.isFreeLookMode()) {
+               boolean cameraOnlyPlaneFreelook = ac instanceof MCP_EntityPlane
+                     && MCP_PlaneChaseCamera.shouldUseHoldFreelookAsCameraOnly((MCP_EntityPlane)ac, player);
+               if(!cameraOnlyPlaneFreelook) {
+                  if (this.KeyFreeLook.isKeyDown() && !ac.isFreeLookMode()) {
+                     pc.switchFreeLook = 1;
+                     send = true;
+                  } else if (this.KeyFreeLook.isKeyUp() && ac.isFreeLookMode()) {
+                     pc.switchFreeLook = 2;
+                     send = true;
+                  }
+               } else if(ac.isFreeLookMode()) {
                   pc.switchFreeLook = 2;
                   send = true;
                }

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -136,7 +136,7 @@ public class MCP_PlaneChaseCamera {
       lastClientTickComputed = clientTick;
 
       this.wasFreelookActive = this.freelookActive;
-      this.freelookActive = false;
+      this.freelookActive = shouldUseHoldFreelookAsCameraOnly(plane, player);
       this.updateFreelookOrbit();
       Vec3 anchor = this.getCameraFocusPoint(plane);
       Vec3 focus = this.computeHeldLookAheadFocus(plane, anchor);
@@ -573,7 +573,24 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean shouldConsumeFreelookMouse(MCP_EntityPlane plane, EntityPlayer player) {
-      return false;
+      return shouldUseHoldFreelookAsCameraOnly(plane, player);
+   }
+
+   public static boolean shouldUseHoldFreelookAsCameraOnly(MCP_EntityPlane plane, EntityPlayer player) {
+      if(plane == null || player == null) {
+         return false;
+      }
+      Minecraft mc = Minecraft.getMinecraft();
+      return MCH_Config.EnableHoldFreelook.prmBool
+            && MCH_Config.EnableNewPlaneThirdPersonCamera.prmBool
+            && plane.isNewFlightModelEnabled()
+            && plane.isPilot(player)
+            && mc != null
+            && mc.gameSettings != null
+            && mc.gameSettings.thirdPersonView > 0
+            && plane.getCameraId() <= 0
+            && !plane.getIsGunnerMode(player)
+            && MCH_Key.isKeyDown(MCH_Config.KeyFreeLook.prmInt);
    }
 
    public static void addFreelookMouseDelta(double deltaX, double deltaY) {


### PR DESCRIPTION
### Motivation
- Prevent planes from unintentionally losing altitude when the player holds freelook while using the third-person chase camera; freelook input was being forwarded into aircraft rotation/throttle control in some cases. 
- Ensure that holding freelook in third-person for new-flight-model planes controls only the chase-camera orbit and consumes mouse input instead of switching the aircraft into a control-suppressing freelook state.

### Description
- Updated `MCH_BaseVehicleClientTickHandler` to detect when hold-freelook should be treated as camera-only for new-flight-model planes in the third-person chase camera and avoid sending aircraft freelook-on packets in that case. 
- Made the handler send a freelook-off packet (`pc.switchFreeLook = 2`) if the plane is already in aircraft freelook when camera-only hold-freelook becomes active. 
- Modified `MCP_PlaneChaseCamera` to set `freelookActive` based on a new eligibility check and to make `shouldConsumeFreelookMouse` use that same check so the chase camera consumes raw mouse deltas for orbiting. 
- Added `shouldUseHoldFreelookAsCameraOnly` helper that centralizes the eligibility logic (checks `EnableHoldFreelook`, third-person chase camera enabled, new-flight-model plane, pilot seat, third-person view, camera id, not gunner mode, and freelook key held).

### Testing
- Ran `git diff --check` which reported no whitespace errors. 
- Attempted to compile with `bash ./gradlew compileJava`, but the Gradle wrapper failed to download the distribution due to a proxy error (`HTTP/1.1 403 Forbidden`), so a full build could not be completed. 
- Verified code changes via `git status`/`git diff` and committed the fix with message `Fix plane hold freelook altitude loss`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36eeb5d64083238cb3ec2f3bd017bf)