### PR TITLE
Roll out new helicopter flight-model baselines to all helicopter configs

### DIFF
--- a/configreference/helicopters/ach47a.txt
+++ b/configreference/helicopters/ach47a.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = Up Armed Boeing ACH-47A "Guns A Go-Go" Chinook
+DisplayName = Up Armed Boeing ACH-47A "Guns A Go-Go" Chinook
 AddDisplayName = en_US, Up Armed Boeing ACH-47A "Guns A Go-Go" Chinook
 AddDisplayName = ja_JP, ACH47a アームド チヌーク
 ItemID = 28811
@@ -19,17 +19,10 @@ soundpitch = 1.0
 soundvolume = 15
 
 ; M = Military(軍用機).  S = Multi-Mission(多目的機)
-Category = TH/GH
 
-HUD = helinvg, heli_gnrnvg, gunner, gunner, gunner, gunner,
-
-MobilityYaw = 0.7
-MobilityPitch = 0.7
-MobilityRoll = 0.7
-
-; Initial new helicopter flight-model test opt-in; tune thrust-to-weight before control authority: heavy armed transport.
+; New helicopter flight model: heavy transport/attack baseline tuning.
 UseNewHelicopterFlightModel = true
-PhysicalMass = 1.90
+PhysicalMass = 1.9
 MainRotorMaxThrust = 0.235
 RotorInertia = 1.85
 RotorSpoolUpRate = 0.016
@@ -38,12 +31,21 @@ CollectiveResponse = 0.060
 CyclicAuthority = 0.62
 TailRotorAuthority = 0.88
 YawDamping = 0.32
-AngularInertia = 1.90
+AngularInertia = 1.9
 TranslationalLiftCoefficient = 0.0034
 VerticalDrag = 0.032
 ParasiteDrag = 0.045
-HorizontalRotorThrustScale = 0.55
+HorizontalRotorThrustScale = 0.6
 HoverAssistStrength = 0.32
+
+Category = TH/GH
+
+HUD = helinvg, heli_gnrnvg, gunner, gunner, gunner, gunner,
+
+MobilityYaw = 0.7
+MobilityPitch = 0.7
+MobilityRoll = 0.7
+
 
 AddPartWeapon    = achm3m_l,    false, true, true,   -0.7,    1.4433,   -4.7
 

--- a/configreference/helicopters/ah-1.txt
+++ b/configreference/helicopters/ah-1.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = AH-1F/S Cobra
+DisplayName = AH-1F/S Cobra
 AddDisplayName = en_US, AH-1F/S Cobra
 AddDisplayName = ja_JP, AH-1F/S コブラ
 ItemID = 28824
@@ -14,6 +14,25 @@ Sound = r44_heli
 soundpitch = 1.45
 soundvolume = 15
 ThirdPersonDist = 20
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.92
+MainRotorMaxThrust = 0.248
+RotorInertia = 1
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.82
+TailRotorAuthority = 1
+YawDamping = 0.19
+AngularInertia = 1.02
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.03
+HorizontalRotorThrustScale = 0.78
+HoverAssistStrength = 0.2
+
 
 AddTexture = AH-1_1
 

--- a/configreference/helicopters/ah-1w.txt
+++ b/configreference/helicopters/ah-1w.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = AH-1W Super Cobra
+DisplayName = AH-1W Super Cobra
 AddDisplayName = en_US, AH-1W Super Cobra
 AddDisplayName = ja_JP, AH-1W スーパーコブラ
 ItemID = 28824
@@ -14,6 +14,25 @@ Sound = r44_heli
 soundpitch = 1.45
 soundvolume = 15
 ThirdPersonDist = 20
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.98
+MainRotorMaxThrust = 0.258
+RotorInertia = 1.06
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.81
+TailRotorAuthority = 1
+YawDamping = 0.19
+AngularInertia = 1.08
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.031
+HorizontalRotorThrustScale = 0.76
+HoverAssistStrength = 0.2
+
 
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)

--- a/configreference/helicopters/ah-1z.txt
+++ b/configreference/helicopters/ah-1z.txt
@@ -12,6 +12,25 @@ MaxFuel         = 1270
 FuelConsumption = 0.529
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.02
+MainRotorMaxThrust = 0.266
+RotorInertia = 1.1
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.8
+TailRotorAuthority = 1
+YawDamping = 0.19
+AngularInertia = 1.12
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.032
+HorizontalRotorThrustScale = 0.75
+HoverAssistStrength = 0.2
+
+
 Sound = r44_heli
 soundpitch = 1.45
 soundvolume = 15

--- a/configreference/helicopters/ah-6.txt
+++ b/configreference/helicopters/ah-6.txt
@@ -11,7 +11,7 @@ FuelConsumption = 0.228
 ThirdPersonDist = 20
 
 
-; Initial new helicopter flight-model test opt-in; tune thrust-to-weight before control authority: light attack scout.
+; New helicopter flight model: light scout/attack baseline tuning.
 UseNewHelicopterFlightModel = true
 PhysicalMass = 0.75
 MainRotorMaxThrust = 0.225
@@ -19,14 +19,14 @@ RotorInertia = 0.85
 RotorSpoolUpRate = 0.028
 RotorSpoolDownRate = 0.035
 CollectiveResponse = 0.10
-CyclicAuthority = 0.92
+CyclicAuthority = 0.88
 TailRotorAuthority = 1.05
 YawDamping = 0.18
 AngularInertia = 0.85
 TranslationalLiftCoefficient = 0.0045
 VerticalDrag = 0.024
 ParasiteDrag = 0.025
-HorizontalRotorThrustScale = 0.95
+HorizontalRotorThrustScale = 0.90
 HoverAssistStrength = 0.22
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)
@@ -72,7 +72,7 @@ AddRecipe = "ABC", "   ", "   ", A, mcheli:mh-6, B, mcheli:rocket, C, mcheli:can
 
 BoundingBox =  0.0, 1.7, -1.5,  2.0, 2.0
 
-BoundingBox = 0.0, 2.8, 0.0, 1.0, 1.5, 1.5 
+BoundingBox = 0.0, 2.8, 0.0, 1.0, 1.5, 1.5
 
 BoundingBox = 0.0, 1.96, -2.83, 1.0, 1.0
 BoundingBox = 0.0, 1.96, -3.83, 1.0, 1.0

