### PR TITLE
Support turrets moved from vehicles -> turrets: load, render, and placement fixes

### DIFF
--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -368,18 +368,19 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
    public void registerModelsVehicle(String name, boolean reload) {
       MCH_ModelManager.setForceReloadMode(reload);
       MCH_TurretInfo info = (MCH_TurretInfo)MCH_TurretInfoManager.map.get(name);
-      info.model = MCH_ModelManager.load("vehicles", info.name);
+      String turretDirectory = info.getDirectoryName();
+      info.model = MCH_ModelManager.load(turretDirectory, info.name);
       Iterator i$ = info.partList.iterator();
 
       while(i$.hasNext()) {
          MCH_TurretInfo.VPart vp = (MCH_TurretInfo.VPart)i$.next();
-         vp.model = this.loadPartModel("vehicles", info.name, info.model, vp.modelName);
+         vp.model = this.loadPartModel(turretDirectory, info.name, info.model, vp.modelName);
          if(vp.child != null) {
             this.registerVCPModels(info, vp);
          }
       }
 
-      this.registerCommonPart("vehicles", info);
+      this.registerCommonPart(turretDirectory, info);
       MCH_ModelManager.setForceReloadMode(false);
    }
 
@@ -475,7 +476,7 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
 
       while(i$.hasNext()) {
          MCH_TurretInfo.VPart vcp = (MCH_TurretInfo.VPart)i$.next();
-         vcp.model = this.loadPartModel("vehicles", info.name, info.model, vcp.modelName);
+         vcp.model = this.loadPartModel(info.getDirectoryName(), info.name, info.model, vcp.modelName);
          if(vcp.child != null) {
             this.registerVCPModels(info, vcp);
          }

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -238,6 +238,7 @@ public class MCH_MOD {
       MCH_ShipInfoManager.getInstance().load(sourcePath + "/assets/" + "mcheli" + "/", "ships");
       MCH_TankInfoManager.getInstance().load(sourcePath + "/assets/" + "mcheli" + "/", "tanks");
       MCH_TurretInfoManager.getInstance().load(sourcePath + "/assets/" + "mcheli" + "/", "vehicles");
+      MCH_TurretInfoManager.getInstance().load(sourcePath + "/assets/" + "mcheli" + "/", "turrets");
       MCH_ItemInfoManager.load(sourcePath + "/assets/" + "mcheli" + "/item");
       MCH_ThrowableInfoManager.load(sourcePath + "/assets/" + "mcheli" + "/throwable");
       MCH_SoundsJson.update(sourcePath + "/assets/" + "mcheli" + "/");

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -473,7 +473,7 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
 
    private String getInfoDebugName() {
       MCH_BaseVehicleInfo info = this.getAircraftInfo();
-      return info != null ? info.getKindName() + "/" + info.name : "null";
+      return info != null ? info.getKindName() + "/" + info.name + " category=" + info.category + " dir=" + info.getDirectoryName() : "null";
    }
 
    private static String getItemDebugName(ItemStack stack) {

--- a/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
@@ -26,6 +26,7 @@ public class MCH_ItemTurret extends MCH_ItemBaseVehicle {
          MCH_Lib.Log(world, "##### MCH_ItemTurret Turret info null %s", new Object[]{this.getUnlocalizedName()});
          return null;
       } else {
+         MCH_Lib.Log(world, "[VehiclePlacement] turret factory selected: item=%s info=%s category=%s dir=%s entityClass=%s", new Object[]{this.getUnlocalizedName(), info.name, info.category, info.getDirectoryName(), MCH_EntityTurret.class.getName()});
          MCH_EntityTurret vehicle = new MCH_EntityTurret(world);
          vehicle.setPosition(x, y + (double)vehicle.yOffset, z);
          vehicle.prevPosX = x;

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -44,7 +44,7 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);
             GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
             try {
-            this.bindTexture("textures/vehicles/" + vehicle.getTextureName() + ".png", vehicle);
+            this.bindTexture("textures/" + turretInfo.getDirectoryName() + "/" + vehicle.getTextureName() + ".png", vehicle);
             } catch (Exception var15) {
                System.out.println("Texture not found : " + vehicle.getTextureName());
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));
@@ -110,7 +110,7 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
 
       if((vp.drawFP || !W_Lib.isClientPlayer(vehicle.riddenByEntity) || !W_Lib.isFirstPerson()) && (vp.type != 3 || !vehicle.isWeaponNotCooldown(ws, index))) {
          renderPart(vp.model, info.model, vp.modelName);
-         MCH_ModelManager.render("vehicles", vp.modelName);
+         MCH_ModelManager.render(info.getDirectoryName(), vp.modelName);
       }
 
       GL11.glPopMatrix();

--- a/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
@@ -80,7 +80,31 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
    }
 
    public String getDirectoryName() {
-      return "vehicles";
+      return this.isTurretAssetDirectory() ? "turrets" : "vehicles";
+   }
+
+   public boolean isTurretCategory(String category) {
+      if(category == null) {
+         return false;
+      }
+
+      String normalized = category.trim().toLowerCase();
+      return normalized.equals("turret") || normalized.equals("turrets") || normalized.endsWith(".turret") || normalized.endsWith(".turrets");
+   }
+
+   /**
+    * Turrets historically lived under assets/mcheli/vehicles.  New packs may
+    * place the same turret info files under assets/mcheli/turrets after the
+    * vehicle-to-turret reclassification.  Keep both locations valid without
+    * changing legacy registry/type names.
+    */
+   public boolean isTurretAssetDirectory() {
+      if(super.filePath == null) {
+         return isTurretCategory(super.category);
+      }
+
+      String path = super.filePath.replace('\\', '/').toLowerCase();
+      return path.indexOf("/turrets/") >= 0;
    }
 
    public String getKindName() {


### PR DESCRIPTION
### Motivation
- Some turret assets were relocated/reclassified from the legacy `vehicles` folder/category to `turrets` and became unplaceable because they were never loaded into the turret info registry or resolved correctly during client model/texture lookup. 
- The change preserves legacy behavior while making the placement pipeline accept both legacy and new turret asset layouts so existing saves/registry names are not broken.

### Description
- Load turret info from both `assets/mcheli/vehicles` and `assets/mcheli/turrets` by calling the turret info loader for both directories so reclassified turret info files are registered. (modified: `MCH_MOD.java`)
- Add directory/category resolution helpers to `MCH_TurretInfo` (`getDirectoryName`, `isTurretCategory`, `isTurretAssetDirectory`) to accept `turret`, `turrets`, dotted category suffixes, and to detect whether an info file came from a `turrets` path so client model/texture lookups can use the correct directory. (modified: `src/main/java/mcheli/vehicle/MCH_TurretInfo.java`)
- Stop hardcoding the `vehicles` directory for client-side model/part loading and texture binding and use the resolved directory from the info object so models/textures load for assets under `turrets`. (modified: `MCH_ClientProxy.java`, `MCH_RenderTurret.java`)
- Add placement/creation debug logging when the turret factory path is chosen and include item, info name, category, resolved directory and entity class to make placement failures easier to triage. (modified: `MCH_ItemTurret.java`)
- Improve placement debug context to include the resolved category/directory when deployment fails so logs show whether the info resolution or spawn call was the issue. (modified: `MCH_ItemBaseVehicle.java`)
- All changes are additive and preserve legacy behavior (registry names and vehicle entity registration were not renamed).

Files changed:
- `src/main/java/mcheli/MCH_MOD.java`
- `src/main/java/mcheli/vehicle/MCH_TurretInfo.java`
- `src/main/java/mcheli/MCH_ClientProxy.java`
- `src/main/java/mcheli/vehicle/MCH_RenderTurret.java`
- `src/main/java/mcheli/vehicle/MCH_ItemTurret.java`
- `src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java`

### Testing
- Ran `git diff --check` to ensure no whitespace/patch errors; it returned clean results. 
- Attempted to run `./gradlew compileJava` to compile the changes, but the Gradle wrapper failed to download the distribution due to an external network/proxy returning HTTP 403 so a full compile could not be completed in this environment. 
- Verified via static code inspection and targeted runtime-debug additions that the placement path now logs the resolved info directory and factory selection, enabling easy verification when running in-game (logs will show item, info name, category, directory and entity class during placement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370382a6508323bfc047b8195ec632)