### PR TITLE
Add opt-in helicopter flight-model foundation, telemetry, and rotor spool handling

### DIFF
--- a/docs/vehicle-config/helicopters.md
+++ b/docs/vehicle-config/helicopters.md
@@ -9,6 +9,21 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 | `enablefoldblade` | boolean | false | Enables blade-folding support. |
 | `addrotor` | `bladeNum,bladeRot,x,y,z,rx,ry,rz[,fold]` | none | Adds a rotor using the current renderer. Field 9 controls whether this rotor has fold functionality. |
 | `addrotorold` | same as `addrotor` | none | Legacy rotor renderer. Compatibility-only. |
+| `UseNewHelicopterFlightModel` / `EnableNewHelicopterFlightModel` | boolean | false | Helicopter-specific opt-in gate for the future rewritten helicopter model. This is intentionally separate from `UseNewMobilitySystem`; when false, all new helicopter physical tuning values are inert and legacy helicopter flight remains unchanged. |
+| `PhysicalMass` | float >= 0.01 | 1.0 | Relative mass for future force calculations. `1.0` is the legacy-scale baseline rather than real kilograms. |
+| `MainRotorMaxThrust` | float >= 0 | 0.06 | Future maximum main-rotor upward force in legacy motion units per tick at full collective. Default is near the current hover/lift scale. |
+| `RotorInertia` | float >= 0.01 | 1.0 | Future rotor RPM acceleration resistance; larger values should make RPM change more slowly. |
+| `RotorSpoolUpRate` | 0.0-1.0 | 0.02 | Future normalized rotor RPM gain per tick while spooling up. |
+| `RotorSpoolDownRate` | 0.0-1.0 | 0.03 | Future normalized rotor RPM loss per tick while spooling down. |
+| `CollectiveResponse` | 0.0-1.0 | 0.08 | Future smoothing rate for collective/lift input changes. |
+| `CyclicAuthority` | float >= 0 | 1.0 | Future pitch/roll cyclic authority multiplier. |
+| `TailRotorAuthority` | float >= 0 | 1.0 | Future yaw/tail-rotor authority multiplier. |
+| `YawDamping` | float >= 0 | 0.15 | Future yaw stabilization/damping multiplier. |
+| `AngularInertia` | float >= 0.01 | 1.0 | Relative rotational inertia for future angular acceleration. |
+| `TranslationalLiftCoefficient` | float >= 0 | 0.004 | Future forward-speed lift bonus coefficient; default mirrors the current translational-lift cap scale. |
+| `VerticalDrag` | float >= 0 | 0.02 | Future vertical climb/descent damping coefficient. |
+| `ParasiteDrag` | float >= 0 | 0.01 | Future horizontal air-drag coefficient. |
+| `HoverAssistStrength` | 0.0-1.0 | 0.0 | Future hover assistance strength. `0.0` keeps assist disabled by default. |
 
 ## Helicopter defaults that differ from base
 
@@ -18,6 +33,15 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 - Default `camerazoom = 8`.
 - HUD defaults are `heli`, `heli_gnr`, then `gunner`.
 - `speed` is multiplied by global `AllHeliSpeed` during validation.
+
+## Future helicopter flight-model foundation
+
+The new keys above only expose configuration and telemetry for a future helicopter-specific model. They do not change runtime helicopter physics unless `UseNewHelicopterFlightModel = true`, and the current implementation still leaves actual flight forces on the legacy path. Existing helicopter asset files do not need to define any of the new values.
+
+
+### Rotor RPM foundation
+
+When `UseNewHelicopterFlightModel = true`, helicopters now maintain a normalized runtime rotor state for future lift and yaw work. `targetRotorRPM` is derived from current throttle only while the engine can run, fuel is available, the canopy is closed, and blades are usable/unfolded. `normalizedRotorRPM` then moves toward that target using `RotorSpoolUpRate` while increasing, `RotorSpoolDownRate` while decreasing, and `RotorInertia` as resistance. This rotor state drives visual rotor rotation for opted-in helicopters only; legacy helicopters keep the original throttle-driven animation and lift behavior. Vertical lift, cyclic, hover mode, and yaw physics still use the legacy systems in this phase.
 
 ## Rotorcraft lift formulas
 

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -44,6 +44,22 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    public byte lastFoldBladeStat;
    public int foldBladesCooldown;
    public float prevRollFactor = 0.0F;
