### PR TITLE
Fix uncrewed helicopter rotor spool-down

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -1102,8 +1102,15 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       boolean enginePowered = !this.isDestroyed() && bladesUsable && this.isCanopyClose() && this.canUseFuel(true);
       this.normalizedRotorRPM = this.sanitizeClamped(this.normalizedRotorRPM, 0.0F, 1.0F, 0.0F);
       this.lastRotorRPM = this.normalizedRotorRPM;
-      this.enginePowerOutput = enginePowered?MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F):0.0F;
-      this.targetRotorRPM = this.enginePowerOutput;
+
+      // Keep visual rotor RPM coupled to the aircraft throttle while the blades are
+      // still usable.  Player dismount intentionally leaves currentThrottle to be
+      // reduced by the existing auto-throttle-down path; forcing engine output to
+      // zero just because there is no active pilot makes the new flight model stop
+      // the rendered blades immediately while sound and particles continue to idle.
+      float throttleRotorCommand = MathHelper.clamp_float((float)this.getCurrentThrottle(), 0.0F, 1.0F);
+      this.enginePowerOutput = enginePowered?throttleRotorCommand:0.0F;
+      this.targetRotorRPM = (!this.isDestroyed() && bladesUsable && this.isCanopyClose())?throttleRotorCommand:this.enginePowerOutput;
 
       float delta = this.targetRotorRPM - this.normalizedRotorRPM;
       float configuredRate = Math.max(delta >= 0.0F?this.heliInfo.rotorSpoolUpRate:this.heliInfo.rotorSpoolDownRate, 0.0F);


### PR DESCRIPTION
### Motivation
- New realistic helicopter code could force the rotor visual target to zero when the player exits, making blades stop instantly while smoke/sound still indicate an idling engine.  The change decouples the visual rotor command from immediate engine gating so the rotor visibly spools down instead of snapping to zero.

### Description
- Adjusted `updateNewHelicopterRotorSpool()` in `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` to compute a `throttleRotorCommand` from `getCurrentThrottle()` and use it as the visual rotor target when blades are usable. 
- Kept `enginePowerOutput` gated by `enginePowered` (fuel/canopy/destruction) but stopped forcing the visual target to zero solely because a pilot left, so auto-throttle-down produces a visible spool-down.
- The change is limited to rotor spool/target selection and does not change throttle persistence, fuel checks, or other class APIs.

### Testing
- `git diff --check` — succeeded.
- `bash ./gradlew compileJava` — failed to run in this environment because the Gradle wrapper download was blocked by a network/proxy (HTTP 403), so compilation could not be verified here.
- `gradle compileJava` — attempted but failed to resolve ForgeGradle artifacts due to HTTP 403 from remote Maven repositories, so a full build was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab1fbb0048323a2bd56a02ed6cfde)