### PR TITLE
Add pitch-envelope energy limiter and extend plane debug output

### DIFF
--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -340,7 +340,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             : 0.0D;
 
       System.out.println(String.format(
-              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) finalPitchAngularVelocity=%.4f rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,forwardAirspeed=%.3f,horizontalSpeed=%.3f,totalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),pitchPlaneAoA=%.2f,sideslipAngle=%.2f,oldAoA=%.2f,selectedEffectiveAoA=%.2f,criticalAoA=%.2f,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,pitchMoment=%.4f,aoaMoment=%.4f,stabilityMoment=%.4f,airflowScale=%.4f,pitchMomentAngularVelocity=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,speedRatio=%.2f,deepStallSeverity=%.2f,pilotControlAuthority=%.2f,softStallAuthority=%.2f,pitchAuthority=%.2f,pitchUpLimiter=%.2f,pitchDownAuthority=%.2f,rollAuthority=%.2f,yawAuthority=%.2f,finalPitchAuthority=%.2f,pitchInputRequested=%.4f,pitchInputAfterAuthority=%.4f,pitchAuthorityAfterSuppression=%.2f,pilotPitchAngularVelocity=%.4f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,noseDownRecoverySeverity=%.2f,forcedPitchDelta=%.4f,pitchBreakAngularVelocity=%.4f,kineticEnergy=%.4f,potentialEnergy=%.4f,totalEnergy=%.4f,specificEnergy=%.4f,energyDelta=%.4f,excessPower=%.4f,energyDeficitSeverity=%.2f,climbEnergyDemand=%.4f,pitchEnergyDemand=%.4f,energyUnsupportedClimb=%s,energyForcedRecovery=%s) %s",
+              "[MCHeli] flight-control dt=%.3f inputMouse=(%.3f,%.3f) inputStick=(%.3f,%.3f) angularVelocity=(pitch=%.4f,yaw=%.4f,roll=%.4f) finalPitchAngularVelocity=%.4f rot=(pitch=%.2f,yaw=%.2f,roll=%.2f) aero=(throttle=%.0f%%,engineOutput=%.0f%%,effectiveThrottle=%.0f%%,propulsiveThrottle=%.0f%%,flaps=%s,airspeed=%.3f,forwardAirspeed=%.3f,horizontalSpeed=%.3f,totalSpeed=%.3f,forwardSpeed=%.3f,verticalSpeed=%.4f,pitch=%.2f,mass=%.2f,weightForce=%.4f,engineThrust=%.4f,liftForce=%.4f,liftBeforeStall=%.4f,liftAfterStall=%.4f,liftCoeff=%.2f,liftToWeight=%.2f,thrustToWeight=%.2f,netForward=%.4f,takeoffMult=%.2f,takeoffBase=%.3f,takeoffEffective=%.3f,takeoffActive=%s,validTakeoff=%s,validClimb=%s,stallSuppressedHeadroom=%s,gravity=%.4f,resolvedGravity=%.4f,gravityOverride=%s,liftAccel=%.4f,netY=%.4f,airborne=%s,placementLock=%s,motion=(%.4f,%.4f,%.4f),cachedVelocity=(%.4f,%.4f,%.4f),pitchPlaneAoA=%.2f,sideslipAngle=%.2f,oldAoA=%.2f,selectedEffectiveAoA=%.2f,criticalAoA=%.2f,stallSpeed=%.3f,energyRatio=%.2f,sustainablePitch=%.2f,pitchExcess=%.2f,noseUpAuthority=%.2f,noseDownRecoveryTorque=%.4f,finalElevatorInput=%.4f,envelopeRecoveryActive=%s,recoveryDueToLowEnergy=%s,recoveryDueToAoA=%s,recoveryDueToLiftDeficit=%s,recoveryDueToUnsupportedClimb=%s,stallDemand=%.2f,speedSeverity=%.2f,aoaSeverity=%.2f,stallSeverity=%.2f,stallPitchMoment=%.4f,throttlePitchDown=%.4f,pitchMoment=%.4f,aoaMoment=%.4f,stabilityMoment=%.4f,airflowScale=%.4f,pitchMomentAngularVelocity=%.4f,stallState=%s,recovery=%s,overspeed=%s,g=%.2f,drag=%.3f,liftLoss=%.2f,controlAuthority=%.2f,speedRatio=%.2f,deepStallSeverity=%.2f,pilotControlAuthority=%.2f,softStallAuthority=%.2f,pitchAuthority=%.2f,pitchUpLimiter=%.2f,pitchDownAuthority=%.2f,rollAuthority=%.2f,yawAuthority=%.2f,finalPitchAuthority=%.2f,pitchInputRequested=%.4f,pitchInputAfterAuthority=%.4f,pitchAuthorityAfterSuppression=%.2f,pilotPitchAngularVelocity=%.4f,noseUpSuppress=%.2f,unsupportedClimb=%s,unsupportedSeverity=%.2f,idleUnsupported=%s,idleWarning=%s,lowHorizontalWarning=%s,pitchBreak=%s,noseDownRecoverySeverity=%.2f,forcedPitchDelta=%.4f,pitchBreakAngularVelocity=%.4f,kineticEnergy=%.4f,potentialEnergy=%.4f,totalEnergy=%.4f,specificEnergy=%.4f,energyDelta=%.4f,excessPower=%.4f,energyDeficitSeverity=%.2f,climbEnergyDemand=%.4f,pitchEnergyDemand=%.4f,energyUnsupportedClimb=%s,energyForcedRecovery=%s) %s",
               simDelta,
               mouseX,
               mouseY,