+   private boolean newHeliFlightModelEnabled;
+   private float physicalMass = 1.0F;
+   private float normalizedRotorRPM;
+   private float targetRotorRPM;
+   private float rotorEnergy;
+   private float enginePowerOutput;
+   private float lastRotorRPM;
+   private float rotorSpoolDelta;
+   private boolean rotorReadyForLift;
+   private float collectiveInput;
+   private float rotorThrust;
+   private float verticalForce;
+   private float cyclicPitchInput;
+   private float cyclicRollInput;
+   private float tailRotorInput;
+   private boolean hoverAssistActive;
 
 
    public MCH_EntityHeli(World world) {
@@ -86,12 +102,102 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          this.setDead(true);
       } else {
          this.setAcInfo(this.heliInfo);
+         this.updateNewHelicopterFlightTelemetryConfig();
          this.newSeats(this.getAcInfo().getNumSeatAndRack());
          this.createRotors();
          super.weapons = this.createWeapon(1 + this.getSeatNum());
          this.initPartRotation(this.getRotYaw(), this.getRotPitch());
       }
 
+   }
+
+   private void updateNewHelicopterFlightTelemetryConfig() {
+      this.newHeliFlightModelEnabled = this.heliInfo != null && this.heliInfo.useNewHelicopterFlightModel;
+      this.physicalMass = this.newHeliFlightModelEnabled?this.heliInfo.physicalMass:1.0F;
+      if(!this.newHeliFlightModelEnabled) {
+         this.normalizedRotorRPM = 0.0F;
+         this.targetRotorRPM = 0.0F;
+         this.rotorEnergy = 0.0F;
+         this.enginePowerOutput = 0.0F;
+         this.lastRotorRPM = 0.0F;
+         this.rotorSpoolDelta = 0.0F;
+         this.rotorReadyForLift = false;
+         this.collectiveInput = 0.0F;
+         this.rotorThrust = 0.0F;
+         this.verticalForce = 0.0F;
+         this.cyclicPitchInput = 0.0F;
+         this.cyclicRollInput = 0.0F;
+         this.tailRotorInput = 0.0F;
+         this.hoverAssistActive = false;
+      }
+   }
+
+   public boolean isNewHeliFlightModelEnabled() {
+      return this.newHeliFlightModelEnabled;
+   }
+
+   public float getPhysicalMass() {
+      return this.physicalMass;
+   }
+
+   public float getNormalizedRotorRPM() {
+      return this.normalizedRotorRPM;
+   }
+
+   public float getRotorRPM() {
+      return this.normalizedRotorRPM;
+   }
+
+   public float getTargetRotorRPM() {
+      return this.targetRotorRPM;
+   }
+
+   public float getRotorEnergy() {
+      return this.rotorEnergy;
+   }
+
+   public float getEnginePowerOutput() {
+      return this.enginePowerOutput;
+   }
+
+   public float getLastRotorRPM() {
+      return this.lastRotorRPM;
+   }
+
+   public float getRotorSpoolDelta() {
+      return this.rotorSpoolDelta;
+   }
+
+   public boolean isRotorReadyForLift() {
+      return this.rotorReadyForLift;
+   }
+
+   public float getCollectiveInput() {
+      return this.collectiveInput;
+   }
+
+   public float getRotorThrust() {
+      return this.rotorThrust;
+   }
+
+   public float getVerticalForce() {
+      return this.verticalForce;
+   }
+
+   public float getCyclicPitchInput() {
+      return this.cyclicPitchInput;
+   }
+
+   public float getCyclicRollInput() {
+      return this.cyclicRollInput;
+   }
+
+   public float getTailRotorInput() {
+      return this.tailRotorInput;
+   }
+
+   public boolean isHoverAssistActive() {
+      return this.hoverAssistActive;
    }
 
    public Item getItem() {
@@ -113,6 +219,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       par1NBTTagCompound.setDouble("RotorSpeed", this.getCurrentThrottle());
       par1NBTTagCompound.setDouble("rotetionRotor", this.rotationRotor);
       par1NBTTagCompound.setBoolean("FoldBlade", this.getFoldBladeStat() == 0);
+      par1NBTTagCompound.setFloat("NewHeliRotorRPM", this.normalizedRotorRPM);
+      par1NBTTagCompound.setFloat("NewHeliTargetRotorRPM", this.targetRotorRPM);
+      par1NBTTagCompound.setFloat("NewHeliRotorEnergy", this.rotorEnergy);
+      par1NBTTagCompound.setFloat("NewHeliEnginePower", this.enginePowerOutput);
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
@@ -130,6 +240,18 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
       this.setCurrentThrottle(par1NBTTagCompound.getDouble("RotorSpeed"));
       this.rotationRotor = par1NBTTagCompound.getDouble("rotetionRotor");
+      if(par1NBTTagCompound.hasKey("NewHeliRotorRPM")) {
+         this.normalizedRotorRPM = MathHelper.clamp_float(par1NBTTagCompound.getFloat("NewHeliRotorRPM"), 0.0F, 1.0F);
+      }
+      if(par1NBTTagCompound.hasKey("NewHeliTargetRotorRPM")) {
+         this.targetRotorRPM = MathHelper.clamp_float(par1NBTTagCompound.getFloat("NewHeliTargetRotorRPM"), 0.0F, 1.0F);
+      }
+      if(par1NBTTagCompound.hasKey("NewHeliRotorEnergy")) {
+         this.rotorEnergy = Math.max(par1NBTTagCompound.getFloat("NewHeliRotorEnergy"), 0.0F);
+      }
+      if(par1NBTTagCompound.hasKey("NewHeliEnginePower")) {
+         this.enginePowerOutput = MathHelper.clamp_float(par1NBTTagCompound.getFloat("NewHeliEnginePower"), 0.0F, 1.0F);
+      }
       this.setFoldBladeStat((byte)(par1NBTTagCompound.getBoolean("FoldBlade")?0:2));
       if(this.heliInfo == null) {
          this.heliInfo = MCH_HeliInfoManager.get(this.getTypeName());
@@ -138,6 +260,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             this.setDead(true);
          } else {
             this.setAcInfo(this.heliInfo);
+            this.updateNewHelicopterFlightTelemetryConfig();
          }
       }
 
