### PR TITLE
Hover-mode vertical stabilization using motionY-based vertical-speed hold

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -38,8 +38,12 @@ public final class MCH_HudShared {
       return String.format("ALT   %d m", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(ac.posY)))});
    }
 
+   public static double getVerticalSpeedMotionY(MCH_EntityBaseVehicle ac) {
+      return ac != null?ac.motionY:0.0D;
+   }
+
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(ac.motionY * 20.0D))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -83,6 +83,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float finalMotionZ;
    private float hoverAssistStrength;
    private float hoverCollectiveCorrection;
+   private float hoverThrottleBias;
    private float hoverCyclicPitchCorrection;
    private float hoverCyclicRollCorrection;
    private float manualInputOverrideFactor;
@@ -219,6 +220,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.finalMotionZ = 0.0F;
       this.hoverAssistStrength = 0.0F;
       this.hoverCollectiveCorrection = 0.0F;
+      this.hoverThrottleBias = 0.0F;
       this.hoverCyclicPitchCorrection = 0.0F;
       this.hoverCyclicRollCorrection = 0.0F;
       this.manualInputOverrideFactor = 0.0F;
@@ -1326,12 +1328,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.hoverAssistActive = false;
 
       if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
       float configuredStrength = MathHelper.clamp_float(this.heliInfo.hoverAssistStrength, 0.0F, 1.0F);
       this.hoverAssistStrength = configuredStrength;
       if(configuredStrength <= 0.0F) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
@@ -1341,21 +1345,32 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       float assistBlend = configuredStrength * (1.0F - this.manualInputOverrideFactor);
       this.hoverAssistActive = assistBlend > 0.001F;
       if(!this.hoverAssistActive) {
+         this.hoverThrottleBias *= 0.90F;
+         this.hoverCollectiveCorrection = this.hoverThrottleBias;
          return;
       }
 
       this.targetVerticalSpeed = 0.0F;
       this.targetHorizontalSpeed = 0.0F;
-      float mass = this.sanitizePositive(this.physicalMass, 1.0F, NEW_HELI_MIN_MASS);
-      float gravity = MathHelper.abs(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
-      float liftSpool = MathHelper.clamp_float((this.normalizedRotorRPM - 0.35F) / 0.65F, 0.0F, 1.0F);
-      liftSpool *= liftSpool;
-      float availableLift = Math.max(this.heliInfo.mainRotorMaxThrust * liftSpool, 0.001F);
-      float hoverCollective = MathHelper.clamp_float(mass * gravity / availableLift, 0.0F, 1.0F);
-      float currentCollective = MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F);
-      float descentRecovery = MathHelper.clamp_float((this.targetVerticalSpeed - (float)super.motionY) * 2.0F, 0.0F, 0.22F);
-      float altitudeHoldDemand = MathHelper.clamp_float(hoverCollective + descentRecovery - currentCollective, 0.0F, 0.55F);
-      this.hoverCollectiveCorrection = altitudeHoldDemand * assistBlend;
+      float verticalSpeed = (float)MCH_HudShared.getVerticalSpeedMotionY(this);
+      float deadzone = MathHelper.clamp_float(this.heliInfo.hoverVerticalSpeedDeadzone, 0.0F, 1.0F);
+      float correctionLimit = MathHelper.clamp_float(this.heliInfo.hoverVerticalCorrectionLimit, 0.0F, 1.0F);
+      float biasLimit = MathHelper.clamp_float(this.heliInfo.hoverThrottleBiasLimit, 0.0F, 1.0F);
+      float verticalError = this.targetVerticalSpeed - verticalSpeed;
+      if(MathHelper.abs(verticalError) <= deadzone) {
+         if(this.hoverThrottleBias > correctionLimit) {
+            this.hoverThrottleBias -= correctionLimit;
+         } else if(this.hoverThrottleBias < -correctionLimit) {
+            this.hoverThrottleBias += correctionLimit;
+         } else {
+            this.hoverThrottleBias = 0.0F;
+         }
+      } else {
+         float strength = Math.max(this.heliInfo.hoverVerticalStabilizerStrength, 0.0F);
+         float correctionStep = MathHelper.clamp_float(verticalError * strength, -correctionLimit, correctionLimit) * assistBlend;
+         this.hoverThrottleBias = MathHelper.clamp_float(this.hoverThrottleBias + correctionStep, -biasLimit, biasLimit);
+      }
+      this.hoverCollectiveCorrection = this.hoverThrottleBias;
 
       float yawRadians = this.getRotYaw() / 180.0F * 3.1415927F;
       float forwardX = -MathHelper.sin(yawRadians);

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -56,6 +56,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
    public float helicopterMaxBackwardSpeedScale;
    /** Strength of new-model hover assistance; 0 disables assist, 1 is full configured assist. */
    public float hoverAssistStrength;