@@ -400,6 +400,18 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
               plane != null ? plane.getOldAngleOfAttackDegrees() : ac.getAngleOfAttackDegrees(),
               ac.getAngleOfAttackDegrees(),
               ac.getCriticalAoA(),
+              plane != null && plane.getPlaneInfo() != null ? MCH_FlightModel.getStallSpeed(plane.getPlaneInfo().stallSpeed, plane.getMaxSpeed(), plane.getPlaneInfo().stallSpeedFactor) : 0.0D,
+              plane != null ? plane.getLastPitchEnvelopeEnergyRatio() : 1.0D,
+              plane != null ? plane.getLastSustainableNoseUpPitch() : 90.0D,
+              plane != null ? plane.getLastPitchEnvelopeExcess() : 0.0D,
+              plane != null ? plane.getLastPitchUpAuthority() : ac.getLastPitchAuthority(),
+              plane != null ? plane.getLastNoseDownRecoveryTorque() : 0.0D,
+              plane != null ? plane.getLastFinalElevatorInput() : 0.0D,
+              Boolean.valueOf(plane != null && plane.isLastEnvelopeRecoveryActive()),
+              Boolean.valueOf(plane != null && plane.isLastRecoveryDueToLowEnergy()),
+              Boolean.valueOf(plane != null && plane.isLastRecoveryDueToAoA()),
+              Boolean.valueOf(plane != null && plane.isLastRecoveryDueToLiftDeficit()),
+              Boolean.valueOf(plane != null && plane.isLastRecoveryDueToUnsupportedClimb()),
               ac.getStallDemand(),
               ac.getSpeedStallSeverity(),
               ac.getAoAStallSeverity(),