--- a/configreference/helicopters/ah-60.txt
+++ b/configreference/helicopters/ah-60.txt
@@ -17,6 +17,25 @@ FuelConsumption = 0.681
 Stealth = 0.8
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 10

--- a/configreference/helicopters/ah-64.txt
+++ b/configreference/helicopters/ah-64.txt
@@ -18,6 +18,25 @@ CameraPosition = 0.0, 1.1, 4.5
 onGroundPitch = 3.5
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.24
+MainRotorMaxThrust = 0.286
+RotorInertia = 1.3
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.77
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.32
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.027
+ParasiteDrag = 0.036
+HorizontalRotorThrustScale = 0.64
+HoverAssistStrength = 0.18
+
+
 ; M = Military(軍用機).  A = Attacker(攻撃機)
 Category = AH
 
@@ -105,7 +124,7 @@ AddWeapon = uhf_radar,  0.00, 3.0, 0.0,    0.0
 ;advanced armored modern helicopter armed, AOW3 style
 AddRecipe = "ABC", "DEF", "G  ", A, mcheli:airframe3, B, mcheli:heliblade, C, mcheli:engine1, D, mcheli:wheelair, E, mcheli:fcs2, F, mcheli:cannon2, G, mcheli:rocket3
 
-;RideRack = 乗る機体名, ラック番号 (1～) 
+;RideRack = 乗る機体名, ラック番号 (1～)
 RideRack = c5, 1
 RideRack = c5, 2
 

--- a/configreference/helicopters/ah-6x.txt
+++ b/configreference/helicopters/ah-6x.txt
@@ -11,6 +11,25 @@ MaxFuel         = 410
 FuelConsumption = 0.228
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.78
+MainRotorMaxThrust = 0.23
+RotorInertia = 0.88
+RotorSpoolUpRate = 0.027
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.1
+CyclicAuthority = 0.87
+TailRotorAuthority = 1.04
+YawDamping = 0.18
+AngularInertia = 0.88
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.025
+ParasiteDrag = 0.026
+HorizontalRotorThrustScale = 0.88
+HoverAssistStrength = 0.22
+
+
 Sound = littlebird
 Soundvolume = 15
 
@@ -61,7 +80,7 @@ BoundingBox =  0.0, 1.7, -0.5,  2.4, 2.5
 
 BoundingBox =  0.0, 1.7, -1.5,  2.0, 2.0
 
-BoundingBox = 0.0, 2.8, 0.0, 1.0, 1.5, 1.5 
+BoundingBox = 0.0, 2.8, 0.0, 1.0, 1.5, 1.5
 
 BoundingBox = 0.0, 1.96, -2.83, 1.0, 1.0
 BoundingBox = 0.0, 1.96, -3.83, 1.0, 1.0

--- a/configreference/helicopters/as365n3_dauphin.txt
+++ b/configreference/helicopters/as365n3_dauphin.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = Eurocopter AS365 Dauphin
+DisplayName = Eurocopter AS365 Dauphin
 AddDisplayName = en_US, Eurocopter AS365 Dauphin
 AddDisplayName = ja_JP, AS365N3 ドーファン
 
@@ -18,6 +18,25 @@ RotorSpeed = 90
 EnableParachuting = true
 MobDropOption  =  -1.75,  0.72,  -2.67,  10
 ThirdPersonDist = 20
+
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
 
 sound = chinesedauphin
 soundvolume = 15
@@ -76,8 +95,8 @@ AddSearchLight    = 0.53,  0.39,  -0.06,   0x50FFFFFF,   0x10FFFFC0,    50.0, 30
 AddSearchLight    = -0.53,  0.39,  -0.06,   0x50FFFFFF,   0x10FFFFC0,    50.0, 30.0,   0,  30
 
 
-AddPartThrottle =  0.244, 2.116, 1.006, 0, 0, 1, 310 
-AddPartThrottle =  -0.369, 2.116, 1.006, 0, 0, 1, 310 
+AddPartThrottle =  0.244, 2.116, 1.006, 0, 0, 1, 310
+AddPartThrottle =  -0.369, 2.116, 1.006, 0, 0, 1, 310
 
 
 AddPartCamera = 0.00, 0.88, 1.88, true, false

--- a/configreference/helicopters/bell206l.txt
+++ b/configreference/helicopters/bell206l.txt
@@ -6,11 +6,30 @@ MaxFuel         = 625
 FuelConsumption = 0.174
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.76
+MainRotorMaxThrust = 0.222
+RotorInertia = 0.86
+RotorSpoolUpRate = 0.028
+RotorSpoolDownRate = 0.036
+CollectiveResponse = 0.1
+CyclicAuthority = 0.84
+TailRotorAuthority = 1.01
+YawDamping = 0.19
+AngularInertia = 0.86
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.024
+ParasiteDrag = 0.026
+HorizontalRotorThrustScale = 0.84
+HoverAssistStrength = 0.22
+
+
 ; C = Civilian(民間機)
 ;multipurpose
 Category = MUUH
 
-Sound = littlebird 
+Sound = littlebird
 Soundvolume = 15
 
 HUD = civilian_aircraft, none, none, none, none, none

--- a/configreference/helicopters/bell47g.txt
+++ b/configreference/helicopters/bell47g.txt
@@ -8,6 +8,25 @@ MaxFuel         = 258
 FuelConsumption = 0.096
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.66
+MainRotorMaxThrust = 0.205
+RotorInertia = 0.76
+RotorSpoolUpRate = 0.03
+RotorSpoolDownRate = 0.038
+CollectiveResponse = 0.11
+CyclicAuthority = 0.82
+TailRotorAuthority = 0.99
+YawDamping = 0.2
+AngularInertia = 0.74
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.023
+ParasiteDrag = 0.024
+HorizontalRotorThrustScale = 0.82
+HoverAssistStrength = 0.24
+
+
 Sound = bellfourtyseven
 soundpitch = 1.3
 Soundvolume = 15

