### PR TITLE
Rebalance legacy helicopter hover vs forward speed

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -111,6 +111,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private static final float NEW_HELI_MIN_INERTIA = 0.01F;
    private static final float NEW_HELI_GROUNDED_YAW_INPUT_DEADZONE = 0.04F;
    private static final float NEW_HELI_GROUNDED_YAW_DAMPING = 0.35F;
+   private static final double LEGACY_HELI_REGULAR_FORWARD_ACCEL = 0.24D;
+   private static final double LEGACY_HELI_HOVER_TRANSLATION_ACCEL = 0.0035D;
 
 
    public MCH_EntityHeli(World world) {
@@ -1322,8 +1324,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
          if(move) {
             double d = Math.sqrt(x * x + z * z);
-            super.motionX -= x / d * 0.009999999776482582D * (double)this.getAcInfo().speed;
-            super.motionZ += z / d * 0.009999999776482582D * (double)this.getAcInfo().speed;
+            super.motionX -= x / d * LEGACY_HELI_HOVER_TRANSLATION_ACCEL * (double)this.getAcInfo().speed;
+            super.motionZ += z / d * LEGACY_HELI_HOVER_TRANSLATION_ACCEL * (double)this.getAcInfo().speed;
          }
       }
 
@@ -1747,8 +1749,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
             }
 
             if(!this.newHeliFlightModelEnabled) {
-               super.motionX += 0.1D * (double)MathHelper.sin(speedLimit) * super.currentSpeed * (double)(-(pitch * pitch * pitch / 30000.0F)) * this.getCurrentThrottle();
-               super.motionZ += 0.1D * (double)MathHelper.cos(speedLimit) * super.currentSpeed * (double)(pitch * pitch * pitch / 30000.0F) * this.getCurrentThrottle();
+               super.motionX += LEGACY_HELI_REGULAR_FORWARD_ACCEL * (double)MathHelper.sin(speedLimit) * super.currentSpeed * (double)(-(pitch * pitch * pitch / 30000.0F)) * this.getCurrentThrottle();
+               super.motionZ += LEGACY_HELI_REGULAR_FORWARD_ACCEL * (double)MathHelper.cos(speedLimit) * super.currentSpeed * (double)(pitch * pitch * pitch / 30000.0F) * this.getCurrentThrottle();
             }
             double y = (double)(MathHelper.abs(this.getRotPitch()) + MathHelper.abs(this.getRotRoll()));
             y *= 0.6000000238418579D;


### PR DESCRIPTION
### Motivation
- Players reported that hover-mode translation is unrealistically fast while regular/pitched forward flight is too slow, so legacy helicopter movement tuning needed rebalancing.
- Make legacy-mode tuning explicit and easier to adjust by replacing magic numbers with named constants.

### Description
- Added two named constants `LEGACY_HELI_REGULAR_FORWARD_ACCEL` and `LEGACY_HELI_HOVER_TRANSLATION_ACCEL` to `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` to separate regular forward accel from hover translation.
- Replaced the hardcoded forward acceleration factor (`0.1D`) with `LEGACY_HELI_REGULAR_FORWARD_ACCEL` and increased its value to `0.24D` to make pitched forward flight noticeably faster.
- Replaced the hardcoded hover translation multiplier (`0.009999999776482582D`) with `LEGACY_HELI_HOVER_TRANSLATION_ACCEL` and reduced it to `0.0035D` so hover movement is slower and more controllable.

### Testing
- Ran `git diff --check` which reported no whitespace/format issues and the patch applies cleanly.
- Attempted to run `./gradlew compileJava` but the wrapper was not executable in this checkout so the task could not run locally.
- Attempted `bash ./gradlew compileJava` to force execution, but the Gradle wrapper failed to download the distribution due to an external proxy returning HTTP 403, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab028fb348323a98096bc7af21138)