### PR TITLE
HUD/control: expose fuel helper, restore stick gauge & overheat bars, use vehicle pitch, scale HUD speeds, 0.5% throttle steps

### DIFF
--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -178,6 +178,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm EnableNewHeliHudSharedReadouts;
    public static MCH_ConfigPrm EnableNewHeliWeaponHud;
    public static MCH_ConfigPrm EnableNewVehicleHudGlow;
+   public static MCH_ConfigPrm EnableNewVehicleStickInputGauge;
    public static MCH_ConfigPrm NewPlaneSimpleHudX;
    public static MCH_ConfigPrm NewPlaneSimpleHudY;
    public static MCH_ConfigPrm NewPlaneWeaponHudRightMargin;
@@ -506,6 +507,8 @@ public class MCH_Config {
       EnableNewHeliWeaponHud.desc = ";Render the existing-style helicopter weapon/ammo list for new-flight helicopters only.";
       EnableNewVehicleHudGlow = new MCH_ConfigPrm("EnableNewVehicleHudGlow", true);
       EnableNewVehicleHudGlow.desc = ";Draw subtle background panels and one-pixel glow text for shared new vehicle HUD additions.";
+      EnableNewVehicleStickInputGauge = new MCH_ConfigPrm("EnableNewVehicleStickInputGauge", true);
+      EnableNewVehicleStickInputGauge.desc = ";Draw the stick/mouse input gauge beside new plane and helicopter HUD readouts.";
       NewPlaneSimpleHudX = new MCH_ConfigPrm("NewPlaneSimpleHudX", 12);
       NewPlaneSimpleHudX.desc = ";Top-left new-plane simple HUD X offset in scaled GUI pixels.";
       NewPlaneSimpleHudY = new MCH_ConfigPrm("NewPlaneSimpleHudY", 12);
@@ -756,6 +759,7 @@ public class MCH_Config {
               EnableNewHeliHudSharedReadouts,
               EnableNewHeliWeaponHud,
               EnableNewVehicleHudGlow,
+              EnableNewVehicleStickInputGauge,
               NewPlaneSimpleHudX,
               NewPlaneSimpleHudY,
               NewPlaneWeaponHudRightMargin,

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -771,11 +771,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public double getThrottle() {
-      return 0.05D * (double)this.getDataWatcher().getWatchableObjectInt(29);
+      return 0.005D * (double)this.getDataWatcher().getWatchableObjectInt(29);
    }
 
    public void setThrottle(double t) {
-      int n = (int)(t * 20.0D);
+      int n = (int)Math.round(t * 200.0D);
       if(n == 0 && t > 0.0D) {
          n = 1;
       }
@@ -1728,7 +1728,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setCurrentThrottle(double throttle) {
-      this.currentThrottle = throttle;
+      this.currentThrottle = MathHelper.clamp_double(Math.round(throttle * 200.0D) / 200.0D, 0.0D, 1.0D);
    }
 
    public void addCurrentThrottle(double throttle) {
@@ -1938,6 +1938,27 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    /** Effective 0..1 control authority after stall and high-G penalties. */
    public float getDebugControlAuthority() {
       return this.getControlAuthorityFactor();
+   }
+
+
+   public int getFuelRemainingTicks() {
+      if(this.getMaxFuel() <= 0 || this.getFuel() <= 0 || this.isInfinityFuel(this.getRiddenByEntity(), true)) {
+         return -1;
+      }
+      if(this.getAcInfo() == null || this.getAcInfo().fuelConsumption <= 0.0F) {
+         return -1;
+      }
+      double throttle = MathHelper.clamp_double(this.getNormalizedThrottle(), 0.0D, 1.0D);
+      double burnPerSecond = Math.min(throttle * 1.4D, 1.0D) * (double)this.getAcInfo().fuelConsumption * (double)this.getFuelConsumptionFactor();
+      if(burnPerSecond <= 0.01D || Double.isNaN(burnPerSecond) || Double.isInfinite(burnPerSecond)) {
+         return -1;
+      }
+      return Math.max(0, (int)Math.round((double)this.getFuel() / burnPerSecond * 20.0D));
+   }
+
+   public int getFuelRemainingSeconds() {
+      int ticks = this.getFuelRemainingTicks();
+      return ticks < 0 ? -1 : Math.max(0, (int)Math.round((double)ticks / 20.0D));
    }
 
    /** Normalized pilot throttle for debug/HUD text. */

--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -10,6 +10,8 @@ import net.minecraft.util.MathHelper;
 
 public final class MCH_HudShared {
 
+   public static final double HUD_SPEED_DISPLAY_MULTIPLIER = 5.0D;
+
    private MCH_HudShared() {
    }
 
@@ -26,11 +28,11 @@ public final class MCH_HudShared {
    }
 
    public static String formatThrottleOrCollective(String label, MCH_EntityBaseVehicle ac) {
-      return String.format("%s %3d%%", new Object[]{label, Integer.valueOf(MathHelper.clamp_int((int)Math.round(ac.getNormalizedThrottle() * 100.0D), 0, 100))});
+      return String.format("%s %5.1f%%", new Object[]{label, Double.valueOf(MathHelper.clamp_double(ac.getNormalizedThrottle() * 100.0D, 0.0D, 100.0D))});
    }
 
    public static String formatSpeedKmh(MCH_EntityBaseVehicle ac) {
-      double speedKmh = Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D;
+      double speedKmh = Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D * HUD_SPEED_DISPLAY_MULTIPLIER;
       return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
    }
 
@@ -43,12 +45,16 @@ public final class MCH_HudShared {
    }
 
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D * HUD_SPEED_DISPLAY_MULTIPLIER))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {
-      int minutes = estimateFuelMinutes(ac);
-      return minutes < 0 ? "FUEL  -- min" : String.format("FUEL  %d min", new Object[]{Integer.valueOf(minutes)});
+      int seconds = ac != null ? ac.getFuelRemainingSeconds() : -1;
+      if(seconds < 0) {
+         return "FUEL  -- min";
+      }
+      int minutes = Math.max(0, (int)Math.round((double)seconds / 60.0D));
+      return String.format("FUEL  %d min", new Object[]{Integer.valueOf(minutes)});
    }
 
    public static String formatDamagePercent(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_GuiHeli.java
@@ -5,6 +5,7 @@ import cpw.mods.fml.relauncher.SideOnly;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_Config;
 import mcheli.MCH_KeyName;
 import mcheli.MCH_Lib;
@@ -94,6 +95,7 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
                if(seatID == 0) {
                   this.drawNewHeliSharedHud(heli, player);
                   this.drawNewHeliHealthHud(heli, player);
+                  this.drawNewHeliPitchReadout(heli, player);
                   this.drawNewHeliWeaponHud(heli, player);
                }
 
@@ -131,8 +133,23 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       for(int i = 0; i < lines.size(); ++i) {
          this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, color, 0x5528D448, !heli.getIsGunnerMode(player));
       }
+      this.drawStickInputGauge(x + 88, y + 6, color);
    }
 
+
+
+   private void drawStickInputGauge(int x, int y, int color) {
+      if(!MCH_Config.EnableNewVehicleStickInputGauge.prmBool) {
+         return;
+      }
+      int size = 30;
+      int half = size / 2;
+      double max = Math.max(1.0D, MCH_ClientCommonTickHandler.getMaxStickLength());
+      int sx = x + half + (int)Math.round(MathHelper.clamp_double(MCH_ClientCommonTickHandler.getCurrentStickX() / max, -1.0D, 1.0D) * (double)(half - 3));
+      int sy = y + half - (int)Math.round(MathHelper.clamp_double(MCH_ClientCommonTickHandler.getCurrentStickY() / max, -1.0D, 1.0D) * (double)(half - 3));
+      this.drawLine(new double[]{(double)x, (double)(y + half), (double)(x + size), (double)(y + half), (double)(x + half), (double)y, (double)(x + half), (double)(y + size)}, color, 1);
+      drawRect(sx - 2, sy - 2, sx + 3, sy + 3, color);
+   }
 
    private void drawNewHeliHealthHud(MCH_EntityHeli heli, EntityPlayer player) {
       if(!this.shouldDrawNewHeliHudAdditions(heli)) {
@@ -157,7 +174,7 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       int y = super.centerY - 4;
       this.clearLegacyPitchReadoutBox();
       this.drawPitchReadoutBox(x, super.centerY);
-      this.drawNewHeliHudText(String.format("%.0f", new Object[]{Float.valueOf(-player.rotationPitch)}), x, y, -14101432, 0x5528D448);
+      this.drawNewHeliHudText(String.format("%.0f", new Object[]{Float.valueOf(heli.getRotPitch())}), x, y, -14101432, 0x5528D448);
    }
 
    private void clearLegacyPitchReadoutBox() {
@@ -243,6 +260,28 @@ public class MCH_GuiHeli extends MCH_BaseVehicleCommonGui {
       }
       for(int i = 0; i < lines.size(); ++i) {
          this.drawNewHeliHudText((String)lines.get(i), x, y + i * 10, this.getNewHeliHudColor(heli, player), 0x5528D448, !heli.getIsGunnerMode(player));
+      }
+      this.drawWeaponOverheatBars(heli, x, y + lines.size() * 10 + 2, 72);
+   }
+
+
+   private void drawWeaponOverheatBars(MCH_EntityBaseVehicle ac, int x, int y, int width) {
+      if(ac == null || ac.weapons == null) {
+         return;
+      }
+      int row = 0;
+      for(int i = 0; i < ac.weapons.length; ++i) {
+         mcheli.weapon.MCH_WeaponSet ws = ac.weapons[i];
+         if(ws != null && ws.getCurrentWeapon() != null && ws.getCurrentWeapon().getInfo() != null) {
+            int maxHeat = ws.getCurrentWeapon().getInfo().maxHeatCount;
+            if(maxHeat > 0) {
+               int by = y + row * 5;
+               int fill = MathHelper.clamp_int((int)Math.round((double)Math.max(0, ws.currentHeat) * (double)width / (double)maxHeat), 0, width);
+               drawRect(x, by, x + width, by + 3, 0x66303030);
+               drawRect(x, by, x + fill, by + 3, ws.currentHeat >= maxHeat ? 0xFFFF3030 : 0xFFFFAA30);
+               ++row;
+            }
+         }
       }
    }
 

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_Config;
 import mcheli.MCH_KeyName;
 import mcheli.MCH_MOD;
@@ -106,6 +107,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(MCH_HudShared.formatSpeedKmh(plane));
       lines.add(MCH_HudShared.formatAltitude(plane));
       lines.add(MCH_HudShared.formatVerticalSpeed(plane));
+      lines.add(String.format("PITCH %+.0f\u00B0", new Object[]{Float.valueOf(plane.getRotPitch())}));
       lines.add(MCH_HudShared.formatFuelMinutes(plane));
       lines.add(MCH_HudShared.formatDamagePercent(plane));
       lines.add(this.formatSimpleHudGLoad(plane));
@@ -113,9 +115,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
       List warnings = this.collectSimpleHudWarnings(plane);
       int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - 118));
-      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - 92));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - 102));
       this.drawHudPanel(x - 4, y - 4, 116, lines.size() * 10 + 8);
       this.drawHudLines(lines, x, y, 0xFFE8E8E8, 0x66303030);