--- a/configreference/helicopters/bell47gf.txt
+++ b/configreference/helicopters/bell47gf.txt
@@ -10,6 +10,25 @@ MaxFuel         = 258
 FuelConsumption = 0.096
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.68
+MainRotorMaxThrust = 0.208
+RotorInertia = 0.78
+RotorSpoolUpRate = 0.03
+RotorSpoolDownRate = 0.038
+CollectiveResponse = 0.11
+CyclicAuthority = 0.82
+TailRotorAuthority = 1
+YawDamping = 0.2
+AngularInertia = 0.76
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.023
+ParasiteDrag = 0.024
+HorizontalRotorThrustScale = 0.82
+HoverAssistStrength = 0.24
+
+
 
 Sound = bellfourtyseven
 soundpitch = 1.3

--- a/configreference/helicopters/bk117.txt
+++ b/configreference/helicopters/bk117.txt
@@ -8,6 +8,25 @@ FuelConsumption = 0.317
 onGroundPitch = 2.09
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = eurocopter
 ;soundpitch = 1.3
 soundvolume = 15

--- a/configreference/helicopters/bk117p.txt
+++ b/configreference/helicopters/bk117p.txt
@@ -9,6 +9,25 @@ onGroundPitch = 2.09
 EnableGunnerMode = true
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = eurocopter
 ;soundpitch = 1.3
 soundvolume = 15

--- a/configreference/helicopters/ch-46.txt
+++ b/configreference/helicopters/ch-46.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = Boeing Vertol CH-46
+DisplayName = Boeing Vertol CH-46
 AddDisplayName = en_US, Boeing Vertol CH-46
 AddDisplayName = ja_JP, ボーイング・バートル CH-46
 ItemID = 28811
@@ -15,6 +15,25 @@ Float = true
 FloatOffset = -0.93
 EnableFoldBlade = true
 ThirdPersonDist = 20
+
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.58
+MainRotorMaxThrust = 0.22
+RotorInertia = 1.62
+RotorSpoolUpRate = 0.021
+RotorSpoolDownRate = 0.029
+CollectiveResponse = 0.075
+CyclicAuthority = 0.66
+TailRotorAuthority = 0.92
+YawDamping = 0.23
+AngularInertia = 1.62
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.03
+ParasiteDrag = 0.042
+HorizontalRotorThrustScale = 0.62
+HoverAssistStrength = 0.15
+
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)
 Category = TH
@@ -36,7 +55,7 @@ MobilityRoll = 0.7
 
 
 
-AddPartHatch = 0.00, 0.53, -5.79, -1.0, 0.0, 0.0, 50 
+AddPartHatch = 0.00, 0.53, -5.79, -1.0, 0.0, 0.0, 50
 AddPartHatch = 0.00, 2.84, -8.93, 1, 0,0, -10
 
 AddRotor = 3, 120, 0.0,  3.77, 4.38,  0.0, 1.0, 0.0, true

--- a/configreference/helicopters/ch-53e.txt
+++ b/configreference/helicopters/ch-53e.txt
@@ -17,6 +17,25 @@ FuelConsumption = 3.542
 CameraPosition = 1.52, 0.46, 1.55
 ThirdPersonDist = 20
 
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 2.2
+MainRotorMaxThrust = 0.262
+RotorInertia = 2.1
+RotorSpoolUpRate = 0.019
+RotorSpoolDownRate = 0.027
+CollectiveResponse = 0.07
+CyclicAuthority = 0.58
+TailRotorAuthority = 0.84
+YawDamping = 0.25
+AngularInertia = 2.2
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.034
+ParasiteDrag = 0.05
+HorizontalRotorThrustScale = 0.57
+HoverAssistStrength = 0.13
+
+
 sound = stallion
 soundvolume = 15
 

--- a/configreference/helicopters/ch47.txt
+++ b/configreference/helicopters/ch47.txt
@@ -14,6 +14,25 @@ Float = true
 FloatOffset = -0.9
 ThirdPersonDist = 20
 
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.9
+MainRotorMaxThrust = 0.235
+RotorInertia = 1.85
+RotorSpoolUpRate = 0.02
+RotorSpoolDownRate = 0.028
+CollectiveResponse = 0.075
+CyclicAuthority = 0.62
+TailRotorAuthority = 0.88
+YawDamping = 0.24
+AngularInertia = 1.9
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.032
+ParasiteDrag = 0.045
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.14
+
+
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)
 Category = TH
 

--- a/configreference/helicopters/ch47_radicon.txt
+++ b/configreference/helicopters/ch47_radicon.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = CH47 chnuke radicon
+DisplayName = CH47 chnuke radicon
 ;i might remove this...
 AddDisplayName = en_US, CH47 CHnuke RC
 AddDisplayName = ja_JP, CH-47 チヌーク ラジコンヘリ
@@ -15,6 +15,25 @@ MaxFuel         = 18
 FuelConsumption = 0.010
 
 ; C = Civilian(民間機)
+
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.9
+MainRotorMaxThrust = 0.235
+RotorInertia = 1.85
+RotorSpoolUpRate = 0.02
+RotorSpoolDownRate = 0.028
+CollectiveResponse = 0.075
+CyclicAuthority = 0.62
+TailRotorAuthority = 0.88
+YawDamping = 0.24
+AngularInertia = 1.9
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.032
+ParasiteDrag = 0.045
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.14
+
 Category = sUAS
 
 HUD = civilian_aircraft

--- a/configreference/helicopters/ec665.txt
+++ b/configreference/helicopters/ec665.txt
@@ -18,6 +18,25 @@ sound = eurocoptertiger
 soundvolume = 15
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.96
+MainRotorMaxThrust = 0.258
+RotorInertia = 1.04
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.82
+TailRotorAuthority = 1.01
+YawDamping = 0.18
+AngularInertia = 1.06
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.031
+HorizontalRotorThrustScale = 0.78
+HoverAssistStrength = 0.2
+
 Category = AH/ATH
 
 HUD = heli, heli_gnr

--- a/configreference/helicopters/ec665gp.txt
+++ b/configreference/helicopters/ec665gp.txt
@@ -18,6 +18,25 @@ sound = eurocoptertiger
 soundvolume = 15
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.98
+MainRotorMaxThrust = 0.262
+RotorInertia = 1.06
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.82
+TailRotorAuthority = 1.01
+YawDamping = 0.18
+AngularInertia = 1.08
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.031
+HorizontalRotorThrustScale = 0.78
+HoverAssistStrength = 0.2
+
 Category = AH/ATH
 
 HUD = heli, heli_gnr

