### PR TITLE
Introduce shared HUD utilities, add heli HUD components, and new vehicle HUD glow/configs

### DIFF
--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -175,6 +175,9 @@ public class MCH_Config {
    public static MCH_ConfigPrm EnableNewPlaneSimpleHud;
    public static MCH_ConfigPrm EnableNewPlaneWeaponHud;
    public static MCH_ConfigPrm EnableNewPlaneHudGlow;
+   public static MCH_ConfigPrm EnableNewHeliHudSharedReadouts;
+   public static MCH_ConfigPrm EnableNewHeliWeaponHud;
+   public static MCH_ConfigPrm EnableNewVehicleHudGlow;
    public static MCH_ConfigPrm NewPlaneSimpleHudX;
    public static MCH_ConfigPrm NewPlaneSimpleHudY;
    public static MCH_ConfigPrm NewPlaneWeaponHudRightMargin;
@@ -496,7 +499,13 @@ public class MCH_Config {
       EnableNewPlaneWeaponHud = new MCH_ConfigPrm("EnableNewPlaneWeaponHud", true);
       EnableNewPlaneWeaponHud.desc = ";Render the compact right-side weapon/ammo HUD for new-flight-model planes only.";
       EnableNewPlaneHudGlow = new MCH_ConfigPrm("EnableNewPlaneHudGlow", true);
-      EnableNewPlaneHudGlow.desc = ";Draw subtle background panels and one-pixel glow text for the new-flight plane HUD.";
+      EnableNewPlaneHudGlow.desc = ";Deprecated plane-specific glow toggle; EnableNewVehicleHudGlow controls shared new vehicle HUD glow.";
+      EnableNewHeliHudSharedReadouts = new MCH_ConfigPrm("EnableNewHeliHudSharedReadouts", true);
+      EnableNewHeliHudSharedReadouts.desc = ";Render ALT/VS/FUEL readouts inside the existing helicopter HUD for new-flight helicopters only.";
+      EnableNewHeliWeaponHud = new MCH_ConfigPrm("EnableNewHeliWeaponHud", true);
+      EnableNewHeliWeaponHud.desc = ";Render the existing-style helicopter weapon/ammo list for new-flight helicopters only.";
+      EnableNewVehicleHudGlow = new MCH_ConfigPrm("EnableNewVehicleHudGlow", true);
+      EnableNewVehicleHudGlow.desc = ";Draw subtle background panels and one-pixel glow text for shared new vehicle HUD additions.";
       NewPlaneSimpleHudX = new MCH_ConfigPrm("NewPlaneSimpleHudX", 12);
       NewPlaneSimpleHudX.desc = ";Top-left new-plane simple HUD X offset in scaled GUI pixels.";
       NewPlaneSimpleHudY = new MCH_ConfigPrm("NewPlaneSimpleHudY", 12);
@@ -744,6 +753,9 @@ public class MCH_Config {
               EnableNewPlaneSimpleHud,
               EnableNewPlaneWeaponHud,
               EnableNewPlaneHudGlow,
+              EnableNewHeliHudSharedReadouts,
+              EnableNewHeliWeaponHud,
+              EnableNewVehicleHudGlow,
               NewPlaneSimpleHudX,
               NewPlaneSimpleHudY,
               NewPlaneWeaponHudRightMargin,

--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -1,0 +1,102 @@
+package mcheli.aircraft;
+
+import java.util.ArrayList;
+import java.util.List;
+import mcheli.weapon.MCH_WeaponSet;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.MathHelper;
+
+public final class MCH_HudShared {
+
+   private MCH_HudShared() {
+   }
+
+   public static String formatThrottleOrCollective(String label, MCH_EntityBaseVehicle ac) {
+      return String.format("%s %3d%%", new Object[]{label, Integer.valueOf(MathHelper.clamp_int((int)Math.round(ac.getNormalizedThrottle() * 100.0D), 0, 100))});
+   }
+
+   public static String formatSpeedKmh(MCH_EntityBaseVehicle ac) {
+      double speedKmh = Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D;
+      return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
+   }
+
+   public static String formatAltitude(MCH_EntityBaseVehicle ac) {
+      return String.format("ALT   %d m", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(ac.posY)))});
+   }
+
+   public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(ac.motionY * 20.0D))});
+   }
+
+   public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {
+      int minutes = estimateFuelMinutes(ac);
+      return minutes < 0 ? "FUEL  -- min" : String.format("FUEL  %d min", new Object[]{Integer.valueOf(minutes)});
+   }
+
+   public static String formatDamagePercent(MCH_EntityBaseVehicle ac) {
+      return String.format("DMG   %d%%", new Object[]{Integer.valueOf(getDamagePercent(ac))});
+   }
+
+   public static int getDamagePercent(MCH_EntityBaseVehicle ac) {
+      int max = ac.getMaxHP();
+      if(max <= 0) {
+         return 100;
+      }
+      return MathHelper.clamp_int((int)Math.round((double)ac.getHP() * 100.0D / (double)max), 0, 100);
+   }
+
+   public static int estimateFuelMinutes(MCH_EntityBaseVehicle ac) {
+      if(ac.getMaxFuel() <= 0 || ac.getFuel() <= 0 || ac.isInfinityFuel(ac.getRiddenByEntity(), true)) {
+         return -1;
+      }
+      if(ac.getAcInfo() == null || ac.getAcInfo().fuelConsumption <= 0.0F) {
+         return -1;
+      }
+      double throttle = MathHelper.clamp_double(ac.getNormalizedThrottle(), 0.0D, 1.0D);
+      double burnPerSecond = Math.min(throttle * 1.4D, 1.0D) * (double)ac.getAcInfo().fuelConsumption * (double)ac.getFuelConsumptionFactor();
+      if(burnPerSecond <= 0.01D) {
+         return -1;
+      }
+      return Math.max(0, (int)Math.round((double)ac.getFuel() / burnPerSecond / 60.0D));
+   }
+
+   public static List collectWeaponAmmoLines(MCH_EntityBaseVehicle ac, Minecraft mc, int maxTextWidth, boolean includeSelector, int selectedWeaponId) {
+      List lines = new ArrayList();
+      if(ac == null || ac.weapons == null || mc == null || mc.fontRenderer == null) {
+         return lines;
+      }
+      for(int i = 0; i < ac.weapons.length; ++i) {
+         MCH_WeaponSet ws = ac.weapons[i];
+         if(ws != null) {
+            lines.add(formatWeaponAmmoLine(ws, mc, maxTextWidth, includeSelector, i == selectedWeaponId));
+         }
+      }
+      return lines;
+   }
+
+   private static String formatWeaponAmmoLine(MCH_WeaponSet ws, Minecraft mc, int maxTextWidth, boolean includeSelector, boolean selected) {
+      String prefix = includeSelector ? (selected ? "> " : "  ") : "";
+      String ammo = getWeaponHudAmmo(ws);
+      String name = getWeaponHudName(ws);
+      String line = String.format("%s%-18s %5s", new Object[]{prefix, name, ammo});
+      while(mc.fontRenderer.getStringWidth(line) > maxTextWidth && name.length() > 4) {
+         name = name.substring(0, name.length() - 2) + "~";
+         line = String.format("%s%-18s %5s", new Object[]{prefix, name, ammo});
+      }
+      return line;
+   }
+
+   private static String getWeaponHudName(MCH_WeaponSet ws) {
+      String name = ws.getName();
+      return name == null || name.length() == 0 ? "WEAPON" : name.toUpperCase();
+   }
+
+   private static String getWeaponHudAmmo(MCH_WeaponSet ws) {
+      try {
+         int ammo = ws.getAmmoNum() + ws.getRestAllAmmoNum();
+         return ammo >= 0 ? String.valueOf(ammo) : "--";
+      } catch(RuntimeException ex) {
+         return "--";
+      }
+   }
+}

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -2,12 +2,15 @@ package mcheli.helicopter;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
+import java.util.List;
 import mcheli.MCH_Config;
 import mcheli.MCH_KeyName;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_BaseVehicleCommonGui;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.aircraft.MCH_HudShared;
 import mcheli.gui.MCH_Gui;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.helicopter.MCH_HeliInfo;