+   /** Vertical-speed deadzone for new-heli hover hold, in motionY blocks per tick. */
+   public float hoverVerticalSpeedDeadzone;
+   /** Proportional strength for new-heli hover vertical-speed hold. */
+   public float hoverVerticalStabilizerStrength;
+   /** Maximum per-tick hover throttle bias change. */
+   public float hoverVerticalCorrectionLimit;
+   /** Maximum total hover throttle/collective bias. */
+   public float hoverThrottleBiasLimit;
    /** Show compact player-power readout to pilots using the new helicopter flight model. */
    public boolean newHeliControlHudDisplay;
    public List rotorList;
@@ -87,6 +95,10 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       this.helicopterBackwardThrustScale = Float.NaN;
       this.helicopterMaxBackwardSpeedScale = Float.NaN;
       this.hoverAssistStrength = 0.75F;
+      this.hoverVerticalSpeedDeadzone = 0.01F;
+      this.hoverVerticalStabilizerStrength = 0.35F;
+      this.hoverVerticalCorrectionLimit = 0.01F;
+      this.hoverThrottleBiasLimit = 0.25F;
       this.newHeliControlHudDisplay = true;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;
@@ -168,6 +180,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
          this.helicopterMaxBackwardSpeedScale = this.toFloat(data, 0.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("HoverAssistStrength")) {
          this.hoverAssistStrength = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalSpeedDeadzone")) {
+         this.hoverVerticalSpeedDeadzone = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalStabilizerStrength")) {
+         this.hoverVerticalStabilizerStrength = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalCorrectionLimit")) {
+         this.hoverVerticalCorrectionLimit = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverThrottleBiasLimit")) {
+         this.hoverThrottleBiasLimit = this.toFloat(data, 0.0F, 1.0F);
       } else if(item.equalsIgnoreCase("NewHeliControlHudDisplay") || item.equalsIgnoreCase("NewHelicopterControlHudDisplay")) {
          this.newHeliControlHudDisplay = this.toBool(data);
       } else if(item.compareTo("addrotor") == 0 || item.compareTo("addrotorold") == 0) {


### PR DESCRIPTION
### Motivation
- Provide a simple hover-mode vertical-speed hold for helicopters that opt into the new flight model, using the same vertical-speed source players see on the HUD instead of direct altitude math. 
- Expose clear tuning parameters named like `HoverVerticalSpeedDeadzone`, `HoverVerticalStabilizerStrength`, `HoverVerticalCorrectionLimit`, and `HoverThrottleBiasLimit` to allow safe, bounded tuning. 
- Ensure pilot collective (`W/S`) input still overrides/ biases the assist and that legacy/ non-hover behavior is unaffected.

### Description
- Added per-heli configuration fields to `MCH_HeliInfo` with defaults and parser support for `HoverVerticalSpeedDeadzone`, `HoverVerticalStabilizerStrength`, `HoverVerticalCorrectionLimit`, and `HoverThrottleBiasLimit` (new float members and parsing). 
- Added a shared vertical-speed accessor `MCH_HudShared.getVerticalSpeedMotionY(...)` and updated the HUD VS readout to use it so the HUD and controller reference the same `motionY` source. 
- Implemented a motionY-based hover stabilizer in `MCH_EntityHeli.updateNewHelicopterHoverAssist(...)` that: targets vertical speed `0`, applies a deadzone, computes a proportional per-tick correction scaled by the hover assist blend, clamps both the per-tick correction and the cumulative throttle/collective bias, decays the stored bias when assist is inactive, and writes the result into the existing `hoverCollectiveCorrection` used by lift application. 
- Added `hoverThrottleBias` state to `MCH_EntityHeli` and preserved manual throttle/collective behavior by blending assist down when the pilot is providing collective/cyclic input; the controller is applied as an additive bias to collective/throttle only on the new helicopter flight-model path so legacy flight remains unchanged. 

### Testing
- Ran `git diff --check` to validate the working tree for whitespace/patch issues, which produced no errors. (success) 
- Ran `find . -name '*.class' -print -quit` to confirm no compiled `.class` files were added to the PR, which returned no results. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3995ae358c832996b606a0c7bb01db)