### PR TITLE
Separate HUD speed scaling; improve heli hover throttle/exit behavior; fix plane debug HUD

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -10,7 +10,8 @@ import net.minecraft.util.MathHelper;
 
 public final class MCH_HudShared {
 
-   public static final double HUD_SPEED_DISPLAY_MULTIPLIER = 5.0D;
+   public static final double HUD_HELI_SPEED_MULTIPLIER = 3.5D;
+   public static final double HUD_PLANE_SPEED_MULTIPLIER = 2.0D;
 
    private MCH_HudShared() {
    }
@@ -31,8 +32,27 @@ public final class MCH_HudShared {
       return String.format("%s %5.1f%%", new Object[]{label, Double.valueOf(MathHelper.clamp_double(ac.getNormalizedThrottle() * 100.0D, 0.0D, 100.0D))});
    }
 
+   public static double getRawSpeedKmh(MCH_EntityBaseVehicle ac) {
+      if(ac == null) {
+         return 0.0D;
+      }
+      return Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D;
+   }
+
+   public static double getDisplaySpeedHeli(MCH_EntityBaseVehicle ac) {
+      return getRawSpeedKmh(ac) * HUD_HELI_SPEED_MULTIPLIER;
+   }
+
+   public static double getDisplaySpeedPlane(MCH_EntityBaseVehicle ac) {
+      return getRawSpeedKmh(ac) * HUD_PLANE_SPEED_MULTIPLIER;
+   }
+
+   public static double getDisplaySpeedKmh(MCH_EntityBaseVehicle ac) {
+      return ac instanceof MCH_EntityHeli ? getDisplaySpeedHeli(ac) : getDisplaySpeedPlane(ac);
+   }
+
    public static String formatSpeedKmh(MCH_EntityBaseVehicle ac) {
-      double speedKmh = Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D * HUD_SPEED_DISPLAY_MULTIPLIER;
+      double speedKmh = getDisplaySpeedKmh(ac);
       return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
    }
 
@@ -45,7 +65,7 @@ public final class MCH_HudShared {
    }
 
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D * HUD_SPEED_DISPLAY_MULTIPLIER))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -1129,6 +1129,19 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
    protected void onUpdate_ControlNotHovering() {
       float throttleUpDown = this.getAcInfo().throttleUpDown;
+      if(this.getRiddenByEntity() == null) {
+         this.hoverThrottleBias = 0.0F;
+         this.hoverCollectiveCorrection = 0.0F;
+         this.hoverVerticalNextAdjustmentTick = 0;
+         if(this.getCurrentThrottle() > 0.0D) {
+            double decay = Math.max(0.02D * (double)Math.max(throttleUpDown, 0.0F), 0.005D);
+            this.addCurrentThrottle(-decay);
+         } else {
+            this.setCurrentThrottle(0.0D);
+         }
+         return;
+      }
+
       if(super.throttleUp) {
          if(this.getCurrentThrottle() < 1.0D) {
             this.addCurrentThrottle(0.02D * (double)throttleUpDown);
@@ -1277,9 +1290,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       if(correctingVerticalSpeed) {
          if(this.ticksExisted >= this.hoverVerticalNextAdjustmentTick) {
             float strength = Math.max(this.heliInfo.hoverVerticalStabilizerStrength, 0.0F);
-            float correctionStep = MathHelper.clamp_float(verticalError * strength * configuredStrength, -correctionLimit, correctionLimit);
+            float normalizedError = MathHelper.clamp_float(MathHelper.abs(verticalError) / Math.max(deadzone, 0.01F), 0.0F, 6.0F);
+            float responseCurve = 1.0F + normalizedError * normalizedError * 0.35F;
+            float dynamicLimit = MathHelper.clamp_float(correctionLimit * responseCurve, correctionLimit, Math.min(biasLimit, correctionLimit * 4.0F));
+            float correctionStep = MathHelper.clamp_float(verticalError * strength * configuredStrength * responseCurve, -dynamicLimit, dynamicLimit);
             this.hoverThrottleBias = MathHelper.clamp_float(this.hoverThrottleBias + correctionStep, -biasLimit, biasLimit);
-            this.addCurrentThrottle((double)(this.hoverThrottleBias * Math.max(throttleUpDown, 0.0F)));
+            float throttleStepLimit = MathHelper.clamp_float(correctionLimit * (1.0F + normalizedError * 0.75F), correctionLimit, Math.min(biasLimit, correctionLimit * 5.0F));
+            float throttleStep = MathHelper.clamp_float(this.hoverThrottleBias * Math.max(throttleUpDown, 0.0F), -throttleStepLimit, throttleStepLimit);
+            this.addCurrentThrottle((double)throttleStep);
             this.setCurrentThrottle(MathHelper.clamp_double(this.getCurrentThrottle(), 0.0D, 1.0D));
             this.enforceNewHelicopterHoverMinimumThrottle();
             int adjustmentInterval = this.heliInfo != null?MathHelper.clamp_int(this.heliInfo.hoverVerticalAdjustmentInterval, 0, 200):0;

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -145,7 +145,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    }
 
    private void drawNewPlaneDebugHud(MCP_EntityPlane plane) {
-      if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool && !MCH_Config.MouseAimDebug.prmBool) {
+      if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool) {
          return;
       }
 
@@ -159,8 +159,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(String.format("NF DBG  stall=%s recover=%s flap=%s", new Object[]{
             Boolean.valueOf(plane.getStallSeverity() > 0.0D), Boolean.valueOf(plane.isStallRecovering()),
             Boolean.valueOf(plane.isCombatFlapsDeployed())}));
-      lines.add(String.format("spd fwd=%.3f hor=%.3f stall=%.3f", new Object[]{
-            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed()), Double.valueOf(stallSpeed)}));
+      lines.add(String.format("spd raw=%.0f disp=%.0f km/h stall=%.3f", new Object[]{
+            Double.valueOf(MCH_HudShared.getRawSpeedKmh(plane)), Double.valueOf(MCH_HudShared.getDisplaySpeedPlane(plane)), Double.valueOf(stallSpeed)}));
+      lines.add(String.format("phys fwd=%.3f hor=%.3f", new Object[]{
+            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed())}));
       lines.add(String.format("aoa=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
             Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getStallDemand()),
             Double.valueOf(plane.getSpeedStallSeverity()), Double.valueOf(plane.getAoAStallSeverity()),
@@ -178,9 +180,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Double.valueOf(plane.getLastPitchEnvelopeEnergyRatio()), Double.valueOf(plane.getLastEnergyDeficitSeverity()),
             Double.valueOf(plane.getLastEnergyDelta())}));
 
