### PR TITLE
Refine HUD speed/pitch displays, heli unpiloted throttle decay and hover stabilization, and plane HUD debug layout

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -10,7 +10,8 @@ import net.minecraft.util.MathHelper;
 
 public final class MCH_HudShared {
 
-   public static final double HUD_SPEED_DISPLAY_MULTIPLIER = 5.0D;
+   public static final double HUD_HELI_SPEED_MULTIPLIER = 3.5D;
+   public static final double HUD_PLANE_SPEED_MULTIPLIER = 2.0D;
 
    private MCH_HudShared() {
    }
@@ -31,8 +32,27 @@ public final class MCH_HudShared {
       return String.format("%s %5.1f%%", new Object[]{label, Double.valueOf(MathHelper.clamp_double(ac.getNormalizedThrottle() * 100.0D, 0.0D, 100.0D))});
    }
 
+   public static double getRawSpeedKmh(MCH_EntityBaseVehicle ac) {
+      if(ac == null) {
+         return 0.0D;
+      }
+      return Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D;
+   }
+
+   public static double getDisplaySpeedHeli(MCH_EntityBaseVehicle ac) {
+      return getRawSpeedKmh(ac) * HUD_HELI_SPEED_MULTIPLIER;
+   }
+
+   public static double getDisplaySpeedPlane(MCH_EntityBaseVehicle ac) {
+      return getRawSpeedKmh(ac) * HUD_PLANE_SPEED_MULTIPLIER;
+   }
+
+   public static double getDisplaySpeedKmh(MCH_EntityBaseVehicle ac) {
+      return ac instanceof MCH_EntityHeli ? getDisplaySpeedHeli(ac) : getDisplaySpeedPlane(ac);
+   }
+
    public static String formatSpeedKmh(MCH_EntityBaseVehicle ac) {
-      double speedKmh = Math.sqrt(ac.motionX * ac.motionX + ac.motionY * ac.motionY + ac.motionZ * ac.motionZ) * 72.0D * HUD_SPEED_DISPLAY_MULTIPLIER;
+      double speedKmh = getDisplaySpeedKmh(ac);
       return String.format("SPD   %d km/h", new Object[]{Integer.valueOf(Math.max(0, (int)Math.round(speedKmh)))});
    }
 
@@ -45,7 +65,7 @@ public final class MCH_HudShared {
    }
 
    public static String formatVerticalSpeed(MCH_EntityBaseVehicle ac) {
-      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D * HUD_SPEED_DISPLAY_MULTIPLIER))});
+      return String.format("VS    %+d m/s", new Object[]{Integer.valueOf((int)Math.round(getVerticalSpeedMotionY(ac) * 20.0D))});
    }
 
    public static String formatFuelMinutes(MCH_EntityBaseVehicle ac) {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -576,6 +576,21 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.prevRotationRotor = this.rotationRotor;
    }
 
