### PR TITLE
Heli: Fix Gunner Mode behavior, HUD, and yaw authority

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
@@ -156,7 +156,9 @@ public class MCH_ClientHeliTickHandler extends MCH_BaseVehicleClientTickHandler 
          }
 
          if(this.KeySwitchHovering.isKeyDown()) {
-            if(heli.canSwitchHoveringMode()) {
+            if(heli.getIsGunnerMode(player)) {
+               playSoundNG();
+            } else if(heli.canSwitchHoveringMode()) {
                pc.switchMode = (byte)(heli.isHoveringMode()?2:3);
                heli.switchHoveringMode(!heli.isHoveringMode());
                send = true;

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -103,6 +103,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float yawAngularAcceleration;
    private float finalRotYaw;
    private boolean hoverAssistActive;
+   private boolean mouseFlightInputLocked;
+   private float debugYawInput;
+   private float debugYawAuthority;
+   private float debugFinalYawRate;
    private static final float NEW_HELI_MIN_MASS = 0.01F;
    private static final float NEW_HELI_MIN_INERTIA = 0.01F;
 
@@ -241,6 +245,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.yawAngularAcceleration = 0.0F;
       this.finalRotYaw = this.getRotYaw();
       this.hoverAssistActive = false;
+      this.mouseFlightInputLocked = false;
+      this.debugYawInput = 0.0F;
+      this.debugYawAuthority = 0.0F;
+      this.debugFinalYawRate = 0.0F;
    }
 
    public boolean isNewHeliFlightModelEnabled() {
@@ -466,6 +474,22 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
    public boolean isHoverAssistActive() {
       return this.hoverAssistActive;
+   }
+
+   public boolean isMouseFlightInputLocked() {
+      return this.mouseFlightInputLocked;
+   }
+
+   public float getDebugYawInput() {
+      return this.debugYawInput;
+   }
+
+   public float getDebugYawAuthority() {
+      return this.debugYawAuthority;
+   }
+
+   public float getDebugFinalYawRate() {
+      return this.debugFinalYawRate;
    }
 
    public Item getItem() {
@@ -772,7 +796,11 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    public boolean canMouseRot() {
-      return super.canMouseRot();
+      return super.canMouseRot() && !this.isMouseFlightInputLocked();
+   }
+
+   public boolean canSwitchFreeLook() {
+      return !super.isGunnerMode && super.canSwitchFreeLook();
    }
 
    public boolean canUpdatePitch(Entity player) {
@@ -804,9 +832,16 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    public float getControlRotYaw(float mouseX, float mouseY, float tick) {
+      this.mouseFlightInputLocked = this.newHeliFlightModelEnabled && super.isGunnerMode;
       if(this.newHeliFlightModelEnabled) {
+         if(this.mouseFlightInputLocked) {
+            this.tailRotorInput = 0.0F;
+            this.debugYawInput = 0.0F;
+            return 0.0F;
+         }
          float yawLimit = (float)Math.max(this.getAddRotationYawLimit(), 1.0D);
          this.tailRotorInput = MathHelper.clamp_float(mouseX / yawLimit, -1.0F, 1.0F);
+         this.debugYawInput = this.tailRotorInput;
          return 0.0F;
       }
 
@@ -887,7 +922,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       // Positive reaction is the fuselage yawing right from main-rotor drag; tail-rotor torque subtracts from it.
       this.mainRotorTorqueReaction = engineUsable?rotorLoad * rpmAuthority:0.0F;
 
-      float tailAuthority = Math.max(this.heliInfo.tailRotorAuthority, 0.0F) * rpmAuthority * damageAuthority;
+      float tailAuthority = Math.max(this.heliInfo.tailRotorAuthority, 0.0F) * this.getNewHelicopterYawAuthorityBoost() * rpmAuthority * damageAuthority;
+      this.debugYawAuthority = tailAuthority;
       this.tailRotorTorque = this.tailRotorInput * tailAuthority * Math.max(maxThrust, 0.01F);
       this.heliYawTorque = this.tailRotorTorque - this.mainRotorTorqueReaction;
 
@@ -898,9 +934,38 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.yawDampingApplied = -this.heliYawAngularVelocity * Math.max(this.heliInfo.yawDamping, 0.0F) * tickDelta;
       this.heliYawAngularVelocity += this.yawDampingApplied;
       this.heliYawAngularVelocity = MathHelper.clamp_float(this.heliYawAngularVelocity, -8.0F, 8.0F);
+      this.debugFinalYawRate = this.heliYawAngularVelocity;
+      this.logNewHelicopterControlDebug();
 
       this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
       this.setRotYaw(this.finalRotYaw);
+   }
+
+   private float getNewHelicopterYawAuthorityBoost() {
+      if(!this.newHeliFlightModelEnabled || this.heliInfo == null) {
+         return 1.0F;
+      }
+
+      float mass = this.sanitizePositive(this.heliInfo.physicalMass, 1.0F, NEW_HELI_MIN_MASS);
+      float size = Math.max(super.width, super.height);
+      if(mass <= 1.25F && size <= 2.5F) {
+         return 2.35F;
+      } else if(mass <= 3.0F && size <= 4.5F) {
+         return 1.75F;
+      }
+      return 1.30F;
+   }
+
+   private boolean isNewHelicopterHoverAssistMode() {
+      return this.isHoveringMode() || super.isGunnerMode;
+   }
+
+   private void logNewHelicopterControlDebug() {
+      if(MCH_Config.DebugFlightControl == null || !MCH_Config.DebugFlightControl.prmBool || this.ticksExisted % 20 != 0) {
+         return;
+      }
+      MCH_Lib.Log((Entity)this, "[MCHeli][NewHeliControl] gunnerModeActive=%s hoverAssistActive=%s mouseFlightInputLocked=%s yawInput=%.3f yawAuthority=%.3f finalYawRate=%.3f",
+            new Object[]{Boolean.valueOf(super.isGunnerMode), Boolean.valueOf(this.hoverAssistActive), Boolean.valueOf(this.mouseFlightInputLocked), Float.valueOf(this.debugYawInput), Float.valueOf(this.debugYawAuthority), Float.valueOf(this.debugFinalYawRate)});
    }
 
    protected void onUpdate_Rotor() {
@@ -944,6 +1009,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    protected void onUpdate_Control() {
+      this.mouseFlightInputLocked = super.isGunnerMode;
+      if(super.isGunnerMode && this.isFreeLookMode()) {
+         this.switchFreeLookMode(false);
+      }
 
       //if(getHP() * 100 / getMaxHP() < getAcInfo().engineShutdownThreshold) {
       //   setCurrentThrottle(0);
@@ -1120,7 +1189,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    private void enforceNewHelicopterHoverMinimumThrottle() {
-      if(this.newHeliFlightModelEnabled && this.isHoveringMode() && this.heliInfo != null) {
+      if(this.newHeliFlightModelEnabled && this.isNewHelicopterHoverAssistMode() && this.heliInfo != null) {
          float minimumThrottle = Math.max(MathHelper.clamp_float(this.heliInfo.hoverMinimumThrottle, 0.0F, 1.0F), this.getNewHelicopterCalculatedHoverThrottle());
          if(this.getCurrentThrottle() < (double)minimumThrottle) {
             this.setCurrentThrottle((double)minimumThrottle);
@@ -1129,7 +1198,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    }
 
    private void updateNewHelicopterHoverThrottleController(float throttleUpDown) {
-      if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+      if(!this.newHeliFlightModelEnabled || !this.isNewHelicopterHoverAssistMode() || this.heliInfo == null) {
          this.hoverThrottleBias = 0.0F;
          this.hoverVerticalSpeedAverage = 0.0F;
          this.hoverVerticalNextAdjustmentTick = 0;
@@ -1432,7 +1501,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.localDriftRight = 0.0F;
       this.hoverAssistActive = false;
 
-      if(!this.newHeliFlightModelEnabled || !this.isHoveringMode() || this.heliInfo == null) {
+      if(!this.newHeliFlightModelEnabled || !this.isNewHelicopterHoverAssistMode() || this.heliInfo == null) {
          this.hoverThrottleBias = 0.0F;
          return;
       }

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -70,8 +70,8 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
                }
 
                if(seatID == 0) {
-                  this.drawNewHeliSharedHud(heli);
-                  this.drawNewHeliHealthHud(heli);
+                  this.drawNewHeliSharedHud(heli, player);
+                  this.drawNewHeliHealthHud(heli, player);
                   this.drawNewHeliPitchReadout(heli, player);
                   this.drawNewHeliRadarHud(heli);
                   this.drawNewHeliWeaponHud(heli, player);
@@ -91,6 +91,12 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
                }
 
                MCH_EntityTvMissile tvmissile = heli.getTVMissile();
+               if(seatID == 0) {
+                  this.drawNewHeliSharedHud(heli, player);
+                  this.drawNewHeliHealthHud(heli, player);
+                  this.drawNewHeliWeaponHud(heli, player);
+               }
+
                if(!heli.isMissileCameraMode(player)) {
                   this.drawKeyBind(heli, player, seatID);
                } else if(tvmissile != null) {
@@ -104,7 +110,7 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       }
    }
 
-   private void drawNewHeliSharedHud(MCH_EntityHeli heli) {
+   private void drawNewHeliSharedHud(MCH_EntityHeli heli, EntityPlayer player) {
       if(!this.shouldDrawNewHeliHudAdditions(heli) || !MCH_Config.EnableNewHeliHudSharedReadouts.prmBool) {
          return;
       }
@@ -116,27 +122,27 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       lines.add(MCH_HudShared.formatVerticalSpeed(heli));
       lines.add(String.format("PWR   %3d%%", new Object[]{Integer.valueOf(this.toPercent(heli.getEnginePowerOutput()))}));
       if(info != null && info.newHeliControlHudDisplay && heli.isHoverAssistActive()) {
-         lines.add("SAS   ON");
+         lines.add((heli.getIsGunnerMode(player)?"GNR":"SAS") + "   ON");
       }
       lines.add(MCH_HudShared.formatFuelMinutes(heli));
-      int color = -14101432;
+      int color = this.getNewHeliHudColor(heli, player);
       int x = super.centerX - 205;
       int y = super.centerY + 20;
       for(int i = 0; i < lines.size(); ++i) {
-         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, color, 0x5528D448);
+         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, color, 0x5528D448, !heli.getIsGunnerMode(player));
       }
    }
 
 
-   private void drawNewHeliHealthHud(MCH_EntityHeli heli) {
+   private void drawNewHeliHealthHud(MCH_EntityHeli heli, EntityPlayer player) {
       if(!this.shouldDrawNewHeliHudAdditions(heli)) {
          return;
       }
       int hp = MCH_HudShared.getDamagePercent(heli);
-      int color = hp > 20 ? -14101432 : -2162680;
+      int color = heli.getIsGunnerMode(player) ? 0xFFFFFFFF : (hp > 20 ? -14101432 : -2162680);
       int x = super.centerX - 205;
       int y = super.centerY + 83;
-      this.drawNewHeliHudText(String.format("HP    %3d%%", new Object[]{Integer.valueOf(hp)}), x, y, color, 0x5528D448);
+      this.drawNewHeliHudText(String.format("HP    %3d%%", new Object[]{Integer.valueOf(hp)}), x, y, color, 0x5528D448, !heli.getIsGunnerMode(player));
       int barWidth = MathHelper.clamp_int(hp * 60 / 100, 0, 60);
       drawRect(x, y + 10, x + 60, y + 13, 0x66188428);
       drawRect(x, y + 10, x + barWidth, y + 13, color);
@@ -236,7 +242,7 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
          return;
       }
       for(int i = 0; i < lines.size(); ++i) {
-         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, -14101432, 0x5528D448);
+         this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, this.getNewHeliHudColor(heli, player), 0x5528D448, !heli.getIsGunnerMode(player));
       }
    }
 
@@ -246,10 +252,18 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
    }
 
    private void drawNewHeliHudText(String text, int x, int y, int color, int glowColor) {
-      if(this.isVehicleHudGlowEnabled()) {
+      this.drawNewHeliHudText(text, x, y, color, glowColor, true);
+   }
+
+   private void drawNewHeliHudText(String text, int x, int y, int color, int glowColor, boolean allowGlow) {
+      if(allowGlow && this.isVehicleHudGlowEnabled()) {
          this.drawString(text, x + 1, y + 1, glowColor);
       }
       this.drawString(text, x, y, color);
+   }
+
+   private int getNewHeliHudColor(MCH_EntityHeli heli, EntityPlayer player) {
+      return heli.getIsGunnerMode(player)?0xFFFFFFFF:-14101432;
    }
 
    private boolean isVehicleHudGlowEnabled() {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -158,7 +158,7 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
          this.collectiveResponse = this.toFloat(data, 0.0F, 1.0F);
       } else if(item.equalsIgnoreCase("CyclicAuthority")) {
          this.cyclicAuthority = this.toFloat(data, 0.0F, 1000.0F);
-      } else if(item.equalsIgnoreCase("TailRotorAuthority")) {
+      } else if(item.equalsIgnoreCase("TailRotorAuthority") || item.equalsIgnoreCase("YawAuthority")) {
          this.tailRotorAuthority = this.toFloat(data, 0.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("YawDamping")) {
          this.yawDamping = this.toFloat(data, 0.0F, 1000.0F);

--- a/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
@@ -132,8 +132,10 @@ public class MCH_HeliPacketHandler {
                   heli.foldHatch(pc.switchHatch == 2);
                }
 
-               if(pc.switchFreeLook > 0) {
+               if(pc.switchFreeLook > 0 && !heli.getIsGunnerMode(player)) {
                   heli.switchFreeLookMode(pc.switchFreeLook == 1);
+               } else if(heli.getIsGunnerMode(player) && heli.isFreeLookMode()) {
+                  heli.switchFreeLookMode(false);
                }
 
                if(pc.switchGear == 1) {


### PR DESCRIPTION
### Motivation
- Make Gunner Mode behave like Hover Mode for stable altitude/drift while preventing mouse flight from changing aircraft attitude. 
- Prevent freelook/hover toggles and freelook packets from creating unwanted forward acceleration or flight-mode quirk when a gunner is active. 
- Improve helicopter yaw responsiveness with a realistic, role/size-based authority boost. 
- Surface the same improved helicopter readouts to gunner HUDs using the normal white HUD style and keep layout consistent.

### Description
- Lock/suppress mouse flight inputs during pilot `Gunner Mode` by adding `mouseFlightInputLocked` and gating `canMouseRot()` and `getControlRotYaw()` in `MCH_EntityHeli`, while preserving weapon/camera aiming through the view path. 
- Reuse the new hover stabilization for Gunner Mode by introducing `isNewHelicopterHoverAssistMode()` and switching hover/minimum-throttle and hover-assist checks to include gunner state so altitude/drift correction runs unless the pilot overrides with keyboard input. 
- Add size/mass-based yaw authority scaling via `getNewHelicopterYawAuthorityBoost()` and honor a `YawAuthority` alias in `MCH_HeliInfo` (adds to existing `TailRotorAuthority`), then apply the boost in the new-heli yaw model; keep damping/inertia so yaw remains realistic. 
- Suppress freelook/hover toggles while gunner-active by adjusting `MCH_ClientHeliTickHandler` and ignore freelook packet toggles server-side when gunner is active in `MCH_HeliPacketHandler`. 
- Move the new-heli shared readouts (SPD, ALT, VS, PWR, FUEL, HP, weapon/ammo list and a SAS/GNR indicator) into the Gunner HUD path in `MCH_GuiHeli`, using the normal white HUD color and disabling the green glow for gunner-mode items to maintain visual consistency. 
- Add debug state variables and logging: `gunnerModeActive`, `hoverAssistActive`, `mouseFlightInputLocked`, `yawInput`, `yawAuthority`, and `finalYawRate` (debug fields and `MCH_Lib.Log` call guarded by `MCH_Config.DebugFlightControl`).

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and reviewed diffs, which passed without reported conflicts. 
- Committed changes locally (`Clean up helicopter gunner mode controls`) but Java/Gradle compilation and runtime tests were not executed per instruction to avoid compiling `.class` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39fff0d2d48329a1e7b096c52382d1)