### PR TITLE
Gate fixed‑wing nose‑down recovery on AoA/stall and remove attitude-based pitch wall

### DIFF
--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -256,6 +256,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private boolean lastRecoveryDueToAoA;
    private boolean lastRecoveryDueToLiftDeficit;
    private boolean lastRecoveryDueToUnsupportedClimb;
+   private double lastPitchWallRecoveryDemand;
+   private boolean lastShouldForceNoseDownRecovery;
    /** Final body-rate after post-control stall/energy recovery is applied. */
    private double lastFinalPitchAngularVelocity;
    /** Last airborne state used by the new fixed-wing force model. */
@@ -378,6 +380,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNoseDownRecoverySeverity = 0.0D;
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
+      this.lastNoseDownRecoveryTorque = 0.0D;
+      this.lastPitchWallRecoveryDemand = 0.0D;
+      this.lastShouldForceNoseDownRecovery = false;
       this.lastPitchMoment = 0.0D;
       this.lastAoAPitchMoment = 0.0D;
       this.lastStabilityPitchMoment = 0.0D;
@@ -761,6 +766,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastRecoveryDueToAoA = false;
       this.lastRecoveryDueToLiftDeficit = false;
       this.lastRecoveryDueToUnsupportedClimb = false;
+      this.lastPitchWallRecoveryDemand = 0.0D;
+      this.lastShouldForceNoseDownRecovery = false;
       this.lastCommandPitchExcess = 0.0D;
       this.lastPhysicalPitchExcess = 0.0D;
       this.lastPitchEnvelopeExcess = 0.0D;
@@ -774,31 +781,25 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       double stallSpeed = Math.max(0.05D, MCH_FlightModel.getStallSpeed(info.stallSpeed, this.getMaxSpeed(), info.stallSpeedFactor));
       double forwardAirspeed = Math.max(0.0D, this.getForwardAirspeed());
       double energyRatio = forwardAirspeed / stallSpeed;
-      double liftMargin = this.lastWeightForce > 1.0E-6D
-            ? MCH_FlightModel.clamp(this.getLiftToWeightRatio(), 0.0D, 1.8D) : 1.0D;
-      double thrustMargin = this.lastWeightForce > 1.0E-6D
-            ? MCH_FlightModel.clamp(this.getThrustToWeightRatio(), 0.0D, 1.6D) : 0.0D;
-      double criticalAoA = Math.max(5.0D, (double)info.criticalAoA);
-      double aoaSeverity = this.smooth01(MCH_FlightModel.clamp((this.angleOfAttack - criticalAoA) / Math.max(1.0D, criticalAoA), 0.0D, 1.0D));
-      double speedDeficit = this.smooth01(MCH_FlightModel.clamp((1.0D - energyRatio) / 0.55D, 0.0D, 1.0D));
-      double liftDeficit = MCH_FlightModel.clamp((0.92D - liftMargin) / 0.42D, 0.0D, 1.0D);
-      double thrustDeficit = MCH_FlightModel.clamp(1.0D - thrustMargin, 0.0D, 1.0D);
-      double climbDemand = MCH_FlightModel.clamp(super.motionY / Math.max(0.10D, stallSpeed * 0.65D), 0.0D, 1.0D);
-      double unsupportedClimb = Math.max(this.lastUnsupportedClimbSeverity,
-            climbDemand * Math.max(Math.max(speedDeficit, liftDeficit), thrustDeficit));
-      double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 90.0D, 0.0D, 1.0D);
-      double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
-            Math.max(speedDeficit, liftDeficit));
-      double recoveryDemand = Math.max(Math.max(aerodynamicDeficit, this.lastEnergyDeficitSeverity), unsupportedClimb);
+      double positiveAoA = this.getPositiveNormalAoAForStall();
+      double criticalAoA = Math.max(1.0D, (double)info.criticalAoA);
+      double aoaSeverity = this.smooth01(MCH_FlightModel.clamp((positiveAoA - criticalAoA) / Math.max(1.0D, criticalAoA), 0.0D, 1.0D));
+      double stallRecoveryDemand = Math.max(Math.max(aoaSeverity, this.aoaStallSeverity),
+            Math.max(this.stallSeverity, this.deepStallSeverity));
+      boolean lowEnergyAfterStall = this.timeAfterLowEnergyStall > 0.0D && stallRecoveryDemand > 0.05D;
+      double recoveryDemand = lowEnergyAfterStall
+            ? Math.max(stallRecoveryDemand, this.lastEnergyDeficitSeverity) : stallRecoveryDemand;
 
