### PR TITLE
Add idle glide assist to new fixed-wing flight model

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1879,6 +1879,34 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftAcceleration = Math.max(this.lastLiftAcceleration, liftAccel);
    }
 
+   private void applyNewFlightIdleGlideAssist(double gravityAccel) {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F
+            || super.onGround || MCH_Lib.getBlockIdY(this, 1, -2) > 0 || this.getCurrentThrottle() > 0.01D
+            || super.motionY >= 0.0D) {
+         return;
+      }
+
+      double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+            this.getPlaneInfo().stallSpeedFactor);
+      double targetGlideSpeed = Math.min((double)this.getMaxSpeed() * 0.45D, Math.max(stallSpeed * 0.85D, 0.05D));
+      if(horizontalSpeed >= targetGlideSpeed) {
+         return;
+      }
+
+      double descent01 = MCH_FlightModel.clamp(-super.motionY / 0.35D, 0.0D, 1.0D);
+      double speedDeficit01 = MCH_FlightModel.clamp((targetGlideSpeed - horizontalSpeed)
+            / Math.max(0.05D, targetGlideSpeed), 0.0D, 1.0D);
+      double glideGain = Math.max(0.0D, gravityAccel) * 0.45D * descent01 * speedDeficit01;
+      if(glideGain <= 0.0D) {
+         return;
+      }
+
+      double yaw = Math.toRadians((double)this.getRotYaw());
+      super.motionX += -Math.sin(yaw) * glideGain;
+      super.motionZ += Math.cos(yaw) * glideGain;
+   }
+
    private void resetNewFlightDiveAssistDebug() {
       this.lastDiveAssistNoseDownDegrees = Math.max(0.0D, (double)this.getRotPitch());
       this.lastDiveAssistFalling01 = 0.0D;
@@ -3112,6 +3140,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             super.motionX += -Math.sin(yaw) * targetSpeed;
             super.motionZ += Math.cos(yaw) * targetSpeed;
          }
+         this.applyNewFlightIdleGlideAssist(gravityAccel);
          this.lastHorizontalSpeedAfterEnergyDrag = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
          this.applyNewFlightDiveAssist(gravityAccel);
       } else {


### PR DESCRIPTION
### Motivation
- Prevent aircraft with the new fixed-wing model from sinking almost vertically at zero throttle by providing a small aerodynamic glide acceleration while dead-stick and descending. 
- Preserve existing behavior for VTOL/nozzle mode, ground, water/near-ground cases, non-new-flight planes, and when throttle is not effectively closed. 
- Keep the change localized to the fixed-wing energy path without altering unrelated propulsion, VTOL, or GUI code. 

### Description
- Add a new helper `applyNewFlightIdleGlideAssist(double gravityAccel)` in `src/main/java/mcheli/plane/MCP_EntityPlane.java` that computes a small forward acceleration from descent and speed deficit and applies it to `motionX`/`motionZ`. 
- The assist is guarded to run only when `useNewMobilitySystem()` is true, the plane uses the new flight info, the nozzle/VTOL is inactive, the entity is airborne (not near ground/in water), the commanded throttle is essentially zero, and the aircraft is descending. 
- The method derives a `targetGlideSpeed` from `stallSpeed` and `getMaxSpeed()`, computes `descent01` and `speedDeficit01`, and applies `glideGain = gravityAccel * 0.45 * descent01 * speedDeficit01` along the nose heading. 
- Invoke the assist inside the new-flight airborne energy branch before dive assist and after the energy drag/target-speed adjustments so it complements the existing energy model without changing other flight logic. 

### Testing
- Ran `git diff --check` which completed cleanly with no whitespace errors. 
- Attempted `./gradlew compileJava` but the wrapper is not executable in the checkout, so the build did not run. 
- Attempted `bash gradlew compileJava` to download Gradle and run a build, but the download was blocked by an HTTP 403 from the proxy, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0ed6605083239875b9c8dae65b8d)