--- a/configreference/helicopters/fl282.txt
+++ b/configreference/helicopters/fl282.txt
@@ -11,6 +11,25 @@ Speed = 0.2
 MaxFuel         = 95
 FuelConsumption = 0.088
 ThirdPersonDist = 12
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.62
+MainRotorMaxThrust = 0.198
+RotorInertia = 0.72
+RotorSpoolUpRate = 0.03
+RotorSpoolDownRate = 0.038
+CollectiveResponse = 0.11
+CyclicAuthority = 0.84
+TailRotorAuthority = 0.98
+YawDamping = 0.2
+AngularInertia = 0.7
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.023
+ParasiteDrag = 0.024
+HorizontalRotorThrustScale = 0.84
+HoverAssistStrength = 0.24
+
 unmountposition = 0.0,  1.45,  0.25
 ; W = WWII.  R = Reconnaissance(偵察機)
 Category = H

--- a/configreference/helicopters/fpvdrone.txt
+++ b/configreference/helicopters/fpvdrone.txt
@@ -19,6 +19,25 @@ HideEntity = true
 HUD = heli
 
 ; C = Civilian(–¯ŠÔ‹@)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.24
+MainRotorMaxThrust = 0.105
+RotorInertia = 0.34
+RotorSpoolUpRate = 0.045
+RotorSpoolDownRate = 0.055
+CollectiveResponse = 0.16
+CyclicAuthority = 0.96
+TailRotorAuthority = 1.15
+YawDamping = 0.24
+AngularInertia = 0.3
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.018
+ParasiteDrag = 0.018
+HorizontalRotorThrustScale = 0.92
+HoverAssistStrength = 0.28
+
 Category = sUAS
 
 MobilityYaw = 10.0

--- a/configreference/helicopters/ka-27.txt
+++ b/configreference/helicopters/ka-27.txt
@@ -14,6 +14,25 @@ MaxFuel         = 6500
 FuelConsumption = 1.505
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 
 sound = hind
 soundvolume = 15

--- a/configreference/helicopters/ka-29.txt
+++ b/configreference/helicopters/ka-29.txt
@@ -15,6 +15,25 @@ FuelConsumption = 1.505
 Sound = heli_k
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)
 Category = AH/TH
 

--- a/configreference/helicopters/ka50n.txt
+++ b/configreference/helicopters/ka50n.txt
@@ -6,6 +6,25 @@ Speed = 1.96
 soundpitch = 1.4
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1
+MainRotorMaxThrust = 0.27
+RotorInertia = 1.1
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.82
+TailRotorAuthority = 1.08
+YawDamping = 0.18
+AngularInertia = 1.12
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.032
+HorizontalRotorThrustScale = 0.78
+HoverAssistStrength = 0.2
+
+
 EnableEjectionSeat = true
 
 ThrottleUpDown = 1.0

--- a/configreference/helicopters/ka52.txt
+++ b/configreference/helicopters/ka52.txt
@@ -6,6 +6,25 @@ Speed = 1.86
 ThrottleUpDown = 0.7
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.04
+MainRotorMaxThrust = 0.276
+RotorInertia = 1.14
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.81
+TailRotorAuthority = 1.08
+YawDamping = 0.18
+AngularInertia = 1.16
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.033
+HorizontalRotorThrustScale = 0.76
+HoverAssistStrength = 0.2
+
+
 ; M = Military(軍用機).  A = Attacker(攻撃機)
 Category = AH/SH
 

--- a/configreference/helicopters/mavic3.txt
+++ b/configreference/helicopters/mavic3.txt
@@ -15,6 +15,25 @@ Stealth = 0.4
 HUD = heli
 
 ; C = Civilian(–¯ŠÔ‹@)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.3
+MainRotorMaxThrust = 0.12
+RotorInertia = 0.4
+RotorSpoolUpRate = 0.042
+RotorSpoolDownRate = 0.052
+CollectiveResponse = 0.15
+CyclicAuthority = 0.92
+TailRotorAuthority = 1.12
+YawDamping = 0.24
+AngularInertia = 0.36
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.019
+ParasiteDrag = 0.019
+HorizontalRotorThrustScale = 0.88
+HoverAssistStrength = 0.28
+
 Category = sUAS
 
 AddSeat =  0.0, 1.0, 0.0

--- a/configreference/helicopters/mavic3bomb.txt
+++ b/configreference/helicopters/mavic3bomb.txt
@@ -15,6 +15,25 @@ Stealth = 0.4
 HUD = heli
 
 ; C = Civilian(–¯ŠÔ‹@)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.34
+MainRotorMaxThrust = 0.13
+RotorInertia = 0.44
+RotorSpoolUpRate = 0.04
+RotorSpoolDownRate = 0.05
+CollectiveResponse = 0.14
+CyclicAuthority = 0.9
+TailRotorAuthority = 1.1
+YawDamping = 0.24
+AngularInertia = 0.4
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.019
+ParasiteDrag = 0.02
+HorizontalRotorThrustScale = 0.86
+HoverAssistStrength = 0.27
+
 Category = sUAS
 
 AddSeat =  0.0, 1.0, 0.0

--- a/configreference/helicopters/mc_drone_farmer.txt
+++ b/configreference/helicopters/mc_drone_farmer.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = DJI Phantom Farming UAV
+DisplayName = DJI Phantom Farming UAV
 AddDisplayName = en_US, DJI Phantom Farming UAV
 AddDisplayName = ja_JP, 農業用RCドローンUAV
 
@@ -24,6 +24,25 @@ MobilityRoll = 1.4
 HUD = heli
 
 ; C = Civilian(民間機)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.38
+MainRotorMaxThrust = 0.142
+RotorInertia = 0.48
+RotorSpoolUpRate = 0.038
+RotorSpoolDownRate = 0.048
+CollectiveResponse = 0.13
+CyclicAuthority = 0.88
+TailRotorAuthority = 1.08
+YawDamping = 0.23
+AngularInertia = 0.44
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.02
+ParasiteDrag = 0.021
+HorizontalRotorThrustScale = 0.84
+HoverAssistStrength = 0.26
+
 Category = UAS
 
 

