### PR TITLE
Add simple top-left HUD for new-flight planes

### DIFF
--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -172,6 +172,9 @@ public class MCH_Config {
    public static MCH_ConfigPrm PlaneMouseAimMaxScreenRadius;
    public static MCH_ConfigPrm PlaneMouseAimYawVisualRange;
    public static MCH_ConfigPrm PlaneMouseAimReticleDebug;
+   public static MCH_ConfigPrm EnableNewPlaneSimpleHud;
+   public static MCH_ConfigPrm NewPlaneSimpleHudX;
+   public static MCH_ConfigPrm NewPlaneSimpleHudY;
    public static MCH_ConfigPrm SwitchWeaponWithMouseWheel;
    public static MCH_ConfigPrm AllPlaneSpeed;
    public static MCH_ConfigPrm NewFlightGravity;
@@ -484,6 +487,12 @@ public class MCH_Config {
       PlaneMouseAimMaxScreenRadius = new MCH_ConfigPrm("PlaneMouseAimMaxScreenRadius", 0.42D);
       PlaneMouseAimYawVisualRange = new MCH_ConfigPrm("PlaneMouseAimYawVisualRange", 45.0D);
       PlaneMouseAimReticleDebug = new MCH_ConfigPrm("PlaneMouseAimReticleDebug", false);
+      EnableNewPlaneSimpleHud = new MCH_ConfigPrm("EnableNewPlaneSimpleHud", true);
+      EnableNewPlaneSimpleHud.desc = ";Render the compact top-left HUD for new-flight-model planes only.";
+      NewPlaneSimpleHudX = new MCH_ConfigPrm("NewPlaneSimpleHudX", 12);
+      NewPlaneSimpleHudX.desc = ";Top-left new-plane simple HUD X offset in scaled GUI pixels.";
+      NewPlaneSimpleHudY = new MCH_ConfigPrm("NewPlaneSimpleHudY", 12);
+      NewPlaneSimpleHudY.desc = ";Top-left new-plane simple HUD Y offset in scaled GUI pixels.";
       SwitchWeaponWithMouseWheel = new MCH_ConfigPrm("SwitchWeaponWithMouseWheel", true);
       AllHeliSpeed = new MCH_ConfigPrm("AllHeliSpeed", 1.5D);
       AllPlaneSpeed = new MCH_ConfigPrm("AllPlaneSpeed", 1000.00D);
@@ -720,6 +729,9 @@ public class MCH_Config {
               PlaneMouseAimMaxScreenRadius,
               PlaneMouseAimYawVisualRange,
               PlaneMouseAimReticleDebug,
+              EnableNewPlaneSimpleHud,
+              NewPlaneSimpleHudX,
+              NewPlaneSimpleHudY,
               AutoThrottleDownHeli,
               AutoThrottleDownPlane,
               AutoThrottleDownShip,

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -50,10 +50,12 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                }
             }
 
-            if(seatID == 0 && plane.getIsGunnerMode(player)) {
-               this.drawHud(ac, player, 1);
-            } else {
-               this.drawHud(ac, player, seatID);
+            if(!this.shouldDrawNewPlaneSimpleHud(plane, seatID)) {
+               if(seatID == 0 && plane.getIsGunnerMode(player)) {
+                  this.drawHud(ac, player, 1);
+               } else {
+                  this.drawHud(ac, player, seatID);
+               }
             }
          }
 
@@ -67,7 +69,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             }
 
             if(seatID == 0) {
-               this.drawNewFlightThrottleHud(plane);
+               if(this.shouldDrawNewPlaneSimpleHud(plane, seatID)) {
+                  this.drawNewPlaneSimpleHud(plane);
+               } else {
+                  this.drawNewFlightThrottleHud(plane);
+               }
             }
 
             if(plane.getTVMissile() != null && (plane.getIsGunnerMode(player) || plane.isUAV())) {
@@ -80,6 +86,56 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
          this.drawHitBullet(plane, -14101432, seatID);
       }