-      this.lastRecoveryDueToLowEnergy = speedDeficit > 0.20D || this.lastEnergyDeficitSeverity > 0.20D;
-      this.lastRecoveryDueToAoA = aoaSeverity > 0.05D || this.aoaStallSeverity > 0.05D;
-      this.lastRecoveryDueToLiftDeficit = liftDeficit > 0.15D;
-      this.lastRecoveryDueToUnsupportedClimb = unsupportedClimb > 0.25D;
+      this.lastPitchWallRecoveryDemand = recoveryDemand;
+      this.lastShouldForceNoseDownRecovery = this.shouldForceNoseDownRecovery();
+      this.lastRecoveryDueToLowEnergy = lowEnergyAfterStall;
+      this.lastRecoveryDueToAoA = positiveAoA > criticalAoA || this.aoaStallSeverity > 0.05D;
+      this.lastRecoveryDueToLiftDeficit = false;
+      this.lastRecoveryDueToUnsupportedClimb = false;
 
-      if(recoveryDemand > 0.20D && noseUpAttitude > 0.05D) {
-         double recoveryScale = this.smooth01(MCH_FlightModel.clamp((recoveryDemand - 0.20D) / 0.80D, 0.0D, 1.0D));
-         this.lastNoseDownRecoveryTorque = recoveryScale * noseUpAttitude
+      if(this.lastShouldForceNoseDownRecovery && recoveryDemand > 0.05D) {
+         double recoveryScale = this.smooth01(MCH_FlightModel.clamp(recoveryDemand, 0.0D, 1.0D));
+         this.lastNoseDownRecoveryTorque = recoveryScale
                * (0.08D + 0.32D * Math.max(this.stallSeverity, this.deepStallSeverity))
                * (0.55D + (double)info.stallPitchRecoveryStrength);
          this.lastPhysicalRecoveryActive = this.lastNoseDownRecoveryTorque > 1.0E-5D;
@@ -818,13 +819,19 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return 0.0D;
       }
 
-      double liftDeficit = this.lastWeightForce > 1.0E-6D
-            ? MCH_FlightModel.clamp(1.0D - this.getLiftToWeightRatio(), 0.0D, 1.0D) : 0.0D;
-      double noseUpAttitude = MCH_FlightModel.clamp((double)(-this.getRotPitch()) / 45.0D, 0.0D, 1.0D);
-      double aerodynamicDeficit = Math.max(Math.max(this.stallSeverity, this.aoaStallSeverity),
-            Math.max(this.speedStallSeverity, liftDeficit));
-      double energyDeficit = Math.max(Math.max(aerodynamicDeficit, this.lastEnergyDeficitSeverity), this.getUnsupportedClimbSeverity());
-      return MCH_FlightModel.clamp(energyDeficit * (0.35D + 0.65D * noseUpAttitude), 0.0D, 1.0D);
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      double positiveAoA = this.getPositiveNormalAoAForStall();
+      double criticalAoA = Math.max(1.0D, (double)info.criticalAoA);
+      boolean actualAoAThreat = positiveAoA > criticalAoA * 0.85D || this.timePastCriticalAoA > 0.0D;
+      boolean actualStallThreat = this.stalling || this.stallSeverity > 0.05D || this.deepStallSeverity > 0.05D
+            || this.aoaStallSeverity > 0.05D || this.timeAfterLowEnergyStall > 0.0D;
+      if(!actualAoAThreat && !actualStallThreat) {
+         return 0.0D;
+      }
+
+      double aoaWarning = MCH_FlightModel.clamp((positiveAoA - criticalAoA * 0.85D) / Math.max(1.0D, criticalAoA * 0.15D), 0.0D, 1.0D);
+      double stallThreat = Math.max(Math.max(this.stallSeverity, this.deepStallSeverity), this.aoaStallSeverity);
+      return MCH_FlightModel.clamp(Math.max(aoaWarning, stallThreat), 0.0D, 1.0D);
    }
 
    public double getCurrentGForce() {
@@ -1333,6 +1340,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    public boolean isLastRecoveryDueToAoA() { return this.lastRecoveryDueToAoA; }
    public boolean isLastRecoveryDueToLiftDeficit() { return this.lastRecoveryDueToLiftDeficit; }
    public boolean isLastRecoveryDueToUnsupportedClimb() { return this.lastRecoveryDueToUnsupportedClimb; }
+   public double getLastPitchWallRecoveryDemand() { return this.lastPitchWallRecoveryDemand; }
+   public boolean isLastShouldForceNoseDownRecovery() { return this.lastShouldForceNoseDownRecovery; }
 
    public double getLastFinalPitchAngularVelocity() {
       return this.lastFinalPitchAngularVelocity;
@@ -1563,6 +1572,30 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    private double getPositiveNormalAoAForStall() {
       double sideslipPenalty = Math.max(0.0D, Math.abs(this.sideslipAngle) - 8.0D) * 0.20D;
       return Math.max(0.0D, this.angleOfAttack) + sideslipPenalty;
+   }
+
+   public double getPositiveNormalAoAForDebug() {
+      return this.getPositiveNormalAoAForStall();
+   }
+
+   private boolean shouldForceNoseDownRecovery() {
+      MCP_PlaneInfo info = this.getPlaneInfo();
+      if(info == null) {
+         return false;
+      }
+
+      double positiveAoA = this.getPositiveNormalAoAForStall();
+      double criticalAoA = Math.max(1.0D, (double)info.criticalAoA);
+      return positiveAoA > criticalAoA
+            || this.aoaStallSeverity > 0.05D
+            || this.stalling
+            || this.stallSeverity > 0.10D
+            || this.deepStallSeverity > 0.10D
+            || this.timeAfterLowEnergyStall > 0.0D;
+   }
+
+   public boolean shouldForceNoseDownRecoveryForDebug() {
+      return this.shouldForceNoseDownRecovery();
    }
 
    private boolean shouldUseLegacyRotationClamp() {
@@ -2593,6 +2626,10 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
          return;
       }
 
+      if(!this.shouldForceNoseDownRecovery()) {
+         return;
+      }
+
       double thrustDeficit = MCH_FlightModel.clamp(1.0D - this.getThrustToWeightRatio(), 0.0D, 1.0D);
       double climbDemand = Math.max(super.motionY > 0.0D ? MCH_FlightModel.clamp(super.motionY / 0.18D, 0.0D, 1.0D) : 0.35D,
             this.speedStallSeverity);
@@ -2621,7 +2658,8 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    private void queueNoseDownRecovery(double pitchDownVelocity, double severity, double noseUpDamping) {
-      if(pitchDownVelocity <= 1.0E-5D) {
+      this.lastShouldForceNoseDownRecovery = this.shouldForceNoseDownRecovery();
+      if(pitchDownVelocity <= 1.0E-5D || !this.lastShouldForceNoseDownRecovery) {
          return;
       }
 
@@ -2767,6 +2805,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNoseDownRecoverySeverity = 0.0D;
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
+      this.lastNoseDownRecoveryTorque = 0.0D;
+      this.lastPitchWallRecoveryDemand = 0.0D;
+      this.lastShouldForceNoseDownRecovery = false;
       this.lastPitchMoment = 0.0D;
       this.lastAoAPitchMoment = 0.0D;
       this.lastStabilityPitchMoment = 0.0D;
@@ -3507,6 +3548,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.lastNoseDownRecoverySeverity = 0.0D;
       this.lastStallPitchMoment = 0.0D;
       this.lastThrustPitchDownMoment = 0.0D;
+      this.lastNoseDownRecoveryTorque = 0.0D;
+      this.lastPitchWallRecoveryDemand = 0.0D;
+      this.lastShouldForceNoseDownRecovery = false;
       this.lastPitchMoment = 0.0D;
       this.lastAoAPitchMoment = 0.0D;
       this.lastStabilityPitchMoment = 0.0D;

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -180,8 +180,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Double.valueOf(plane.getLastRollBeforeClamp()), Double.valueOf(plane.getLastRollAfterClamp())}));
       lines.add(String.format("SPD raw=%.0f display=%.0f km/h stall=%.3f", new Object[]{
             Double.valueOf(MCH_HudShared.getRawSpeedKmh(plane)), Double.valueOf(MCH_HudShared.getDisplaySpeedPlane(plane)), Double.valueOf(stallSpeed)}));
-      lines.add(String.format("aoa=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
-            Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getStallDemand()),
+      lines.add(String.format("aoa=%.1f pos=%.1f crit=%.1f demand=%.2f sev=%.2f/%.2f/%.2f", new Object[]{
+            Double.valueOf(plane.getAngleOfAttackDegrees()), Double.valueOf(plane.getPositiveNormalAoAForDebug()),
+            Double.valueOf(plane.getCriticalAoA()), Double.valueOf(plane.getStallDemand()),
             Double.valueOf(plane.getSpeedStallSeverity()), Double.valueOf(plane.getAoAStallSeverity()),
             Double.valueOf(plane.getDeepStallSeverity())}));
       lines.add(String.format("auth pitch=%.2f roll=%.2f finalPitch=%.4f finalRollAV=%.4f", new Object[]{
@@ -201,8 +202,17 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(String.format("auth ctrl=%.2f up=%.2f down=%.2f yaw=%.2f", new Object[]{
             Double.valueOf(plane.getLastControlAuthority()), Double.valueOf(plane.getLastPitchUpAuthority()),
             Double.valueOf(plane.getLastPitchDownAuthority()), Double.valueOf(plane.getLastYawAuthority())}));
-      lines.add(String.format("mom stall=%.4f forced=%.4f finalAV=%.4f", new Object[]{
-            Double.valueOf(plane.getLastStallPitchMoment()), Double.valueOf(plane.getLastForcedNoseDownPitchDelta()),
+      lines.add(String.format("wall force=%s sup=%.3f demand=%.3f torque=%.4f forcedThisTick=%.4f", new Object[]{
+            Boolean.valueOf(plane.isLastShouldForceNoseDownRecovery()), Double.valueOf(plane.getLastNoseUpPitchSuppression()),
+            Double.valueOf(plane.getLastPitchWallRecoveryDemand()), Double.valueOf(plane.getLastNoseDownRecoveryTorque()),
+            Double.valueOf(plane.getLastForcedNoseDownPitchDelta())}));
+      lines.add(String.format("wall due lift=%s climb=%s aoa=%s pitchAV %.3f->%.3f->%.3f d=%.3f", new Object[]{
+            Boolean.valueOf(plane.isLastRecoveryDueToLiftDeficit()), Boolean.valueOf(plane.isLastRecoveryDueToUnsupportedClimb()),
+            Boolean.valueOf(plane.isLastRecoveryDueToAoA()), Double.valueOf(plane.getLastPitchAngularVelocityBeforeUpdate()),
+            Double.valueOf(plane.getLastPitchAngularVelocityAfterUpdate()), Double.valueOf(plane.getLastFinalPitchAngularVelocity()),
+            Double.valueOf(plane.getLastPitchDeltaApplied())}));
+      lines.add(String.format("mom stall=%.4f thrust=%.4f finalAV=%.4f", new Object[]{
+            Double.valueOf(plane.getLastStallPitchMoment()), Double.valueOf(plane.getLastThrustPitchDownMoment()),
             Double.valueOf(plane.getLastFinalPitchAngularVelocity())}));
       lines.add(String.format("lift L/W=%.2f T/W=%.2f loss=%.2f validClimb=%s", new Object[]{
             Double.valueOf(plane.getLiftToWeightRatio()), Double.valueOf(plane.getThrustToWeightRatio()),


### PR DESCRIPTION
### Motivation
- Remove an unintended soft pitch wall that suppressed/full‑authority nose‑up beyond ~35–45° when the aircraft was not actually stalled. 
- Ensure forced nose‑down recovery only triggers for real AoA/stall/low‑energy stall conditions and not for lift/thrust/unsupported‑climb signals alone. 
- Make per‑tick forced recovery debug fields reflect the current physics tick instead of accumulating across ticks so troubleshooting is reliable.

### Description
- Replaced attitude/lift/thrust/unsupported‑climb triggers in `updatePitchEnvelope()` with an AoA/stall‑led `stallRecoveryDemand` and only compute `lastNoseDownRecoveryTorque` when a real AoA/stall/low‑energy‑after‑stall condition is present. 
- Rewrote `getNoseUpPitchSuppression()` so it returns `0.0D` unless there is an actual AoA warning or stall threat (uses positive AoA vs `criticalAoA` and stall severity thresholds). 
- Added `shouldForceNoseDownRecovery()` helper and gated both `queueNoseDownRecovery()` and `applyThrottleDeficitPitchDown()` so throttle/lift/unsupported‑climb cannot queue recovery unless AoA/stall criteria are met. 
- Reset per‑tick recovery debug state (`lastForcedNoseDownPitchDelta`, `lastNoseDownRecoveryTorque`, `lastPitchWallRecoveryDemand`, `lastShouldForceNoseDownRecovery`, etc.) at the start of the flight tick so `forcedThisTick` is not cumulative. 
- Extended debug HUD (`MCP_GuiPlane`) with positive AoA, critical AoA, `shouldForceNoseDownRecovery` flag, nose‑up suppression, recovery demand/torque/forcedThisTick, and pitch AV before/after pilot/recovery for visibility while testing.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge problems (passed). 
- Attempted `bash ./gradlew compileJava` but the Gradle distribution download failed due to an HTTP 403 from the environment proxy, so a local compile could not be completed. 
- Attempted `gradle compileJava --no-daemon` which failed to resolve build classpath dependencies (ForgeGradle/remote metadata) with HTTP 403 responses, so automated compilation tests are blocked by the environment network/proxy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dba5af3208323afcba6b014bc086b)