### PR TITLE
Add compact COL/RPM/ENG helicopter HUD for new flight model

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -14,6 +14,7 @@ import mcheli.helicopter.MCH_HeliInfo;
 import mcheli.weapon.MCH_EntityTvMissile;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MathHelper;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
 
@@ -64,6 +65,10 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
                   }
                }
 
+               if(seatID == 0) {
+                  this.drawNewHeliControlHud(heli);
+               }
+
                this.drawKeyBind(heli, player, seatID);
             }
 
@@ -89,6 +94,26 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
          }
 
       }
+   }
+
+   private void drawNewHeliControlHud(MCH_EntityHeli heli) {
+      MCH_HeliInfo info = heli.getHeliInfo();
+      if(info == null || !heli.isNewHeliFlightModelEnabled() || !info.newHeliControlHudDisplay) {
+         return;
+      }
+
+      int collective = this.toPercent(heli.getCollectiveInput());
+      int rpm = this.toPercent(heli.getNormalizedRotorRPM());
+      int engine = this.toPercent(heli.getEnginePowerOutput());
+      String sas = heli.isHoverAssistActive()?" SAS":"";
+      int color = rpm < 85 && collective > 10?-65536:-1;
+      this.drawString(String.format("COL %3d%%  RPM %3d%%  ENG %3d%%%s",
+            new Object[]{Integer.valueOf(collective), Integer.valueOf(rpm), Integer.valueOf(engine), sas}),
+            super.centerX - 92, super.centerY + 42, color);
+   }
+
+   private int toPercent(float value) {
+      return Math.round(MathHelper.clamp_float(value, 0.0F, 1.0F) * 100.0F);
    }
 
    public void drawKeyBind(MCH_EntityHeli heli, EntityPlayer player, int seatID) {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -44,6 +44,8 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
    public float horizontalRotorThrustScale;
    /** Strength of future hover assistance; 0 disables assist, 1 is full configured assist. */
    public float hoverAssistStrength;
+   /** Show compact collective/RPM readouts to pilots using the new helicopter flight model. */
+   public boolean newHeliControlHudDisplay;
    public List rotorList;
 
 
@@ -67,6 +69,7 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       this.parasiteDrag = 0.01F;
       this.horizontalRotorThrustScale = 0.35F;
       this.hoverAssistStrength = 0.0F;
+      this.newHeliControlHudDisplay = true;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;
       super.maxRotationPitch = 20.0F;
@@ -135,6 +138,8 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
          this.horizontalRotorThrustScale = this.toFloat(data, 0.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("HoverAssistStrength")) {
          this.hoverAssistStrength = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("NewHeliControlHudDisplay") || item.equalsIgnoreCase("NewHelicopterControlHudDisplay")) {
+         this.newHeliControlHudDisplay = this.toBool(data);
       } else if(item.compareTo("addrotor") == 0 || item.compareTo("addrotorold") == 0) {
          String[] s = data.split("\\s*,\\s*");
          if(s.length == 8 || s.length == 9) {


### PR DESCRIPTION
### Motivation
- Make helicopter pilot controls readable for the new helicopter flight model by exposing collective, rotor RPM, engine output, and hover-assist state in a compact HUD element.
- Integrate with the existing HUD code-path so the indicator is pilot-scoped and respects existing HUD/third-person visibility rules.

### Description
- Added a compact HUD draw routine `drawNewHeliControlHud` in `MCH_GuiHeli` that renders `COL`, `RPM`, `ENG`, and an active `SAS` label using `collectiveInput`, `normalizedRotorRPM`, `enginePowerOutput`, and `hoverAssistActive` respectively, with percentages rounded via a new `toPercent` helper (uses `MathHelper.clamp_float`).
- The readout is shown only to the pilot (`seatID == 0`) and is gated by `heli.isNewHeliFlightModelEnabled()` and a new per-helicopter toggle `info.newHeliControlHudDisplay`, and it respects existing `DisplayHUDThirdPerson` visibility behavior.
- Added a new boolean `newHeliControlHudDisplay` to `MCH_HeliInfo`, defaulting to enabled, and added content keys `NewHeliControlHudDisplay` / `NewHelicopterControlHudDisplay` to allow disabling per helicopter.
- Kept the change scoped to helicopter HUD code and used existing HUD rendering helpers and label conventions to avoid creating new GUI frameworks.

### Testing
- Ran a code consistency check with `git diff --check`, which reported no whitespace errors.
- Searched and inspected relevant telemetry fields (`collectiveInput`, `normalizedRotorRPM`, `enginePowerOutput`, `hoverAssistActive`) and HUD hooks to ensure correct integration.
- Did not run `./gradlew compileJava` or any Java compilation because the work directive forbids compiling or producing `.class` files and the user explicitly requested not to compile them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3779d36c848329af71f5e21a379210)