@@ -334,6 +457,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             this.initCurrentWeapon(this.getRiddenByEntity());
          }
 
+         this.updateNewHelicopterFlightTelemetryConfig();
          this.updateWeapons();
          this.onUpdate_Seats();
          this.onUpdate_Control();
@@ -545,9 +669,40 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       }
 
       this.prevRotationRotor = this.rotationRotor;
-      float rp1 = (float)(1.0D - this.getCurrentThrottle());
-      this.rotationRotor += (double)((1.0F - rp1 * rp1 * rp1) * this.getAcInfo().rotorSpeed);
+      if(this.newHeliFlightModelEnabled) {
+         this.updateNewHelicopterRotorSpool();
+         this.rotationRotor += (double)(this.normalizedRotorRPM * this.getAcInfo().rotorSpeed);
+      } else {
+         float rp1 = (float)(1.0D - this.getCurrentThrottle());
+         this.rotationRotor += (double)((1.0F - rp1 * rp1 * rp1) * this.getAcInfo().rotorSpeed);
+      }
+
       this.rotationRotor %= 360.0D;
+   }
+
+   private void updateNewHelicopterRotorSpool() {
+      boolean bladesUsable = this.canUseBlades() && !this.isFoldBlades();
+      boolean enginePowered = !this.isDestroyed() && bladesUsable && this.isCanopyClose() && this.canUseFuel(true);
+      this.lastRotorRPM = this.normalizedRotorRPM;
+      this.enginePowerOutput = enginePowered?MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F):0.0F;
+      this.targetRotorRPM = this.enginePowerOutput;
+
+      float delta = this.targetRotorRPM - this.normalizedRotorRPM;
+      float configuredRate = delta >= 0.0F?this.heliInfo.rotorSpoolUpRate:this.heliInfo.rotorSpoolDownRate;
+      float inertia = Math.max(this.heliInfo.rotorInertia, 0.01F);
+      float maxStep = configuredRate / inertia;
+      if(MathHelper.abs(delta) <= maxStep) {
+         this.normalizedRotorRPM = this.targetRotorRPM;
+      } else if(delta > 0.0F) {
+         this.normalizedRotorRPM += maxStep;
+      } else {
+         this.normalizedRotorRPM -= maxStep;
+      }
+
+      this.normalizedRotorRPM = MathHelper.clamp_float(this.normalizedRotorRPM, 0.0F, 1.0F);
+      this.rotorSpoolDelta = this.normalizedRotorRPM - this.lastRotorRPM;
+      this.rotorEnergy = this.normalizedRotorRPM * this.normalizedRotorRPM * inertia;
+      this.rotorReadyForLift = bladesUsable && this.normalizedRotorRPM >= 0.85F;
    }
 
    protected void onUpdate_ControlNotHovering() {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -12,6 +12,36 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
 
    public MCH_ItemHeli item = null;
    public boolean isEnableFoldBlade;
+   /** Opt-in gate for the isolated helicopter flight-model rewrite. Default false keeps legacy lift/motion behavior. */
+   public boolean useNewHelicopterFlightModel;
+   /** Relative vehicle mass used by future helicopter physics. 1.0 matches current legacy scale. */
+   public float physicalMass;
+   /** Maximum upward rotor force for future physics, in legacy motion units per tick at full collective. */
+   public float mainRotorMaxThrust;
+   /** Rotor acceleration resistance for future spool calculations; larger values change RPM more slowly. */
+   public float rotorInertia;
+   /** Normalized rotor RPM increase per tick while spooling up in the future model. */
+   public float rotorSpoolUpRate;
+   /** Normalized rotor RPM decrease per tick while spooling down in the future model. */
+   public float rotorSpoolDownRate;
+   /** Collective input smoothing rate for future lift control, normalized per tick. */
+   public float collectiveResponse;
+   /** Pitch/roll cyclic control authority multiplier for future helicopter physics. */
+   public float cyclicAuthority;
+   /** Tail rotor yaw authority multiplier for future helicopter physics. */
+   public float tailRotorAuthority;
+   /** Yaw damping multiplier for future angular stabilization. */
+   public float yawDamping;
+   /** Relative rotational inertia used by future angular acceleration calculations. */
+   public float angularInertia;
+   /** Forward-speed lift bonus coefficient for future translational-lift calculations. */
+   public float translationalLiftCoefficient;
+   /** Vertical drag coefficient for future climb/descent damping. */
+   public float verticalDrag;
+   /** Horizontal air-drag coefficient for future speed damping. */
+   public float parasiteDrag;
+   /** Strength of future hover assistance; 0 disables assist, 1 is full configured assist. */
+   public float hoverAssistStrength;
    public List rotorList;
 
 
@@ -19,6 +49,21 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       super(name);
       super.isEnableGunnerMode = false;
       this.isEnableFoldBlade = false;
+      this.useNewHelicopterFlightModel = false;
+      this.physicalMass = 1.0F;
+      this.mainRotorMaxThrust = 0.06F;
+      this.rotorInertia = 1.0F;
+      this.rotorSpoolUpRate = 0.02F;
+      this.rotorSpoolDownRate = 0.03F;
+      this.collectiveResponse = 0.08F;
+      this.cyclicAuthority = 1.0F;
+      this.tailRotorAuthority = 1.0F;
+      this.yawDamping = 0.15F;
+      this.angularInertia = 1.0F;
+      this.translationalLiftCoefficient = 0.004F;
+      this.verticalDrag = 0.02F;
+      this.parasiteDrag = 0.01F;
+      this.hoverAssistStrength = 0.0F;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;
       super.maxRotationPitch = 20.0F;
@@ -55,6 +100,36 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       super.loadItemData(item, data);
       if(item.compareTo("enablefoldblade") == 0) {
          this.isEnableFoldBlade = this.toBool(data);
+      } else if(item.equalsIgnoreCase("UseNewHelicopterFlightModel") || item.equalsIgnoreCase("EnableNewHelicopterFlightModel")) {
+         this.useNewHelicopterFlightModel = this.toBool(data);
+      } else if(item.equalsIgnoreCase("PhysicalMass")) {
+         this.physicalMass = this.toFloat(data, 0.01F, 100000.0F);
+      } else if(item.equalsIgnoreCase("MainRotorMaxThrust")) {
+         this.mainRotorMaxThrust = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("RotorInertia")) {
+         this.rotorInertia = this.toFloat(data, 0.01F, 100000.0F);
+      } else if(item.equalsIgnoreCase("RotorSpoolUpRate")) {
+         this.rotorSpoolUpRate = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("RotorSpoolDownRate")) {
+         this.rotorSpoolDownRate = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("CollectiveResponse")) {
+         this.collectiveResponse = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("CyclicAuthority")) {
+         this.cyclicAuthority = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("TailRotorAuthority")) {
+         this.tailRotorAuthority = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("YawDamping")) {
+         this.yawDamping = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("AngularInertia")) {
+         this.angularInertia = this.toFloat(data, 0.01F, 100000.0F);
+      } else if(item.equalsIgnoreCase("TranslationalLiftCoefficient")) {
+         this.translationalLiftCoefficient = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("VerticalDrag")) {
+         this.verticalDrag = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("ParasiteDrag")) {
+         this.parasiteDrag = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("HoverAssistStrength")) {
+         this.hoverAssistStrength = this.toFloat(data, 0.0F, 1.0F);
       } else if(item.compareTo("addrotor") == 0 || item.compareTo("addrotorold") == 0) {
          String[] s = data.split("\\s*,\\s*");
          if(s.length == 8 || s.length == 9) {


### PR DESCRIPTION
### Motivation

- Introduce an opt-in helicopter-specific flight-model foundation and telemetry so new physics can be implemented without changing legacy helicopter behavior.
- Expose tuning/configuration keys and defaults for future rotor, collective, cyclic, and drag parameters to make new-flight-model tuning data-driven.

### Description

- Documented new helicopter-only config keys and added an explanation of the future flight-model and rotor RPM foundation in `docs/vehicle-config/helicopters.md`.
- Extended `MCH_HeliInfo` with new fields, defaults, and parsing for flags and parameters such as `UseNewHelicopterFlightModel`, `PhysicalMass`, `MainRotorMaxThrust`, `RotorInertia`, `RotorSpoolUpRate`, `RotorSpoolDownRate`, `CollectiveResponse`, `CyclicAuthority`, `TailRotorAuthority`, `YawDamping`, `AngularInertia`, `TranslationalLiftCoefficient`, `VerticalDrag`, `ParasiteDrag`, and `HoverAssistStrength`.
- Added runtime state and telemetry fields and getters to `MCH_EntityHeli` (normalized rotor RPM, target RPM, rotor energy, engine power output, spool delta, readiness flag, collective/cyclic/tail inputs, etc.).
- Implemented `updateNewHelicopterFlightTelemetryConfig()` to initialize and reset new-model state when type/metadata change, and persisted relevant telemetry to NBT with safe clamping on read.
- Added `updateNewHelicopterRotorSpool()` which computes `targetRotorRPM`, applies spool up/down rates and `rotorInertia`, clamps values, computes `rotorSpoolDelta` and `rotorEnergy`, and sets `rotorReadyForLift`.
- Gated rotor visual rotation on `newHeliFlightModelEnabled` so opted-in helicopters use `normalizedRotorRPM * rotorSpeed` while legacy helicopters keep the original throttle-driven animation.

### Testing

- Built the project and ran the test task using `./gradlew build` and `./gradlew test`, and the build succeeded and any automated tests present completed without failures.
- Verified that NBT read/write paths include the new telemetry keys and that values are clamped during `readEntityFromNBT` by inspection (no runtime regression tests added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a375a8f7054832995b242867c0b1d9f)