### PR TITLE
Fix fixed-wing pitch and roll control rates

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -41,6 +41,8 @@ import net.minecraft.world.World;
 public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
    private static final float PLANE_MANEUVERABILITY_FACTOR = 1.0F;
+   private static final float NEW_FLIGHT_PITCH_RATE_SCALE = 1.20F;
+   private static final float NEW_FLIGHT_ROLL_RATE_SCALE = 3.00F;
 
    private MCP_PlaneInfo planeInfo = null;
    public float soundVolume;
@@ -217,6 +219,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double lastPitchAfterClamp;
    private double lastRollBeforeClamp;
    private double lastRollAfterClamp;
+   private double lastRawPitchCommandNormalized;
+   private double lastDesiredPitchRate;
+   private double lastPitchAngularVelocityBeforeUpdate;
+   private double lastPitchAngularVelocityAfterUpdate;
+   private double lastPitchDeltaApplied;
+   private double lastRawRollCommandNormalized;
+   private double lastDesiredRollRate;
+   private double lastRollAngularVelocityBeforeUpdate;
+   private double lastRollAngularVelocityAfterUpdate;
+   private double lastRollDeltaApplied;
+   private double lastManualRollKeyCommand;
+   private double lastMouseRollCommand;
+   private boolean lastUseMouseAim;
    private boolean lastNewFlightControlPathActive;
    private boolean lastSetAnglesRemote;
    private float lastSetAnglesPartialTicks;
@@ -394,6 +409,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastRecoveryDueToLiftDeficit = false;
       this.lastRecoveryDueToUnsupportedClimb = false;
       this.lastFinalPitchAngularVelocity = 0.0D;
+      this.lastRawPitchCommandNormalized = 0.0D;
+      this.lastDesiredPitchRate = 0.0D;
+      this.lastPitchAngularVelocityBeforeUpdate = 0.0D;
+      this.lastPitchAngularVelocityAfterUpdate = 0.0D;
+      this.lastPitchDeltaApplied = 0.0D;
+      this.lastRawRollCommandNormalized = 0.0D;
+      this.lastDesiredRollRate = 0.0D;
+      this.lastRollAngularVelocityBeforeUpdate = 0.0D;
+      this.lastRollAngularVelocityAfterUpdate = 0.0D;
+      this.lastRollDeltaApplied = 0.0D;
+      this.lastManualRollKeyCommand = 0.0D;
+      this.lastMouseRollCommand = 0.0D;
+      this.lastUseMouseAim = false;
       this.lastAirborne = false;
       this.angleOfAttack = 0.0D;
       this.oldAngleOfAttack = 0.0D;
@@ -863,6 +891,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public double getLastPitchAfterClamp() { return this.lastPitchAfterClamp; }
    public double getLastRollBeforeClamp() { return this.lastRollBeforeClamp; }
    public double getLastRollAfterClamp() { return this.lastRollAfterClamp; }
+   public double getLastRawPitchCommandNormalized() { return this.lastRawPitchCommandNormalized; }
+   public double getLastDesiredPitchRate() { return this.lastDesiredPitchRate; }
+   public double getLastPitchAngularVelocityBeforeUpdate() { return this.lastPitchAngularVelocityBeforeUpdate; }
+   public double getLastPitchAngularVelocityAfterUpdate() { return this.lastPitchAngularVelocityAfterUpdate; }
+   public double getLastPitchDeltaApplied() { return this.lastPitchDeltaApplied; }
+   public double getLastRawRollCommandNormalized() { return this.lastRawRollCommandNormalized; }
+   public double getLastDesiredRollRate() { return this.lastDesiredRollRate; }
+   public double getLastRollAngularVelocityBeforeUpdate() { return this.lastRollAngularVelocityBeforeUpdate; }
+   public double getLastRollAngularVelocityAfterUpdate() { return this.lastRollAngularVelocityAfterUpdate; }
+   public double getLastRollDeltaApplied() { return this.lastRollDeltaApplied; }
+   public double getLastManualRollKeyCommand() { return this.lastManualRollKeyCommand; }
+   public double getLastMouseRollCommand() { return this.lastMouseRollCommand; }
+   public boolean isLastUseMouseAim() { return this.lastUseMouseAim; }
    public boolean isLastNewFlightControlPathActive() { return this.lastNewFlightControlPathActive; }
    public boolean isLastSetAnglesRemote() { return this.lastSetAnglesRemote; }
    public float getLastSetAnglesPartialTicks() { return this.lastSetAnglesPartialTicks; }
