### PR TITLE
Use true/body-forward airspeed for new fixed-wing authority, thrust and speed capping

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_FlightModel.java
+++ b/src/main/java/mcheli/aircraft/MCH_FlightModel.java
@@ -183,7 +183,10 @@ public final class MCH_FlightModel {
          double post = clamp((abs - 1.0D) / 2.0D, 0.0D, 1.0D);
          lift = 1.0D - post * (0.65D + 0.25D * clamp(stallSeverity, 0.0D, 1.0D));
       }
-      return sign * clamp(lift, 0.08D, 1.0D);
+      if(abs < 1.0E-4D) {
+         return 0.0D;
+      }
+      return sign * clamp(lift, 0.0D, 1.0D);
    }
 
    /** Coefficient-like AoA drag curve with a strong post-critical rise. */

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -1618,7 +1618,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.updateVehicleStress();
 
       float controlAuthority = this.getControlAuthorityFactor();
-      double pitchAuthoritySpeed = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      double pitchAuthoritySpeed = this.getNewFlightAuthoritySpeed();
       double pitchAuthority = MCH_FlightModel.getCompressibilityPitchAuthority(pitchAuthoritySpeed,
             this.getCompressibilitySpeed(), this.getMaxSafeSpeed(), this.getPlaneInfo().compressibilityPitchPenalty);
       double stallSpeedForAuthority = MCH_FlightModel.getStallSpeed(planeInfo.stallSpeed, this.getMaxSpeed(), planeInfo.stallSpeedFactor);
@@ -2474,6 +2474,18 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastFinalPitchAngularVelocity = this.pitchAngularVelocity;
    }
 
+   private boolean isAirborneNewConventionalFlight(boolean levelOff, double dp) {
+      return this.useNewMobilitySystem() && this.getPlaneInfo() != null && dp == 0.0D && !super.onGround
+            && this.getNozzleRotation() <= 0.01F && !levelOff;
+   }
+
+   private double getNewFlightAuthoritySpeed() {
+      if(this.useNewMobilitySystem() && this.getPlaneInfo() != null && !super.onGround && this.getNozzleRotation() <= 0.01F) {
+         return Math.max(this.getTrueAirspeed(), this.getForwardAirspeed());
+      }
+      return Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+   }
+
    private double updateNewFlightEnergyState(double mass, double gravityAccel, double horizontalSpeed, double drag) {
       MCP_PlaneInfo info = this.getPlaneInfo();
       double vx = super.motionX;
@@ -3313,6 +3325,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastPitchMomentAirflowScale = 0.0D;
       this.lastPitchMomentAngularVelocity = 0.0D;
 
+      boolean airborneNewConventional = this.isAirborneNewConventionalFlight(levelOff, dp);
+
       // If nozzle rotation angle is greater than0.001F
       if(this.getNozzleRotation() > 0.001F) {
          // Adjusts aircraft pitch according to nozzle rotation angle
@@ -3324,6 +3338,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             v.xCoord *= 0.800000011920929D;
             v.zCoord *= 0.800000011920929D;
          }
+      } else if(airborneNewConventional) {
+         // New fixed-wing flight applies thrust on the actual body-forward axis.
+         // Do not use the legacy pitch-10 vector in sustained climbs/aerobatics; gravity, drag,
+         // AoA and thrust-to-weight decide whether the climb is sustainable.
+         v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch());
       } else {
          // Otherwise calculates default direction vector with pitch minus 10 degrees
          v = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch() - 10.0F);