@@ -458,7 +470,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
       if(plane != null && plane.getLastLowHorizontalSpeedWarning().length() > 0) {
          System.out.println(String.format(
-               "[MCHeli][WARN] low-horizontal-speed flight sanity: reason=%s motionX=%.4f motionZ=%.4f forwardAirspeed=%.3f horizontalSpeed=%.3f totalSpeed=%.3f verticalSpeed=%.4f airspeed=%.3f pitchPlaneAoA=%.2f sideslipAngle=%.2f oldAoA=%.2f selectedEffectiveAoA=%.2f stallSpeed=%.3f speedSeverity=%.2f aoaSeverity=%.2f stallDemand=%.2f stallSeverity=%.2f liftToWeight=%.3f thrustToWeight=%.3f validClimb=%s validTakeoff=%s controlAuthority=%.2f speedRatio=%.2f deepStallSeverity=%.2f pilotControlAuthority=%.2f softStallAuthority=%.2f pitchAuthority=%.2f pitchUpLimiter=%.2f pitchDownAuthority=%.2f rollAuthority=%.2f yawAuthority=%.2f finalPitchAuthority=%.2f pitchInputRequested=%.4f pitchInputAfterAuthority=%.4f pitchAuthorityAfterSuppression=%.2f pilotPitchAngularVelocity=%.4f noseDownRecoverySeverity=%.2f forcedPitchDelta=%.4f finalPitchAngularVelocity=%.4f unsupportedClimb=%.3f netY=%.4f",
+               "[MCHeli][WARN] low-horizontal-speed flight sanity: reason=%s motionX=%.4f motionZ=%.4f forwardAirspeed=%.3f horizontalSpeed=%.3f totalSpeed=%.3f verticalSpeed=%.4f airspeed=%.3f pitchPlaneAoA=%.2f sideslipAngle=%.2f oldAoA=%.2f selectedEffectiveAoA=%.2f stallSpeed=%.3f speedSeverity=%.2f aoaSeverity=%.2f stallDemand=%.2f stallSeverity=%.2f liftToWeight=%.3f thrustToWeight=%.3f validClimb=%s validTakeoff=%s controlAuthority=%.2f speedRatio=%.2f deepStallSeverity=%.2f pilotControlAuthority=%.2f softStallAuthority=%.2f pitchAuthority=%.2f pitchUpLimiter=%.2f pitchDownAuthority=%.2f rollAuthority=%.2f yawAuthority=%.2f finalPitchAuthority=%.2f pitchInputRequested=%.4f pitchInputAfterAuthority=%.4f pitchAuthorityAfterSuppression=%.2f pilotPitchAngularVelocity=%.4f noseDownRecoverySeverity=%.2f forcedPitchDelta=%.4f finalPitchAngularVelocity=%.4f sustainablePitch=%.2f pitchExcess=%.2f energyRatio=%.2f noseDownRecoveryTorque=%.4f finalElevatorInput=%.4f envelopeRecoveryActive=%s recoveryDueToLowEnergy=%s recoveryDueToAoA=%s recoveryDueToLiftDeficit=%s recoveryDueToUnsupportedClimb=%s unsupportedClimb=%.3f netY=%.4f",
                plane.getLastLowHorizontalSpeedWarning(),
                plane.motionX,
                plane.motionZ,
@@ -498,6 +510,16 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                plane.getLastNoseDownRecoverySeverity(),
                plane.getLastForcedNoseDownPitchDelta(),
                plane.getLastFinalPitchAngularVelocity(),
+               plane.getLastSustainableNoseUpPitch(),
+               plane.getLastPitchEnvelopeExcess(),
+               plane.getLastPitchEnvelopeEnergyRatio(),
+               plane.getLastNoseDownRecoveryTorque(),
+               plane.getLastFinalElevatorInput(),
+               Boolean.valueOf(plane.isLastEnvelopeRecoveryActive()),
+               Boolean.valueOf(plane.isLastRecoveryDueToLowEnergy()),
+               Boolean.valueOf(plane.isLastRecoveryDueToAoA()),
+               Boolean.valueOf(plane.isLastRecoveryDueToLiftDeficit()),
+               Boolean.valueOf(plane.isLastRecoveryDueToUnsupportedClimb()),
                plane.getLastUnsupportedClimbSeverity(),
                plane.getLastNetVerticalAcceleration()));
       }

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -176,7 +176,22 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastRequestedPitchInput;
    /** Last pitch command after control authority and low-speed/stall suppression. */
    private double lastPitchInputAfterAuthority;
-   /** Final pitch body-rate after post-control stall/energy recovery is applied. */
+   /** Fresh per-tick sustainable nose-up pitch envelope in degrees. */
+   private double lastSustainableNoseUpPitch;
+   /** Current nose-up pitch demand above the sustainable envelope in degrees. */
+   private double lastPitchEnvelopeExcess;
+   /** Energy ratio used by the pitch-envelope limiter (forward airspeed / stall speed). */
+   private double lastPitchEnvelopeEnergyRatio;
+   /** Final nose-down angular-velocity torque requested by pitch-envelope recovery. */
+   private double lastNoseDownRecoveryTorque;
+   /** Final pitch/elevator command after envelope limiting and authority shaping. */
+   private double lastFinalElevatorInput;
+   private boolean lastEnvelopeRecoveryActive;
+   private boolean lastRecoveryDueToLowEnergy;
+   private boolean lastRecoveryDueToAoA;
+   private boolean lastRecoveryDueToLiftDeficit;
+   private boolean lastRecoveryDueToUnsupportedClimb;
+   /** Final body-rate after post-control stall/energy recovery is applied. */
    private double lastFinalPitchAngularVelocity;
    /** Last airborne state used by the new fixed-wing force model. */
    private boolean lastAirborne;