+   }
+
+   private boolean shouldDrawNewPlaneSimpleHud(MCP_EntityPlane plane, int seatID) {
+      return seatID == 0 && MCH_Config.EnableNewPlaneSimpleHud.prmBool && plane != null && !plane.isDestroyed()
+            && plane.isNewFlightModelEnabled();
+   }
+
+   private void drawNewPlaneSimpleHud(MCP_EntityPlane plane) {
+      int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - 80));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - 36));
+      int color = 0xFFE8E8E8;
+      this.drawString(this.formatSimpleHudThrottle(plane), x, y, color);
+      this.drawString(this.formatSimpleHudFuel(plane), x, y + 10, color);
+      this.drawString(this.formatSimpleHudAltitude(plane), x, y + 20, color);
+   }
+
+   private String formatSimpleHudThrottle(MCP_EntityPlane plane) {
+      int throttle = MathHelper.clamp_int(plane.getThrottlePercent(), 0, 100);
+      return String.format("THR %d%%", new Object[]{Integer.valueOf(throttle)});
+   }
+
+   private String formatSimpleHudFuel(MCP_EntityPlane plane) {
+      int minutes = this.getEstimatedFuelMinutes(plane);
+      return minutes < 0 ? "FUEL -- min" : String.format("FUEL %d min", new Object[]{Integer.valueOf(minutes)});
+   }
+
+   private int getEstimatedFuelMinutes(MCP_EntityPlane plane) {
+      if(plane.getMaxFuel() <= 0 || plane.getFuel() <= 0 || plane.isInfinityFuel(plane.getRiddenByEntity(), true)) {
+         return -1;
+      }
+
+      if(plane.getAcInfo() == null || plane.getAcInfo().fuelConsumption <= 0.0F) {
+         return -1;
+      }
+
+      double burnPerSecond = Math.min(plane.getNormalizedThrottle() * 1.4D, 1.0D)
+            * (double)plane.getAcInfo().fuelConsumption * (double)plane.getFuelConsumptionFactor();
+      if(burnPerSecond <= 0.01D) {
+         return -1;
+      }
+
+      return Math.max(0, (int)Math.round((double)plane.getFuel() / burnPerSecond / 60.0D));
+   }
+
+   private String formatSimpleHudAltitude(MCP_EntityPlane plane) {
+      return String.format("ALT %d m", new Object[]{Integer.valueOf(this.getSimpleHudAltitudeMeters(plane))});
+   }
+
+   private int getSimpleHudAltitudeMeters(MCP_EntityPlane plane) {
+      return Math.max(0, (int)Math.round(plane.posY));
    }
 
    private void drawNewFlightThrottleHud(MCP_EntityPlane plane) {


### PR DESCRIPTION
### Motivation
- Provide a clean, War Thunder–style compact HUD for planes using the new flight/mobility model to improve readability for new-flight aircraft pilots. 
- Ensure the new HUD does not affect legacy MCHeli HUDs and avoids duplicate throttle/fuel/altitude readouts when active. 
- Keep the implementation lightweight, frame-safe, and configurable so it can be iterated on later.

### Description
- Add config toggles `EnableNewPlaneSimpleHud` (default `true`) and scaled offset parameters `NewPlaneSimpleHudX` / `NewPlaneSimpleHudY` in `MCH_Config.java` to enable/position the HUD.  
- Gate the simple HUD to pilot seat new-flight planes via `shouldDrawNewPlaneSimpleHud(...)` and suppress the legacy `drawHud(...)` path when the simple HUD is active in `MCP_GuiPlane.java`.  
- Render a compact top-left vertical list of readouts (`THR`, `FUEL`, `ALT`) using existing font/draw methods and scaled-safe clamped offsets to avoid clipping across GUI scales.  
- Factor calculations into helper methods: `formatSimpleHudThrottle(...)`, `formatSimpleHudFuel(...)` (with safe `FUEL -- min` fallback), `getEstimatedFuelMinutes(...)`, `formatSimpleHudAltitude(...)`, and `getSimpleHudAltitudeMeters(...)` so runtime formatting logic remains isolated and lightweight.

### Testing
- Ran `git diff --check` to verify no whitespace/merge errors and it returned clean (no failures).  
- Searched the codebase with `rg -n` for `EnableNewPlaneSimpleHud`, `NewPlaneSimpleHud`, and the new helper names to verify the symbols are present and referenced as expected and the legacy HUD path is gated; the searches returned the modified files.  
- Verified code-level behavior by inspecting the updated `MCP_GuiPlane.java` and `MCH_Config.java` diffs to confirm the new HUD is only drawn for `plane.isNewFlightModelEnabled()` and that fuel/time formatting falls back to `FUEL -- min` when consumption is unavailable.  

No `.class` files were compiled or added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388d008c708329bbbe6049548b4f29)