### PR TITLE
New helicopter: stop W/S backward thrust, fix gunner-mode acceleration, strengthen hover assist, and integrate HUD

### DIFF
--- a/configreference/helicopters/ach47a.txt
+++ b/configreference/helicopters/ach47a.txt
@@ -36,7 +36,7 @@ TranslationalLiftCoefficient = 0.0034
 VerticalDrag = 0.032
 ParasiteDrag = 0.045
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.32
+HoverAssistStrength = 0.75
 
 Category = TH/GH
 

--- a/configreference/helicopters/ah-1.txt
+++ b/configreference/helicopters/ah-1.txt
@@ -31,7 +31,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.03
 HorizontalRotorThrustScale = 0.78
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 AddTexture = AH-1_1

--- a/configreference/helicopters/ah-1w.txt
+++ b/configreference/helicopters/ah-1w.txt
@@ -31,7 +31,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.031
 HorizontalRotorThrustScale = 0.76
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/ah-1z.txt
+++ b/configreference/helicopters/ah-1z.txt
@@ -30,7 +30,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.032
 HorizontalRotorThrustScale = 0.75
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 Sound = r44_heli

--- a/configreference/helicopters/ah-6.txt
+++ b/configreference/helicopters/ah-6.txt
@@ -27,7 +27,7 @@ TranslationalLiftCoefficient = 0.0045
 VerticalDrag = 0.024
 ParasiteDrag = 0.025
 HorizontalRotorThrustScale = 0.90
-HoverAssistStrength = 0.22
+HoverAssistStrength = 0.75
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)
 Category = LA/MM

--- a/configreference/helicopters/ah-60.txt
+++ b/configreference/helicopters/ah-60.txt
@@ -35,7 +35,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/ah-64.txt
+++ b/configreference/helicopters/ah-64.txt
@@ -36,7 +36,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.027
 ParasiteDrag = 0.036
 HorizontalRotorThrustScale = 0.64
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)

--- a/configreference/helicopters/ah-6x.txt
+++ b/configreference/helicopters/ah-6x.txt
@@ -27,7 +27,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.025
 ParasiteDrag = 0.026
 HorizontalRotorThrustScale = 0.88
-HoverAssistStrength = 0.22
+HoverAssistStrength = 0.75
 
 
 Sound = littlebird

--- a/configreference/helicopters/as365n3_dauphin.txt
+++ b/configreference/helicopters/as365n3_dauphin.txt
@@ -35,7 +35,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = chinesedauphin

--- a/configreference/helicopters/bell206l.txt
+++ b/configreference/helicopters/bell206l.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.024
 ParasiteDrag = 0.026
 HorizontalRotorThrustScale = 0.84
-HoverAssistStrength = 0.22
+HoverAssistStrength = 0.75
 
 
 ; C = Civilian(民間機)

--- a/configreference/helicopters/bell47g.txt
+++ b/configreference/helicopters/bell47g.txt
@@ -24,7 +24,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.023
 ParasiteDrag = 0.024
 HorizontalRotorThrustScale = 0.82
-HoverAssistStrength = 0.24
+HoverAssistStrength = 0.75
 
 
 Sound = bellfourtyseven

--- a/configreference/helicopters/bell47gf.txt
+++ b/configreference/helicopters/bell47gf.txt
@@ -26,7 +26,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.023
 ParasiteDrag = 0.024
 HorizontalRotorThrustScale = 0.82
-HoverAssistStrength = 0.24
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/bk117.txt
+++ b/configreference/helicopters/bk117.txt
@@ -24,7 +24,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = eurocopter

--- a/configreference/helicopters/bk117p.txt
+++ b/configreference/helicopters/bk117p.txt
@@ -25,7 +25,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = eurocopter

--- a/configreference/helicopters/ch-46.txt
+++ b/configreference/helicopters/ch-46.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.03
 ParasiteDrag = 0.042
 HorizontalRotorThrustScale = 0.62
-HoverAssistStrength = 0.15
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)

--- a/configreference/helicopters/ch-53e.txt
+++ b/configreference/helicopters/ch-53e.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.034
 ParasiteDrag = 0.05
 HorizontalRotorThrustScale = 0.57
-HoverAssistStrength = 0.13
+HoverAssistStrength = 0.75
 
 
 sound = stallion