--- a/configreference/helicopters/mc_drone_military.txt
+++ b/configreference/helicopters/mc_drone_military.txt
@@ -33,6 +33,25 @@ AddPartCamera =  -0.03, 0.015, 0.281, true, false
 
 
 ; M = Military(???).  M = Multi-Mission(????)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.44
+MainRotorMaxThrust = 0.158
+RotorInertia = 0.54
+RotorSpoolUpRate = 0.036
+RotorSpoolDownRate = 0.046
+CollectiveResponse = 0.12
+CyclicAuthority = 0.87
+TailRotorAuthority = 1.08
+YawDamping = 0.22
+AngularInertia = 0.5
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.021
+ParasiteDrag = 0.022
+HorizontalRotorThrustScale = 0.84
+HoverAssistStrength = 0.25
+
 Category = UAS
 
 

--- a/configreference/helicopters/mh-53e.txt
+++ b/configreference/helicopters/mh-53e.txt
@@ -15,6 +15,25 @@ MaxFuel         = 15300
 FuelConsumption = 3.542
 ThirdPersonDist = 20
 
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 2.18
+MainRotorMaxThrust = 0.26
+RotorInertia = 2.08
+RotorSpoolUpRate = 0.019
+RotorSpoolDownRate = 0.027
+CollectiveResponse = 0.07
+CyclicAuthority = 0.58
+TailRotorAuthority = 0.84
+YawDamping = 0.25
+AngularInertia = 2.18
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.034
+ParasiteDrag = 0.05
+HorizontalRotorThrustScale = 0.57
+HoverAssistStrength = 0.13
+
+
 sound = stallion
 soundvolume = 15
 

--- a/configreference/helicopters/mh-6.txt
+++ b/configreference/helicopters/mh-6.txt
@@ -11,6 +11,25 @@ MaxFuel         = 410
 FuelConsumption = 0.228
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.74
+MainRotorMaxThrust = 0.224
+RotorInertia = 0.84
+RotorSpoolUpRate = 0.028
+RotorSpoolDownRate = 0.035
+CollectiveResponse = 0.1
+CyclicAuthority = 0.88
+TailRotorAuthority = 1.04
+YawDamping = 0.18
+AngularInertia = 0.84
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.024
+ParasiteDrag = 0.025
+HorizontalRotorThrustScale = 0.9
+HoverAssistStrength = 0.22
+
+
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)
 Category = LA/MM/OH
 

--- a/configreference/helicopters/mh-60g.txt
+++ b/configreference/helicopters/mh-60g.txt
@@ -15,6 +15,25 @@ FuelConsumption = 0.681
 Stealth = 0.8
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 10

--- a/configreference/helicopters/mh-60l_dap.txt
+++ b/configreference/helicopters/mh-60l_dap.txt
@@ -15,6 +15,25 @@ MaxFuel         = 2450
 FuelConsumption = 0.681
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 10

--- a/configreference/helicopters/mi-24.txt
+++ b/configreference/helicopters/mi-24.txt
@@ -17,6 +17,25 @@ soundvolume = 15
 HUD = helinvg, heli_gnrnvg, none, none, none, none, none, none
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)
+
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.38
+MainRotorMaxThrust = 0.302
+RotorInertia = 1.42
+RotorSpoolUpRate = 0.023
+RotorSpoolDownRate = 0.031
+CollectiveResponse = 0.08
+CyclicAuthority = 0.74
+TailRotorAuthority = 0.98
+YawDamping = 0.21
+AngularInertia = 1.46
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.028
+ParasiteDrag = 0.039
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.17
+
 Category = AH/TH/HG
 
 AddTexture = mi-24_close

--- a/configreference/helicopters/mi-24_mk4.txt
+++ b/configreference/helicopters/mi-24_mk4.txt
@@ -12,6 +12,25 @@ FuelConsumption = 1.250
 onGroundPitch = 4.56
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.4
+MainRotorMaxThrust = 0.306
+RotorInertia = 1.44
+RotorSpoolUpRate = 0.023
+RotorSpoolDownRate = 0.031
+CollectiveResponse = 0.08
+CyclicAuthority = 0.74
+TailRotorAuthority = 0.98
+YawDamping = 0.21
+AngularInertia = 1.48
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.028
+ParasiteDrag = 0.039
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.17
+
+
 sound = hind
 soundvolume = 15
 

--- a/configreference/helicopters/mi-24ps.txt
+++ b/configreference/helicopters/mi-24ps.txt
@@ -11,6 +11,25 @@ FuelConsumption = 1.250
 onGroundPitch = 4.56
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.38
+MainRotorMaxThrust = 0.302
+RotorInertia = 1.42
+RotorSpoolUpRate = 0.023
+RotorSpoolDownRate = 0.031
+CollectiveResponse = 0.08
+CyclicAuthority = 0.74
+TailRotorAuthority = 0.98
+YawDamping = 0.21
+AngularInertia = 1.46
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.028
+ParasiteDrag = 0.039
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.17
+
+
 sound = hind
 soundvolume = 15
 

--- a/configreference/helicopters/mi-24pu1.txt
+++ b/configreference/helicopters/mi-24pu1.txt
@@ -13,6 +13,25 @@ FuelConsumption = 1.250
 onGroundPitch = 4.56
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.4
+MainRotorMaxThrust = 0.306
+RotorInertia = 1.44
+RotorSpoolUpRate = 0.023
+RotorSpoolDownRate = 0.031
+CollectiveResponse = 0.08
+CyclicAuthority = 0.74
+TailRotorAuthority = 0.98
+YawDamping = 0.21
+AngularInertia = 1.48
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.028
+ParasiteDrag = 0.039
+HorizontalRotorThrustScale = 0.6
+HoverAssistStrength = 0.17
+
+
 sound = hind
 soundvolume = 15
 

--- a/configreference/helicopters/mi28.txt
+++ b/configreference/helicopters/mi28.txt
@@ -13,6 +13,25 @@ MaxFuel         = 3800
 FuelConsumption = 1.056
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.3
+MainRotorMaxThrust = 0.292
+RotorInertia = 1.34
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.08
+CyclicAuthority = 0.76
+TailRotorAuthority = 1
+YawDamping = 0.2
+AngularInertia = 1.36
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.027
+ParasiteDrag = 0.037
+HorizontalRotorThrustScale = 0.62
+HoverAssistStrength = 0.18
+
+
 
 HUD = heli, heli_gnr
 

