### PR TITLE
Fix turret placement support collisions

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -119,6 +119,7 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
          ac.initRotationYaw((float)(((MathHelper.floor_double((double)(rotationYaw * 4.0F / 360.0F) + 0.5D) & 3) - 1) * 90));
          AxisAlignedBB placementBox = ac.boundingBox.expand(-0.1D, -0.1D, -0.1D);
          List collisionBoxes = world.getCollidingBoundingBoxes(ac, placementBox);
+         removePlacementSupportCollisions(collisionBoxes, (double)y + 1.0D);
          if(!collisionBoxes.isEmpty()) {
             logPlacementDebug(world, "onTileClick blocked by collision: item=%s info=%s entity=%s pos=(%.3f,%.3f,%.3f) target=(%d,%d,%d) size=(%.3f,%.3f) bb=%s collisions=%s", getItemDebugName(itemStack), getInfoDebugName(), ac.getEntityName(), Double.valueOf(ac.posX), Double.valueOf(ac.posY), Double.valueOf(ac.posZ), Integer.valueOf(x), Integer.valueOf(y), Integer.valueOf(z), Float.valueOf(ac.width), Float.valueOf(ac.height), formatAabb(placementBox), describeCollisionBoxes(collisionBoxes));
             return null;
@@ -487,6 +488,15 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
 
    private static String formatAabb(AxisAlignedBB bb) {
       return bb == null ? "null" : String.format("[%.3f,%.3f,%.3f -> %.3f,%.3f,%.3f]", new Object[]{Double.valueOf(bb.minX), Double.valueOf(bb.minY), Double.valueOf(bb.minZ), Double.valueOf(bb.maxX), Double.valueOf(bb.maxY), Double.valueOf(bb.maxZ)});
+   }
+
+   private static void removePlacementSupportCollisions(List boxes, double supportTopY) {
+      for(java.util.Iterator it = boxes.iterator(); it.hasNext();) {
+         AxisAlignedBB bb = (AxisAlignedBB)it.next();
+         if(bb.maxY <= supportTopY + 1.0E-4D) {
+            it.remove();
+         }
+      }
    }
 
    private static String describeCollisionBoxes(List boxes) {

--- a/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
@@ -26,7 +26,9 @@ public class MCH_ItemTurret extends MCH_ItemBaseVehicle {
          MCH_Lib.Log(world, "##### MCH_ItemTurret Turret info null %s", new Object[]{this.getUnlocalizedName()});
          return null;
       } else {
-         MCH_Lib.Log(world, "[VehiclePlacement] turret factory selected: item=%s info=%s category=%s dir=%s entityClass=%s", new Object[]{this.getUnlocalizedName(), info.name, info.category, info.getDirectoryName(), MCH_EntityTurret.class.getName()});
+         if(!world.isRemote) {
+            MCH_Lib.Log(world, "[VehiclePlacement] turret factory selected: item=%s info=%s category=%s dir=%s entityClass=%s", new Object[]{this.getUnlocalizedName(), info.name, info.category, info.getDirectoryName(), MCH_EntityTurret.class.getName()});
+         }
          MCH_EntityTurret vehicle = new MCH_EntityTurret(world);
          vehicle.setPosition(x, y + (double)vehicle.yOffset, z);
          vehicle.prevPosX = x;


### PR DESCRIPTION
### Motivation
- Turrets with wide footprints were failing placement because collision checks included the support block(s) beneath them and client-side logging spammed repeated "turret factory selected" messages; this change intends to allow turrets to be placed on top of their support surface and reduce noisy client logs.

### Description
- Filter out collision boxes that are at or below the clicked block top when checking placement by adding `removePlacementSupportCollisions` and invoking it before rejecting placement (`src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java`).
- Only emit the "turret factory selected" placement debug log on the server side (wrap with `if(!world.isRemote)`) to avoid excessive client-side logging (`src/main/java/mcheli/vehicle/MCH_ItemTurret.java`).

### Testing
- Ran `gradle compileJava` which failed due to repository/HTTP 403 errors resolving ForgeGradle from remote Maven repositories. (network/proxy error)
- Ran `bash ./gradlew compileJava` which failed while downloading the Gradle distribution due to an HTTP 403 through the environment proxy.
- No local compile succeeded in this environment because external dependency resolution and Gradle distribution download were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3706d8b864832386fe4782f0f4b7ae)