### PR TITLE
Fix destroyed helicopter lift (prevent upward spiral on death)

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -1736,7 +1736,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
 
          if(motion == 0.0D) {
-            if(!this.newHeliFlightModelEnabled) {
+            if(!this.newHeliFlightModelEnabled || this.isDestroyed()) {
                super.motionY += !this.isInWater()?(double)this.getAcInfo().gravity:(double)this.getAcInfo().gravityInWater;
             }
 
@@ -1760,7 +1760,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
             double throttle = this.getCurrentThrottle();
             if(this.isDestroyed()) {
-               throttle *= 0.65D;
+               // A destroyed helicopter should autorotate/fall instead of feeding residual
+               // throttle into lift. Keeping visual rotor throttle separate prevents the
+               // death spin from turning into an upward spiral while the engine winds down.
+               throttle = 0.0D;
             }
 
             double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);


### PR DESCRIPTION
### Motivation
- Destroyed helicopters could gain lift and spiral upward during the rotor wind-down because gravity was not applied under the new helicopter flight model and residual death-throttle still fed lift calculations.

### Description
- Update `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` to apply gravity to destroyed helicopters even when the new helicopter flight model is enabled by changing the gravity branch in `onUpdate_Server`.
- Stop residual death throttle from contributing lift by forcing `throttle = 0.0D` when `isDestroyed()` so damaged helicopters autorotate/fall instead of climbing.

### Testing
- Ran `git diff --check` which completed without blocking issues.
- Attempted `./gradlew compileJava` which failed because `gradlew` is not executable in this environment.
- Attempted `bash ./gradlew compileJava` which failed due to the Gradle distribution download being blocked by a proxy (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a9ef932d88323b7ac4b3854e8c797)