--- a/configreference/helicopters/mi8t.txt
+++ b/configreference/helicopters/mi8t.txt
@@ -1,6 +1,6 @@
-﻿DisplayName = Mil Mi-8 T Armed
+DisplayName = Mil Mi-8 T Armed
 AddDisplayName = ja_JP, Mil Mi-8 T Armed
-AddDisplayName = en_US, Mi-8 T 
+AddDisplayName = en_US, Mi-8 T
 ItemID = 28831
 MaxHp = 100
 Speed = 1.45
@@ -8,6 +8,25 @@ MaxFuel         = 4110
 FuelConsumption = 0.951
 onGroundPitch = 4.56
 ThirdPersonDist = 20
+
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.62
+MainRotorMaxThrust = 0.225
+RotorInertia = 1.64
+RotorSpoolUpRate = 0.021
+RotorSpoolDownRate = 0.029
+CollectiveResponse = 0.075
+CyclicAuthority = 0.65
+TailRotorAuthority = 0.92
+YawDamping = 0.23
+AngularInertia = 1.64
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.03
+ParasiteDrag = 0.042
+HorizontalRotorThrustScale = 0.62
+HoverAssistStrength = 0.15
+
 
 sound = hind
 soundvolume = 15

--- a/configreference/helicopters/mi8tu.txt
+++ b/configreference/helicopters/mi8tu.txt
@@ -1,5 +1,5 @@
-﻿DisplayName = Mil Mi-8 T 
-AddDisplayName = ja_JP, Mil Mi-8 T 
+DisplayName = Mil Mi-8 T
+AddDisplayName = ja_JP, Mil Mi-8 T
 AddDisplayName = en_US, Mi-8 T Unarmed
 ItemID = 28831
 MaxHp = 100
@@ -8,6 +8,25 @@ MaxFuel         = 4110
 FuelConsumption = 0.951
 onGroundPitch = 4.56
 ThirdPersonDist = 20
+
+; New helicopter flight model: heavy transport/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.66
+MainRotorMaxThrust = 0.23
+RotorInertia = 1.68
+RotorSpoolUpRate = 0.021
+RotorSpoolDownRate = 0.029
+CollectiveResponse = 0.075
+CyclicAuthority = 0.64
+TailRotorAuthority = 0.91
+YawDamping = 0.23
+AngularInertia = 1.68
+TranslationalLiftCoefficient = 0.003
+VerticalDrag = 0.03
+ParasiteDrag = 0.043
+HorizontalRotorThrustScale = 0.61
+HoverAssistStrength = 0.15
+
 
 sound = hind
 soundvolume = 15

--- a/configreference/helicopters/mq-8b.txt
+++ b/configreference/helicopters/mq-8b.txt
@@ -19,7 +19,26 @@ HideEntity = true
 
 ThirdPersonDist = 20
 
-Sound = littlebird 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.72
+MainRotorMaxThrust = 0.218
+RotorInertia = 0.82
+RotorSpoolUpRate = 0.029
+RotorSpoolDownRate = 0.036
+CollectiveResponse = 0.1
+CyclicAuthority = 0.85
+TailRotorAuthority = 1.02
+YawDamping = 0.19
+AngularInertia = 0.82
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.024
+ParasiteDrag = 0.025
+HorizontalRotorThrustScale = 0.86
+HoverAssistStrength = 0.23
+
+
+Sound = littlebird
 Soundvolume = 15
 
 ; M = Military(軍用機).  Q = Drone(無人航空機)

--- a/configreference/helicopters/nh90.txt
+++ b/configreference/helicopters/nh90.txt
@@ -15,6 +15,25 @@ ArmorDamageFactor = 1
 Category = TTH/MUMH
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = nhninety
 soundvolume = 15
 

--- a/configreference/helicopters/oh-1.txt
+++ b/configreference/helicopters/oh-1.txt
@@ -14,7 +14,26 @@ ThrottleUpDown = 1.4
 
 ThirdPersonDist = 20
 
-Sound = littlebird 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.82
+MainRotorMaxThrust = 0.236
+RotorInertia = 0.92
+RotorSpoolUpRate = 0.027
+RotorSpoolDownRate = 0.035
+CollectiveResponse = 0.1
+CyclicAuthority = 0.86
+TailRotorAuthority = 1.03
+YawDamping = 0.18
+AngularInertia = 0.94
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.025
+ParasiteDrag = 0.027
+HorizontalRotorThrustScale = 0.86
+HoverAssistStrength = 0.22
+
+
+Sound = littlebird
 Soundvolume = 15
 
 ; M = Military(軍用機).  R = Reconnaissance(偵察機)

--- a/configreference/helicopters/rc-goblin-bomb.txt
+++ b/configreference/helicopters/rc-goblin-bomb.txt
@@ -17,6 +17,25 @@ explosionSizeByCrash = 4
 HUD = heli
 
 ; C = Civilian(–¯ŠÔ‹@)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.46
+MainRotorMaxThrust = 0.165
+RotorInertia = 0.54
+RotorSpoolUpRate = 0.035
+RotorSpoolDownRate = 0.043
+CollectiveResponse = 0.12
+CyclicAuthority = 0.88
+TailRotorAuthority = 1.08
+YawDamping = 0.22
+AngularInertia = 0.5
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.021
+ParasiteDrag = 0.021
+HorizontalRotorThrustScale = 0.86
+HoverAssistStrength = 0.25
+
 Category = sUAS
 
 AddSeat =  0.0, 0.0, 0.0

--- a/configreference/helicopters/rc-goblin.txt
+++ b/configreference/helicopters/rc-goblin.txt
@@ -15,6 +15,25 @@ Stealth = 0.4
 HUD = heli
 
 ; C = Civilian(–¯ŠÔ‹@)
+
+; New helicopter flight model: special case / unusual rotorcraft baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.42
+MainRotorMaxThrust = 0.155
+RotorInertia = 0.5
+RotorSpoolUpRate = 0.036
+RotorSpoolDownRate = 0.044
+CollectiveResponse = 0.13
+CyclicAuthority = 0.9
+TailRotorAuthority = 1.1
+YawDamping = 0.22
+AngularInertia = 0.46
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.02
+ParasiteDrag = 0.02
+HorizontalRotorThrustScale = 0.88
+HoverAssistStrength = 0.26
+
 Category = sUAS
 
 AddSeat =  0.0, 0.0, 0.0

