### PR TITLE
Opt in three helicopters to new flight model (initial conservative test pass)

### DIFF
--- a/configreference/helicopters/ach47a.txt
+++ b/configreference/helicopters/ach47a.txt
@@ -26,6 +26,23 @@ HUD = helinvg, heli_gnrnvg, gunner, gunner, gunner, gunner,
 MobilityYaw = 0.7
 MobilityPitch = 0.7
 MobilityRoll = 0.7
+
+; Initial new helicopter flight-model test opt-in: heavy armed transport.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.90
+MainRotorMaxThrust = 0.235
+RotorInertia = 1.85
+RotorSpoolUpRate = 0.016
+RotorSpoolDownRate = 0.024
+CollectiveResponse = 0.060
+CyclicAuthority = 0.78
+TailRotorAuthority = 0.88
+YawDamping = 0.32
+AngularInertia = 1.90
+TranslationalLiftCoefficient = 0.0034
+VerticalDrag = 0.032
+ParasiteDrag = 0.018
+HoverAssistStrength = 0.32
 AddPartWeapon    = achm3m_l,    false, true, true,   -0.7,    1.4433,   -4.7
 
 AddPartWeapon    = achm134_l50,  false, true,  false,  -1.2859,  1.7843,  4.9367

--- a/configreference/helicopters/ah-6.txt
+++ b/configreference/helicopters/ah-6.txt
@@ -10,6 +10,23 @@ MaxFuel         = 1200
 FuelConsumption = 1.0
 ThirdPersonDist = 20
 
+; Initial new helicopter flight-model test opt-in: light attack scout.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.75
+MainRotorMaxThrust = 0.105
+RotorInertia = 0.85
+RotorSpoolUpRate = 0.028
+RotorSpoolDownRate = 0.035
+CollectiveResponse = 0.10
+CyclicAuthority = 1.08
+TailRotorAuthority = 1.05
+YawDamping = 0.18
+AngularInertia = 0.85
+TranslationalLiftCoefficient = 0.0045
+VerticalDrag = 0.024
+ParasiteDrag = 0.012
+HoverAssistStrength = 0.22
+
 ; M = Military(軍用機).  A = Attacker(攻撃機)
 Category = LA/MM
 

--- a/configreference/helicopters/uh-60ja.txt
+++ b/configreference/helicopters/uh-60ja.txt
@@ -16,6 +16,23 @@ FuelConsumption = 1.0
 Stealth = 0.2
 ThirdPersonDist = 20
 
+; Initial new helicopter flight-model test opt-in: medium utility helicopter.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.20
+MainRotorMaxThrust = 0.155
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.022
+RotorSpoolDownRate = 0.030
+CollectiveResponse = 0.082
+CyclicAuthority = 0.96
+TailRotorAuthority = 1.02
+YawDamping = 0.22
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.0040
+VerticalDrag = 0.026
+ParasiteDrag = 0.014
+HoverAssistStrength = 0.28
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 10

--- a/docs/vehicle-config/helicopters.md
+++ b/docs/vehicle-config/helicopters.md
@@ -38,6 +38,8 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 
 The new keys above are inert unless `UseNewHelicopterFlightModel = true`. Existing helicopter asset files do not need to define any of the new values, and helicopters that leave the opt-in disabled keep the legacy flight path.
 
+The first controlled asset opt-in pass is intentionally small and conservative. `ah-6`, `uh-60ja`, and `ach47a` provide light, medium utility, and heavy armed-transport test coverage without globally changing the helicopter folder. Their values are initial flyability probes, not final realism or balance targets.
+
 
 ### Rotor RPM foundation
 
@@ -84,6 +86,23 @@ HUD = heli
 speed = 0.85
 maxhp = 100
 addrotor = 4, 45, 0.0, 2.2, 0.0, 0.0, 0.0, 0.0
+
+; Optional initial-test new-model values. Tune per aircraft role/size.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.0
+MainRotorMaxThrust = 0.13
+RotorInertia = 1.0
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.08
+CyclicAuthority = 1.0
+TailRotorAuthority = 1.0
+YawDamping = 0.20
+AngularInertia = 1.0
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.014
+HoverAssistStrength = 0.25
 ```
 
 ## Legacy compatibility


### PR DESCRIPTION
### Motivation
- Begin a small, controlled opt-in for the new helicopter flight model to exercise rotor RPM, force-based collective lift, cyclic thrust-vectoring, hover SAS, and tail-rotor yaw without changing the entire helicopter set. 
- Provide one representative aircraft per role/size (light, medium, heavy) with conservative, flyable parameters so early testing can proceed safely.

### Description
- Enabled `UseNewHelicopterFlightModel = true` and added a conservative set of new tuning keys (PhysicalMass, MainRotorMaxThrust, RotorInertia, RotorSpoolUpRate, RotorSpoolDownRate, CollectiveResponse, CyclicAuthority, TailRotorAuthority, YawDamping, AngularInertia, TranslationalLiftCoefficient, VerticalDrag, ParasiteDrag, HoverAssistStrength) to `configreference/helicopters/ah-6.txt` (light attack/scout). 
- Applied a medium/stable tuning block to `configreference/helicopters/uh-60ja.txt` (medium utility). 
- Applied a heavier, slower-spool and higher-inertia tuning block to `configreference/helicopters/ach47a.txt` (heavy armed transport). 
- Updated `docs/vehicle-config/helicopters.md` to call out that this is an initial, intentionally conservative tuning pass and added an example optional block for testers; no other helicopter configs were modified. 
- No Java source files were changed because parsing/defaults were sufficient for the new keys.

### Testing
- Ran `rg -n "UseNewHelicopterFlightModel\s*=\s*true" configreference/helicopters docs/vehicle-config/helicopters.md` to verify the opt-ins appear in intended files and the docs. 
- Executed a `python3` required-key validation script that confirmed each selected config contains all required new-model keys and reported success. 
- Executed a `python3` scope validation script that confirmed only `ah-6`, `uh-60ja`, and `ach47a` were opted in and reported success. 
- Ran `git diff --check` to ensure there are no whitespace/format issues and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3767bea9e08329a73692494988cf7e)