### PR TITLE
Add vertical-speed hover stabilizer and HUD speed getter; expose heli hover tuning params

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -38,8 +38,12 @@ public final class MCH_HudShared {
       return String.format("ALT   %d m", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(ac.posY)))});
    }
 
+   public static double getVerticalSpeedMotionY(MCH_EntityBaseVehicle ac) {
+      return ac != null?ac.motionY:0.0D;
+   }
+
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(ac.motionY * 20.0D))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -83,6 +83,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float finalMotionZ;
    private float hoverAssistStrength;
    private float hoverCollectiveCorrection;
+   private float hoverThrottleBias;
    private float hoverCyclicPitchCorrection;
    private float hoverCyclicRollCorrection;
    private float manualInputOverrideFactor;
@@ -219,6 +220,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.finalMotionZ = 0.0F;
       this.hoverAssistStrength = 0.0F;
       this.hoverCollectiveCorrection = 0.0F;
+      this.hoverThrottleBias = 0.0F;
       this.hoverCyclicPitchCorrection = 0.0F;
       this.hoverCyclicRollCorrection = 0.0F;
       this.manualInputOverrideFactor = 0.0F;
@@ -1326,12 +1328,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.hoverAssistActive = false;
 
       if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
       float configuredStrength = MathHelper.clamp_float(this.heliInfo.hoverAssistStrength, 0.0F, 1.0F);
       this.hoverAssistStrength = configuredStrength;
       if(configuredStrength <= 0.0F) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
@@ -1341,21 +1345,32 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       float assistBlend = configuredStrength * (1.0F - this.manualInputOverrideFactor);
       this.hoverAssistActive = assistBlend > 0.001F;
       if(!this.hoverAssistActive) {
+         this.hoverThrottleBias *= 0.90F;
+         this.hoverCollectiveCorrection = this.hoverThrottleBias;
          return;
       }
 
       this.targetVerticalSpeed = 0.0F;
       this.targetHorizontalSpeed = 0.0F;
-      float mass = this.sanitizePositive(this.physicalMass, 1.0F, NEW_HELI_MIN_MASS);
-      float gravity = MathHelper.abs(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
-      float liftSpool = MathHelper.clamp_float((this.normalizedRotorRPM - 0.35F) / 0.65F, 0.0F, 1.0F);
-      liftSpool *= liftSpool;
-      float availableLift = Math.max(this.heliInfo.mainRotorMaxThrust * liftSpool, 0.001F);
-      float hoverCollective = MathHelper.clamp_float(mass * gravity / availableLift, 0.0F, 1.0F);
-      float currentCollective = MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F);
-      float descentRecovery = MathHelper.clamp_float((this.targetVerticalSpeed - (float)super.motionY) * 2.0F, 0.0F, 0.22F);
-      float altitudeHoldDemand = MathHelper.clamp_float(hoverCollective + descentRecovery - currentCollective, 0.0F, 0.55F);
-      this.hoverCollectiveCorrection = altitudeHoldDemand * assistBlend;
+      float verticalSpeed = (float)MCH_HudShared.getVerticalSpeedMotionY(this);
+      float deadzone = MathHelper.clamp_float(this.heliInfo.hoverVerticalSpeedDeadzone, 0.0F, 1.0F);
+      float correctionLimit = MathHelper.clamp_float(this.heliInfo.hoverVerticalCorrectionLimit, 0.0F, 1.0F);
+      float biasLimit = MathHelper.clamp_float(this.heliInfo.hoverThrottleBiasLimit, 0.0F, 1.0F);
+      float verticalError = this.targetVerticalSpeed - verticalSpeed;
+      if(MathHelper.abs(verticalError) <= deadzone) {
+         if(this.hoverThrottleBias > correctionLimit) {
+            this.hoverThrottleBias -= correctionLimit;
+         } else if(this.hoverThrottleBias < -correctionLimit) {
+            this.hoverThrottleBias += correctionLimit;
+         } else {
+            this.hoverThrottleBias = 0.0F;
+         }
+      } else {
+         float strength = Math.max(this.heliInfo.hoverVerticalStabilizerStrength, 0.0F);
+         float correctionStep = MathHelper.clamp_float(verticalError * strength, -correctionLimit, correctionLimit) * assistBlend;
+         this.hoverThrottleBias = MathHelper.clamp_float(this.hoverThrottleBias + correctionStep, -biasLimit, biasLimit);
+      }
+      this.hoverCollectiveCorrection = this.hoverThrottleBias;
 
       float yawRadians = this.getRotYaw() / 180.0F * 3.1415927F;
       float forwardX = -MathHelper.sin(yawRadians);

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -240,22 +240,6 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       return MCH_Config.EnableNewVehicleHudGlow != null ? MCH_Config.EnableNewVehicleHudGlow.prmBool : MCH_Config.EnableNewPlaneHudGlow.prmBool;
    }
 