@@ -298,6 +313,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastControlAuthority = 1.0D;
       this.lastRequestedPitchInput = 0.0D;
       this.lastPitchInputAfterAuthority = 0.0D;
+      this.lastSustainableNoseUpPitch = 90.0D;
+      this.lastPitchEnvelopeExcess = 0.0D;
+      this.lastPitchEnvelopeEnergyRatio = 1.0D;
+      this.lastNoseDownRecoveryTorque = 0.0D;
+      this.lastFinalElevatorInput = 0.0D;
+      this.lastEnvelopeRecoveryActive = false;
+      this.lastRecoveryDueToLowEnergy = false;
+      this.lastRecoveryDueToAoA = false;
+      this.lastRecoveryDueToLiftDeficit = false;
+      this.lastRecoveryDueToUnsupportedClimb = false;
       this.lastFinalPitchAngularVelocity = 0.0D;
       this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
@@ -614,17 +639,93 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    private float clampIdleUnsupportedNoseUpPitch(float pitch, double stallSpeed) {
-      if(!this.isIdleUnsupportedClimb(MCH_FlightModel.clamp((double)(-pitch - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeed)) {
-         return pitch;
+      // New-flight pitch recovery must not snap or clamp the airframe to a magic angle.
+      // The continuous energy envelope limits pilot nose-up input and applies recovery
+      // through pitchAngularVelocity instead.
+      return pitch;
+   }
+
+
+   private double smooth01(double value) {
+      value = MCH_FlightModel.clamp(value, 0.0D, 1.0D);
+      return value * value * (3.0D - 2.0D * value);
+   }
+
+   private double updatePitchEnvelope(double desiredPitchInput) {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      this.lastEnvelopeRecoveryActive = false;
+      this.lastRecoveryDueToLowEnergy = false;
+      this.lastRecoveryDueToAoA = false;
+      this.lastRecoveryDueToLiftDeficit = false;
+      this.lastRecoveryDueToUnsupportedClimb = false;
+      if(!this.useNewMobilitySystem() || info == null || this.getNozzleRotation() > 0.01F || this.onGround) {
+         this.lastSustainableNoseUpPitch = 90.0D;
+         this.lastPitchEnvelopeExcess = 0.0D;
+         this.lastPitchEnvelopeEnergyRatio = 1.0D;
+         this.lastNoseDownRecoveryTorque = 0.0D;
+         return 1.0D;
       }
 
-      double pitchLimit = this.getIdleNoseUpPitchLimit(stallSpeed);
-      if((double)pitch < -pitchLimit) {
-         this.pitchAngularVelocity = Math.max(0.0F, this.pitchAngularVelocity);
-         this.lastNoseUpPitchSuppression = 1.0D;
-         return (float)(-pitchLimit);
+      double stallSpeed = Math.max(0.05D, MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor));
+      double forwardAirspeed = Math.max(0.0D, this.getForwardAirspeed());
+      double energyRatio = forwardAirspeed / stallSpeed;
+      double energyCurve = this.smooth01(MCH_FlightModel.clamp((energyRatio - 0.65D) / 1.05D, 0.0D, 1.0D));
+      double liftMargin = this.lastWeightForce > 1.0E-6D
+            ? MCH_FlightModel.clamp(this.getLiftToWeightRatio(), 0.0D, 1.8D) : 1.0D;
+      double thrustMargin = this.lastWeightForce > 1.0E-6D
+            ? MCH_FlightModel.clamp(this.getThrustToWeightRatio(), 0.0D, 1.6D) : 0.0D;
+      double criticalAoA = Math.max(5.0D, (double)info.criticalAoA);
+      double aoaSeverity = this.smooth01(MCH_FlightModel.clamp((this.angleOfAttack - criticalAoA) / Math.max(1.0D, criticalAoA * 1.35D), 0.0D, 1.0D));
+      double liftDeficit = MCH_FlightModel.clamp((0.92D - liftMargin) / 0.42D, 0.0D, 1.0D);
+      double lowEnergyGate = this.smooth01(MCH_FlightModel.clamp((1.35D - energyRatio) / 0.70D, 0.0D, 1.0D));
+      double climbGate = Math.max(lowEnergyGate, liftDeficit);
+      double rawClimbPenalty = this.smooth01(MCH_FlightModel.clamp(super.motionY / Math.max(0.10D, stallSpeed * 0.65D), 0.0D, 1.0D));
+      double climbPenalty = rawClimbPenalty * climbGate;
+      double liftCurve = this.smooth01(MCH_FlightModel.clamp(liftMargin / 1.05D, 0.0D, 1.0D));
+      double thrustCurve = this.smooth01(MCH_FlightModel.clamp(thrustMargin / 0.85D, 0.0D, 1.0D));
+      double support = MCH_FlightModel.clamp(0.62D * energyCurve + 0.25D * liftCurve + 0.13D * thrustCurve, 0.0D, 1.25D);
+      double sustainable = 4.0D + 76.0D * support;
+      if(energyRatio >= 1.35D && aoaSeverity <= 0.05D && liftMargin >= 0.90D) {
+         sustainable = Math.max(sustainable, 68.0D);
       }
-      return pitch;
+      sustainable -= aoaSeverity * (30.0D + 24.0D * (1.0D - energyCurve));
+      sustainable -= climbPenalty * (16.0D + 24.0D * lowEnergyGate);
+      sustainable = MCH_FlightModel.clamp(sustainable, -12.0D, 82.0D);
+
+      double currentNoseUp = Math.max(0.0D, (double)-this.getRotPitch());
+      double commandedNoseUp = desiredPitchInput < 0.0D ? Math.min(90.0D, currentNoseUp + (double)(-desiredPitchInput) * 28.0D) : currentNoseUp;
+      double demandedNoseUp = Math.max(currentNoseUp, commandedNoseUp);
+      double pitchExcess = Math.max(0.0D, demandedNoseUp - sustainable);
+
+      boolean safelyInsideEnvelope = energyRatio >= 1.35D && aoaSeverity <= 0.05D && liftMargin >= 0.90D;
+      boolean absurdHighEnergyOverpull = demandedNoseUp > 78.0D && pitchExcess > 12.0D;
+      this.lastRecoveryDueToLowEnergy = energyRatio < 1.20D;
+      this.lastRecoveryDueToAoA = aoaSeverity > 0.05D;
+      this.lastRecoveryDueToLiftDeficit = liftDeficit > 0.15D;
+      this.lastRecoveryDueToUnsupportedClimb = rawClimbPenalty > 0.35D && (energyRatio < 1.25D || liftDeficit > 0.20D || this.lastUnsupportedClimbSeverity > 0.25D);
+      boolean recoveryGate = this.lastRecoveryDueToLowEnergy || this.lastRecoveryDueToAoA
+            || this.lastRecoveryDueToLiftDeficit || this.lastRecoveryDueToUnsupportedClimb || absurdHighEnergyOverpull;
+      if(safelyInsideEnvelope && !absurdHighEnergyOverpull) {
+         recoveryGate = false;
+         pitchExcess = 0.0D;
+      }
+
+      double severity = this.smooth01(MCH_FlightModel.clamp(pitchExcess / 42.0D, 0.0D, 1.0D));
+      double recoveryScale = Math.max(lowEnergyGate, Math.max(aoaSeverity, liftDeficit));
+      if(absurdHighEnergyOverpull) {
+         recoveryScale = Math.max(recoveryScale, 0.35D);
+      }
+      double recoveryTorque = recoveryGate && severity > 1.0E-5D
+            ? severity * recoveryScale * (0.10D + 0.30D * Math.max(this.stallSeverity, this.deepStallSeverity))
+                  * (0.55D + (double)info.stallPitchRecoveryStrength)
+            : 0.0D;
+
+      this.lastSustainableNoseUpPitch = sustainable;
+      this.lastPitchEnvelopeExcess = pitchExcess;
+      this.lastPitchEnvelopeEnergyRatio = energyRatio;
+      this.lastNoseDownRecoveryTorque = recoveryTorque;
+      this.lastEnvelopeRecoveryActive = recoveryTorque > 1.0E-5D;
+      return MCH_FlightModel.clamp(1.0D - severity * (0.78D + 0.22D * Math.max(aoaSeverity, lowEnergyGate)), 0.0D, 1.0D);
    }
 
    private double getNoseUpPitchSuppression() {
@@ -1033,6 +1134,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       return this.lastPitchInputAfterAuthority;
    }
 
+   public double getLastSustainableNoseUpPitch() { return this.lastSustainableNoseUpPitch; }
+   public double getLastPitchEnvelopeExcess() { return this.lastPitchEnvelopeExcess; }
+   public double getLastPitchEnvelopeEnergyRatio() { return this.lastPitchEnvelopeEnergyRatio; }
+   public double getLastNoseDownRecoveryTorque() { return this.lastNoseDownRecoveryTorque; }
+   public double getLastFinalElevatorInput() { return this.lastFinalElevatorInput; }
+   public boolean isLastEnvelopeRecoveryActive() { return this.lastEnvelopeRecoveryActive; }
+   public boolean isLastRecoveryDueToLowEnergy() { return this.lastRecoveryDueToLowEnergy; }
+   public boolean isLastRecoveryDueToAoA() { return this.lastRecoveryDueToAoA; }
+   public boolean isLastRecoveryDueToLiftDeficit() { return this.lastRecoveryDueToLiftDeficit; }
+   public boolean isLastRecoveryDueToUnsupportedClimb() { return this.lastRecoveryDueToUnsupportedClimb; }
+
    public double getLastFinalPitchAngularVelocity() {
       return this.lastFinalPitchAngularVelocity;
    }
@@ -1227,6 +1339,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastFinalPitchAngularVelocity = 0.0D;
          this.lastRequestedPitchInput = 0.0F;
          this.lastPitchInputAfterAuthority = 0.0F;
+         this.lastSustainableNoseUpPitch = 90.0D;
+         this.lastPitchEnvelopeExcess = 0.0D;
+         this.lastPitchEnvelopeEnergyRatio = 1.0D;
+         this.lastNoseDownRecoveryTorque = 0.0D;
+         this.lastFinalElevatorInput = 0.0D;
          this.lastControlAuthority = this.getControlAuthorityFactor();
          this.lastPitchAuthority = 1.0D;
          this.lastAirflowAuthority = 1.0D;
@@ -1323,7 +1440,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double pilotControlAuthority = planeInfo.newFlightDisableForwardAirspeedControlScaling
             ? (double)controlAuthority
             : (double)controlAuthority * softStallAuthority;
+      double envelopeNoseUpAuthority = this.updatePitchEnvelope(pitch);
       double finalPitchAuthority = pilotControlAuthority * pitchAuthority;
+      if(pitch < 0.0F) {
+         finalPitchAuthority *= envelopeNoseUpAuthority;
+      }
       this.lastControlAuthority = controlAuthority;
       this.lastPitchAuthority = pitchAuthority;
       this.lastAirflowAuthority = pilotControlAuthority;
@@ -1338,10 +1459,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastPitchAuthorityAfterSuppression = finalPitchAuthority;
       }
       this.lastFinalPitchAuthority = finalPitchAuthority;
-      this.lastPitchUpAuthority = pitchUpLimiter;
+      this.lastPitchUpAuthority = pitchUpLimiter * envelopeNoseUpAuthority;
       this.lastPitchDownAuthority = (double)controlAuthority * pitchAuthority;
       pitch *= (float)finalPitchAuthority;
       this.lastPitchInputAfterAuthority = pitch;
+      this.lastFinalElevatorInput = pitch;
       double deepAxisLimiter = MCH_FlightModel.clamp(1.0D - deepControlLoss * 0.25D, 0.70D, 1.0D);
       this.lastRollAuthority = controlAuthority * deepAxisLimiter;
       this.lastYawAuthority = controlAuthority * MCH_FlightModel.clamp(1.0D - deepControlLoss * 0.18D, 0.75D, 1.0D);
@@ -1359,6 +1481,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.yawAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.yawAngularVelocity, yaw,
             info.yawTorque, info.yawDamping, info.inertiaMultiplier, partialTicks);
       this.lastPilotPitchAngularVelocity = this.pitchAngularVelocity;
+      if(this.lastNoseDownRecoveryTorque > 1.0E-5D) {
+         double envelopeSeverity = MCH_FlightModel.clamp(this.lastPitchEnvelopeExcess / 42.0D, 0.0D, 1.0D);
+         this.queueNoseDownRecovery(this.lastNoseDownRecoveryTorque, envelopeSeverity,
+               MCH_FlightModel.clamp(envelopeSeverity * 0.35D, 0.0D, 0.55D));
+      }
       this.applyAerodynamicAngularMoments(partialTicks);
       this.lastFinalPitchAngularVelocity = this.pitchAngularVelocity;
       pitch = this.pitchAngularVelocity * partialTicks;
@@ -1826,9 +1953,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
-      double appliedPitchDelta = MCH_FlightModel.clamp(this.lastForcedNoseDownPitchDelta, 0.0D, 2.5D);
-      this.setRotPitch(this.getRotPitch() + (float)appliedPitchDelta);
-      this.lastForcedNoseDownPitchDelta = appliedPitchDelta;
+      // Recovery is already queued into pitchAngularVelocity; do not directly assign or clamp rotation.
+      this.lastForcedNoseDownPitchDelta = MCH_FlightModel.clamp(this.lastForcedNoseDownPitchDelta, 0.0D, 2.5D);
       this.lastFinalPitchAngularVelocity = this.pitchAngularVelocity;
    }
 
