### PR TITLE
Fix destroyed helicopter lift behavior and preserve rotor telemetry for new flight model

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -763,7 +763,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
 
          this.updateNewHelicopterFlightTelemetryConfig();
-         if(this.newHeliFlightModelEnabled && (this.isDestroyed() || !this.canUseBlades() || this.isFoldBlades())) {
+         if(this.newHeliFlightModelEnabled && (!this.canUseBlades() || this.isFoldBlades())) {
             this.resetNewHelicopterFlightTelemetry();
          }
          this.updateWeapons();
@@ -1736,7 +1736,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
 
          if(motion == 0.0D) {
-            if(!this.newHeliFlightModelEnabled) {
+            if(!this.newHeliFlightModelEnabled || this.isDestroyed()) {
                super.motionY += !this.isInWater()?(double)this.getAcInfo().gravity:(double)this.getAcInfo().gravityInWater;
             }
 
@@ -1760,7 +1760,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
             double throttle = this.getCurrentThrottle();
             if(this.isDestroyed()) {
-               throttle *= 0.65D;
+               // A destroyed helicopter should autorotate/fall instead of feeding residual
+               // throttle into lift. Keeping visual rotor throttle separate prevents the
+               // death spin from turning into an upward spiral while the engine winds down.
+               throttle = 0.0D;
             }
 
             double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
@@ -1819,6 +1822,11 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             this.updateNewHelicopterCyclicInput();
             this.applyNewHelicopterCollectiveLift(1.0D, throttle, horizontalSpeed, 1.0F);
             this.applyNewHelicopterCyclicThrust(1.0F);
+         } else if(this.newHeliFlightModelEnabled && this.isDestroyed()) {
+            // Destroyed new-flight helicopters can still be in hover mode. Do not reset
+            // rotor telemetry here; let rotor RPM spool down naturally while applying
+            // gravity so the aircraft falls instead of hanging or climbing.
+            super.motionY += !this.isInWater()?(double)this.getAcInfo().gravity:(double)this.getAcInfo().gravityInWater;
          } else if(this.newHeliFlightModelEnabled) {
             this.resetNewHelicopterFlightTelemetry();
          }
@@ -1834,6 +1842,10 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          if(!this.newHeliFlightModelEnabled && super.rand.nextInt(50) == 0) {
             super.motionZ += (super.rand.nextDouble() - 0.5D) / 30.0D;
          }
+      }
+
+      if(this.isDestroyed() && super.motionY > 0.0D) {
+         super.motionY *= 0.25D;
       }
 
       if(this.useNewMobilitySystem()) {


### PR DESCRIPTION
### Motivation
- Ensure destroyed helicopters do not generate residual lift or climb unexpectedly. 
- Preserve new-flight-model rotor telemetry after destruction so the rotor spools down naturally rather than being reset. 
- Reduce upward momentum spikes for destroyed aircraft to produce more realistic fall behavior.

### Description
- Removed resetting of new helicopter flight telemetry on destruction by changing the telemetry reset condition to only check `!canUseBlades()` or `isFoldBlades()` instead of `isDestroyed()`.
- Stop feeding residual throttle into lift for destroyed helicopters by setting `throttle = 0.0D` when `isDestroyed()`.
- Apply gravity to destroyed helicopters when using the new flight model in both free-flight and hover-mode paths by adding gravity application for destroyed new-model helicopters and for the non-hover path.
- Damp any upward motion for destroyed helicopters by scaling down `motionY` when `isDestroyed()` and `motionY > 0.0D`.

### Testing
- Ran the project's automated unit test suite with `mvn test` and the tests completed successfully. 
- Executed CI build/compile (`mvn -DskipTests=false package`) which succeeded with no compilation errors. 
- Ran automated flight-physics regression tests (integration) which passed and showed destroyed helicopters no longer gain lift or reset rotor telemetry unexpectedly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a9ef932d88323b7ac4b3854e8c797)