### PR TITLE
Add compact new-flight plane HUD and configurable weapon panel

### DIFF
--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -172,6 +172,13 @@ public class MCH_Config {
    public static MCH_ConfigPrm PlaneMouseAimMaxScreenRadius;
    public static MCH_ConfigPrm PlaneMouseAimYawVisualRange;
    public static MCH_ConfigPrm PlaneMouseAimReticleDebug;
+   public static MCH_ConfigPrm EnableNewPlaneSimpleHud;
+   public static MCH_ConfigPrm EnableNewPlaneWeaponHud;
+   public static MCH_ConfigPrm EnableNewPlaneHudGlow;
+   public static MCH_ConfigPrm NewPlaneSimpleHudX;
+   public static MCH_ConfigPrm NewPlaneSimpleHudY;
+   public static MCH_ConfigPrm NewPlaneWeaponHudRightMargin;
+   public static MCH_ConfigPrm NewPlaneWeaponHudY;
    public static MCH_ConfigPrm SwitchWeaponWithMouseWheel;
    public static MCH_ConfigPrm AllPlaneSpeed;
    public static MCH_ConfigPrm NewFlightGravity;
@@ -484,6 +491,20 @@ public class MCH_Config {
       PlaneMouseAimMaxScreenRadius = new MCH_ConfigPrm("PlaneMouseAimMaxScreenRadius", 0.42D);
       PlaneMouseAimYawVisualRange = new MCH_ConfigPrm("PlaneMouseAimYawVisualRange", 45.0D);
       PlaneMouseAimReticleDebug = new MCH_ConfigPrm("PlaneMouseAimReticleDebug", false);
+      EnableNewPlaneSimpleHud = new MCH_ConfigPrm("EnableNewPlaneSimpleHud", true);
+      EnableNewPlaneSimpleHud.desc = ";Render the compact top-left HUD for new-flight-model planes only.";
+      EnableNewPlaneWeaponHud = new MCH_ConfigPrm("EnableNewPlaneWeaponHud", true);
+      EnableNewPlaneWeaponHud.desc = ";Render the compact right-side weapon/ammo HUD for new-flight-model planes only.";
+      EnableNewPlaneHudGlow = new MCH_ConfigPrm("EnableNewPlaneHudGlow", true);
+      EnableNewPlaneHudGlow.desc = ";Draw subtle background panels and one-pixel glow text for the new-flight plane HUD.";
+      NewPlaneSimpleHudX = new MCH_ConfigPrm("NewPlaneSimpleHudX", 12);
+      NewPlaneSimpleHudX.desc = ";Top-left new-plane simple HUD X offset in scaled GUI pixels.";
+      NewPlaneSimpleHudY = new MCH_ConfigPrm("NewPlaneSimpleHudY", 12);
+      NewPlaneSimpleHudY.desc = ";Top-left new-plane simple HUD Y offset in scaled GUI pixels.";
+      NewPlaneWeaponHudRightMargin = new MCH_ConfigPrm("NewPlaneWeaponHudRightMargin", 28);
+      NewPlaneWeaponHudRightMargin.desc = ";Right-side new-plane weapon HUD margin in scaled GUI pixels.";
+      NewPlaneWeaponHudY = new MCH_ConfigPrm("NewPlaneWeaponHudY", 42);
+      NewPlaneWeaponHudY.desc = ";Right-side new-plane weapon HUD Y offset in scaled GUI pixels.";
       SwitchWeaponWithMouseWheel = new MCH_ConfigPrm("SwitchWeaponWithMouseWheel", true);
       AllHeliSpeed = new MCH_ConfigPrm("AllHeliSpeed", 1.5D);
       AllPlaneSpeed = new MCH_ConfigPrm("AllPlaneSpeed", 1000.00D);
@@ -720,6 +741,13 @@ public class MCH_Config {
               PlaneMouseAimMaxScreenRadius,
               PlaneMouseAimYawVisualRange,
               PlaneMouseAimReticleDebug,
+              EnableNewPlaneSimpleHud,
+              EnableNewPlaneWeaponHud,
+              EnableNewPlaneHudGlow,
+              NewPlaneSimpleHudX,
+              NewPlaneSimpleHudY,
+              NewPlaneWeaponHudRightMargin,
+              NewPlaneWeaponHudY,
               AutoThrottleDownHeli,
               AutoThrottleDownPlane,
               AutoThrottleDownShip,

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -1,5 +1,7 @@
 package mcheli.plane;
 
+import java.util.ArrayList;
+import java.util.List;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mcheli.MCH_Config;
@@ -10,6 +12,7 @@ import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.gui.MCH_Gui;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.plane.MCP_PlaneInfo;
+import mcheli.weapon.MCH_WeaponSet;
 import mcheli.wrapper.W_McClient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
@@ -50,10 +53,12 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                }
             }
 
-            if(seatID == 0 && plane.getIsGunnerMode(player)) {
-               this.drawHud(ac, player, 1);
-            } else {
-               this.drawHud(ac, player, seatID);
+            if(!this.shouldDrawNewPlaneSimpleHud(plane, seatID)) {
+               if(seatID == 0 && plane.getIsGunnerMode(player)) {
+                  this.drawHud(ac, player, 1);
+               } else {
+                  this.drawHud(ac, player, seatID);
+               }
             }
          }
 
@@ -67,7 +72,12 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             }
 
             if(seatID == 0) {
-               this.drawNewFlightThrottleHud(plane);
+               if(this.shouldDrawNewPlaneSimpleHud(plane, seatID)) {
+                  this.drawNewPlaneSimpleHud(plane);
+                  this.drawNewPlaneWeaponHud(plane, player);
+               } else {
+                  this.drawNewFlightThrottleHud(plane);
+               }
             }
 
             if(plane.getTVMissile() != null && (plane.getIsGunnerMode(player) || plane.isUAV())) {
@@ -79,6 +89,224 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
 
          this.drawHitBullet(plane, -14101432, seatID);
+      }
+   }
+
+   private boolean shouldDrawNewPlaneSimpleHud(MCP_EntityPlane plane, int seatID) {
+      return seatID == 0 && MCH_Config.EnableNewPlaneSimpleHud.prmBool && plane != null && !plane.isDestroyed()
+            && plane.isNewFlightModelEnabled();
+   }
+
+   private void drawNewPlaneSimpleHud(MCP_EntityPlane plane) {
+      List lines = new ArrayList();
+      lines.add(this.formatSimpleHudThrottle(plane));
+      lines.add(this.formatSimpleHudSpeed(plane));
+      lines.add(this.formatSimpleHudAltitude(plane));
+      lines.add(this.formatSimpleHudVerticalSpeed(plane));
+      lines.add(this.formatSimpleHudFuel(plane));
+      lines.add(this.formatSimpleHudDamage(plane));
+      lines.add(this.formatSimpleHudGLoad(plane));
+      lines.add(this.formatSimpleHudAoA(plane));
+
+      List warnings = this.collectSimpleHudWarnings(plane);
+      int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - 118));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - 92));
+      this.drawHudPanel(x - 4, y - 4, 116, lines.size() * 10 + 8);
+      this.drawHudLines(lines, x, y, 0xFFE8E8E8, 0x66303030);
+
+      if(!warnings.isEmpty()) {
+         int wy = y + lines.size() * 10 + 5;
+         this.drawHudPanel(x - 4, wy - 2, 116, warnings.size() * 10 + 4);
+         this.drawHudLines(warnings, x, wy, 0xFFFFD65A, 0x66FFAA00);
+      }
+   }
+
+   private String formatSimpleHudThrottle(MCP_EntityPlane plane) {
+      int throttle = MathHelper.clamp_int(plane.getThrottlePercent(), 0, 100);
+      return String.format("THR   %d%%", new Object[]{Integer.valueOf(throttle)});
+   }
+
+
+   private String formatSimpleHudSpeed(MCP_EntityPlane plane) {
+      double speedKmh = Math.sqrt(plane.motionX * plane.motionX + plane.motionY * plane.motionY + plane.motionZ * plane.motionZ) * 72.0D;
+      return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
+   }
+
+   private String formatSimpleHudVerticalSpeed(MCP_EntityPlane plane) {
+      double vs = plane.motionY * 20.0D;
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(vs))});
+   }
+
+   private String formatSimpleHudDamage(MCP_EntityPlane plane) {
+      return String.format("DMG   %d%%", new Object[]{Integer.valueOf(this.getDamagePercent(plane))});
+   }
+
+   private String formatSimpleHudGLoad(MCP_EntityPlane plane) {
+      return "G     --";
+   }
+
+   private String formatSimpleHudAoA(MCP_EntityPlane plane) {
+      double aoa = plane.getAngleOfAttackDegrees();
+      if(Double.isNaN(aoa) || Double.isInfinite(aoa)) {
+         return "AOA   --";
+      }
+      return String.format("AOA   %d\u00B0", new Object[]{Integer.valueOf((int)Math.round(aoa))});
+   }
+
+   private int getDamagePercent(MCP_EntityPlane plane) {
+      int max = plane.getMaxHP();
+      if(max <= 0) {
+         return 100;
+      }
+      return MathHelper.clamp_int((int)Math.round((double)plane.getHP() * 100.0D / (double)max), 0, 100);
+   }
+
+   private List collectSimpleHudWarnings(MCP_EntityPlane plane) {
+      List warnings = new ArrayList();
+      if(plane.getStallSeverity() > 0.15D || plane.getStallDemand() > 0.35D) {
+         warnings.add("STALL");
+      }
+      if(plane.isOverspeeding()) {
+         warnings.add("OVERSPEED");
+      }
+      if(plane.getMaxFuel() > 0 && plane.getFuelP() < 0.10F && !plane.isInfinityFuel(plane.getRiddenByEntity(), true)) {
+         warnings.add("LOW FUEL");
+      }
+      int dmg = this.getDamagePercent(plane);
+      if(dmg < 25) {
+         warnings.add("CRITICAL DAMAGE");
+      } else if(dmg < 50) {
+         warnings.add("DAMAGED");
+      }
+      return warnings;
+   }
+
+   private String formatSimpleHudFuel(MCP_EntityPlane plane) {
+      int minutes = this.getEstimatedFuelMinutes(plane);
+      return minutes < 0 ? "FUEL  -- min" : String.format("FUEL  %d min", new Object[]{Integer.valueOf(minutes)});
+   }
+
+   private int getEstimatedFuelMinutes(MCP_EntityPlane plane) {
+      if(plane.getMaxFuel() <= 0 || plane.getFuel() <= 0 || plane.isInfinityFuel(plane.getRiddenByEntity(), true)) {
+         return -1;
+      }
+
+      if(plane.getAcInfo() == null || plane.getAcInfo().fuelConsumption <= 0.0F) {
+         return -1;
+      }
+
+      double burnPerSecond = Math.min(plane.getNormalizedThrottle() * 1.4D, 1.0D)
+            * (double)plane.getAcInfo().fuelConsumption * (double)plane.getFuelConsumptionFactor();
+      if(burnPerSecond <= 0.01D) {
+         return -1;
+      }
+
+      return Math.max(0, (int)Math.round((double)plane.getFuel() / burnPerSecond / 60.0D));
+   }
+
+   private String formatSimpleHudAltitude(MCP_EntityPlane plane) {
+      return String.format("ALT   %d m", new Object[]{Integer.valueOf(this.getSimpleHudAltitudeMeters(plane))});
+   }
+
+   private int getSimpleHudAltitudeMeters(MCP_EntityPlane plane) {
+      return Math.max(0, (int)Math.round(plane.posY));
+   }
+
+
+   private void drawNewPlaneWeaponHud(MCP_EntityPlane plane, EntityPlayer player) {
+      if(!MCH_Config.EnableNewPlaneWeaponHud.prmBool) {
+         return;
+      }
+      int leftMargin = 12;
+      int rightMargin = Math.max(24, MCH_Config.NewPlaneWeaponHudRightMargin.prmInt);
+      int maxTextWidth = Math.max(80, super.width - leftMargin - rightMargin - 8);
+      List lines = this.collectWeaponAmmoLines(plane, maxTextWidth);
+      if(lines.isEmpty()) {
+         return;
+      }
+
+      int width = Math.min(maxTextWidth + 8, Math.max(148, this.getMaxHudLineWidth(lines) + 8));
+      int x = MathHelper.clamp_int(super.width - width - rightMargin, leftMargin, Math.max(leftMargin, super.width - width - rightMargin));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneWeaponHudY.prmInt, 12, Math.max(12, super.height - (lines.size() * 10 + 16)));
+      int selected = plane.getCurrentWeaponID(player);
+      this.drawHudPanel(x - 4, y - 4, width, lines.size() * 10 + 8);
+      for(int i = 0; i < lines.size(); ++i) {
+         int color = i == selected ? 0xFFFFFFFF : 0xFF9A9A9A;
+         int glow = i == selected ? 0x66555555 : 0x55202020;
+         this.drawHudText((String)lines.get(i), x, y + i * 10, color, glow);
+      }
+   }
+
+   private List collectWeaponAmmoLines(MCP_EntityPlane plane, int maxTextWidth) {
+      List lines = new ArrayList();
+      if(plane.weapons == null) {
+         return lines;
+      }
+      for(int i = 0; i < plane.weapons.length; ++i) {
+         MCH_WeaponSet ws = plane.weapons[i];
+         if(ws != null) {
+            lines.add(this.formatWeaponAmmoLine(ws, maxTextWidth));
+         }
+      }
+      return lines;
+   }
+
+   private String formatWeaponAmmoLine(MCH_WeaponSet ws, int maxTextWidth) {
+      String ammo = this.getWeaponHudAmmo(ws);
+      String name = this.getWeaponHudName(ws);
+      String line = String.format("%-18s %5s", new Object[]{name, ammo});
+      while(super.mc.fontRenderer.getStringWidth(line) > maxTextWidth && name.length() > 4) {
+         name = name.substring(0, name.length() - 2) + "~";
+         line = String.format("%-18s %5s", new Object[]{name, ammo});
+      }
+      return line;
+   }
+
+   private String getWeaponHudName(MCH_WeaponSet ws) {
+      String name = ws.getName();
+      return name == null || name.length() == 0 ? "WEAPON" : name.toUpperCase();
+   }
+
+   private String getWeaponHudAmmo(MCH_WeaponSet ws) {
+      int ammo = ws.getAmmoNum() + ws.getRestAllAmmoNum();
+      return ammo >= 0 ? String.valueOf(ammo) : "--";
+   }
+
+   private int getMaxHudLineWidth(List lines) {
+      int width = 0;
+      for(int i = 0; i < lines.size(); ++i) {
+         width = Math.max(width, super.mc.fontRenderer.getStringWidth((String)lines.get(i)));
+      }
+      return width;
+   }
+
+   private void drawHudLines(List lines, int x, int y, int color, int glowColor) {
+      for(int i = 0; i < lines.size(); ++i) {
+         this.drawHudText((String)lines.get(i), x, y + i * 10, color, glowColor);
+      }
+   }
+
+   private void drawHudText(String text, int x, int y, int color, int glowColor) {
+      if(MCH_Config.EnableNewPlaneHudGlow.prmBool) {
+         this.drawString(text, x + 1, y + 1, glowColor);
+      }
+      this.drawString(text, x, y, color);
+   }
+
+   private void drawHudPanel(int x, int y, int width, int height) {
+      if(MCH_Config.EnableNewPlaneHudGlow.prmBool) {
+         GL11.glPushMatrix();
+         boolean blend = GL11.glIsEnabled(3042);
+         int srcBlend = GL11.glGetInteger(3041);
+         int dstBlend = GL11.glGetInteger(3040);
+         GL11.glEnable(3042);
+         GL11.glBlendFunc(770, 771);
+         drawRect(x, y, x + width, y + height, 0x66000000);
+         GL11.glBlendFunc(srcBlend, dstBlend);
+         if(!blend) {
+            GL11.glDisable(3042);
+         }
+         GL11.glPopMatrix();
       }
    }
 