+
+      this.drawStickInputGauge(x + 126, y + 12);
 
       if(!warnings.isEmpty()) {
          int wy = y + lines.size() * 10 + 5;
@@ -124,6 +128,21 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       }
    }
 
+
+
+   private void drawStickInputGauge(int x, int y) {
+      if(!MCH_Config.EnableNewVehicleStickInputGauge.prmBool) {
+         return;
+      }
+      int size = 34;
+      int half = size / 2;
+      double max = Math.max(1.0D, MCH_ClientCommonTickHandler.getMaxStickLength());
+      int sx = x + half + (int)Math.round(MathHelper.clamp_double(MCH_ClientCommonTickHandler.getCurrentStickX() / max, -1.0D, 1.0D) * (double)(half - 3));
+      int sy = y + half - (int)Math.round(MathHelper.clamp_double(MCH_ClientCommonTickHandler.getCurrentStickY() / max, -1.0D, 1.0D) * (double)(half - 3));
+      this.drawHudPanel(x - 2, y - 2, size + 4, size + 4);
+      this.drawLine(new double[]{(double)x, (double)(y + half), (double)(x + size), (double)(y + half), (double)(x + half), (double)y, (double)(x + half), (double)(y + size)}, 0x8855FF66, 1);
+      drawRect(sx - 2, sy - 2, sx + 3, sy + 3, 0xFF55FF66);
+   }
 
    private void drawNewPlaneDebugHud(MCP_EntityPlane plane) {
       if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool && !MCH_Config.MouseAimDebug.prmBool) {
@@ -270,10 +289,32 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       int y = MathHelper.clamp_int(MCH_Config.NewPlaneWeaponHudY.prmInt, 12, Math.max(12, super.height - (lines.size() * 10 + 16)));
       int selected = plane.getCurrentWeaponID(player);
       this.drawHudPanel(x - 4, y - 4, width, lines.size() * 10 + 8);
+      this.drawWeaponOverheatBars(plane, x, y + lines.size() * 10 + 2, width - 8);
       for(int i = 0; i < lines.size(); ++i) {
          int color = i == selected ? 0xFFFFFFFF : 0xFF9A9A9A;
          int glow = i == selected ? 0x66555555 : 0x55202020;
          this.drawHudText((String)lines.get(i), x, y + i * 10, color, glow);
+      }
+   }
+
+
+   private void drawWeaponOverheatBars(MCH_EntityBaseVehicle ac, int x, int y, int width) {
+      if(ac == null || ac.weapons == null) {
+         return;
+      }
+      int row = 0;
+      for(int i = 0; i < ac.weapons.length; ++i) {
+         MCH_WeaponSet ws = ac.weapons[i];
+         if(ws != null && ws.getCurrentWeapon() != null && ws.getCurrentWeapon().getInfo() != null) {
+            int maxHeat = ws.getCurrentWeapon().getInfo().maxHeatCount;
+            if(maxHeat > 0) {
+               int by = y + row * 5;
+               int fill = MathHelper.clamp_int((int)Math.round((double)Math.max(0, ws.currentHeat) * (double)width / (double)maxHeat), 0, width);
+               drawRect(x, by, x + width, by + 3, 0x66303030);
+               drawRect(x, by, x + fill, by + 3, ws.currentHeat >= maxHeat ? 0xFFFF3030 : 0xFFFFAA30);
+               ++row;
+            }
+         }
       }
    }
 