@@ -991,6 +1032,12 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
       this.mouseAimYawError = MathHelper.wrapAngleTo180_float(this.mouseAimSmoothedYaw - this.getRotYaw());
       this.mouseAimPitchError = MathHelper.wrapAngleTo180_float(this.mouseAimSmoothedPitch - this.getRotPitch());
+   }
+
+   private float getRateControlForAngularVelocityTarget(float desiredRate, float torque, float damping) {
+      float usableTorque = Math.max(1.0E-4F, torque);
+      float usableDamping = Math.max(1.0E-4F, damping);
+      return desiredRate * usableDamping / usableTorque;
    }
 
    private float getMouseAimYawCommand(double limit) {
@@ -1626,6 +1673,13 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          this.lastRequestedPitchInput = 0.0F;
          this.lastPitchInputAfterAuthority = 0.0F;
          this.lastFinalElevatorInput = 0.0D;
+         this.lastRawPitchCommandNormalized = 0.0D;
+         this.lastDesiredPitchRate = 0.0D;
+         this.lastRawRollCommandNormalized = 0.0D;
+         this.lastDesiredRollRate = 0.0D;
+         this.lastManualRollKeyCommand = 0.0D;
+         this.lastMouseRollCommand = 0.0D;
+         this.lastUseMouseAim = false;
          this.addkeyRotValue = 0.0F;
 
          // Free look decouples pilot camera input from the airframe, but it must not
@@ -1647,6 +1701,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       }
 
       boolean useMouseAim = this.shouldUseMouseAimControls(player);
+      this.lastUseMouseAim = useMouseAim;
       if(useMouseAim) {
          this.updateMouseAimState(deltaX, deltaY, partialTicks);
          x = 0.0F;
@@ -1689,16 +1744,25 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
 
          this.lastPitchAfterClamp = pitch;
-         pitch = (float)((double)(-pitch * this.getPitchFactor()) * 0.06D);
+         this.lastRawPitchCommandNormalized = m_add > 1.0E-4D ? MCH_FlightModel.clamp((double)(-pitch) / m_add, -1.0D, 1.0D) : 0.0D;
+         pitch = (float)(this.lastRawPitchCommandNormalized * (double)planeInfo.mobilityPitch * (double)NEW_FLIGHT_PITCH_RATE_SCALE);
       }
 
       if(this.canUpdateRoll(player)) {
          m_add = this.getAddRotationRollLimit();
          this.lastRollMAdd = m_add;
-         roll = useMouseAim ? this.getManualRollKeyCommand(m_add) : this.getControlRotRoll(x, y, partialTicks);
-
-         if(useMouseAim) {
-            roll = this.getMouseAimRollCommand(roll, m_add);
+         float manualRoll = this.getManualRollKeyCommand(m_add);
+         this.lastManualRollKeyCommand = manualRoll;
+         this.lastMouseRollCommand = 0.0D;
+         if(MathHelper.abs(manualRoll) > 0.001F) {
+            roll = manualRoll;
+            this.mouseAimManualRollActive = true;
+            this.mouseAimGeneratedRollCommand = manualRoll;
+         } else if(useMouseAim) {
+            roll = this.getMouseAimRollCommand(0.0F, m_add);
+            this.lastMouseRollCommand = roll;
+         } else {
+            roll = this.getControlRotRoll(x, y, partialTicks);
          }
          this.lastRollBeforeClamp = roll;
          if((double)roll < -m_add) {
@@ -1710,7 +1774,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          }
 
          this.lastRollAfterClamp = roll;
-         roll = roll * this.getRollFactor() * 0.06F;
+         this.lastRawRollCommandNormalized = m_add > 1.0E-4D ? MCH_FlightModel.clamp((double)roll / m_add, -1.0D, 1.0D) : 0.0D;
+         roll = (float)(this.lastRawRollCommandNormalized * (double)planeInfo.mobilityRoll * (double)NEW_FLIGHT_ROLL_RATE_SCALE);
       }
 
       this.updateVehicleStress();
@@ -1754,22 +1819,30 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastPitchUpAuthority = pitchUpLimiter * envelopeNoseUpAuthority;
       this.lastPitchDownAuthority = (double)controlAuthority * pitchAuthority;
       pitch *= (float)finalPitchAuthority;
+      this.lastDesiredPitchRate = pitch;
       this.lastPitchInputAfterAuthority = pitch;
       this.lastFinalElevatorInput = pitch;
       double deepAxisLimiter = MCH_FlightModel.clamp(1.0D - deepControlLoss * 0.25D, 0.70D, 1.0D);
       this.lastRollAuthority = controlAuthority * deepAxisLimiter;
       this.lastYawAuthority = controlAuthority * MCH_FlightModel.clamp(1.0D - deepControlLoss * 0.18D, 0.75D, 1.0D);
       roll *= (float)this.lastRollAuthority;
+      this.lastDesiredRollRate = roll;
       yaw *= (float)this.lastYawAuthority;
 
       // The legacy controls above still define the requested angular rate.
       // Integrating that request as a damped body rate retains existing mobility
       // tuning while preventing the airframe from snapping to every mouse movement.
       MCP_PlaneInfo info = this.getPlaneInfo();
-      this.pitchAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.pitchAngularVelocity, pitch,
+      this.lastPitchAngularVelocityBeforeUpdate = this.pitchAngularVelocity;
+      this.lastRollAngularVelocityBeforeUpdate = this.rollAngularVelocity;
+      float pitchRateControl = this.getRateControlForAngularVelocityTarget(pitch, info.pitchTorque, info.pitchDamping);
+      float rollRateControl = this.getRateControlForAngularVelocityTarget(roll, info.rollTorque, info.rollDamping);
+      this.pitchAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.pitchAngularVelocity, pitchRateControl,
             info.pitchTorque, info.pitchDamping, info.inertiaMultiplier, partialTicks);
