### PR TITLE
Heli: implement tail-rotor / anti-torque yaw physics for new helicopter model

### DIFF
--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -332,6 +332,20 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
 
       MCP_EntityPlane plane = ac instanceof MCP_EntityPlane ? (MCP_EntityPlane)ac : null;
+      MCH_EntityHeli heli = ac instanceof MCH_EntityHeli ? (MCH_EntityHeli)ac : null;
+      if(heli != null && heli.isNewHeliFlightModelEnabled()) {
+         System.out.println(String.format(
+               "[MCHeli] heli-yaw dt=%.3f yawInput=%.4f mainRotorTorqueReaction=%.4f tailRotorTorque=%.4f netYawTorque=%.4f yawAngularAcceleration=%.4f heliYawAngularVelocity=%.4f yawDampingApplied=%.4f finalRotYaw=%.2f",
+               simDelta,
+               heli.getTailRotorInput(),
+               heli.getMainRotorTorqueReaction(),
+               heli.getTailRotorTorque(),
+               heli.getHeliYawTorque(),
+               heli.getYawAngularAcceleration(),
+               heli.getYawAngularVelocity(),
+               heli.getYawDampingApplied(),
+               heli.getFinalRotYaw()));
+      }
 
       double forwardSpeed = plane != null
             ? ac.motionX * MCH_Lib.Rot2Vec3(ac.getRotYaw(), ac.getRotPitch()).xCoord

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -85,6 +85,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float localDriftForward;
    private float localDriftRight;
    private float tailRotorInput;
+   /** Positive main-rotor torque reaction yaws the fuselage right unless countered by tail rotor thrust. */
+   private float heliYawAngularVelocity;
+   private float heliYawTorque;
+   private float tailRotorTorque;
+   private float mainRotorTorqueReaction;
+   private float yawDampingApplied;
+   private float yawAngularAcceleration;
+   private float finalRotYaw;
    private boolean hoverAssistActive;
 
 
@@ -180,6 +188,13 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          this.localDriftForward = 0.0F;
          this.localDriftRight = 0.0F;
          this.tailRotorInput = 0.0F;
+         this.heliYawAngularVelocity = 0.0F;
+         this.heliYawTorque = 0.0F;
+         this.tailRotorTorque = 0.0F;
+         this.mainRotorTorqueReaction = 0.0F;
+         this.yawDampingApplied = 0.0F;
+         this.yawAngularAcceleration = 0.0F;
+         this.finalRotYaw = this.getRotYaw();
          this.hoverAssistActive = false;
       }
    }
@@ -352,6 +367,35 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       return this.tailRotorInput;
    }
 
+   @Override
+   public float getYawAngularVelocity() {
+      return this.newHeliFlightModelEnabled?this.heliYawAngularVelocity:super.getYawAngularVelocity();
+   }
+
+   public float getHeliYawTorque() {
+      return this.heliYawTorque;
+   }
+
+   public float getTailRotorTorque() {
+      return this.tailRotorTorque;
+   }
+
+   public float getMainRotorTorqueReaction() {
+      return this.mainRotorTorqueReaction;
+   }
+
+   public float getYawDampingApplied() {
+      return this.yawDampingApplied;
+   }
+
+   public float getYawAngularAcceleration() {
+      return this.yawAngularAcceleration;
+   }
+
+   public float getFinalRotYaw() {
+      return this.finalRotYaw;
+   }
+
    public boolean isHoverAssistActive() {
       return this.hoverAssistActive;
    }
@@ -379,6 +423,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       par1NBTTagCompound.setFloat("NewHeliTargetRotorRPM", this.targetRotorRPM);
       par1NBTTagCompound.setFloat("NewHeliRotorEnergy", this.rotorEnergy);
       par1NBTTagCompound.setFloat("NewHeliEnginePower", this.enginePowerOutput);
+      par1NBTTagCompound.setFloat("NewHeliYawAngularVelocity", this.heliYawAngularVelocity);
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
@@ -407,6 +452,9 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       }
       if(par1NBTTagCompound.hasKey("NewHeliEnginePower")) {
          this.enginePowerOutput = MathHelper.clamp_float(par1NBTTagCompound.getFloat("NewHeliEnginePower"), 0.0F, 1.0F);
+      }
+      if(par1NBTTagCompound.hasKey("NewHeliYawAngularVelocity")) {
+         this.heliYawAngularVelocity = par1NBTTagCompound.getFloat("NewHeliYawAngularVelocity");
       }
       this.setFoldBladeStat((byte)(par1NBTTagCompound.getBoolean("FoldBlade")?0:2));
       if(this.heliInfo == null) {
@@ -678,6 +726,12 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    public float getControlRotYaw(float mouseX, float mouseY, float tick) {
+      if(this.newHeliFlightModelEnabled) {
+         float yawLimit = (float)Math.max(this.getAddRotationYawLimit(), 1.0D);
+         this.tailRotorInput = MathHelper.clamp_float(mouseX / yawLimit, -1.0F, 1.0F);
+         return 0.0F;
+      }
+
       return mouseX;
    }
 
@@ -717,7 +771,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
                this.applyOnGroundPitch(0.97F);
             }
 