--- a/configreference/helicopters/ch47.txt
+++ b/configreference/helicopters/ch47.txt
@@ -30,7 +30,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.032
 ParasiteDrag = 0.045
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.14
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)

--- a/configreference/helicopters/ch47_radicon.txt
+++ b/configreference/helicopters/ch47_radicon.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.032
 ParasiteDrag = 0.045
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.14
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/ec665.txt
+++ b/configreference/helicopters/ec665.txt
@@ -37,7 +37,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.031
 HorizontalRotorThrustScale = 0.78
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 Category = AH/ATH
 

--- a/configreference/helicopters/ec665gp.txt
+++ b/configreference/helicopters/ec665gp.txt
@@ -37,7 +37,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.031
 HorizontalRotorThrustScale = 0.78
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 Category = AH/ATH
 

--- a/configreference/helicopters/fl282.txt
+++ b/configreference/helicopters/fl282.txt
@@ -28,7 +28,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.023
 ParasiteDrag = 0.024
 HorizontalRotorThrustScale = 0.84
-HoverAssistStrength = 0.24
+HoverAssistStrength = 0.75
 
 unmountposition = 0.0,  1.45,  0.25
 ; W = WWII.  R = Reconnaissance(偵察機)

--- a/configreference/helicopters/fpvdrone.txt
+++ b/configreference/helicopters/fpvdrone.txt
@@ -36,7 +36,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.018
 ParasiteDrag = 0.018
 HorizontalRotorThrustScale = 0.92
-HoverAssistStrength = 0.28
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/ka-27.txt
+++ b/configreference/helicopters/ka-27.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/ka-29.txt
+++ b/configreference/helicopters/ka-29.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)

--- a/configreference/helicopters/ka50n.txt
+++ b/configreference/helicopters/ka50n.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.032
 HorizontalRotorThrustScale = 0.78
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 EnableEjectionSeat = true

--- a/configreference/helicopters/ka52.txt
+++ b/configreference/helicopters/ka52.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.033
 HorizontalRotorThrustScale = 0.76
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  A = Attacker(攻撃機)

--- a/configreference/helicopters/mavic3.txt
+++ b/configreference/helicopters/mavic3.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.019
 ParasiteDrag = 0.019
 HorizontalRotorThrustScale = 0.88
-HoverAssistStrength = 0.28
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/mavic3bomb.txt
+++ b/configreference/helicopters/mavic3bomb.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.019
 ParasiteDrag = 0.02
 HorizontalRotorThrustScale = 0.86
-HoverAssistStrength = 0.27
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/mc_drone_farmer.txt
+++ b/configreference/helicopters/mc_drone_farmer.txt
@@ -41,7 +41,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.02
 ParasiteDrag = 0.021
 HorizontalRotorThrustScale = 0.84
-HoverAssistStrength = 0.26
+HoverAssistStrength = 0.75
 
 Category = UAS
 

--- a/configreference/helicopters/mc_drone_military.txt
+++ b/configreference/helicopters/mc_drone_military.txt
@@ -50,7 +50,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.021
 ParasiteDrag = 0.022
 HorizontalRotorThrustScale = 0.84
-HoverAssistStrength = 0.25
+HoverAssistStrength = 0.75
 
 Category = UAS
 

--- a/configreference/helicopters/mh-53e.txt
+++ b/configreference/helicopters/mh-53e.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.034
 ParasiteDrag = 0.05
 HorizontalRotorThrustScale = 0.57
-HoverAssistStrength = 0.13
+HoverAssistStrength = 0.75
 
 
 sound = stallion

--- a/configreference/helicopters/mh-6.txt
+++ b/configreference/helicopters/mh-6.txt
@@ -27,7 +27,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.024
 ParasiteDrag = 0.025
 HorizontalRotorThrustScale = 0.9
-HoverAssistStrength = 0.22
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)

--- a/configreference/helicopters/mh-60g.txt
+++ b/configreference/helicopters/mh-60g.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/mh-60l_dap.txt
+++ b/configreference/helicopters/mh-60l_dap.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/mi-24.txt
+++ b/configreference/helicopters/mi-24.txt
@@ -34,7 +34,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.028
 ParasiteDrag = 0.039
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.17
+HoverAssistStrength = 0.75
 
 Category = AH/TH/HG
 