@@ -67,6 +70,8 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
 
                if(seatID == 0) {
                   this.drawNewHeliControlHud(heli);
+                  this.drawNewHeliSharedHud(heli, player);
+                  this.drawNewHeliWeaponHud(heli, player);
                }
 
                this.drawKeyBind(heli, player, seatID);
@@ -110,6 +115,56 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       if(heli.isHoverAssistActive()) {
          this.drawString("SAS: ON", x, y + 10, color);
       }
+   }
+
+   private void drawNewHeliSharedHud(MCH_EntityHeli heli, EntityPlayer player) {
+      if(!this.shouldDrawNewHeliHudAdditions(heli) || !MCH_Config.EnableNewHeliHudSharedReadouts.prmBool) {
+         return;
+      }
+
+      List lines = new ArrayList();
+      lines.add(MCH_HudShared.formatSpeedKmh(heli));
+      lines.add(MCH_HudShared.formatAltitude(heli));
+      lines.add(MCH_HudShared.formatVerticalSpeed(heli));
+      lines.add(MCH_HudShared.formatFuelMinutes(heli));
+      int color = -14101432;
+      int x = super.centerX - 200;
+      int y = super.centerY + 55;
+      for(int i = 0; i < lines.size(); ++i) {
+         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, color, 0x5528D448);
+      }
+   }
+
+   private void drawNewHeliWeaponHud(MCH_EntityHeli heli, EntityPlayer player) {
+      if(!this.shouldDrawNewHeliHudAdditions(heli) || !MCH_Config.EnableNewHeliWeaponHud.prmBool) {
+         return;
+      }
+      int x = super.centerX + 120;
+      int y = super.centerY - 15;
+      int maxTextWidth = Math.max(90, super.width - x - 8);
+      List lines = MCH_HudShared.collectWeaponAmmoLines(heli, super.mc, maxTextWidth, true, heli.getCurrentWeaponID(player));
+      if(lines.isEmpty()) {
+         return;
+      }
+      for(int i = 0; i < lines.size(); ++i) {
+         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, -14101432, 0x5528D448);
+      }
+   }
+
+   private boolean shouldDrawNewHeliHudAdditions(MCH_EntityHeli heli) {
+      MCH_HeliInfo info = heli.getHeliInfo();
+      return info != null && heli.isNewHeliFlightModelEnabled() && !heli.isDestroyed();
+   }
+
+   private void drawNewHeliHudText(String text, int x, int y, int color, int glowColor) {
+      if(this.isVehicleHudGlowEnabled()) {
+         this.drawString(text, x + 1, y + 1, glowColor);
+      }
+      this.drawString(text, x, y, color);
+   }
+
+   private boolean isVehicleHudGlowEnabled() {
+      return MCH_Config.EnableNewVehicleHudGlow != null ? MCH_Config.EnableNewVehicleHudGlow.prmBool : MCH_Config.EnableNewPlaneHudGlow.prmBool;
    }
 
    private int toPercent(float value) {

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -9,6 +9,7 @@ import mcheli.MCH_KeyName;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_BaseVehicleCommonGui;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.aircraft.MCH_HudShared;
 import mcheli.gui.MCH_Gui;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.plane.MCP_PlaneInfo;
@@ -99,12 +100,12 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
    private void drawNewPlaneSimpleHud(MCP_EntityPlane plane) {
       List lines = new ArrayList();
-      lines.add(this.formatSimpleHudThrottle(plane));
-      lines.add(this.formatSimpleHudSpeed(plane));
-      lines.add(this.formatSimpleHudAltitude(plane));
-      lines.add(this.formatSimpleHudVerticalSpeed(plane));
-      lines.add(this.formatSimpleHudFuel(plane));
-      lines.add(this.formatSimpleHudDamage(plane));
+      lines.add(MCH_HudShared.formatThrottleOrCollective("THR  ", plane));
+      lines.add(MCH_HudShared.formatSpeedKmh(plane));
+      lines.add(MCH_HudShared.formatAltitude(plane));
+      lines.add(MCH_HudShared.formatVerticalSpeed(plane));
+      lines.add(MCH_HudShared.formatFuelMinutes(plane));
+      lines.add(MCH_HudShared.formatDamagePercent(plane));
       lines.add(this.formatSimpleHudGLoad(plane));
       lines.add(this.formatSimpleHudAoA(plane));
 
@@ -127,18 +128,13 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    }
 
 
-   private String formatSimpleHudSpeed(MCP_EntityPlane plane) {
-      double speedKmh = Math.sqrt(plane.motionX * plane.motionX + plane.motionY * plane.motionY + plane.motionZ * plane.motionZ) * 72.0D;
-      return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
-   }
-
    private String formatSimpleHudVerticalSpeed(MCP_EntityPlane plane) {
       double vs = plane.motionY * 20.0D;
       return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(vs))});
    }
 
    private String formatSimpleHudDamage(MCP_EntityPlane plane) {
-      return String.format("DMG   %d%%", new Object[]{Integer.valueOf(this.getDamagePercent(plane))});
+      return String.format("DMG   %d%%", new Object[]{Integer.valueOf(MCH_HudShared.getDamagePercent(plane))});
    }
 
    private String formatSimpleHudGLoad(MCP_EntityPlane plane) {
@@ -172,7 +168,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       if(plane.getMaxFuel() > 0 && plane.getFuelP() < 0.10F && !plane.isInfinityFuel(plane.getRiddenByEntity(), true)) {
          warnings.add("LOW FUEL");
       }
-      int dmg = this.getDamagePercent(plane);
+      int dmg = MCH_HudShared.getDamagePercent(plane);
       if(dmg < 25) {
          warnings.add("CRITICAL DAMAGE");
       } else if(dmg < 50) {
@@ -220,7 +216,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       int leftMargin = 12;
       int rightMargin = Math.max(24, MCH_Config.NewPlaneWeaponHudRightMargin.prmInt);
       int maxTextWidth = Math.max(80, super.width - leftMargin - rightMargin - 8);
-      List lines = this.collectWeaponAmmoLines(plane, maxTextWidth);
+      List lines = MCH_HudShared.collectWeaponAmmoLines(plane, super.mc, maxTextWidth, false, -1);
       if(lines.isEmpty()) {
          return;
       }
@@ -287,14 +283,14 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    }
 
    private void drawHudText(String text, int x, int y, int color, int glowColor) {
-      if(MCH_Config.EnableNewPlaneHudGlow.prmBool) {
+      if(this.isVehicleHudGlowEnabled()) {
          this.drawString(text, x + 1, y + 1, glowColor);
       }
       this.drawString(text, x, y, color);
    }
 
    private void drawHudPanel(int x, int y, int width, int height) {
-      if(MCH_Config.EnableNewPlaneHudGlow.prmBool) {
+      if(this.isVehicleHudGlowEnabled()) {
          GL11.glPushMatrix();
          boolean blend = GL11.glIsEnabled(3042);
          int srcBlend = GL11.glGetInteger(3041);
@@ -308,6 +304,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          }
          GL11.glPopMatrix();
       }
+   }
+
+   private boolean isVehicleHudGlowEnabled() {
+      return MCH_Config.EnableNewVehicleHudGlow != null ? MCH_Config.EnableNewVehicleHudGlow.prmBool : MCH_Config.EnableNewPlaneHudGlow.prmBool;
    }
 
    private void drawNewFlightThrottleHud(MCP_EntityPlane plane) {


### PR DESCRIPTION
### Motivation
- Consolidate common HUD formatting and weapon-ammo layout code used by multiple vehicle GUIs to reduce duplication and ensure consistent display.
- Add helicopter-specific shared readouts and weapon HUD using the new shared helpers to match the plane HUD features.
- Provide a unified, vehicle-wide toggle for HUD glow visuals and deprecate the plane-only glow flag.

### Description
- Added a new `MCH_HudShared` utility class that exposes shared formatting functions: `formatThrottleOrCollective`, `formatSpeedKmh`, `formatAltitude`, `formatVerticalSpeed`, `formatFuelMinutes`, `formatDamagePercent`, `getDamagePercent`, `estimateFuelMinutes`, and `collectWeaponAmmoLines` for weapon HUD text generation.
- Extended `MCH_Config` with three new parameters: `EnableNewHeliHudSharedReadouts`, `EnableNewHeliWeaponHud`, and `EnableNewVehicleHudGlow`, and updated the `EnableNewPlaneHudGlow` description to mark it deprecated in favor of the new vehicle-level glow flag, plus added the new params to the config list.
- Updated helicopter GUI (`MCH_GuiHeli`) to render shared readouts and a helicopter weapon HUD using `MCH_HudShared`, plus added helper methods `drawNewHeliSharedHud`, `drawNewHeliWeaponHud`, `shouldDrawNewHeliHudAdditions`, `drawNewHeliHudText`, and `isVehicleHudGlowEnabled` to centralize glow behavior and drawing logic.
- Updated plane GUI (`MCP_GuiPlane`) to use `MCH_HudShared` for several simple-HUD formatters and to use the shared `collectWeaponAmmoLines`, and replaced plane-only HUD glow checks with `isVehicleHudGlowEnabled` for consistent behavior.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39888ed97083298a201dad904754b8)