### PR TITLE
Sync plane attitude during freelook

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1096,6 +1096,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             super.prevRotationYaw = this.getRotYaw();
          }
 
+         // Free look intentionally decouples the pilot camera from the airframe, but the
+         // server-side new flight model still derives AoA/stall state from the last
+         // aircraft rotation packet it received. Keep the server synchronized with the
+         // client airframe attitude while the mouse is being consumed by free look;
+         // otherwise the server can continue simulating an old nose-high attitude and
+         // report a stall only while free look is active.
+         this.aircraftRotChanged = true;
          player.setAngles(deltaX, deltaY);
          return;
       }


### PR DESCRIPTION
### Motivation
- While freelook is active the client consumes mouse input and decouples the pilot camera from the airframe, which allowed server-side AoA/stall logic to operate on a stale airframe rotation and report stalls only during freelook.

### Description
- Mark `aircraftRotChanged = true` in `MCP_EntityPlane#setAngles` when the freelook early-return path is taken so the client continues to indicate an updated aircraft rotation to the server, keeping server-side stall/AoA calculations synchronized (change in `src/main/java/mcheli/plane/MCP_EntityPlane.java`).

### Testing
- Attempted to run `./gradlew test` but the wrapper is not executable in this checkout; `bash ./gradlew test` also failed because the Gradle distribution download was blocked by the proxy (HTTP 403), so no automated tests completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36f2fe3e748323947bb69623bec502)