### PR TITLE
Add hover-throttle bias controller for new heli model and tidy HUD pitch readout

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -38,8 +38,12 @@ public final class MCH_HudShared {
       return String.format("ALT   %d m", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(ac.posY)))});
    }
 
+   public static double getVerticalSpeedMotionY(MCH_EntityBaseVehicle ac) {
+      return ac != null?ac.motionY:0.0D;
+   }
+
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(ac.motionY * 20.0D))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -83,6 +83,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float finalMotionZ;
    private float hoverAssistStrength;
    private float hoverCollectiveCorrection;
+   private float hoverThrottleBias;
    private float hoverCyclicPitchCorrection;
    private float hoverCyclicRollCorrection;
    private float manualInputOverrideFactor;
@@ -219,6 +220,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.finalMotionZ = 0.0F;
       this.hoverAssistStrength = 0.0F;
       this.hoverCollectiveCorrection = 0.0F;
+      this.hoverThrottleBias = 0.0F;
       this.hoverCyclicPitchCorrection = 0.0F;
       this.hoverCyclicRollCorrection = 0.0F;
       this.manualInputOverrideFactor = 0.0F;
@@ -1042,13 +1044,15 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          } else {
             this.setCurrentThrottle(0.0D);
          }
-      } else if((!super.worldObj.isRemote || W_Lib.isClientPlayer(this.getRiddenByEntity())) && super.cs_heliAutoThrottleDown) {
+      } else if((!super.worldObj.isRemote || W_Lib.isClientPlayer(this.getRiddenByEntity())) && super.cs_heliAutoThrottleDown && (!this.newHeliFlightModelEnabled || !this.isHoveringMode())) {
          if(this.getCurrentThrottle() > 0.52D) {
             this.addCurrentThrottle(-0.01D * (double)throttleUpDown);
          } else if(this.getCurrentThrottle() < 0.48D) {
             this.addCurrentThrottle(0.01D * (double)throttleUpDown);
          }
       }
+
+      this.updateNewHelicopterHoverThrottleController(throttleUpDown);
 
       if(!super.worldObj.isRemote && !this.newHeliFlightModelEnabled) {
          boolean move = false;
@@ -1077,6 +1081,45 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
       }
 
