### PR TITLE
Fix plane freelook control isolation

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -256,8 +256,13 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
             }
             pc.throttleDown = ac.throttleDown = this.KeyDown.isKeyPress();
             pc.throttleUp = ac.throttleUp = this.KeyUp.isKeyPress();
-            pc.moveRight = ac.moveRight = this.KeyRight.isKeyPress();
-            pc.moveLeft = ac.moveLeft = this.KeyLeft.isKeyPress();
+            if(ac instanceof MCP_EntityPlane && ac.isFreeLookMode()) {
+               pc.moveRight = ac.moveRight = false;
+               pc.moveLeft = ac.moveLeft = false;
+            } else {
+               pc.moveRight = ac.moveRight = this.KeyRight.isKeyPress();
+               pc.moveLeft = ac.moveLeft = this.KeyLeft.isKeyPress();
+            }
          }
       }
       if (!ac.isDestroyed() && this.KeyFlare.isKeyDown()) {

--- a/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
+++ b/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
@@ -94,8 +94,14 @@ public class MCP_PlanePacketHandler {
                if(plane.isPilot(player)) {
                   plane.throttleUp = pc.throttleUp;
                   plane.throttleDown = pc.throttleDown;
-                  plane.moveLeft = pc.moveLeft;
-                  plane.moveRight = pc.moveRight;
+                  boolean freeLookControlsOnlyThrottle = pc.switchFreeLook == 1 || (plane.isFreeLookMode() && pc.switchFreeLook != 2);
+                  if(freeLookControlsOnlyThrottle) {
+                     plane.moveLeft = false;
+                     plane.moveRight = false;
+                  } else {
+                     plane.moveLeft = pc.moveLeft;
+                     plane.moveRight = pc.moveRight;
+                  }
                }
 
                if(pc.useFlareType > 0) {


### PR DESCRIPTION
### Motivation
- Free-look mode was letting the player’s look inputs (yaw/pitch/roll/left/right) influence the aircraft, causing unintended attitude changes such as spontaneous altitude loss. 
- During free-look the aircraft should remain driven only by the flight model and throttle input while the player's view is decoupled from plane movement.

### Description
- Prevent client-side lateral steering from being sent while freelook is active by making `MCH_BaseVehicleClientTickHandler` set `moveLeft`/`moveRight` to `false` when the vehicle is a `MCP_EntityPlane` and `isFreeLookMode()` is `true`, while still sending throttle inputs via `pc.throttleUp`/`pc.throttleDown`.
- Harden server-side handling in `MCP_PlanePacketHandler` to ignore client lateral movement when the packet represents entering free look or when the plane is in free look mode, by checking `pc.switchFreeLook` and `plane.isFreeLookMode()` before applying `moveLeft`/`moveRight` to the aircraft.
- The change keeps flight-model rotation and movement updates fully controlled by the aircraft code while allowing throttle control from the player in free-look.

### Testing
- Ran `git diff --check` which reported the modified files staged without whitespace errors.
- Attempted to compile with `./gradlew compileJava` but the wrapper was not executable in the environment (permission denied), so compilation could not be completed here.
- Attempted `bash ./gradlew compileJava` which failed because the Gradle wrapper attempted to download Gradle and the network proxy returned HTTP 403, preventing a build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f116230083239a1c9a58c10d99db)