### PR TITLE
Fix zero-throttle plane sink behavior

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1761,8 +1761,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double aoaExcess = Math.max(0.0D, Math.abs(this.angleOfAttack) - (double)info.criticalAoA);
       double preStallAoALift = MCH_FlightModel.clamp(1.0D - aoaExcess / Math.max(1.0D, (double)info.criticalAoA * 2.5D), 0.35D, 1.0D);
       double aoaLift = preStallAoALift * (1.0D - this.deepStallSeverity * 0.85D);
+      double effectiveThrottle = this.getEffectiveEngineThrottle();
+      double propulsiveThrottle = this.getPropulsiveEngineThrottle();
       double liftPower = (double)info.newFlightLowThrottleLiftRetention
-            + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * this.getEffectiveEngineThrottle();
+            + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * effectiveThrottle;
+      if(propulsiveThrottle <= 0.01D) {
+         // At a hard idle/cut throttle the wing can still glide, but it must not be able to
+         // hold a near-level sink on retained engine smoothing alone.  Keep some dead-stick
+         // lift so landing approaches remain possible, while forcing a real sink when the
+         // player pulls the throttle all the way to zero.
+         liftPower *= 0.45D;
+      }
       if(this.isCombatFlapsDeployed()) {
          liftPower += (double)info.newFlightCombatFlapLift;
       }
@@ -1785,7 +1794,6 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftForceBeforeStallLoss = liftBeforeStallLoss;
       this.lastLiftForceAfterStallLoss = liftForce;
       this.lastNetVerticalAcceleration = netAccel;
-      double propulsiveThrottle = this.getPropulsiveEngineThrottle();
       double thrustForce = Math.max(0.0D, (double)info.engineThrust * propulsiveThrottle);
       double thrustToWeight = thrustForce / Math.max(weightForce, 1.0E-6D);
       double liftToWeight = liftForce / Math.max(weightForce, 1.0E-6D);


### PR DESCRIPTION
### Motivation

- Prevent fixed-wing aircraft from effectively "hovering" or descending like a feather when propulsive throttle is cut to zero by reducing retained lift at hard idle.

### Description

- Compute `effectiveThrottle` and `propulsiveThrottle` and use `effectiveThrottle` when evaluating low-throttle retained lift.
- When `propulsiveThrottle <= 0.01D` reduce the `liftPower` curve by multiplying it with `0.45D` so the aircraft performs a realistic dead-stick sink instead of holding near-level altitude.
- Preserve the existing additive combat-flap lift (`isCombatFlapsDeployed()` still adds `newFlightCombatFlapLift`).

### Testing

- Ran `git diff --check` which completed successfully and reported no whitespace errors.
- Attempted `bash ./gradlew compileJava` to build the project but the Gradle wrapper download failed due to an environment proxy returning `HTTP/1.1 403 Forbidden`, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3affd7f7688323816fde5ac1dab178)