### PR TITLE
Separate airborne glide lift from throttle

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1764,13 +1764,21 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double effectiveThrottle = this.getEffectiveEngineThrottle();
       double propulsiveThrottle = this.getPropulsiveEngineThrottle();
       boolean hardIdle = this.getCurrentThrottle() <= 0.05D;
-      double liftPower = (double)info.newFlightLowThrottleLiftRetention
+      // Wing lift comes from airspeed and attitude, not directly from engine power.
+      // Keep throttle-driven lift retention as a powered-assist floor for legacy tuning,
+      // but never let a closed throttle erase speed-based lift while airborne; a plane
+      // with enough airspeed should glide and bleed energy through drag instead of
+      // being forced into a slow vertical sink just because commanded throttle is zero.
+      double poweredLiftFloor = (double)info.newFlightLowThrottleLiftRetention
             + (1.0D - (double)info.newFlightLowThrottleLiftRetention) * effectiveThrottle;
-      if(hardIdle) {
-         // A commanded zero throttle must be dead-stick flight, not a powered hover.
-         // Keep most speed-based wing lift for a real glide; throttle should remove
-         // thrust, not make the wings forget the aircraft is still moving forward.
-         liftPower *= 0.90D;
+      double liftPower = Math.max(1.0D, poweredLiftFloor);
+      if(hardIdle && forwardAirspeed < stallSpeed * 0.65D) {
+         // Dead-stick flight still cannot prop-hang below flying speed.  Only apply
+         // the closed-throttle penalty once the wing is already running out of usable
+         // airflow, leaving normal glide lift controlled by airspeed, AoA, and drag.
+         double lowAirspeed = MCH_FlightModel.clamp((stallSpeed * 0.65D - forwardAirspeed)
+               / Math.max(0.05D, stallSpeed * 0.65D), 0.0D, 1.0D);
+         liftPower *= 1.0D - lowAirspeed * 0.10D;
       }
       if(this.isCombatFlapsDeployed()) {
          liftPower += (double)info.newFlightCombatFlapLift;
@@ -3029,7 +3037,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             turnLoad = MCH_FlightModel.clamp(turnLoad + (double)this.getPlaneInfo().newFlightCombatFlapLift, 0.0D, 1.0D);
          }
          double mass = this.getPhysicalMass();
-         double drag = MCH_FlightModel.getEnergyDrag(horizontalSpeed, (double)levelSpeed, this.getEffectiveEngineThrottle(),
+         // Drag/sustainable-speed calculations use propulsive throttle, not idle/engine
+         // spool state, so closed-throttle airborne flight coasts as a true glide.
+         double energyThrottle = this.getPropulsiveEngineThrottle();
+         double drag = MCH_FlightModel.getEnergyDrag(horizontalSpeed, (double)levelSpeed, energyThrottle,
                turnLoad, controlLoad, this.getPlaneInfo().baseDrag, this.getPlaneInfo().inducedDrag,
                this.getPlaneInfo().controlSurfaceDrag, (float)engineBrakeDrag) / mass;
          double aoaDrag = MCH_FlightModel.getAngleOfAttackDrag(this.angleOfAttack, this.getPlaneInfo().criticalAoA,


### PR DESCRIPTION
### Motivation
- Fixed-wing aircraft should retain airspeed/AoA-based wing lift and glide when commanded throttle is zero instead of artificially sinking; the energy model must not treat idle/spool state as propulsive thrust. 

### Description
- Modified lift computation in `src/main/java/mcheli/plane/MCP_EntityPlane.java` to compute a `poweredLiftFloor` and then derive `liftPower` as a max with speed/AoA-based lift so wings continue to produce lift while airborne.  
- Only apply the closed-throttle penalty when forward airspeed is below 65% of stall speed so dead-stick flight at flying speeds behaves as a true glide.  
- Use `getPropulsiveEngineThrottle()` (propulsive throttle) rather than `getEffectiveEngineThrottle()` when calling `MCH_FlightModel.getEnergyDrag(...)` so idle/spool state does not count as thrust for sustainable-speed/drag calculations.  
- Added clarifying comments and kept existing combat-flap and stall-lift-loss behavior intact.

### Testing
- Ran `git diff --check` to validate the working tree (succeeded).  
- Attempted `./gradlew test` but the Gradle wrapper was not executable in this environment (permission denied).  
- Attempted `bash ./gradlew test` but the Gradle distribution download failed behind a proxy (HTTP 403), so the full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b0c9ba5b083238a8488a34e585745)