### PR TITLE
Keep new-flight stalls active during freelook and add new-plane debug HUD

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1393,37 +1393,25 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.mouseAimGeneratedYawCommand = 0.0F;
          this.mouseAimGeneratedPitchCommand = 0.0F;
          this.mouseAimGeneratedRollCommand = 0.0F;
-         this.pitchAngularVelocity = 0.0F;
-         this.rollAngularVelocity = 0.0F;
-         this.yawAngularVelocity = 0.0F;
-         this.lastFinalPitchAngularVelocity = 0.0D;
          this.lastRequestedPitchInput = 0.0F;
          this.lastPitchInputAfterAuthority = 0.0F;
-         this.lastPitchEnvelopeReference = 90.0D;
-         this.lastPitchEnvelopeExcess = 0.0D;
-         this.lastPitchEnvelopeEnergyRatio = 1.0D;
-         this.lastNoseDownRecoveryTorque = 0.0D;
          this.lastFinalElevatorInput = 0.0D;
-         this.lastControlAuthority = this.getControlAuthorityFactor();
-         this.lastPitchAuthority = 1.0D;
-         this.lastAirflowAuthority = 1.0D;
-         this.lastFinalPitchAuthority = this.lastControlAuthority;
-         this.lastPitchAuthorityAfterSuppression = this.lastFinalPitchAuthority;
-         this.lastNoseUpPitchSuppression = 0.0D;
          this.addkeyRotValue = 0.0F;
+
+         // Free look decouples pilot camera input from the airframe, but it must not
+         // freeze aerodynamic body rates. Stall buffet, pitch-break recovery, and other
+         // new-flight moments are integrated in onUpdateAngles(), so keep that path
+         // active with zero pilot input while the mouse is consumed by the camera.
+         this.onUpdateAngles(partialTicks);
+
          this.prevRotationRoll = this.getRotRoll();
          super.prevRotationPitch = this.getRotPitch();
          if(this.getRidingEntity() == null) {
             super.prevRotationYaw = this.getRotYaw();
          }
-
-         // Free look intentionally decouples the pilot camera from the airframe, but the
-         // server-side new flight model still derives AoA/stall state from the last
-         // aircraft rotation packet it received. Keep the server synchronized with the
-         // client airframe attitude while the mouse is being consumed by free look;
-         // otherwise the server can continue simulating an old nose-high attitude and
-         // report a stall only while free look is active.
-         this.aircraftRotChanged = true;
+         if(this.getRidingEntity() == null && ac_yaw != this.getRotYaw() || ac_pitch != this.getRotPitch() || ac_roll != this.getRotRoll()) {
+            this.aircraftRotChanged = true;
+         }
          player.setAngles(deltaX, deltaY);
          return;
       }

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -9,6 +9,7 @@ import mcheli.MCH_KeyName;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_BaseVehicleCommonGui;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.aircraft.MCH_FlightModel;
 import mcheli.aircraft.MCH_HudShared;
 import mcheli.gui.MCH_Gui;
 import mcheli.plane.MCP_EntityPlane;
@@ -76,6 +77,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                if(this.shouldDrawNewPlaneSimpleHud(plane, seatID)) {
                   this.drawNewPlaneSimpleHud(plane);
                   this.drawNewPlaneWeaponHud(plane, player);
+                  this.drawNewPlaneDebugHud(plane);
                } else {
                   this.drawNewFlightThrottleHud(plane);
                }
@@ -120,6 +122,48 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          this.drawHudPanel(x - 4, wy - 2, 116, warnings.size() * 10 + 4);
          this.drawHudLines(warnings, x, wy, 0xFFFFD65A, 0x66FFAA00);
       }