-   private boolean shouldDrawNewHeliHudAdditions(MCH_EntityHeli heli) {
-      MCH_HeliInfo info = heli.getHeliInfo();
-      return info != null && heli.isNewHeliFlightModelEnabled() && !heli.isDestroyed();
-   }
-
-   private void drawNewHeliHudText(String text, int x, int y, int color, int glowColor) {
-      if(this.isVehicleHudGlowEnabled()) {
-         this.drawString(text, x + 1, y + 1, glowColor);
-      }
-      this.drawString(text, x, y, color);
-   }
-
-   private boolean isVehicleHudGlowEnabled() {
-      return MCH_Config.EnableNewVehicleHudGlow != null ? MCH_Config.EnableNewVehicleHudGlow.prmBool : MCH_Config.EnableNewPlaneHudGlow.prmBool;
-   }
-
    private int toPercent(float value) {
       return Math.round(MathHelper.clamp_float(value, 0.0F, 1.0F) * 100.0F);
    }

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -56,6 +56,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
    public float helicopterMaxBackwardSpeedScale;
    /** Strength of new-model hover assistance; 0 disables assist, 1 is full configured assist. */
    public float hoverAssistStrength;
+   /** Vertical-speed deadzone for new-heli hover hold, in motionY blocks per tick. */
+   public float hoverVerticalSpeedDeadzone;
+   /** Proportional strength for new-heli hover vertical-speed hold. */
+   public float hoverVerticalStabilizerStrength;
+   /** Maximum per-tick hover throttle bias change. */
+   public float hoverVerticalCorrectionLimit;
+   /** Maximum total hover throttle/collective bias. */
+   public float hoverThrottleBiasLimit;
    /** Show compact player-power readout to pilots using the new helicopter flight model. */
    public boolean newHeliControlHudDisplay;
    public List rotorList;
@@ -87,6 +95,10 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       this.helicopterBackwardThrustScale = Float.NaN;
       this.helicopterMaxBackwardSpeedScale = Float.NaN;
       this.hoverAssistStrength = 0.75F;
+      this.hoverVerticalSpeedDeadzone = 0.01F;
+      this.hoverVerticalStabilizerStrength = 0.35F;
+      this.hoverVerticalCorrectionLimit = 0.01F;
+      this.hoverThrottleBiasLimit = 0.25F;
       this.newHeliControlHudDisplay = true;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;
@@ -168,6 +180,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
          this.helicopterMaxBackwardSpeedScale = this.toFloat(data, 0.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("HoverAssistStrength")) {
          this.hoverAssistStrength = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalSpeedDeadzone")) {
+         this.hoverVerticalSpeedDeadzone = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalStabilizerStrength")) {
+         this.hoverVerticalStabilizerStrength = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalCorrectionLimit")) {
+         this.hoverVerticalCorrectionLimit = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverThrottleBiasLimit")) {
+         this.hoverThrottleBiasLimit = this.toFloat(data, 0.0F, 1.0F);
       } else if(item.equalsIgnoreCase("NewHeliControlHudDisplay") || item.equalsIgnoreCase("NewHelicopterControlHudDisplay")) {
          this.newHeliControlHudDisplay = this.toBool(data);
       } else if(item.compareTo("addrotor") == 0 || item.compareTo("addrotorold") == 0) {


### PR DESCRIPTION
### Motivation
- Provide a more robust hover assist by stabilizing vertical speed with a configurable throttle bias and limits. 
- Expose hover tuning parameters so helicopter configs can control deadzone, stabilizer strength, correction rate, and bias limits. 
- Avoid direct null access of `motionY` when formatting vertical speed for the HUD. 

### Description
- Added `hoverThrottleBias` to `MCH_EntityHeli` and initialize it in the constructor to store the running collective bias for hover stabilization. 
- Reworked `updateNewHelicopterHoverAssist` to compute per-tick throttle bias from the vertical-speed error using `targetVerticalSpeed`, a configurable deadzone, a proportional stabilizer strength, a per-tick correction limit, and a clamp to a total bias limit, and applied a decay when assist is not actively adjusting. 
- Replaced the previous altitude-hold math with the vertical-speed based bias approach and set `hoverCollectiveCorrection = hoverThrottleBias`. 
- Added `MCH_HudShared.getVerticalSpeedMotionY` and updated `formatVerticalSpeed` to call it to guard against null vehicles. 
- Added new heli info fields to `MCH_HeliInfo`: `hoverVerticalSpeedDeadzone`, `hoverVerticalStabilizerStrength`, `hoverVerticalCorrectionLimit`, and `hoverThrottleBiasLimit` with defaults and parsing support in the info loader. 
- Removed duplicated HUD helper methods in `MCH_GuiHeli` as part of cleanup. 

### Testing
- Built the project with `./gradlew build` and compilation succeeded. 
- Executed automated unit tests with `./gradlew test` and the test suite passed. 
- Verified that the code paths touching the new `MCH_HeliInfo` parsing and `MCH_HudShared.formatVerticalSpeed` are covered by the build and tests mentioned above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3995ae358c832996b606a0c7bb01db)