--- a/configreference/helicopters/robinson_r44f.txt
+++ b/configreference/helicopters/robinson_r44f.txt
@@ -9,6 +9,25 @@ MaxFuel         = 300
 FuelConsumption = 0.104
 ThirdPersonDist = 20
 
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.7
+MainRotorMaxThrust = 0.214
+RotorInertia = 0.8
+RotorSpoolUpRate = 0.029
+RotorSpoolDownRate = 0.037
+CollectiveResponse = 0.1
+CyclicAuthority = 0.84
+TailRotorAuthority = 1
+YawDamping = 0.19
+AngularInertia = 0.8
+TranslationalLiftCoefficient = 0.005
+VerticalDrag = 0.024
+ParasiteDrag = 0.024
+HorizontalRotorThrustScale = 0.84
+HoverAssistStrength = 0.23
+
+
 Soundpitch = 1.65
 SoundVolume = 15
 

--- a/configreference/helicopters/s76vip.txt
+++ b/configreference/helicopters/s76vip.txt
@@ -1,4 +1,4 @@
-﻿DisplayName = Sikorsky S-76 VIP
+DisplayName = Sikorsky S-76 VIP
 AddDisplayName = en_US, Sikorsky S-76 VIP
 AddDisplayName = ja_JP, シコルスキー S-76 V.I.P仕様
 ItemID = 30046
@@ -7,6 +7,25 @@ MaxFuel         = 1900
 FuelConsumption = 0.528
 Regeneration = false
 ThirdPersonDist = 20
+
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
 
 AddTexture = s76vip_white
 AddTexture = s76vip_green

--- a/configreference/helicopters/sh-3.txt
+++ b/configreference/helicopters/sh-3.txt
@@ -15,6 +15,25 @@ MaxFuel         = 4300
 FuelConsumption = 0.995
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.48
+MainRotorMaxThrust = 0.32
+RotorInertia = 1.52
+RotorSpoolUpRate = 0.022
+RotorSpoolDownRate = 0.03
+CollectiveResponse = 0.08
+CyclicAuthority = 0.72
+TailRotorAuthority = 0.96
+YawDamping = 0.22
+AngularInertia = 1.56
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.029
+ParasiteDrag = 0.041
+HorizontalRotorThrustScale = 0.58
+HoverAssistStrength = 0.16
+
+
 sound = apache
 soundpitch = 1.0
 soundvolume = 15
@@ -86,7 +105,7 @@ BoundingBox = 0.0, 3.5, -3.75, 2.0, 1.5
 BoundingBox = 0.0, 3.5, -2.75, 2.0, 1.5
 BoundingBox = 0.0, 3.5, -4.75, 2.0, 1.5
 
-;BoundingBox = 0.0, 
+;BoundingBox = 0.0,
 
 unmountposition = -0.5,   1.55,  0.00
 

--- a/configreference/helicopters/sh-60.txt
+++ b/configreference/helicopters/sh-60.txt
@@ -15,6 +15,25 @@ FuelConsumption = 0.681
 Stealth = 0.2
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 15

--- a/configreference/helicopters/uh-1c.txt
+++ b/configreference/helicopters/uh-1c.txt
@@ -6,6 +6,25 @@ EnableGunnerMode = true
 EnableNightVision = true
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.96
+MainRotorMaxThrust = 0.252
+RotorInertia = 1.02
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.8
+TailRotorAuthority = 1.01
+YawDamping = 0.2
+AngularInertia = 1.02
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.025
+ParasiteDrag = 0.031
+HorizontalRotorThrustScale = 0.7
+HoverAssistStrength = 0.2
+
+
 Speed = 1.35
 ThrottleUpDown = 0.8
 FlareType = 3

--- a/configreference/helicopters/uh-1d.txt
+++ b/configreference/helicopters/uh-1d.txt
@@ -6,6 +6,25 @@ EnableGunnerMode = false
 EnableNightVision = true
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.02
+MainRotorMaxThrust = 0.26
+RotorInertia = 1.08
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.79
+TailRotorAuthority = 1.01
+YawDamping = 0.2
+AngularInertia = 1.08
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.025
+ParasiteDrag = 0.032
+HorizontalRotorThrustScale = 0.69
+HoverAssistStrength = 0.2
+
+
 
 
 Speed = 1.35

--- a/configreference/helicopters/uh-1h.txt
+++ b/configreference/helicopters/uh-1h.txt
@@ -6,6 +6,25 @@ EnableGunnerMode = false
 EnableNightVision = true
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.02
+MainRotorMaxThrust = 0.26
+RotorInertia = 1.08
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.79
+TailRotorAuthority = 1.01
+YawDamping = 0.2
+AngularInertia = 1.08
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.025
+ParasiteDrag = 0.032
+HorizontalRotorThrustScale = 0.69
+HoverAssistStrength = 0.2
+
+
 
 
 Speed = 1.35

--- a/configreference/helicopters/uh-1y.txt
+++ b/configreference/helicopters/uh-1y.txt
@@ -15,6 +15,25 @@ MaxFuel         = 2150
 FuelConsumption = 0.597
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.12
+MainRotorMaxThrust = 0.272
+RotorInertia = 1.18
+RotorSpoolUpRate = 0.025
+RotorSpoolDownRate = 0.033
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.18
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.034
+HorizontalRotorThrustScale = 0.66
+HoverAssistStrength = 0.19
+
+
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)
 Category = UH
 

--- a/configreference/helicopters/uh-60j.txt
+++ b/configreference/helicopters/uh-60j.txt
@@ -16,6 +16,25 @@ FuelConsumption = 0.681
 ;Stealth = 0.2
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 15

--- a/configreference/helicopters/uh-60ja.txt
+++ b/configreference/helicopters/uh-60ja.txt
@@ -16,23 +16,25 @@ FuelConsumption = 0.681
 Stealth = 0.2
 ThirdPersonDist = 20
 
-; Initial new helicopter flight-model test opt-in; tune thrust-to-weight before control authority: medium utility helicopter.
+; New helicopter flight model: medium utility/attack baseline tuning.
 UseNewHelicopterFlightModel = true