+   }
+
+   private void updateNewHelicopterHoverThrottleController(float throttleUpDown) {
+      if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+         this.hoverThrottleBias = 0.0F;
+         this.hoverCollectiveCorrection = 0.0F;
+         return;
+      }
+
+      float configuredStrength = MathHelper.clamp_float(this.heliInfo.hoverAssistStrength, 0.0F, 1.0F);
+      if(configuredStrength <= 0.0F || super.throttleUp || super.throttleDown) {
+         this.hoverThrottleBias *= 0.90F;
+         this.hoverCollectiveCorrection = this.hoverThrottleBias;
+         return;
+      }
+
+      this.targetVerticalSpeed = 0.0F;
+      float verticalSpeed = (float)MCH_HudShared.getVerticalSpeedMotionY(this);
+      float deadzone = MathHelper.clamp_float(this.heliInfo.hoverVerticalSpeedDeadzone, 0.0F, 1.0F);
+      float correctionLimit = MathHelper.clamp_float(this.heliInfo.hoverVerticalCorrectionLimit, 0.0F, 1.0F);
+      float biasLimit = MathHelper.clamp_float(this.heliInfo.hoverThrottleBiasLimit, 0.0F, 1.0F);
+      float verticalError = this.targetVerticalSpeed - verticalSpeed;
+      boolean correctingVerticalSpeed = MathHelper.abs(verticalError) > deadzone;
+      if(correctingVerticalSpeed) {
+         float strength = Math.max(this.heliInfo.hoverVerticalStabilizerStrength, 0.0F);
+         float correctionStep = MathHelper.clamp_float(verticalError * strength * configuredStrength, -correctionLimit, correctionLimit);
+         this.hoverThrottleBias = MathHelper.clamp_float(this.hoverThrottleBias + correctionStep, -biasLimit, biasLimit);
+         this.addCurrentThrottle((double)(this.hoverThrottleBias * Math.max(throttleUpDown, 0.0F)));
+         this.setCurrentThrottle(MathHelper.clamp_double(this.getCurrentThrottle(), 0.0D, 1.0D));
+      } else {
+         if(this.hoverThrottleBias > correctionLimit) {
+            this.hoverThrottleBias -= correctionLimit;
+         } else if(this.hoverThrottleBias < -correctionLimit) {
+            this.hoverThrottleBias += correctionLimit;
+         } else {
+            this.hoverThrottleBias = 0.0F;
+         }
+      }
+      this.hoverCollectiveCorrection = this.hoverThrottleBias;
    }
 
    protected void onUpdate_ControlHovering() {
@@ -1326,12 +1369,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.hoverAssistActive = false;
 
       if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
       float configuredStrength = MathHelper.clamp_float(this.heliInfo.hoverAssistStrength, 0.0F, 1.0F);
       this.hoverAssistStrength = configuredStrength;
       if(configuredStrength <= 0.0F) {
+         this.hoverThrottleBias = 0.0F;
          return;
       }
 
@@ -1341,21 +1386,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       float assistBlend = configuredStrength * (1.0F - this.manualInputOverrideFactor);
       this.hoverAssistActive = assistBlend > 0.001F;
       if(!this.hoverAssistActive) {
+         this.hoverThrottleBias *= 0.90F;
+         this.hoverCollectiveCorrection = this.hoverThrottleBias;
          return;
       }
 
       this.targetVerticalSpeed = 0.0F;
       this.targetHorizontalSpeed = 0.0F;
-      float mass = this.sanitizePositive(this.physicalMass, 1.0F, NEW_HELI_MIN_MASS);
-      float gravity = MathHelper.abs(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
-      float liftSpool = MathHelper.clamp_float((this.normalizedRotorRPM - 0.35F) / 0.65F, 0.0F, 1.0F);
-      liftSpool *= liftSpool;
-      float availableLift = Math.max(this.heliInfo.mainRotorMaxThrust * liftSpool, 0.001F);
-      float hoverCollective = MathHelper.clamp_float(mass * gravity / availableLift, 0.0F, 1.0F);
-      float currentCollective = MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F);
-      float descentRecovery = MathHelper.clamp_float((this.targetVerticalSpeed - (float)super.motionY) * 2.0F, 0.0F, 0.22F);
-      float altitudeHoldDemand = MathHelper.clamp_float(hoverCollective + descentRecovery - currentCollective, 0.0F, 0.55F);
-      this.hoverCollectiveCorrection = altitudeHoldDemand * assistBlend;
+      this.hoverCollectiveCorrection = this.hoverThrottleBias;
 
       float yawRadians = this.getRotYaw() / 180.0F * 3.1415927F;
       float forwardX = -MathHelper.sin(yawRadians);
@@ -1575,7 +1613,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
             if(this.newHeliFlightModelEnabled && !this.isDestroyed() && this.canUseBlades() && !this.isFoldBlades()) {
                this.updateNewHelicopterCyclicInput();
-               this.applyNewHelicopterCollectiveLift(y, throttle + (double)this.hoverCollectiveCorrection, horizontalSpeed, 1.0F);
+               this.applyNewHelicopterCollectiveLift(y, throttle, horizontalSpeed, 1.0F);
                this.applyNewHelicopterCyclicThrust(1.0F);
             } else {
                double rotorEfficiency = 1.0D;
@@ -1626,7 +1664,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             double throttle = this.isDestroyed()?this.getCurrentThrottle() * 0.65D:this.getCurrentThrottle();
             double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
             this.updateNewHelicopterCyclicInput();
-            this.applyNewHelicopterCollectiveLift(1.0D, throttle + (double)this.hoverCollectiveCorrection, horizontalSpeed, 1.0F);
+            this.applyNewHelicopterCollectiveLift(1.0D, throttle, horizontalSpeed, 1.0F);
             this.applyNewHelicopterCyclicThrust(1.0F);
          } else if(this.newHeliFlightModelEnabled) {
             this.resetNewHelicopterFlightTelemetry();

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -72,7 +72,7 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
                if(seatID == 0) {
                   this.drawNewHeliSharedHud(heli);
                   this.drawNewHeliHealthHud(heli);
-                  this.drawNewHeliPitchReadout(player);
+                  this.drawNewHeliPitchReadout(heli, player);
                   this.drawNewHeliRadarHud(heli);
                   this.drawNewHeliWeaponHud(heli, player);
                }
@@ -143,10 +143,26 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
    }
 
 
-   private void drawNewHeliPitchReadout(EntityPlayer player) {
+   private void drawNewHeliPitchReadout(MCH_EntityHeli heli, EntityPlayer player) {
+      if(!this.shouldDrawNewHeliHudAdditions(heli)) {
+         return;
+      }
       int x = super.centerX + 90;
       int y = super.centerY - 4;
+      this.clearLegacyPitchReadoutBox();
+      this.drawPitchReadoutBox(x, super.centerY);
       this.drawNewHeliHudText(String.format("%.0f", new Object[]{Float.valueOf(-player.rotationPitch)}), x, y, -14101432, 0x5528D448);
+   }
+
+   private void clearLegacyPitchReadoutBox() {
+      drawRect(super.centerX + 116, super.centerY - 8, super.centerX + 154, super.centerY + 9, 0xAA000000);
+   }
+
+   private void drawPitchReadoutBox(int readoutX, int centerY) {
+      int left = readoutX - 20;
+      this.drawLine(new double[]{(double)left, (double)centerY, (double)(left + 5), (double)(centerY - 5),
+            (double)(left + 30), (double)(centerY - 5), (double)(left + 30), (double)(centerY + 5),
+            (double)(left + 5), (double)(centerY + 5), (double)left, (double)centerY}, -14101432, 1);
    }
 
    private void drawNewHeliRadarHud(MCH_EntityHeli heli) {
@@ -222,22 +238,6 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       for(int i = 0; i < lines.size(); ++i) {
          this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, -14101432, 0x5528D448);
       }
-   }
-
-   private boolean shouldDrawNewHeliHudAdditions(MCH_EntityHeli heli) {
-      MCH_HeliInfo info = heli.getHeliInfo();
-      return info != null && heli.isNewHeliFlightModelEnabled() && !heli.isDestroyed();
-   }
-
-   private void drawNewHeliHudText(String text, int x, int y, int color, int glowColor) {
-      if(this.isVehicleHudGlowEnabled()) {
-         this.drawString(text, x + 1, y + 1, glowColor);
-      }
-      this.drawString(text, x, y, color);
-   }
-
-   private boolean isVehicleHudGlowEnabled() {
-      return MCH_Config.EnableNewVehicleHudGlow != null ? MCH_Config.EnableNewVehicleHudGlow.prmBool : MCH_Config.EnableNewPlaneHudGlow.prmBool;
    }
 
    private boolean shouldDrawNewHeliHudAdditions(MCH_EntityHeli heli) {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -56,6 +56,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
    public float helicopterMaxBackwardSpeedScale;
    /** Strength of new-model hover assistance; 0 disables assist, 1 is full configured assist. */
    public float hoverAssistStrength;
+   /** Vertical-speed deadzone for new-heli hover hold, in motionY blocks per tick. */
+   public float hoverVerticalSpeedDeadzone;
+   /** Proportional strength for new-heli hover vertical-speed hold. */
+   public float hoverVerticalStabilizerStrength;
+   /** Maximum per-tick hover throttle bias change. */
+   public float hoverVerticalCorrectionLimit;
+   /** Maximum total hover throttle/collective bias. */
+   public float hoverThrottleBiasLimit;
    /** Show compact player-power readout to pilots using the new helicopter flight model. */
    public boolean newHeliControlHudDisplay;
    public List rotorList;
@@ -87,6 +95,10 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
       this.helicopterBackwardThrustScale = Float.NaN;
       this.helicopterMaxBackwardSpeedScale = Float.NaN;
       this.hoverAssistStrength = 0.75F;
+      this.hoverVerticalSpeedDeadzone = 0.01F;
+      this.hoverVerticalStabilizerStrength = 0.35F;
+      this.hoverVerticalCorrectionLimit = 0.01F;
+      this.hoverThrottleBiasLimit = 0.25F;
       this.newHeliControlHudDisplay = true;
       this.rotorList = new ArrayList();
       super.minRotationPitch = -20.0F;
@@ -168,6 +180,14 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
          this.helicopterMaxBackwardSpeedScale = this.toFloat(data, 0.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("HoverAssistStrength")) {
          this.hoverAssistStrength = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalSpeedDeadzone")) {
+         this.hoverVerticalSpeedDeadzone = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalStabilizerStrength")) {
+         this.hoverVerticalStabilizerStrength = this.toFloat(data, 0.0F, 1000.0F);
+      } else if(item.equalsIgnoreCase("HoverVerticalCorrectionLimit")) {
+         this.hoverVerticalCorrectionLimit = this.toFloat(data, 0.0F, 1.0F);
+      } else if(item.equalsIgnoreCase("HoverThrottleBiasLimit")) {
+         this.hoverThrottleBiasLimit = this.toFloat(data, 0.0F, 1.0F);
       } else if(item.equalsIgnoreCase("NewHeliControlHudDisplay") || item.equalsIgnoreCase("NewHelicopterControlHudDisplay")) {
          this.newHeliControlHudDisplay = this.toBool(data);
       } else if(item.compareTo("addrotor") == 0 || item.compareTo("addrotorold") == 0) {


### PR DESCRIPTION
### Motivation

- Improve hover stability for the new helicopter flight model by introducing a throttle-bias based hover hold controller to reduce oscillation and provide tunable limits. 
- Clean up the HUD pitch readout to avoid legacy artefacts and make the pitch box render consistently with new heli HUD additions.

### Description

- Added a new hover bias state `hoverThrottleBias` to `MCH_EntityHeli` and initialized it in the constructor to support a throttle-based hover controller. 
- Implemented `updateNewHelicopterHoverThrottleController(float)` in `MCH_EntityHeli`, invoked from `onUpdate_ControlNotHovering`, which adjusts `hoverThrottleBias` and `hoverCollectiveCorrection` using helipad-configurable parameters and `MCH_HudShared.getVerticalSpeedMotionY`. 
- Switched new-heli collective application to use the regular `throttle` argument only (removed direct injection of `hoverCollectiveCorrection` into `applyNewHelicopterCollectiveLift`) so hover bias is applied earlier in the throttle control flow. 
- Added `getVerticalSpeedMotionY` in `MCH_HudShared` and updated `formatVerticalSpeed` to use it. 
- Extended `MCH_HeliInfo` with hover tuning parameters: `hoverVerticalSpeedDeadzone`, `hoverVerticalStabilizerStrength`, `hoverVerticalCorrectionLimit`, and `hoverThrottleBiasLimit`, added defaults, and added parsing for the new config keys. 
- Adjusted HUD code in `MCH_GuiHeli`: changed `drawNewHeliPitchReadout` signature to accept `MCH_EntityHeli`, added `clearLegacyPitchReadoutBox` and `drawPitchReadoutBox` to render a stable pitch readout box, and removed duplicated helper methods that were previously repeated. 

### Testing

- Performed a full project build with `./gradlew build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3995ae358c832996b606a0c7bb01db)