### PR TITLE
Add idle glide assist for new mobility system and hook into flight energy update

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1879,6 +1879,42 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastLiftAcceleration = Math.max(this.lastLiftAcceleration, liftAccel);
    }
 
+   private void applyNewFlightIdleGlideAssist(double gravityAccel) {
+      if(!this.useNewMobilitySystem() || this.getPlaneInfo() == null || this.getNozzleRotation() > 0.01F
+            || super.onGround || MCH_Lib.getBlockIdY(this, 1, -2) > 0 || this.getCurrentThrottle() > 0.01D
+            || super.motionY >= 0.0D) {
+         return;
+      }
+
+      double horizontalSpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      double sinkSpeed = Math.max(0.0D, -super.motionY);
+      double stallSpeed = MCH_FlightModel.getStallSpeed(this.getPlaneInfo().stallSpeed, this.getMaxSpeed(),
+            this.getPlaneInfo().stallSpeedFactor);
+      double targetGlideSpeed = Math.min((double)this.getMaxSpeed() * 0.60D,
+            Math.max(Math.max(stallSpeed * 1.05D, sinkSpeed * 1.40D), 0.08D));
+      double speedDeficit = targetGlideSpeed - horizontalSpeed;
+      if(speedDeficit <= 0.0D) {
+         return;
+      }
+
+      double descent01 = MCH_FlightModel.clamp(sinkSpeed / 0.35D, 0.0D, 1.0D);
+      double speedDeficit01 = MCH_FlightModel.clamp(speedDeficit / Math.max(0.05D, targetGlideSpeed), 0.0D, 1.0D);
+      double glideGain = Math.min(speedDeficit, Math.max(0.0D, gravityAccel) * 2.50D * descent01 * speedDeficit01);
+      if(glideGain <= 0.0D) {
+         return;
+      }
+
+      double yaw = Math.toRadians((double)this.getRotYaw());
+      super.motionX += -Math.sin(yaw) * glideGain;
+      super.motionZ += Math.cos(yaw) * glideGain;
+
+      double horizontalAfter = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      double maxGlideSink = Math.max(0.035D, horizontalAfter * 0.65D);
+      if(-super.motionY > maxGlideSink) {
+         super.motionY = -maxGlideSink;
+      }
+   }
+
    private void resetNewFlightDiveAssistDebug() {
       this.lastDiveAssistNoseDownDegrees = Math.max(0.0D, (double)this.getRotPitch());
       this.lastDiveAssistFalling01 = 0.0D;
@@ -3112,6 +3148,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             super.motionX += -Math.sin(yaw) * targetSpeed;
             super.motionZ += Math.cos(yaw) * targetSpeed;
          }
+         this.applyNewFlightIdleGlideAssist(gravityAccel);
          this.lastHorizontalSpeedAfterEnergyDrag = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
          this.applyNewFlightDiveAssist(gravityAccel);
       } else {


### PR DESCRIPTION
### Motivation
- Provide an automatic idle glide assist to help aircraft using the new mobility system recover horizontal speed and reduce sink rate when coasting with very low throttle.
- Prevent unnecessary stalls and excessive descent when the plane is airborne, idle, and not on the ground or near obstacles below.

### Description
- Introduce `applyNewFlightIdleGlideAssist(double gravityAccel)` which computes a target glide speed and applies a yaw-directed forward impulse to recover horizontal speed when appropriate.
- The assist is gated by `useNewMobilitySystem()`, `getPlaneInfo()` presence, nozzle rotation, ground/contact checks, throttle and vertical motion thresholds, and it clamps sink speed to a calculated maximum.
- Invoke the new idle glide assist from the energy-drag section of the flight update loop so it runs after horizontal energy adjustments.

### Testing
- Built the project with `./gradlew build` which completed successfully. 
- Ran the existing automated unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0ed6605083239875b9c8dae65b8d)