-      this.rollAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.rollAngularVelocity, roll,
+      this.rollAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.rollAngularVelocity, rollRateControl,
             info.rollTorque, info.rollDamping, info.inertiaMultiplier, partialTicks);
+      this.lastPitchAngularVelocityAfterUpdate = this.pitchAngularVelocity;
+      this.lastRollAngularVelocityAfterUpdate = this.rollAngularVelocity;
       this.yawAngularVelocity = MCH_FlightModel.updateAngularVelocity(this.yawAngularVelocity, yaw,
             info.yawTorque, info.yawDamping, info.inertiaMultiplier, partialTicks);
       this.limitPitchYawRateByStructuralG(info);
@@ -1784,6 +1857,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       pitch = this.pitchAngularVelocity * partialTicks;
       roll = this.rollAngularVelocity * partialTicks;
       yaw = this.yawAngularVelocity * partialTicks;
+      this.lastPitchDeltaApplied = pitch;
+      this.lastRollDeltaApplied = roll;
 
       MCH_Math.FMatrix m_add1 = MCH_Math.newMatrix();
       MCH_Math.MatTurnZ(m_add1, roll / 180.0F * 3.1415927F);
@@ -2725,6 +2800,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastRecoveryDueToLiftDeficit = false;
       this.lastRecoveryDueToUnsupportedClimb = false;
       this.lastFinalPitchAngularVelocity = 0.0D;
+      this.lastRawPitchCommandNormalized = 0.0D;
+      this.lastDesiredPitchRate = 0.0D;
+      this.lastPitchAngularVelocityBeforeUpdate = 0.0D;
+      this.lastPitchAngularVelocityAfterUpdate = 0.0D;
+      this.lastPitchDeltaApplied = 0.0D;
+      this.lastRawRollCommandNormalized = 0.0D;
+      this.lastDesiredRollRate = 0.0D;
+      this.lastRollAngularVelocityBeforeUpdate = 0.0D;
+      this.lastRollAngularVelocityAfterUpdate = 0.0D;
+      this.lastRollDeltaApplied = 0.0D;
+      this.lastManualRollKeyCommand = 0.0D;
+      this.lastMouseRollCommand = 0.0D;
+      this.lastUseMouseAim = false;
       this.lastAirborne = false;
       this.pitchAngularVelocity = this.rollAngularVelocity = this.yawAngularVelocity = 0.0F;
       this.currentGForce = 1.0D;

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -187,6 +187,17 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(String.format("auth pitch=%.2f roll=%.2f finalPitch=%.4f finalRollAV=%.4f", new Object[]{
             Double.valueOf(plane.getLastFinalPitchAuthority()), Double.valueOf(plane.getLastRollAuthority()),
             Double.valueOf(plane.getLastPitchInputAfterAuthority()), Float.valueOf(plane.getRollAngularVelocity())}));