@@ -1947,6 +2073,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastControlAuthority = 1.0D;
       this.lastRequestedPitchInput = 0.0D;
       this.lastPitchInputAfterAuthority = 0.0D;
+      this.lastSustainableNoseUpPitch = 90.0D;
+      this.lastPitchEnvelopeExcess = 0.0D;
+      this.lastPitchEnvelopeEnergyRatio = 1.0D;
+      this.lastNoseDownRecoveryTorque = 0.0D;
+      this.lastFinalElevatorInput = 0.0D;
+      this.lastEnvelopeRecoveryActive = false;
+      this.lastRecoveryDueToLowEnergy = false;
+      this.lastRecoveryDueToAoA = false;
+      this.lastRecoveryDueToLiftDeficit = false;
+      this.lastRecoveryDueToUnsupportedClimb = false;
       this.lastFinalPitchAngularVelocity = 0.0D;
       this.lastAirborne = false;
       this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;


### PR DESCRIPTION
### Motivation

- Introduce a continuous energy-based pitch-envelope to limit unrealistic nose-up commands and provide smoother, more physically plausible recoveries instead of abrupt clamping.  
- Surface detailed envelope/energy state to debug logs to aid tuning and troubleshooting of the new flight model.  
- Avoid directly forcing rotations during recovery and instead drive recovery through angular velocity for consistent simulation behavior.  

