### PR TITLE
Fix grounded helicopter yaw drift

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -109,6 +109,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private float debugFinalYawRate;
    private static final float NEW_HELI_MIN_MASS = 0.01F;
    private static final float NEW_HELI_MIN_INERTIA = 0.01F;
+   private static final float NEW_HELI_GROUNDED_YAW_INPUT_DEADZONE = 0.04F;
+   private static final float NEW_HELI_GROUNDED_YAW_DAMPING = 0.35F;
 
 
    public MCH_EntityHeli(World world) {
@@ -922,6 +924,25 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       // Positive reaction is the fuselage yawing right from main-rotor drag; tail-rotor torque subtracts from it.
       this.mainRotorTorqueReaction = engineUsable?rotorLoad * rpmAuthority:0.0F;
 
+      if(this.isNewHelicopterGroundedForYaw()) {
+         float groundedDamping = MathHelper.clamp_float(NEW_HELI_GROUNDED_YAW_DAMPING * tickDelta, 0.0F, 1.0F);
+         this.heliYawAngularVelocity *= 1.0F - groundedDamping;
+         if(MathHelper.abs(this.tailRotorInput) <= NEW_HELI_GROUNDED_YAW_INPUT_DEADZONE || MathHelper.abs(this.heliYawAngularVelocity) < 0.01F) {
+            this.heliYawAngularVelocity = 0.0F;
+         }
+
+         this.mainRotorTorqueReaction = 0.0F;
+         this.tailRotorTorque = 0.0F;
+         this.heliYawTorque = 0.0F;
+         this.yawAngularAcceleration = 0.0F;
+         this.yawDampingApplied = 0.0F;
+         this.debugFinalYawRate = this.heliYawAngularVelocity;
+         this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
+         this.setRotYaw(this.finalRotYaw);
+         this.logNewHelicopterControlDebug();
+         return;
+      }
+
       float tailAuthority = Math.max(this.heliInfo.tailRotorAuthority, 0.0F) * this.getNewHelicopterYawAuthorityBoost() * rpmAuthority * damageAuthority;
       this.debugYawAuthority = tailAuthority;
       this.tailRotorTorque = this.tailRotorInput * tailAuthority * Math.max(maxThrust, 0.01F);
@@ -939,6 +960,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
       this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
       this.setRotYaw(this.finalRotYaw);
+   }
+
+   private boolean isNewHelicopterGroundedForYaw() {
+      if(this.isDestroyed()) {
+         return false;
+      }
+
+      return super.onGround || MCH_Lib.getBlockIdY(this, 1, -2) > 0;
    }
 
    private float getNewHelicopterYawAuthorityBoost() {


### PR DESCRIPTION
### Motivation
- Landed helicopters were slowly rotating like turntables after landing or when mounted, caused by residual yaw angular velocity and passive main-rotor torque in the new helicopter flight model. 
- The change aims to stop that unwanted rotation by damping yaw and suppressing yaw torques while the vehicle is grounded or supported by nearby blocks.

### Description
- Added tuning constants `NEW_HELI_GROUNDED_YAW_INPUT_DEADZONE` and `NEW_HELI_GROUNDED_YAW_DAMPING` to control grounded yaw deadzone and damping. 
- In `applyNewHelicopterYawModel`, detect a grounded state and apply additional damping to `heliYawAngularVelocity`, zero small residuals, and short-circuit yaw torque calculations to prevent passive main-rotor torque from spinning the fuselage. 
- Added helper `isNewHelicopterGroundedForYaw()` which treats the helicopter as grounded when `onGround` is true or when a nearby supporting block is detected. 
- Preserves existing airborne behavior and leaves existing tuning (tail authority, inertia, damping) intact for flying conditions.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed. 
- Attempted `bash ./gradlew compileJava` to compile the change but the Gradle wrapper download failed due to an external proxy returning HTTP 403, so a full compile could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a95f5ed408323943ce36718d5b952)