--- a/configreference/helicopters/mi-24_mk4.txt
+++ b/configreference/helicopters/mi-24_mk4.txt
@@ -28,7 +28,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.028
 ParasiteDrag = 0.039
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.17
+HoverAssistStrength = 0.75
 
 
 sound = hind

--- a/configreference/helicopters/mi-24ps.txt
+++ b/configreference/helicopters/mi-24ps.txt
@@ -27,7 +27,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.028
 ParasiteDrag = 0.039
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.17
+HoverAssistStrength = 0.75
 
 
 sound = hind

--- a/configreference/helicopters/mi-24pu1.txt
+++ b/configreference/helicopters/mi-24pu1.txt
@@ -29,7 +29,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.028
 ParasiteDrag = 0.039
 HorizontalRotorThrustScale = 0.6
-HoverAssistStrength = 0.17
+HoverAssistStrength = 0.75
 
 
 sound = hind

--- a/configreference/helicopters/mi28.txt
+++ b/configreference/helicopters/mi28.txt
@@ -31,7 +31,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.027
 ParasiteDrag = 0.037
 HorizontalRotorThrustScale = 0.62
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/mi8t.txt
+++ b/configreference/helicopters/mi8t.txt
@@ -25,7 +25,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.03
 ParasiteDrag = 0.042
 HorizontalRotorThrustScale = 0.62
-HoverAssistStrength = 0.15
+HoverAssistStrength = 0.75
 
 
 sound = hind

--- a/configreference/helicopters/mi8tu.txt
+++ b/configreference/helicopters/mi8tu.txt
@@ -25,7 +25,7 @@ TranslationalLiftCoefficient = 0.003
 VerticalDrag = 0.03
 ParasiteDrag = 0.043
 HorizontalRotorThrustScale = 0.61
-HoverAssistStrength = 0.15
+HoverAssistStrength = 0.75
 
 
 sound = hind

--- a/configreference/helicopters/mq-8b.txt
+++ b/configreference/helicopters/mq-8b.txt
@@ -36,7 +36,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.024
 ParasiteDrag = 0.025
 HorizontalRotorThrustScale = 0.86
-HoverAssistStrength = 0.23
+HoverAssistStrength = 0.75
 
 
 Sound = littlebird

--- a/configreference/helicopters/nh90.txt
+++ b/configreference/helicopters/nh90.txt
@@ -31,7 +31,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = nhninety

--- a/configreference/helicopters/oh-1.txt
+++ b/configreference/helicopters/oh-1.txt
@@ -30,7 +30,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.025
 ParasiteDrag = 0.027
 HorizontalRotorThrustScale = 0.86
-HoverAssistStrength = 0.22
+HoverAssistStrength = 0.75
 
 
 Sound = littlebird

--- a/configreference/helicopters/rc-goblin-bomb.txt
+++ b/configreference/helicopters/rc-goblin-bomb.txt
@@ -34,7 +34,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.021
 ParasiteDrag = 0.021
 HorizontalRotorThrustScale = 0.86
-HoverAssistStrength = 0.25
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/rc-goblin.txt
+++ b/configreference/helicopters/rc-goblin.txt
@@ -32,7 +32,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.02
 ParasiteDrag = 0.02
 HorizontalRotorThrustScale = 0.88
-HoverAssistStrength = 0.26
+HoverAssistStrength = 0.75
 
 Category = sUAS
 

--- a/configreference/helicopters/robinson_r44f.txt
+++ b/configreference/helicopters/robinson_r44f.txt
@@ -25,7 +25,7 @@ TranslationalLiftCoefficient = 0.005
 VerticalDrag = 0.024
 ParasiteDrag = 0.024
 HorizontalRotorThrustScale = 0.84
-HoverAssistStrength = 0.23
+HoverAssistStrength = 0.75
 
 
 Soundpitch = 1.65

--- a/configreference/helicopters/s76vip.txt
+++ b/configreference/helicopters/s76vip.txt
@@ -24,7 +24,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 AddTexture = s76vip_white

--- a/configreference/helicopters/sh-3.txt
+++ b/configreference/helicopters/sh-3.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.029
 ParasiteDrag = 0.041
 HorizontalRotorThrustScale = 0.58
-HoverAssistStrength = 0.16
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/sh-60.txt
+++ b/configreference/helicopters/sh-60.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/uh-1c.txt
+++ b/configreference/helicopters/uh-1c.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.025
 ParasiteDrag = 0.031
 HorizontalRotorThrustScale = 0.7
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 Speed = 1.35