### Description

- Added new per-plane state fields and accessors such as `lastSustainableNoseUpPitch`, `lastPitchEnvelopeExcess`, `lastPitchEnvelopeEnergyRatio`, `lastNoseDownRecoveryTorque`, `lastFinalElevatorInput`, and recovery flags with corresponding getters.  
- Implemented pitch-envelope logic in `updatePitchEnvelope` (and helper `smooth01`) that computes a continuous sustainable nose-up angle based on energy ratio, lift/thrust margins, AoA, and climb penalties, and returns an authority multiplier used to scale nose-up pitch authority.  
- Integrated the envelope into the control flow by applying `envelopeNoseUpAuthority` when computing `finalPitchAuthority`, queuing nose-down recovery via `queueNoseDownRecovery` when appropriate, and ensuring recoveries are applied through body-rate (`pitchAngularVelocity`) rather than direct rotation changes; removed hard clamping in `clampIdleUnsupportedNoseUpPitch`.  
- Adjusted initialization and reset code to initialize the new state fields and updated `applyQueuedNoseDownRecovery` to avoid directly setting rotation.  
- Extended debug output formatting in `MCH_ClientCommonTickHandler.debugFlightControl` and warning messages to include stall speed and new pitch-envelope / recovery values and compute stall speed via `MCH_FlightModel.getStallSpeed` for accurate reporting.  

### Testing

- Built the project successfully with `./gradlew assemble` to ensure the code compiles after the changes.  
- Ran `./gradlew test` and any available automated tests completed successfully (no failing tests reported).  
- Exercised the modified plane control paths via debug logging enabled to confirm the new envelope values appear in `debugFlightControl` outputs and that recovery is queued instead of snapping rotation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a371c27e1c4832985b4a1143b6ac983)