+   }
+
+
+   private void drawNewPlaneDebugHud(MCP_EntityPlane plane) {
+      if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool && !MCH_Config.MouseAimDebug.prmBool) {
+         return;
+      }
+
+      MCP_PlaneInfo info = plane.getPlaneInfo();
+      if(info == null) {
+         return;
+      }
+
+      double stallSpeed = MCH_FlightModel.getStallSpeed(info.stallSpeed, plane.getMaxSpeed(), info.stallSpeedFactor);
+      List lines = new ArrayList();
+      lines.add(String.format("NF DBG  stall=%s recover=%s flap=%s", new Object[]{
+            Boolean.valueOf(plane.getStallSeverity() > 0.0D), Boolean.valueOf(plane.isStallRecovering()),
+            Boolean.valueOf(plane.isCombatFlapsDeployed())}));
+      lines.add(String.format("spd fwd=%.3f hor=%.3f stall=%.3f", new Object[]{
+            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed()), Double.valueOf(stallSpeed)}));
+      lines.add(String.format("aoa=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
+            Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getStallDemand()),
+            Double.valueOf(plane.getSpeedStallSeverity()), Double.valueOf(plane.getAoAStallSeverity()),
+            Double.valueOf(plane.getDeepStallSeverity())}));
+      lines.add(String.format("auth ctrl=%.2f pitch=%.2f up=%.2f down=%.2f", new Object[]{
+            Double.valueOf(plane.getLastControlAuthority()), Double.valueOf(plane.getLastFinalPitchAuthority()),
+            Double.valueOf(plane.getLastPitchUpAuthority()), Double.valueOf(plane.getLastPitchDownAuthority())}));
+      lines.add(String.format("mom stall=%.4f forced=%.4f finalAV=%.4f", new Object[]{
+            Double.valueOf(plane.getLastStallPitchMoment()), Double.valueOf(plane.getLastForcedNoseDownPitchDelta()),
+            Double.valueOf(plane.getLastFinalPitchAngularVelocity())}));
+      lines.add(String.format("lift L/W=%.2f T/W=%.2f loss=%.2f validClimb=%s", new Object[]{
+            Double.valueOf(plane.getLiftToWeightRatio()), Double.valueOf(plane.getThrustToWeightRatio()),
+            Double.valueOf(plane.getLastLiftLoss()), Boolean.valueOf(plane.isLastValidClimb())}));
+      lines.add(String.format("energy ratio=%.2f deficit=%.2f dE=%.4f", new Object[]{
+            Double.valueOf(plane.getLastPitchEnvelopeEnergyRatio()), Double.valueOf(plane.getLastEnergyDeficitSeverity()),
+            Double.valueOf(plane.getLastEnergyDelta())}));
+
+      int width = Math.min(super.width - 16, Math.max(260, this.getMaxHudLineWidth(lines) + 8));
+      int x = MathHelper.clamp_int(super.width - width - 8, 4, Math.max(4, super.width - width - 8));
+      int y = MathHelper.clamp_int(8, 4, Math.max(4, super.height - (lines.size() * 10 + 12)));
+      this.drawHudPanel(x - 4, y - 4, width, lines.size() * 10 + 8);
+      this.drawHudLines(lines, x, y, 0xFF66FF66, 0x66005500);
    }
 
    private String formatSimpleHudThrottle(MCP_EntityPlane plane) {


### PR DESCRIPTION
### Motivation
- Freelook was suppressing the new-flight plane aerodynamic integration and stall behavior, causing stalls and pitch-break recovery to be frozen while the camera was decoupled. 
- The new flight-model planes no longer showed the old debug HUD because debug rendering remained only in legacy GUI paths. 

### Description
- When freelook is active in `MCP_EntityPlane.setAngles(...)` the code now zeroes pilot inputs but calls `onUpdateAngles(partialTicks)` so aerodynamic body-rate integration (stall buffet, pitch-break recovery, etc.) continues while the camera is decoupled. 
- The freelook path was adjusted to only mark `aircraftRotChanged` when the aircraft attitude actually changed, keeping server sync without freezing physics. 
- Added `drawNewPlaneDebugHud(...)` in `MCP_GuiPlane` and call it alongside the simple new-plane HUD, importing `MCH_FlightModel` and gating the overlay on `DebugFlightControl`, `TestMode`, or `MouseAimDebug`; the overlay reports stall, forward/horizontal speed, AoA, stall severities, control authority, pitch moments, lift/thrust ratios, and energy telemetry. 

### Testing
- Ran `git diff --check` to validate patch whitespace/patch issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39a17b61148329919cfa2110448110)