-      int width = Math.min(super.width - 16, Math.max(260, this.getMaxHudLineWidth(lines) + 8));
-      int x = MathHelper.clamp_int(super.width - width - 8, 4, Math.max(4, super.width - width - 8));
-      int y = MathHelper.clamp_int(8, 4, Math.max(4, super.height - (lines.size() * 10 + 12)));
+      int width = Math.min(super.width - 16, Math.max(220, this.getMaxHudLineWidth(lines) + 8));
+      int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - width - 8));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt + 125, 4, Math.max(4, super.height - (lines.size() * 10 + 12)));
       this.drawHudPanel(x - 4, y - 4, width, lines.size() * 10 + 8);
       this.drawHudLines(lines, x, y, 0xFF66FF66, 0x66005500);
    }


### PR DESCRIPTION
### Motivation
- Provide HUD-only speed multipliers so planes and helicopters display different (scaled) speeds without touching flight physics. 
- Make helicopter hover stabilization and throttle behavior actually hold altitude by increasing correction responsiveness when vertical-speed error is large. 
- Ensure a helicopter with no pilot decays throttle/collective instead of idling forever after the player exits. 
- Restore plane debug output to a compact, gated display that does not overlap weapon HUD elements.

### Description
- Added HUD helpers `getRawSpeedKmh`, `getDisplaySpeedHeli`, `getDisplaySpeedPlane`, and `getDisplaySpeedKmh` and constants `HUD_HELI_SPEED_MULTIPLIER = 3.5` and `HUD_PLANE_SPEED_MULTIPLIER = 2.0` in `MCH_HudShared.java`, and updated `formatSpeedKmh` to use the new display values while leaving raw speed derivation from `motionX/Y/Z` unchanged. 
- Stopped scaling vertical speed by the HUD multiplier so `formatVerticalSpeed` now reports raw vertical motion converted to m/s. 
- Strengthened the helicopter hover controller in `MCH_EntityHeli.java` by adding an error-driven response curve and increased clamped per-tick throttle/collective limits for larger vertical-speed errors to make corrections faster while still clamping to avoid oscillation. 
- Added a no-pilot decay branch in `onUpdate_ControlNotHovering` so an empty helicopter gradually reduces `currentThrottle`/collective toward zero and clears hover bias/correction instead of holding previous inputs. 
- Reworked the plane debug HUD in `MCP_GuiPlane.java` to be gated by the intended debug/test toggles only, relabeled the speed lines to show `raw` vs `disp` speeds, compacted/grouped values, and repositioned the debug block to avoid overlapping weapon/readout HUDs.

### Testing
- Ran `git diff` on the modified files to review the exact changes and confirm the intended diffs applied. (succeeded)
- Searched the codebase with `rg` for the new HUD constants and helpers and for the changed debug/hover logic to verify references: `rg -n "HUD_HELI_SPEED_MULTIPLIER|getDisplaySpeedHeli|getDisplaySpeedPlane|formatVerticalSpeed|drawNewPlaneDebugHud|raw=|getRiddenByEntity\(\) == null|responseCurve"` (succeeded). 
- Listed compiled class artifacts with `find . -name '*.class' -print | head` to verify no new .class files were produced by this change step. (succeeded)
- Did not run a Java build/compile per the project instruction not to compile `.class` files or add them to PRs, so runtime verification in-game was not performed. (no compile/run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad47c24b08329a7f5792d4aef0263)