### PR DESCRIPTION
### Motivation
- Provide reusable fuel-remaining access for HUDs and avoid duplicating fuel math while handling disabled/missing/infinite fuel safely. 
- Restore missing HUD readouts (stick/mouse gauge, weapon overheat bars, vehicle pitch) so new plane/heli HUDs show accurate, non-overlapping information. 
- Make new-flight HUD speed/VS readouts and throttle presentation consistent and more useful by applying a display multiplier and finer throttle increments without changing physics.

### Description
- Added `getFuelRemainingTicks()` and `getFuelRemainingSeconds()` to `MCH_EntityBaseVehicle` that return -1 for disabled/invalid/infinite fuel and compute remaining ticks/seconds using existing fuel consumption values. 
- Centralized HUD speed scaling with `MCH_HudShared.HUD_SPEED_DISPLAY_MULTIPLIER = 5.0D` and applied it to speed and vertical-speed formatting; routed plane/heli fuel display through the new fuel helpers. 
- Increased throttle display precision and quantized stored throttle to 0.5% steps by rounding in `setCurrentThrottle` and updating datawatcher scaling in throttle getters/setters, and updated throttle/collective formatting to use one decimal percent in shared HUD helpers. 
- Restored configurable stick/mouse input gauges for plane and helicopter HUDs and added `EnableNewVehicleStickInputGauge` config (default true), drawing a compact input gauge using `MCH_ClientCommonTickHandler` stick values. 
- Restored weapon overheat bars for new plane and helicopter weapon HUDs, drawing per-weapon bars only when `maxHeatCount > 0` based on existing `MCH_WeaponSet.currentHeat` and `MCH_WeaponInfo.maxHeatCount`. 
- Switched plane simple HUD and helicopter pitch readouts (including gunner HUD) to show vehicle/aircraft pitch (`getRotPitch()` / `getRotPitch()` on heli) instead of player/camera pitch. 

### Testing
- Ran `git diff --check` to verify there were no whitespace/patch errors and it completed successfully. 
- Ran `find . -name '*.class' -print | head -20` to confirm no compiled class artifacts were introduced and it returned no results. 
- Performed repository searches and basic code inspections to validate added helpers and HUD usage paths; no automated unit test suite exists for these UI/flight changes so runtime validation is expected in-game.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ac73ad9ac8329a96a1e7aa9e083ba)