-            if(this.heliInfo.isEnableFoldBlade && this.rotors.length > 0 && this.getFoldBladeStat() == 0 && !this.isDestroyed()) {
+            if(!this.newHeliFlightModelEnabled && this.heliInfo.isEnableFoldBlade && this.rotors.length > 0 && this.getFoldBladeStat() == 0 && !this.isDestroyed()) {
                if(super.moveLeft && !super.moveRight) {
                   this.setRotYaw(this.getRotYaw() - 0.5F * partialTicks);
                }
@@ -728,7 +782,44 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             }
          }
 
+         if(this.newHeliFlightModelEnabled) {
+            this.applyNewHelicopterYawModel(partialTicks);
+         }
       }
+   }
+
+   private void applyNewHelicopterYawModel(float tickDelta) {
+      if(this.heliInfo == null) {
+         return;
+      }
+
+      boolean bladesUsable = this.canUseBlades() && !this.isFoldBlades();
+      boolean engineUsable = !this.isDestroyed() && bladesUsable && this.isCanopyClose() && this.canUseFuel(true);
+      float rpmAuthority = engineUsable?MathHelper.clamp_float(this.normalizedRotorRPM, 0.0F, 1.0F):0.0F;
+      float damageAuthority = MathHelper.clamp_float((float)this.getHP() / Math.max(1.0F, (float)this.getMaxHP()), 0.25F, 1.0F);
+      if(this.isDestroyed()) {
+         damageAuthority = 0.0F;
+      }
+
+      float collective = MathHelper.clamp_float(this.collectiveInput, 0.0F, 1.0F);
+      float rotorLoad = Math.max(this.rotorThrust, this.heliInfo.mainRotorMaxThrust * collective * this.enginePowerOutput);
+      // Positive reaction is the fuselage yawing right from main-rotor drag; tail-rotor torque subtracts from it.
+      this.mainRotorTorqueReaction = engineUsable?rotorLoad * rpmAuthority:0.0F;
+
+      float tailAuthority = Math.max(this.heliInfo.tailRotorAuthority, 0.0F) * rpmAuthority * damageAuthority;
+      this.tailRotorTorque = this.tailRotorInput * tailAuthority * Math.max(this.heliInfo.mainRotorMaxThrust, 0.01F);
+      this.heliYawTorque = this.tailRotorTorque - this.mainRotorTorqueReaction;
+
+      float inertia = Math.max(this.heliInfo.angularInertia, 0.01F);
+      this.yawAngularAcceleration = this.heliYawTorque / inertia;
+      this.heliYawAngularVelocity += this.yawAngularAcceleration * tickDelta;
+
+      this.yawDampingApplied = -this.heliYawAngularVelocity * Math.max(this.heliInfo.yawDamping, 0.0F) * tickDelta;
+      this.heliYawAngularVelocity += this.yawDampingApplied;
+      this.heliYawAngularVelocity = MathHelper.clamp_float(this.heliYawAngularVelocity, -8.0F, 8.0F);
+
+      this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
+      this.setRotYaw(this.finalRotYaw);
    }
 
    protected void onUpdate_Rotor() {


### PR DESCRIPTION
### Motivation
- Replace the legacy instant/direct yaw behavior for helicopters using `UseNewHelicopterFlightModel` with a rotorcraft-style yaw model that simulates main-rotor torque reaction, tail-rotor authority, yaw inertia, and damping. 
- Use the existing rotor spool/RPM, collective, and engine readiness signals so yaw authority scales with rotor/engine state and damage/folding/fuel conditions.

### Description
- Added runtime yaw state fields and telemetry accessors to `MCH_EntityHeli`: `heliYawAngularVelocity`, `heliYawTorque`, `tailRotorTorque`, `mainRotorTorqueReaction`, `yawDampingApplied`, `yawAngularAcceleration`, and `finalRotYaw`, and persisted `heliYawAngularVelocity` to NBT. 
- Replaced direct yaw application for new-model helicopters by capturing pilot yaw/pedal into `tailRotorInput` (via `getControlRotYaw`) and returning zero direct yaw so only the physics model drives rotation when `UseNewHelicopterFlightModel = true`. 
- Implemented computation of main rotor reaction and tail rotor torque and net yaw torque in `applyNewHelicopterYawModel`, gating authority by `normalizedRotorRPM`, `engine/blades/fuel/canopy` readiness, and damage/folding state, with clear sign convention (main-rotor reaction yaws fuselage right and tail torque subtracts from it). 
- Integrated yaw angular velocity using `yawAngularAcceleration = netYawTorque / AngularInertia`, applied velocity-proportional yaw damping (no hard snap), clamped velocity for stability, and applied `heliYawAngularVelocity` to the entity yaw each tick. 
- Preserved legacy yaw behavior when the new helicopter model is disabled, kept fold-on-ground yaw logic disabled for new-model helicopters, and added debug telemetry output for the new yaw variables in `MCH_ClientCommonTickHandler` for `DebugFlightControl`. 

### Testing
- Ran `git diff --check` with no whitespace/merge errors reported. 
- Performed static edits and quick local inspections of modified files: `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` and `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`. 
- Java compilation was not executed because no `.class` outputs were to be generated per project/user constraints, so a full compile check was intentionally skipped. 
- No automated unit tests were added or executed in this change; runtime telemetry was added to assist manual/QA validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37645478fc83298f86684d26057a84)