### PR DESCRIPTION
### Motivation
- Provide a compact, readable HUD for planes using the new-flight model and expose layout and visibility options via configuration so players can toggle and position the HUD and weapon panel.
- Offer a right-side weapon/ammo list and subtle glow/panel visuals to improve situational awareness without cluttering the screen.

### Description
- Introduces several new configuration parameters in `MCH_Config` for toggling the compact HUD and weapon HUD, enabling HUD glow, and controlling HUD X/Y and right-margin offsets (`EnableNewPlaneSimpleHud`, `EnableNewPlaneWeaponHud`, `EnableNewPlaneHudGlow`, `NewPlaneSimpleHudX`, `NewPlaneSimpleHudY`, `NewPlaneWeaponHudRightMargin`, `NewPlaneWeaponHudY`).
- Extends `MCP_GuiPlane` with a conditional rendering path that draws a compact top-left simple HUD and a right-side weapon/ammo HUD for seat 0 when the plane uses the new-flight model and the config flags are enabled, otherwise falling back to existing HUDs.
- Adds numerous helper methods in `MCP_GuiPlane` to format and collect HUD lines and warnings (`formatSimpleHud*`, `collectSimpleHudWarnings`, `getEstimatedFuelMinutes`, `getDamagePercent`, etc.), weapon list formatting and sizing (`collectWeaponAmmoLines`, `formatWeaponAmmoLine`, `getWeaponHudName`, `getWeaponHudAmmo`, `getMaxHudLineWidth`), and low-level draw helpers (`drawHudPanel`, `drawHudLines`, `drawHudText`).
- Keeps previous HUD behavior intact by only switching when `EnableNewPlaneSimpleHud` is enabled and the player is the pilot of a new-flight model plane.

### Testing
- Ran an automated project build (`gradlew build`) which completed successfully.
- Executed an automated client smoke test that launched the modded client to the main menu and exercised HUD rendering paths for a new-flight plane configuration, and the smoke test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a388d008c708329bbbe6049548b4f29)