--- a/configreference/helicopters/uh-1d.txt
+++ b/configreference/helicopters/uh-1d.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.025
 ParasiteDrag = 0.032
 HorizontalRotorThrustScale = 0.69
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/uh-1h.txt
+++ b/configreference/helicopters/uh-1h.txt
@@ -22,7 +22,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.025
 ParasiteDrag = 0.032
 HorizontalRotorThrustScale = 0.69
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/uh-1y.txt
+++ b/configreference/helicopters/uh-1y.txt
@@ -33,7 +33,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.034
 HorizontalRotorThrustScale = 0.66
-HoverAssistStrength = 0.19
+HoverAssistStrength = 0.75
 
 
 ; M = Military(軍用機).  M = Multi-Mission(多目的機)

--- a/configreference/helicopters/uh-60j.txt
+++ b/configreference/helicopters/uh-60j.txt
@@ -34,7 +34,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/uh-60ja.txt
+++ b/configreference/helicopters/uh-60ja.txt
@@ -34,7 +34,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/uh-60m.txt
+++ b/configreference/helicopters/uh-60m.txt
@@ -34,7 +34,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 sound = apache

--- a/configreference/helicopters/w3.txt
+++ b/configreference/helicopters/w3.txt
@@ -27,7 +27,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.65
-HoverAssistStrength = 0.18
+HoverAssistStrength = 0.75
 
 
 

--- a/configreference/helicopters/wz10.txt
+++ b/configreference/helicopters/wz10.txt
@@ -29,7 +29,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.031
 HorizontalRotorThrustScale = 0.78
-HoverAssistStrength = 0.2
+HoverAssistStrength = 0.75
 
 
 

--- a/docs/vehicle-config/helicopters.md
+++ b/docs/vehicle-config/helicopters.md
@@ -24,7 +24,7 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 | `VerticalDrag` | float >= 0 | 0.02 | Future vertical climb/descent damping coefficient. |
 | `ParasiteDrag` | float >= 0 | 0.01 | Future horizontal air-drag coefficient. Increase this to damp horizontal speed and make larger helicopters feel heavier. |
 | `HorizontalRotorThrustScale` / `HelicopterHorizontalThrustScale` | float >= 0 | 0.35 | New-model-only Minecraft-scale multiplier for converting cyclic rotor thrust into horizontal acceleration. This is the primary Minecraft-scale horizontal acceleration knob; lower values preserve hover/climb tuning while reducing map-scale horizontal acceleration. |
-| `HoverAssistStrength` | 0.0-1.0 | 0.0 | Future hover assistance strength. `0.0` keeps assist disabled by default. |
+| `HoverAssistStrength` | 0.0-1.0 | 0.75 | New-model hover assistance strength. `0.0` disables assist; the default now provides strong altitude and horizontal-drift stabilization when hover mode is active and the pilot is not commanding collective/cyclic input. |
 
 ## Helicopter defaults that differ from base
 
@@ -46,7 +46,7 @@ Early in-game tuning should check the effective thrust-to-weight relationship be
 
 ### Rotor RPM foundation
 
-When `UseNewHelicopterFlightModel = true`, helicopters now maintain a normalized runtime rotor state for future lift and yaw work. `targetRotorRPM` is derived from current throttle only while the engine can run, fuel is available, the canopy is closed, and blades are usable/unfolded. `normalizedRotorRPM` then moves toward that target using `RotorSpoolUpRate` while increasing, `RotorSpoolDownRate` while decreasing, and `RotorInertia` as resistance. This rotor state drives visual rotor rotation for opted-in helicopters only; legacy helicopters keep the original throttle-driven animation and lift behavior. Opted-in vertical lift now uses mass, rotor thrust, configured gravity, ceiling/vortex efficiency, and `VerticalDrag`; cyclic, hover mode, yaw, and horizontal motion still use the legacy systems in this phase.
+When `UseNewHelicopterFlightModel = true`, helicopters now maintain a normalized runtime rotor state for future lift and yaw work. `targetRotorRPM` is derived from current throttle only while the engine can run, fuel is available, the canopy is closed, and blades are usable/unfolded. `normalizedRotorRPM` then moves toward that target using `RotorSpoolUpRate` while increasing, `RotorSpoolDownRate` while decreasing, and `RotorInertia` as resistance. This rotor state drives visual rotor rotation for opted-in helicopters only; legacy helicopters keep the original throttle-driven animation and lift behavior. Opted-in vertical lift now uses mass, rotor thrust, configured gravity, ceiling/vortex efficiency, and `VerticalDrag`. W/S are treated as collective-only controls in the new helicopter model; they do not directly request forward/backward horizontal thrust. New-model hover assist uses `HoverAssistStrength` to add bounded collective and cyclic corrections that resist altitude changes and drift without overriding active pilot input.
 
 ## Rotorcraft lift formulas
 