+   private void updateUnpilotedThrottleDecay() {
+      this.hoverThrottleBias = 0.0F;
+      this.hoverCollectiveCorrection = 0.0F;
+      this.hoverVerticalSpeedAverage = 0.0F;
+      this.hoverVerticalNextAdjustmentTick = 0;
+      this.targetVerticalSpeed = 0.0F;
+      if(this.getCurrentThrottle() > 0.0D) {
+         float throttleUpDown = this.getAcInfo() != null?this.getAcInfo().throttleUpDown:1.0F;
+         double decay = Math.max(0.02D * (double)Math.max(throttleUpDown, 0.0F), 0.005D);
+         this.addCurrentThrottle(-decay);
+      } else {
+         this.setCurrentThrottle(0.0D);
+      }
+   }
+
    public int getNumEjectionSeat() {
       if(this.getAcInfo() != null && this.getAcInfo().isEnableEjectionSeat) {
          int n = this.getSeatNum() + 1;
@@ -1054,7 +1069,9 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          this.switchGunnerMode(false);
       }
 
-      if(!this.isDestroyed() && (this.getRiddenByEntity() != null || this.isHoveringMode()) && this.canUseBlades() && this.isCanopyClose() && this.canUseFuel(true)) {
+      if(!this.isDestroyed() && this.getRiddenByEntity() == null && this.canUseBlades() && this.isCanopyClose() && this.canUseFuel(true)) {
+         this.updateUnpilotedThrottleDecay();
+      } else if(!this.isDestroyed() && (this.getRiddenByEntity() != null || this.isHoveringMode()) && this.canUseBlades() && this.isCanopyClose() && this.canUseFuel(true)) {
          if(!this.isHovering()) {
             this.onUpdate_ControlNotHovering();
          } else {
@@ -1129,6 +1146,11 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
    protected void onUpdate_ControlNotHovering() {
       float throttleUpDown = this.getAcInfo().throttleUpDown;
+      if(this.getRiddenByEntity() == null) {
+         this.updateUnpilotedThrottleDecay();
+         return;
+      }
+
       if(super.throttleUp) {
          if(this.getCurrentThrottle() < 1.0D) {
             this.addCurrentThrottle(0.02D * (double)throttleUpDown);
@@ -1277,9 +1299,14 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       if(correctingVerticalSpeed) {
          if(this.ticksExisted >= this.hoverVerticalNextAdjustmentTick) {
             float strength = Math.max(this.heliInfo.hoverVerticalStabilizerStrength, 0.0F);
-            float correctionStep = MathHelper.clamp_float(verticalError * strength * configuredStrength, -correctionLimit, correctionLimit);
+            float normalizedError = MathHelper.clamp_float(MathHelper.abs(verticalError) / Math.max(deadzone, 0.01F), 0.0F, 6.0F);
+            float responseCurve = 1.0F + normalizedError * normalizedError * 0.35F;
+            float dynamicLimit = MathHelper.clamp_float(correctionLimit * responseCurve, correctionLimit, Math.min(biasLimit, correctionLimit * 4.0F));
+            float correctionStep = MathHelper.clamp_float(verticalError * strength * configuredStrength * responseCurve, -dynamicLimit, dynamicLimit);
             this.hoverThrottleBias = MathHelper.clamp_float(this.hoverThrottleBias + correctionStep, -biasLimit, biasLimit);
-            this.addCurrentThrottle((double)(this.hoverThrottleBias * Math.max(throttleUpDown, 0.0F)));
+            float throttleStepLimit = MathHelper.clamp_float(correctionLimit * (1.0F + normalizedError * 0.75F), correctionLimit, Math.min(biasLimit, correctionLimit * 5.0F));
+            float throttleStep = MathHelper.clamp_float(this.hoverThrottleBias * Math.max(throttleUpDown, 0.0F), -throttleStepLimit, throttleStepLimit);
+            this.addCurrentThrottle((double)throttleStep);
             this.setCurrentThrottle(MathHelper.clamp_double(this.getCurrentThrottle(), 0.0D, 1.0D));
             this.enforceNewHelicopterHoverMinimumThrottle();
             int adjustmentInterval = this.heliInfo != null?MathHelper.clamp_int(this.heliInfo.hoverVerticalAdjustmentInterval, 0, 200):0;

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -107,7 +107,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(MCH_HudShared.formatSpeedKmh(plane));
       lines.add(MCH_HudShared.formatAltitude(plane));
       lines.add(MCH_HudShared.formatVerticalSpeed(plane));
-      lines.add(String.format("PITCH %+.0f\u00B0", new Object[]{Float.valueOf(plane.getRotPitch())}));
+      lines.add(String.format("PITCH %+.0f\u00B0", new Object[]{Float.valueOf(this.getDisplayPitchDegrees(plane))}));
       lines.add(MCH_HudShared.formatFuelMinutes(plane));
       lines.add(MCH_HudShared.formatDamagePercent(plane));
       lines.add(this.formatSimpleHudGLoad(plane));
@@ -130,6 +130,13 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
 
 
+   private float getDisplayPitchDegrees(MCP_EntityPlane plane) {
+      // Minecraft aircraft pitch is inverted for pilot-facing attitude readouts:
+      // negative rotation pitch is nose-up and positive rotation pitch is nose-down.
+      // Invert only the displayed HUD value; do not feed this back into physics/control.
+      return plane != null?-plane.getRotPitch():0.0F;
+   }
+
    private void drawStickInputGauge(int x, int y) {
       if(!MCH_Config.EnableNewVehicleStickInputGauge.prmBool) {
          return;
@@ -145,7 +152,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    }
 
    private void drawNewPlaneDebugHud(MCP_EntityPlane plane) {
-      if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool && !MCH_Config.MouseAimDebug.prmBool) {
+      if(!MCH_Config.DebugFlightControl.prmBool && !MCH_Config.TestMode.prmBool) {
          return;
       }
 
@@ -159,8 +166,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(String.format("NF DBG  stall=%s recover=%s flap=%s", new Object[]{
             Boolean.valueOf(plane.getStallSeverity() > 0.0D), Boolean.valueOf(plane.isStallRecovering()),
             Boolean.valueOf(plane.isCombatFlapsDeployed())}));
-      lines.add(String.format("spd fwd=%.3f hor=%.3f stall=%.3f", new Object[]{
-            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed()), Double.valueOf(stallSpeed)}));
+      lines.add(String.format("spd raw=%.0f disp=%.0f km/h stall=%.3f", new Object[]{
+            Double.valueOf(MCH_HudShared.getRawSpeedKmh(plane)), Double.valueOf(MCH_HudShared.getDisplaySpeedPlane(plane)), Double.valueOf(stallSpeed)}));
+      lines.add(String.format("phys fwd=%.3f hor=%.3f", new Object[]{
+            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed())}));
       lines.add(String.format("aoa=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
             Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getStallDemand()),
             Double.valueOf(plane.getSpeedStallSeverity()), Double.valueOf(plane.getAoAStallSeverity()),
@@ -178,9 +187,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Double.valueOf(plane.getLastPitchEnvelopeEnergyRatio()), Double.valueOf(plane.getLastEnergyDeficitSeverity()),
             Double.valueOf(plane.getLastEnergyDelta())}));
 
-      int width = Math.min(super.width - 16, Math.max(260, this.getMaxHudLineWidth(lines) + 8));
-      int x = MathHelper.clamp_int(super.width - width - 8, 4, Math.max(4, super.width - width - 8));
-      int y = MathHelper.clamp_int(8, 4, Math.max(4, super.height - (lines.size() * 10 + 12)));
+      int width = Math.min(super.width - 16, Math.max(220, this.getMaxHudLineWidth(lines) + 8));
+      int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - width - 8));
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt + 125, 4, Math.max(4, super.height - (lines.size() * 10 + 12)));
       this.drawHudPanel(x - 4, y - 4, width, lines.size() * 10 + 8);
       this.drawHudLines(lines, x, y, 0xFF66FF66, 0x66005500);
    }


### PR DESCRIPTION
### Motivation
- Separate and clarify HUD speed calculations for helicopters and planes and remove an erroneous global speed multiplier. 
- Ensure unpiloted helicopters decay throttle reasonably and prevent runaway hover control values when no pilot is present. 
- Make plane HUD pitch display intuitive for pilot view and improve debug instrumentation and layout for readability.

### Description
- Replaced `HUD_SPEED_DISPLAY_MULTIPLIER` with `HUD_HELI_SPEED_MULTIPLIER` and `HUD_PLANE_SPEED_MULTIPLIER` and introduced `getRawSpeedKmh`, `getDisplaySpeedHeli`, `getDisplaySpeedPlane`, and `getDisplaySpeedKmh` to centralize speed math, and updated `formatSpeedKmh` to use them. 
- Removed the extra vertical-speed display multiplier and simplified `formatVerticalSpeed` to use `getVerticalSpeedMotionY` directly. 
- Added `updateUnpilotedThrottleDecay` and wiring so unpiloted helicopters decay throttle and zero hover integrators when no rider is present, and refactored control paths to call this in appropriate conditions. 
- Tuned hover vertical stabilization logic by introducing a normalized error, a response curve, dynamic correction limits, and clamped throttle step limits for more stable and bounded hover corrections. 
- Plane HUD: inverted displayed pitch via `getDisplayPitchDegrees` (so pilot-facing HUD shows nose-up as positive), updated `drawNewPlaneSimpleHud` to use it, and adjusted debug HUD lines to show both raw and displayed speeds along with a small re-layout of the debug panel and removed one debug gating flag. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad47c24b08329a7f5792d4aef0263)