@@ -3332,7 +3351,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       // If steady flight state has not been reached
       if(!levelOff) {
          // If nozzle rotation angle is <= 0.01F, adjusts vertical speed based on throttle
-         if(this.getNozzleRotation() <= 0.01F) {
+         if(this.getNozzleRotation() <= 0.01F && !airborneNewConventional) {
             double verticalThrust = v.yCoord * (double)throttle1 / 2.0D;
             if(this.useNewMobilitySystem() && this.getPlaneInfo() != null && verticalThrust > 0.0D) {
                double mass = this.getPhysicalMass();
@@ -3367,7 +3386,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       double horizontalThrustX = v.xCoord;
       double horizontalThrustZ = v.zCoord;
-      if(this.useNewMobilitySystem() && this.getNozzleRotation() <= 0.01F) {
+      if(this.useNewMobilitySystem() && this.getNozzleRotation() <= 0.01F && !airborneNewConventional) {
          double pitchProjection = Math.sqrt(horizontalThrustX * horizontalThrustX + horizontalThrustZ * horizontalThrustZ);
          if(pitchProjection > 1.0E-4D) {
             // A propeller/jet still accelerates the aircraft along the runway/airflow direction when
@@ -3385,14 +3404,17 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       double forwardSpeedBefore = super.motionX * horizontalThrustX + super.motionZ * horizontalThrustZ;
 
-      // If movement is possible, updates horizontal speed
+      // If movement is possible, updates speed. New airborne conventional fixed-wing uses
+      // full body-axis thrust, while legacy/ground/VTOL paths keep horizontal-only thrust.
       if(canMove) {
-         // If reverse is enabled and throttle is backward, reverses based on throttle
-         if (this.getAcInfo().enableBack && super.throttleBack > 0.0F) {
+         if(airborneNewConventional) {
+            super.motionX += v.xCoord * (double)throttle1;
+            super.motionY += v.yCoord * (double)throttle1;
+            super.motionZ += v.zCoord * (double)throttle1;
+         } else if (this.getAcInfo().enableBack && super.throttleBack > 0.0F) {
             super.motionX -= horizontalThrustX * (double) super.throttleBack;
             super.motionZ -= horizontalThrustZ * (double) super.throttleBack;
          } else {
-            // Otherwise moves forward based on throttle
             super.motionX += horizontalThrustX * (double) throttle1;
             super.motionZ += horizontalThrustZ * (double) throttle1;
          }
@@ -3503,14 +3525,16 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          double energyChange = MCH_FlightModel.getVerticalEnergyChange(super.motionY,
                (float)derivedClimbLoss, (float)derivedDiveGain) / mass;
          this.lastClimbEnergyDrag = Math.max(0.0D, -energyChange);
-         double targetSpeed = Math.max(0.0D, horizontalSpeed * (1.0D - drag) + energyChange);
+         double trueSpeedForEnergy = this.getTrueAirspeed();
+         double targetSpeed = Math.max(0.0D, trueSpeedForEnergy * (1.0D - drag) + energyChange);
 
-         if(horizontalSpeed > 1.0E-4D) {
-            double energyScale = targetSpeed / horizontalSpeed;
+         if(trueSpeedForEnergy > 1.0E-4D) {
+            double energyScale = targetSpeed / trueSpeedForEnergy;
             if(this.deepStallSeverity > 0.65D && noseHighPitch > 0.35D) {
                energyScale *= 1.0D - MCH_FlightModel.clamp((this.deepStallSeverity - 0.65D) / 0.35D, 0.0D, 1.0D) * 0.35D;
             }
             super.motionX *= energyScale;
+            super.motionY *= energyScale;
             super.motionZ *= energyScale;
             if(this.deepStallSeverity > 0.80D && noseHighPitch > 0.45D) {
                double departureClamp = 1.0D - MCH_FlightModel.clamp((this.deepStallSeverity - 0.80D) / 0.20D, 0.0D, 1.0D) * 0.18D;
@@ -3521,9 +3545,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                }
             }
          } else if(targetSpeed > 0.0D) {
-            double yaw = Math.toRadians((double)this.getRotYaw());
-            super.motionX += -Math.sin(yaw) * targetSpeed;
-            super.motionZ += Math.cos(yaw) * targetSpeed;
+            Vec3 forward = MCH_Lib.Rot2Vec3(this.getRotYaw(), this.getRotPitch());
+            super.motionX += forward.xCoord * targetSpeed;
+            super.motionY += forward.yCoord * targetSpeed;
+            super.motionZ += forward.zCoord * targetSpeed;
          }
          this.applyNewFlightIdleGlideAssist(gravityAccel);
          this.lastHorizontalSpeedAfterEnergyDrag = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
@@ -3558,15 +3583,31 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       float speedLimit = this.useNewMobilitySystem()
             ? (float)MCH_FlightModel.getDiveSpeedLimit(levelSpeed, this.getRotPitch(), super.motionY, this.getPlaneInfo().diveSpeedMultiplier)
             : baseSpeedLimit;
-      // If current speed exceeds max speed limit, scales horizontal speed down by max speed ratio
-      if(motion1 > (double)speedLimit) {
+      double speedForCurrentSpeed = motion1;
+      if(airborneNewConventional) {
+         double trueSpeed = this.getTrueAirspeed();
+         if(trueSpeed > (double)speedLimit) {
+            double speedScale = (double)speedLimit / trueSpeed;
+            super.motionX *= speedScale;
+            super.motionY *= speedScale;
+            super.motionZ *= speedScale;
+            trueSpeed = speedLimit;
+         }
+         speedForCurrentSpeed = Math.max(this.getForwardAirspeed(), trueSpeed);
+         motion1 = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      } else if(motion1 > (double)speedLimit) {
          super.motionX *= (double)speedLimit / motion1;
          super.motionZ *= (double)speedLimit / motion1;
          motion1 = speedLimit;
+         speedForCurrentSpeed = motion1;
       }
 
-      // If current speed is greater than previous frame speed and below max speed limit, gradually increases speed
-      if(motion1 > prevMotion && super.currentSpeed < (double)speedLimit) {
+      if(airborneNewConventional) {
+         // New fixed-wing currentSpeed is a telemetry/control basis for airborne flight,
+         // so keep it tied to true/body-forward airspeed instead of the horizontal projection.
+         super.currentSpeed = MCH_FlightModel.clamp(speedForCurrentSpeed, 0.07D, (double)speedLimit);
+      } else if(speedForCurrentSpeed > prevMotion && super.currentSpeed < (double)speedLimit) {
+         // If current speed is greater than previous frame speed and below max speed limit, gradually increases speed
          super.currentSpeed += ((double)speedLimit - super.currentSpeed) / 35.0D;
          if(super.currentSpeed > (double)speedLimit) {
             super.currentSpeed = (double)speedLimit;

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -166,26 +166,30 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(String.format("NF DBG  stall=%s recover=%s flap=%s", new Object[]{
             Boolean.valueOf(plane.getStallSeverity() > 0.0D), Boolean.valueOf(plane.isStallRecovering()),
             Boolean.valueOf(plane.isCombatFlapsDeployed())}));
-      lines.add(String.format("spd raw=%.0f disp=%.0f km/h stall=%.3f", new Object[]{
+      lines.add(String.format("SPD true=%.3f fwd=%.3f horiz=%.3f current=%.3f", new Object[]{
+            Double.valueOf(plane.getTrueAirspeed()), Double.valueOf(plane.getForwardAirspeed()),
+            Double.valueOf(plane.getLastHorizontalSpeed()), Double.valueOf(plane.currentSpeed)}));
+      lines.add(String.format("SPD raw=%.0f display=%.0f km/h stall=%.3f", new Object[]{
             Double.valueOf(MCH_HudShared.getRawSpeedKmh(plane)), Double.valueOf(MCH_HudShared.getDisplaySpeedPlane(plane)), Double.valueOf(stallSpeed)}));
-      lines.add(String.format("phys fwd=%.3f hor=%.3f", new Object[]{
-            Double.valueOf(plane.getLastForwardAirspeed()), Double.valueOf(plane.getLastHorizontalSpeed())}));
       lines.add(String.format("aoa=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
             Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getStallDemand()),
             Double.valueOf(plane.getSpeedStallSeverity()), Double.valueOf(plane.getAoAStallSeverity()),
             Double.valueOf(plane.getDeepStallSeverity())}));
-      lines.add(String.format("auth ctrl=%.2f pitch=%.2f up=%.2f down=%.2f", new Object[]{
-            Double.valueOf(plane.getLastControlAuthority()), Double.valueOf(plane.getLastFinalPitchAuthority()),
-            Double.valueOf(plane.getLastPitchUpAuthority()), Double.valueOf(plane.getLastPitchDownAuthority())}));
+      lines.add(String.format("auth pitch=%.2f roll=%.2f finalPitch=%.4f finalRollAV=%.4f", new Object[]{
+            Double.valueOf(plane.getLastFinalPitchAuthority()), Double.valueOf(plane.getLastRollAuthority()),
+            Double.valueOf(plane.getLastPitchInputAfterAuthority()), Float.valueOf(plane.getRollAngularVelocity())}));
+      lines.add(String.format("auth ctrl=%.2f up=%.2f down=%.2f yaw=%.2f", new Object[]{
+            Double.valueOf(plane.getLastControlAuthority()), Double.valueOf(plane.getLastPitchUpAuthority()),
+            Double.valueOf(plane.getLastPitchDownAuthority()), Double.valueOf(plane.getLastYawAuthority())}));
       lines.add(String.format("mom stall=%.4f forced=%.4f finalAV=%.4f", new Object[]{
             Double.valueOf(plane.getLastStallPitchMoment()), Double.valueOf(plane.getLastForcedNoseDownPitchDelta()),
             Double.valueOf(plane.getLastFinalPitchAngularVelocity())}));
       lines.add(String.format("lift L/W=%.2f T/W=%.2f loss=%.2f validClimb=%s", new Object[]{
             Double.valueOf(plane.getLiftToWeightRatio()), Double.valueOf(plane.getThrustToWeightRatio()),
             Double.valueOf(plane.getLastLiftLoss()), Boolean.valueOf(plane.isLastValidClimb())}));
-      lines.add(String.format("energy ratio=%.2f deficit=%.2f dE=%.4f", new Object[]{
+      lines.add(String.format("energy ratio=%.2f deficit=%.2f dE=%.4f reason=%s", new Object[]{
             Double.valueOf(plane.getLastPitchEnvelopeEnergyRatio()), Double.valueOf(plane.getLastEnergyDeficitSeverity()),
-            Double.valueOf(plane.getLastEnergyDelta())}));
+            Double.valueOf(plane.getLastEnergyDelta()), plane.getLastLowHorizontalSpeedWarning()}));
 
       int width = Math.min(super.width - 16, Math.max(220, this.getMaxHudLineWidth(lines) + 8));
       int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - width - 8));


### PR DESCRIPTION
### Motivation
- Existing new-flight code treated many control/authority and HUD values as horizontal-only, which caused pitch/roll authority and `currentSpeed` to collapse during steep climbs and aerobatics despite nonzero true or body-forward airspeed.
- The goal is a targeted fix that proves the root cause with debug telemetry and then switches airborne new fixed-wing logic to use full 3D and body-forward speed where appropriate without rewriting the flight model or touching assets.

### Description
- Added debug HUD telemetry to display `trueAirspeed`, `bodyForwardAirspeed`, `horizontalSpeed`, `currentSpeed`, displayed SPD, pitch/roll authority, final inputs, stall/AoA severities, and energy reason by extending `MCP_GuiPlane` debug output lines.
- Introduced `isAirborneNewConventionalFlight(...)` and `getNewFlightAuthoritySpeed()` in `MCP_EntityPlane` and updated pitch-authority basis to use `getNewFlightAuthoritySpeed()` (returns `max(trueAirspeed, forwardAirspeed)` when airborne new fixed-wing) instead of the horizontal projection.
- For airborne conventional new fixed-wing cases, applied engine thrust along the body-forward axis (using the body `forward` vector) and retained legacy/ground/VTOL thrust paths for non-airborne or nozzle/legacy paths in `MCP_EntityPlane`.
- Updated airborne energy handling and speed scaling to operate on the full 3D velocity: energy-based scaling now uses `trueAirspeed` and scales `motionX/motionY/motionZ` together, and the dive/overspeed cap is applied to true 3D speed for airborne new fixed-wing while legacy horizontal capping remains for ground/legacy cases.
- Tied airborne `currentSpeed` telemetry/control basis to the true/body-forward speed for new fixed-wing instead of horizontal-only projection, preserving legacy behavior for non-new-flight or grounded states.
- Removed the artificial nonzero lower bound from the signed lift curve in `MCH_FlightModel.getLiftCoefficientLikeCurve()` so near-zero AoA can return near-zero lift while still supporting inverted and post-critical behavior.

### Testing
- Ran `git diff --check` to verify diff hygiene and ensure no whitespace/index issues, which succeeded.
- Attempted `gradle compileJava` and `./gradlew compileJava` in this environment but both failed due to external repository/network access (Maven/ForgeGradle metadata and Gradle wrapper download returned HTTP 403), so a full compile could not be completed here.
- Performed local static edits and repository checks (search/replace and `rg` validations) to ensure modified call sites and new helper methods are present and referenced; these automated checks completed without local errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dabb32c68832394e30a47c8c445a6)