### PR TITLE
Improve idle plane gliding (preserve momentum at zero throttle)

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1768,9 +1768,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * effectiveThrottle;
       if(hardIdle) {
          // A commanded zero throttle must be dead-stick flight, not a powered hover.
-         // Keep enough retained wing lift for a real glide so the plane carries forward
-         // speed, but remove the near-level float caused by smoothed idle engine output.
-         liftPower *= 0.55D;
+         // Keep most speed-based wing lift for a real glide; throttle should remove
+         // thrust, not make the wings forget the aircraft is still moving forward.
+         liftPower *= 0.90D;
       }
       if(this.isCombatFlapsDeployed()) {
          liftPower += (double)info.newFlightCombatFlapLift;
@@ -2991,9 +2991,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       // Dampens vertical speed
       super.motionY *= 0.95D;
-      // Dampens horizontal speed based on aircraft motion factor
-      super.motionX *= this.getAcInfo().motionFactor;
-      super.motionZ *= this.getAcInfo().motionFactor;
+      // Dampens horizontal speed based on aircraft motion factor. New-flight planes in
+      // dead-stick airborne flight should glide on retained momentum instead of losing
+      // horizontal speed just because commanded throttle is zero; aerodynamic drag below
+      // still bleeds energy and the speed cap is applied after all acceleration.
+      double horizontalMotionFactor = (double)this.getAcInfo().motionFactor;
+      if(this.useNewMobilitySystem() && this.getPlaneInfo() != null && dp == 0.0D && !super.onGround
+            && this.getNozzleRotation() <= 0.01F && !levelOff && this.getCurrentThrottle() <= 0.05D) {
+         horizontalMotionFactor = Math.max(horizontalMotionFactor, 0.995D);
+      }
+      super.motionX *= horizontalMotionFactor;
+      super.motionZ *= horizontalMotionFactor;
 
       float baseSpeedLimit = this.getMaxSpeed();
       float levelSpeed = this.useNewMobilitySystem() && this.getPlaneInfo().maxLevelSpeed > 0.0F ? this.getPlaneInfo().maxLevelSpeed : baseSpeedLimit;
@@ -3043,9 +3051,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                MCH_FlightModel.clamp((double)(-this.getRotPitch() - 8.0F) / 42.0D, 0.0D, 1.0D), stallSpeedForIdleDrag);
          this.lastUnsupportedClimbSeverity = this.getUnsupportedClimbSeverity();
          if(this.lastUnsupportedClimbSeverity > 0.0D) {
-            double idleDragBoost = this.lastIdleUnsupportedClimb ? 0.12D : 0.0D;
-            double unsupportedDrag = this.lastUnsupportedClimbSeverity * (0.025D + idleDragBoost
-                  + 0.18D * Math.max(this.stallSeverity, this.aoaStallSeverity));
+            double idleDragBoost = this.lastIdleUnsupportedClimb ? 0.025D : 0.0D;
+            double unsupportedDrag = this.lastUnsupportedClimbSeverity * (0.018D + idleDragBoost
+                  + 0.12D * Math.max(this.stallSeverity, this.aoaStallSeverity));
             drag += unsupportedDrag;
             this.lastPitchClimbDragFactor = Math.max(this.lastPitchClimbDragFactor, this.lastUnsupportedClimbSeverity);
             this.lastStallSuppressedLiftHeadroom = true;


### PR DESCRIPTION
### Motivation
- Prevent fixed-wing aircraft from dropping vertically when commanded throttle is zero by preserving forward kinetic energy and enabling a realistic glide while still enforcing existing speed caps.
- Keep closed-throttle behavior aerodynamically plausible (remove thrust but retain wing lift proportional to speed) and avoid instant loss of horizontal momentum.
- Retain protections against unrealistic idle climbs but soften them so they do not erase forward speed.

### Description
- Increased retained lift during hard-idle dead-stick flight by changing the hard-idle lift multiplier from `0.55` to `0.90` in `MCP_EntityPlane` so wings still provide most speed-based lift when throttle is effectively zero (`hardIdle` branch). 
- Reduced horizontal damping in new-flight dead-stick airborne conditions by introducing a conditional minimum motion-factor (use `Math.max(this.getAcInfo().motionFactor, 0.995D)`) so horizontal momentum is mostly preserved while aerodynamic drag and later energy-drag logic still apply.
- Softened unsupported idle-climb drag tuning by lowering the `idleDragBoost` and the unsupported-drag coefficients so idle-climb prevention still operates but is less aggressive at removing forward speed.
- All edits are contained in `src/main/java/mcheli/plane/MCP_EntityPlane.java` and only adjust numeric factors and the horizontal-motion-factor computation; no class/interface structure was changed.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and it passed successfully.
- Attempted to run the project tests via `./gradlew test` but the wrapper is not executable in this environment, so the wrapper run was not performed.
- Attempted `bash ./gradlew test` and `gradle test` but both runs failed to resolve build dependencies due to external repository access/proxy (HTTP 403), so the full test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0a039de083238faf8a2c7b4d5b68)