-PhysicalMass = 1.20
-MainRotorMaxThrust = 0.280
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
 RotorInertia = 1.25
-RotorSpoolUpRate = 0.022
-RotorSpoolDownRate = 0.030
-CollectiveResponse = 0.082
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
 CyclicAuthority = 0.78
 TailRotorAuthority = 1.02
-YawDamping = 0.22
+YawDamping = 0.2
 AngularInertia = 1.25
-TranslationalLiftCoefficient = 0.0040
+TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.28
+HoverAssistStrength = 0.18
+
+
 
 sound = apache
 soundpitch = 1.3

--- a/configreference/helicopters/uh-60m.txt
+++ b/configreference/helicopters/uh-60m.txt
@@ -16,6 +16,25 @@ MaxFuel         = 2450
 FuelConsumption = 0.681
 ThirdPersonDist = 20
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 sound = apache
 soundpitch = 1.3
 soundvolume = 10

--- a/configreference/helicopters/w3.txt
+++ b/configreference/helicopters/w3.txt
@@ -9,6 +9,25 @@ FlareType = 3
 CameraPosition = 0.0, 1.1, 4.8
 ThirdPersonDist = 16
 
+; New helicopter flight model: medium utility/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 1.2
+MainRotorMaxThrust = 0.28
+RotorInertia = 1.25
+RotorSpoolUpRate = 0.024
+RotorSpoolDownRate = 0.032
+CollectiveResponse = 0.085
+CyclicAuthority = 0.78
+TailRotorAuthority = 1.02
+YawDamping = 0.2
+AngularInertia = 1.25
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.035
+HorizontalRotorThrustScale = 0.65
+HoverAssistStrength = 0.18
+
+
 
 sound = pzl
 soundvolume = 15

--- a/configreference/helicopters/wz10.txt
+++ b/configreference/helicopters/wz10.txt
@@ -1,6 +1,6 @@
-﻿DisplayName = Changhe Z-10
+DisplayName = Changhe Z-10
 AddDisplayName = en_US, Changhe Z-10
-AddDisplayName = ja_JP, WZ  10 
+AddDisplayName = ja_JP, WZ  10
 ItemID = 8994
 MaxHp = 100
 EnableGunnerMode = true
@@ -10,6 +10,25 @@ Speed = 1.86
 FlareType = 3
 
 ThirdPersonDist = 20
+
+; New helicopter flight model: light scout/attack baseline tuning.
+UseNewHelicopterFlightModel = true
+PhysicalMass = 0.98
+MainRotorMaxThrust = 0.262
+RotorInertia = 1.06
+RotorSpoolUpRate = 0.026
+RotorSpoolDownRate = 0.034
+CollectiveResponse = 0.09
+CyclicAuthority = 0.82
+TailRotorAuthority = 1.01
+YawDamping = 0.18
+AngularInertia = 1.08
+TranslationalLiftCoefficient = 0.004
+VerticalDrag = 0.026
+ParasiteDrag = 0.031
+HorizontalRotorThrustScale = 0.78
+HoverAssistStrength = 0.2
+
 
 
 sound = littlebird
@@ -68,7 +87,7 @@ AddPartWeaponMissile = ty90, false,  false,  false,    2.4589,  1.3057, -3.5398
 
 AddRotor= 1, 0,   0.00,  5.8782,  -1.4331,     0.0, 1.0, 0.0
 AddRotor= 1, 0,   0.00,  5.0426, -13.5825,     1.0, 0.0, 0.0
- 
+
 
 
 AddWeapon = targeting_pod1,  0.00, 0.38, 0.90,  0,-1, true,2, 0,-360,360, -25,80


### PR DESCRIPTION
### Motivation
- Enable the new helicopter flight model across the helicopter pack and provide per-asset tuning so the rewrite can be evaluated broadly. 
- Use three tested baselines (AH-6 light, UH-60JA medium, ACH-47A heavy) as role/size anchors so other helicopter configs inherit sensible behavior. 
- Reduce overly‑instant light-heli acceleration and give heavy transports a modest horizontal-speed boost while keeping vertical lift conservative. 
- Keep the change focused to content/config only with no Java physics changes or advanced rotor effects added. 

### Description
- Inserted `UseNewHelicopterFlightModel = true` and explicit tuning blocks into all 59 files under `configreference/helicopters/`, adding per-file comment headers that indicate the chosen category (`light scout/attack`, `medium utility/attack`, `heavy transport/attack`, or `special case / unusual rotorcraft`).
- Added and tuned the new-model keys per file: `PhysicalMass`, `MainRotorMaxThrust`, `RotorInertia`, `RotorSpoolUpRate`, `RotorSpoolDownRate`, `CollectiveResponse`, `CyclicAuthority`, `TailRotorAuthority`, `YawDamping`, `AngularInertia`, `TranslationalLiftCoefficient`, `VerticalDrag`, `ParasiteDrag`, `HorizontalRotorThrustScale`, and `HoverAssistStrength` using scaled values derived from the AH-6, UH-60JA, and ACH-47A baselines.
- Applied targeted refinements: light AH-6 family entries use slightly reduced instant-acceleration knobs (lower `CyclicAuthority` and `HorizontalRotorThrustScale` compared to the original AH-6 values), and heavy ACH-47A family entries use a slightly higher `HorizontalRotorThrustScale` to increase horizontal speed; values were scaled per role/size rather than copied identically.
- Preserved vertical conservatism (configs tuned to lift off after spool-up with light > medium > heavy climb capability), avoided touching Java code or adding autorotation/retreating-blade/overspeed effects, and added no new advanced physics keys beyond the conservative set above. 

### Testing
- Ran `git diff --check` to spot style/fixup issues and corrected trailing whitespace where present. 
- Executed a custom Python validation that confirmed all 59 helicopter configs include every new-flight key exactly once, have `UseNewHelicopterFlightModel = true`, and contain non-negative numeric tuning values, which printed a successful validation message. 
- Verified there are no newly generated `.class` files in the tree and did not perform any Java compilation. 
- Reviewed representative files (e.g. `configreference/helicopters/ah-6.txt`, `uh-60ja.txt`, `ach47a.txt`) to confirm the AH-6, UH-60JA, and ACH-47A baselines and the requested refinements were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a377854154883299874d295218f8a77)