@@ -106,7 +106,7 @@ TranslationalLiftCoefficient = 0.004
 VerticalDrag = 0.026
 ParasiteDrag = 0.035
 HorizontalRotorThrustScale = 0.35
-HoverAssistStrength = 0.25
+HoverAssistStrength = 0.75
 ```
 
 ## Legacy compatibility

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -1242,12 +1242,11 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private void updateNewHelicopterCyclicInput() {
       float pitchInput = 0.0F;
       float rollInput = 0.0F;
-      if(super.throttleUp && !super.throttleDown) {
-         pitchInput = 1.0F;
-      } else if(super.throttleDown && !super.throttleUp) {
-         pitchInput = -1.0F;
-      }
 
+      // In the new helicopter model W/S are collective controls only.
+      // Do not feed them into cyclic pitch, otherwise S creates raw
+      // backward acceleration and gunner/hover paths can manufacture
+      // forward speed from view/control-mode changes.
       if(super.moveRight && !super.moveLeft) {
          rollInput = 1.0F;
       } else if(super.moveLeft && !super.moveRight) {
@@ -1284,7 +1283,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.localDriftRight = 0.0F;
       this.hoverAssistActive = false;
 
-      if(!this.newHeliFlightModelEnabled || !this.isHovering() || this.heliInfo == null) {
+      if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
          return;
       }
 
@@ -1305,7 +1304,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
       this.targetVerticalSpeed = 0.0F;
       this.targetHorizontalSpeed = 0.0F;
-      this.hoverCollectiveCorrection = MathHelper.clamp_float((this.targetVerticalSpeed - (float)super.motionY) * 0.35F, -0.18F, 0.18F) * assistBlend;
+      this.hoverCollectiveCorrection = MathHelper.clamp_float((this.targetVerticalSpeed - (float)super.motionY) * 0.75F, -0.32F, 0.32F) * assistBlend;
 
       float yawRadians = this.getRotYaw() / 180.0F * 3.1415927F;
       float forwardX = -MathHelper.sin(yawRadians);
@@ -1314,8 +1313,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       float rightZ = -MathHelper.sin(yawRadians);
       this.localDriftForward = (float)(super.motionX * (double)forwardX + super.motionZ * (double)forwardZ);
       this.localDriftRight = (float)(super.motionX * (double)rightX + super.motionZ * (double)rightZ);
-      this.hoverCyclicPitchCorrection = MathHelper.clamp_float(-this.localDriftForward * 1.8F, -0.35F, 0.35F) * assistBlend;
-      this.hoverCyclicRollCorrection = MathHelper.clamp_float(-this.localDriftRight * 1.8F, -0.35F, 0.35F) * assistBlend;
+      this.hoverCyclicPitchCorrection = MathHelper.clamp_float(-this.localDriftForward * 3.0F, -0.60F, 0.60F) * assistBlend;
+      this.hoverCyclicRollCorrection = MathHelper.clamp_float(-this.localDriftRight * 3.0F, -0.60F, 0.60F) * assistBlend;
    }
 
    private void applyNewHelicopterCyclicThrust(float tickDelta) {
@@ -1454,7 +1453,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       double motion;
       float speedLimit;
       float pitch;
-      if(!this.isHovering()) {
+      boolean applyNewHeliFreeFlight = this.newHeliFlightModelEnabled && super.isGunnerMode && !this.isHoveringMode();
+      if(!this.isHovering() || applyNewHeliFreeFlight) {
          motion = 0.0D;
          if(this.canFloatWater()) {
             motion = this.getWaterDepth();

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -105,11 +105,15 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       int collective = this.toPercent(heli.getCollectiveInput());
       int rpm = this.toPercent(heli.getNormalizedRotorRPM());
       int engine = this.toPercent(heli.getEnginePowerOutput());
-      String sas = heli.isHoverAssistActive()?" SAS":"";
-      int color = rpm < 85 && collective > 10?-65536:-1;
-      this.drawString(String.format("COL %3d%%  RPM %3d%%  ENG %3d%%%s",
-            new Object[]{Integer.valueOf(collective), Integer.valueOf(rpm), Integer.valueOf(engine), sas}),
-            super.centerX - 92, super.centerY + 42, color);
+      int color = -16711936;
+      int x = super.centerX - 145;
+      int y = super.centerY + 30;
+      this.drawString(String.format("COL: %3d%%", new Object[]{Integer.valueOf(collective)}), x, y, color);
+      this.drawString(String.format("RPM: %3d%%", new Object[]{Integer.valueOf(rpm)}), x, y + 10, color);
+      this.drawString(String.format("ENG: %3d%%", new Object[]{Integer.valueOf(engine)}), x, y + 20, color);
+      if(heli.isHoverAssistActive()) {
+         this.drawString("SAS: ON", x, y + 30, color);
+      }
    }
 
    private int toPercent(float value) {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -42,7 +42,7 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
    public float parasiteDrag;
    /** Minecraft-scale multiplier for cyclic rotor thrust converted into horizontal acceleration. */
    public float horizontalRotorThrustScale;
-   /** Strength of future hover assistance; 0 disables assist, 1 is full configured assist. */
+   /** Strength of new-model hover assistance; 0 disables assist, 1 is full configured assist. */
    public float hoverAssistStrength;
    /** Show compact collective/RPM readouts to pilots using the new helicopter flight model. */
    public boolean newHeliControlHudDisplay;
@@ -68,7 +68,7 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       this.verticalDrag = 0.02F;
       this.parasiteDrag = 0.01F;
       this.horizontalRotorThrustScale = 0.35F;
-      this.hoverAssistStrength = 0.0F;
+      this.hoverAssistStrength = 0.75F;
       this.newHeliControlHudDisplay = true;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;


### PR DESCRIPTION
### Motivation
- Prevent W/S from producing direct forward/backward horizontal acceleration in the new helicopter flight model and keep them as collective/throttle inputs only. 
- Ensure entering Gunner Mode does not inject a free forward thrust or bypass normal inertia/drag behavior. 
- Make hover mode meaningfully stabilize altitude and drift while preserving pilot override. 
- Move the new-model collective/RPM/engine/SAS readouts into the existing helicopter HUD so the UI remains consistent and non-duplicated.

### Description
- Treat W/S as collective-only in `updateNewHelicopterCyclicInput` so `throttleUp`/`throttleDown` no longer feed cyclic pitch and therefore no longer create raw forward/back thrust (changes in `src/main/java/mcheli/helicopter/MCH_EntityHeli.java`).
- Keep new-model Gunner Mode on the free-flight physics path by avoiding hover assist routing when switching to gunner mode (added a gated `applyNewHeliFreeFlight` check in `onUpdate_Server` in `MCH_EntityHeli`).
- Strengthened hover assist by increasing the default `HoverAssistStrength` to `0.75` in `MCH_HeliInfo`, and increased the assist gains and bounds for collective and cyclic corrections (`hoverCollectiveCorrection` and `hoverCyclic*` gains and clamps) to make hover mode more assertive while preserving manual override when collective/cyclic input is active (changes in `MCH_EntityHeli` and `MCH_HeliInfo`).
- Restrict hover-assist activation to the explicit hover mode path (`isHoveringMode()`), leaving legacy helicopter behavior untouched unless `UseNewHelicopterFlightModel = true`.
- Integrate the new helicopter HUD readouts into the existing helicopter common HUD by rendering a green vertically-aligned list with `COL`, `RPM`, `ENG`, and `SAS` indicators in `drawNewHeliControlHud` (changes in `src/main/java/mcheli/helicopter/MCH_GuiHeli.java`).
- Updated documentation and reference configs to reflect the new default `HoverAssistStrength` and note that W/S are collective-only for new-model helicopters, and normalized many `configreference/helicopters/*.txt` entries to the new default.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and found no problems. (passed)
- No full project build or runtime gameplay verification was performed in this PR per instructions; compilation was intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38481558f48329b7f536f0936d35a6)