+      lines.add(String.format("cmd pitch raw=%.2f desired=%.3f av %.3f->%.3f d=%.3f", new Object[]{
+            Double.valueOf(plane.getLastRawPitchCommandNormalized()), Double.valueOf(plane.getLastDesiredPitchRate()),
+            Double.valueOf(plane.getLastPitchAngularVelocityBeforeUpdate()), Double.valueOf(plane.getLastPitchAngularVelocityAfterUpdate()),
+            Double.valueOf(plane.getLastPitchDeltaApplied())}));
+      lines.add(String.format("cmd roll raw=%.2f desired=%.3f av %.3f->%.3f d=%.3f", new Object[]{
+            Double.valueOf(plane.getLastRawRollCommandNormalized()), Double.valueOf(plane.getLastDesiredRollRate()),
+            Double.valueOf(plane.getLastRollAngularVelocityBeforeUpdate()), Double.valueOf(plane.getLastRollAngularVelocityAfterUpdate()),
+            Double.valueOf(plane.getLastRollDeltaApplied())}));
+      lines.add(String.format("roll route manual=%.2f mouse=%.2f mouseAim=%s", new Object[]{
+            Double.valueOf(plane.getLastManualRollKeyCommand()), Double.valueOf(plane.getLastMouseRollCommand()),
+            Boolean.valueOf(plane.isLastUseMouseAim())}));
       lines.add(String.format("auth ctrl=%.2f up=%.2f down=%.2f yaw=%.2f", new Object[]{
             Double.valueOf(plane.getLastControlAuthority()), Double.valueOf(plane.getLastPitchUpAuthority()),
             Double.valueOf(plane.getLastPitchDownAuthority()), Double.valueOf(plane.getLastYawAuthority())}));


### PR DESCRIPTION
### Motivation
- Resolve remaining fixed-wing pitch/aileron roll failures by fixing control integration and roll input routing instead of changing the aerodynamic solver.  
- Debug showed pilot inputs being reduced to legacy small rotation deltas (`* 0.06`) and then re-fed into a second-order integrator, producing vanishing body-rate deltas.  
- Manual roll (A/D) keys were not consistently routed into the new `rollAngularVelocity` path when `mouseAim` was enabled, preventing barrel rolls at full input.

### Description
- Replace use of the legacy small rotation delta as direct integrator input by computing a normalized raw pilot command and converting it to a desired body-rate; added `NEW_FLIGHT_PITCH_RATE_SCALE` and `NEW_FLIGHT_ROLL_RATE_SCALE` constants and use `planeInfo.mobilityPitch`/`mobilityRoll` to compute desired rates.  
- Introduced `getRateControlForAngularVelocityTarget(...)` and use it to convert the desired angular-rate target into the control value passed to `MCH_FlightModel.updateAngularVelocity`, so `updateAngularVelocity` drives the actual angular velocity toward the desired rate (single `* dt` application).  
- Always compute manual roll via `getManualRollKeyCommand(...)` and make manual roll override mouse auto-bank when active, ensuring A/D keys feed the `rollAngularVelocity` path instead of directly calling `setRotRoll`.  
- Added debug state fields, accessors, and HUD output for `rawPitchCommandNormalized`, `desiredPitchRate`, pitch/roll angular velocity before/after update, applied pitch/roll deltas, `manualRollKeyCommand`, `mouseRollCommand`, and `useMouseAim` to make the command→rate→applied-delta chain visible in the HUD (`MCP_EntityPlane.java` and `MCP_GuiPlane.java` changes).

### Testing
- Ran `git diff --check` which returned no whitespace/merge problems.  
- Attempted `bash ./gradlew test` but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), preventing wrapper usage.  
- Attempted `gradle test` (system Gradle) but dependency resolution for ForgeGradle failed with HTTP 403 from configured Maven/JCenter/Forge repositories, so automated test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db6b443b08323a4e11ec184b5f17b)