### PR TITLE
Add HasBallisticComputer flag and CCIP HUD reticle for planes

### DIFF
--- a/configreference/planes/a-10.txt
+++ b/configreference/planes/a-10.txt
@@ -15,6 +15,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.45
 ;420

--- a/configreference/planes/ac-47.txt
+++ b/configreference/planes/ac-47.txt
@@ -10,6 +10,7 @@ ChaffUseTime = 160
 ThrottleDownFactor = 0.20
 HUD = plane_wwiinotherm, plane_wwiinotherm
 EnableEntityRadar = false
+HasBallisticComputer = true
 Speed = 0.626
 ;max speed seemed too fast
 GravityInWater = -0.04

--- a/configreference/planes/an2.txt
+++ b/configreference/planes/an2.txt
@@ -14,6 +14,7 @@ MaxHp = 100
 ;160mph max speed
 
 Speed = 0.449
+HasBallisticComputer = true
 Sound = antwo
 ThrottleUpDown = 0.4
 MaxFuel         = 4960

--- a/configreference/planes/b-1.txt
+++ b/configreference/planes/b-1.txt
@@ -21,6 +21,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableGunnerMode = true
 EnableEjectionSeat = true
 ConcurrentGunnerMode = true

--- a/configreference/planes/b-1nuclear.txt
+++ b/configreference/planes/b-1nuclear.txt
@@ -21,6 +21,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableGunnerMode = true
 EnableEjectionSeat = true
 ConcurrentGunnerMode = true

--- a/configreference/planes/b-2a.txt
+++ b/configreference/planes/b-2a.txt
@@ -14,6 +14,7 @@ EnableNightVision  = true
 EnableEntityRadar  = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.757
 

--- a/configreference/planes/b-2a3.txt
+++ b/configreference/planes/b-2a3.txt
@@ -14,6 +14,7 @@ EnableNightVision  = true
 EnableEntityRadar  = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.757
 

--- a/configreference/planes/b-2a4.txt
+++ b/configreference/planes/b-2a4.txt
@@ -14,6 +14,7 @@ EnableNightVision  = true
 EnableEntityRadar  = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.757
 

--- a/configreference/planes/b29.txt
+++ b/configreference/planes/b29.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28729
 MaxHp = 250
 Speed = 0.999
+HasBallisticComputer = true
 
 ;357 
 

--- a/configreference/planes/b29sp.txt
+++ b/configreference/planes/b29sp.txt
@@ -10,6 +10,7 @@ ChaffUseTime = 0
 ThrottleDownFactor = 0.20
 MaxHp = 250
 Speed = 0.999
+HasBallisticComputer = true
 
 ;357 
 

--- a/configreference/planes/b52.txt
+++ b/configreference/planes/b52.txt
@@ -17,6 +17,7 @@ ThrottleUpDown = 0.1
 ;EnableNightVision = true
 ;EnableEntityRadar = true
 EnableNightVision = true
+HasBallisticComputer = true
 EnableGunnerMode = true
 CameraPosition  = -14.84, 3.96, -18.01
 InventorySize = 9

--- a/configreference/planes/b52d.txt
+++ b/configreference/planes/b52d.txt
@@ -14,6 +14,7 @@ Speed = 1.822
 Sound = bfiftytwo
 ThrottleUpDown = 0.1
 EnableNightVision = false
+HasBallisticComputer = true
 EnableGunnerMode = true
 CameraPosition  = 0.00, 1.80, -2.23
 InventorySize = 9

--- a/configreference/planes/b52n.txt
+++ b/configreference/planes/b52n.txt
@@ -17,6 +17,7 @@ ThrottleUpDown = 0.1
 ;EnableNightVision = true
 ;EnableEntityRadar = true
 EnableNightVision = true
+HasBallisticComputer = true
 EnableGunnerMode = true
 CameraPosition  = -14.84, 3.96, -18.01
 InventorySize = 9

--- a/configreference/planes/bv138.txt
+++ b/configreference/planes/bv138.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28711
 MaxHp = 150
 Speed = 0.496
+HasBallisticComputer = true
 ;177mph
 
 Sound = junkersjumo

--- a/configreference/planes/f-15e.txt
+++ b/configreference/planes/f-15e.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 ;Speed = 40.68
 ;sad

--- a/configreference/planes/f-35a.txt
+++ b/configreference/planes/f-35a.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 sound = fthirtyfive
 Speed = 3.65

--- a/configreference/planes/f-35b.txt
+++ b/configreference/planes/f-35b.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 sound = fthirtyfive
 Speed = 3.55

--- a/configreference/planes/f-35c.txt
+++ b/configreference/planes/f-35c.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 sound = fthirtyfive
 Speed = 3.60

--- a/configreference/planes/f-5e.txt
+++ b/configreference/planes/f-5e.txt
@@ -104,6 +104,7 @@ EnableNightVision = false
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true

--- a/configreference/planes/f117nuc.txt
+++ b/configreference/planes/f117nuc.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 2.05
 

--- a/configreference/planes/f14d.txt
+++ b/configreference/planes/f14d.txt
@@ -17,6 +17,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 ; Realism pass: F-14D top speed ~1,240 mph / 1,996 km/h, service ceiling ~16.15 km,
 ; internal fuel ~2,400 US gal / 9,085 L. MCH speed uses high-speed aircraft mph/1000 tuning.

--- a/configreference/planes/f1m.txt
+++ b/configreference/planes/f1m.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28709
 MaxHp = 100
 Speed = 0.644
+HasBallisticComputer = true
 Float = true
 Sound = prop_fighter
 

--- a/configreference/planes/f4a.txt
+++ b/configreference/planes/f4a.txt
@@ -14,6 +14,7 @@ EnableNightVision = false
 EnableEntityRadar = true
 RWRType = ALL_WAY_EARLY
 RadarType = EARLY_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 4.0
 FlareType = 3

--- a/configreference/planes/fa18e.txt
+++ b/configreference/planes/fa18e.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.65
 EnableRealisticFlightModel = true

--- a/configreference/planes/fa18fold.txt
+++ b/configreference/planes/fa18fold.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.65
 FlareType = 4

--- a/configreference/planes/fa50.txt
+++ b/configreference/planes/fa50.txt
@@ -13,6 +13,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.20
 FlareType = 4

--- a/configreference/planes/geran2.txt
+++ b/configreference/planes/geran2.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 MaxHp = 10
 ;;Speed = 0.006 for a specific server config
 Speed = 0.115
+HasBallisticComputer = true
 
 ;75mph
 Sound = radicon_heli

--- a/configreference/planes/harrier.txt
+++ b/configreference/planes/harrier.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 EnableVtol = true
 DefaultVtol = false

--- a/configreference/planes/ju87.txt
+++ b/configreference/planes/ju87.txt
@@ -10,6 +10,7 @@ ThrottleDownFactor = 0.20
 ItemID = 30005
 MaxHp = 150
 Speed = 0.679
+HasBallisticComputer = true
 
 ;230
 

--- a/configreference/planes/m2000c.txt
+++ b/configreference/planes/m2000c.txt
@@ -19,6 +19,7 @@ EnableNightVision = false
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true

--- a/configreference/planes/mc130.txt
+++ b/configreference/planes/mc130.txt
@@ -17,6 +17,7 @@ AutoPilotRot = -0.00
 CameraPosition = 2.0, 1.40, -4.0
 EnableNightVision = true
 EnableEntityRadar = false
+HasBallisticComputer = true
 EnableGunnerMode = true
 ConcurrentGunnerMode = true
 FlareType = 2

--- a/configreference/planes/mig17f.txt
+++ b/configreference/planes/mig17f.txt
@@ -12,6 +12,7 @@ ItemID = 28731
 MaxHp = 100
 EnableNightVision = false
 EnableEntityRadar = false
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Sound = migfifteen
 Speed = 1.992

--- a/configreference/planes/mig21.txt
+++ b/configreference/planes/mig21.txt
@@ -14,6 +14,7 @@ EnableNightVision = false
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.698
 FlareType = 4

--- a/configreference/planes/mirageiv.txt
+++ b/configreference/planes/mirageiv.txt
@@ -20,6 +20,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true

--- a/configreference/planes/pzl-m18.txt
+++ b/configreference/planes/pzl-m18.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28733
 MaxHp = 100
 Speed = 0.435
+HasBallisticComputer = true
 
 ;140
 ;.140*1.74

--- a/configreference/planes/q-5d.txt
+++ b/configreference/planes/q-5d.txt
@@ -23,6 +23,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true

--- a/configreference/planes/rafalem.txt
+++ b/configreference/planes/rafalem.txt
@@ -20,6 +20,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true

--- a/configreference/planes/su24.txt
+++ b/configreference/planes/su24.txt
@@ -15,6 +15,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 2.878
 FlareType = 4

--- a/configreference/planes/su25.txt
+++ b/configreference/planes/su25.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.697
 ;606mph

--- a/configreference/planes/su34b.txt
+++ b/configreference/planes/su34b.txt
@@ -12,6 +12,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 EnableGunnerMode = true
 ConcurrentGunnerMode = true

--- a/configreference/planes/su37.txt
+++ b/configreference/planes/su37.txt
@@ -15,6 +15,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 4.0
 FlareType = 4

--- a/configreference/planes/tornado-gr4.txt
+++ b/configreference/planes/tornado-gr4.txt
@@ -16,6 +16,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 4.0
 FlareType = 4

--- a/configreference/planes/tornado-ids.txt
+++ b/configreference/planes/tornado-ids.txt
@@ -16,6 +16,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 4.0
 

--- a/configreference/planes/tu142real.txt
+++ b/configreference/planes/tu142real.txt
@@ -15,6 +15,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableGunnerMode = true
 Speed = 1.609
 FlareType = 3

--- a/configreference/planes/tu160m.txt
+++ b/configreference/planes/tu160m.txt
@@ -14,6 +14,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.863
 FlareType = 2

--- a/configreference/planes/tu22m3.txt
+++ b/configreference/planes/tu22m3.txt
@@ -14,6 +14,7 @@ EnableNightVision  = false
 EnableEntityRadar  = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 3.48
 FlareType = 2

--- a/configreference/planes/tu4.txt
+++ b/configreference/planes/tu4.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28777
 MaxHp = 250
 Speed = 0.971
+HasBallisticComputer = true
 
 ;347 
 

--- a/configreference/planes/tu4light.txt
+++ b/configreference/planes/tu4light.txt
@@ -11,6 +11,7 @@ ThrottleDownFactor = 0.20
 ItemID = 28779
 MaxHp = 250
 Speed = 0.971
+HasBallisticComputer = true
 Sound = btwentynine
 ThrottleUpDown = 0.1
 AutoPilotRot = 0.00

--- a/configreference/planes/tu95org.txt
+++ b/configreference/planes/tu95org.txt
@@ -15,6 +15,7 @@ EnableNightVision = false
 EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AS
+HasBallisticComputer = true
 EnableGunnerMode = true
 Speed = 1.601
 FlareType = 3

--- a/configreference/planes/victor_b2.txt
+++ b/configreference/planes/victor_b2.txt
@@ -14,6 +14,7 @@ EnableNightVision  = false
 EnableEntityRadar  = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
+HasBallisticComputer = true
 EnableEjectionSeat = true
 Speed = 1.757
 FlareType = 2

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -30,6 +30,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public HashMap displayNameLang;
    public int itemID;
    public boolean hasalert = true;
+   /** Enables client-side CCIP bomb impact reticle for plane HUDs. */
+   public boolean hasBallisticComputer = false;
    public List recipeString;
    public List recipe;
    public boolean isShapedRecipe;
@@ -872,6 +874,9 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
                                     this.flightCeiling = this.toFloat(data, 32.0F, 37650.0F);
                                  } else if(item.equalsIgnoreCase("FlightCeilingRange")) {
                                     this.flightCeilingRange = this.toFloat(data, 1.0F, 128.0F);
+                                 } else if(item.equalsIgnoreCase("HasBallisticComputer")
+                                       || item.equalsIgnoreCase("EnableBallisticComputer")) {
+                                    this.hasBallisticComputer = this.toBool(data);
                                  } else if(item.equalsIgnoreCase("UseNewMobilitySystem")
                                        || item.equalsIgnoreCase("EnableNewMobilitySystem")
                                        || item.equalsIgnoreCase("UseNewFlightModel")

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -15,11 +15,13 @@ import mcheli.aircraft.MCH_HudShared;
 import mcheli.gui.MCH_Gui;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.plane.MCP_PlaneInfo;
+import mcheli.weapon.MCH_WeaponBase;
 import mcheli.weapon.MCH_WeaponSet;
 import mcheli.wrapper.W_McClient;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.MathHelper;
+import net.minecraft.util.Vec3;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.GL11;
@@ -79,8 +81,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                   this.drawNewPlaneSimpleHud(plane);
                   this.drawNewPlaneWeaponHud(plane, player);
                   this.drawNewPlaneDebugHud(plane);
+                  this.drawPlaneCCIPReticle(plane, player);
                } else {
                   this.drawNewFlightThrottleHud(plane);
+                  this.drawPlaneCCIPReticle(plane, player);
                }
             }
 
@@ -496,6 +500,79 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             x, y - r, x, y - r * 0.35D, x, y + r * 0.35D, x, y + r}, color);
       this.drawLine(new double[]{x - r * 0.55D, y - r * 0.55D, x + r * 0.55D, y - r * 0.55D,
             x + r * 0.55D, y + r * 0.55D, x - r * 0.55D, y + r * 0.55D}, color, 2);
+   }
+
+   private void drawPlaneCCIPReticle(MCP_EntityPlane plane, EntityPlayer player) {
+      MCP_PlaneInfo info = plane != null ? plane.getPlaneInfo() : null;
+      if(plane == null || player == null || info == null || !info.hasBallisticComputer || plane.isDestroyed()) {
+         return;
+      }
+      if(plane.getSeatIdByEntity(player) != 0 || plane.getRiddenByEntity() == null) {
+         return;
+      }
+      MCH_WeaponSet ws = plane.getCurrentWeapon(player);
+      MCH_WeaponBase weapon = ws != null ? ws.getCurrentWeapon() : null;
+      boolean enabled = MCP_PlaneCCIPHelper.isBombWeapon(weapon);
+      MCP_PlaneCCIPHelper.Result result = null;
+      if(enabled) {
+         Vec3 shotOfs = weapon.getShotPos(plane);
+         Vec3 release = Vec3.createVectorHelper(plane.posX + shotOfs.xCoord, plane.posY + shotOfs.yCoord, plane.posZ + shotOfs.zCoord);
+         Vec3 initial = Vec3.createVectorHelper(plane.motionX, plane.motionY, plane.motionZ);
+         result = MCP_PlaneCCIPHelper.predict(plane.worldObj, weapon.getInfo(), release, initial);
+         if(result.valid) {
+            ScreenPoint p = this.projectWorldToHud(result.impact, player, true);
+            if(p != null && p.visible) {
+               this.drawCCIPPipper(p.x, p.y, p.clamped);
+               this.drawLine(new double[]{(double)super.centerX, (double)super.centerY + 10.0D, p.x, p.y}, p.clamped ? 0x8855FF66 : 0xCC55FF66);
+            }
+         }
+      }
+      if(MCH_Config.PlaneMouseAimReticleDebug.prmBool || MCH_Config.DebugFlightControl.prmBool) {
+         String name = weapon != null && weapon.getInfo() != null ? weapon.getInfo().name : "none";
+         String msg = String.format("CCIP enabled=%s weapon=%s valid=%s ticks=%d dist=%.1f alt=%.1f vi=%s vf=%s reason=%s",
+               Boolean.valueOf(enabled), name, Boolean.valueOf(result != null && result.valid), Integer.valueOf(result != null ? result.ticksSimulated : 0),
+               Double.valueOf(result != null ? result.impactDistance : 0.0D), Double.valueOf(result != null ? result.releaseAltitude : 0.0D),
+               this.formatVec(result != null ? result.initialVelocity : null), this.formatVec(result != null ? result.finalVelocity : null),
+               result != null ? result.reasonInvalid : (enabled ? "not_predicted" : "not_bomb_or_disabled"));
+         this.drawString(msg, super.centerX - 170, super.centerY + 70, 0xFF55FF66);
+      }
+   }
+
+   private String formatVec(Vec3 v) {
+      return v == null ? "-" : String.format("%.2f,%.2f,%.2f", Double.valueOf(v.xCoord), Double.valueOf(v.yCoord), Double.valueOf(v.zCoord));
+   }
+
+   private ScreenPoint projectWorldToHud(Vec3 pos, EntityPlayer player, boolean clamp) {
+      double dx = pos.xCoord - player.posX;
+      double dy = pos.yCoord - (player.posY + (double)player.getEyeHeight());
+      double dz = pos.zCoord - player.posZ;
+      Vec3 local = mcheli.MCH_Lib.RotVec3(dx, dy, dz, player.rotationYaw, player.rotationPitch, 0.0F);
+      if(local.zCoord <= 0.05D) return null;
+      double scale = (double)super.height * 0.75D / local.zCoord;
+      double x = (double)super.centerX - local.xCoord * scale;
+      double y = (double)super.centerY - local.yCoord * scale;
+      boolean clamped = false;
+      if(clamp) {
+         double margin = 12.0D;
+         double cx = MathHelper.clamp_double(x, margin, (double)super.width - margin);
+         double cy = MathHelper.clamp_double(y, margin, (double)super.height - margin);
+         clamped = cx != x || cy != y;
+         x = cx; y = cy;
+      }
+      return new ScreenPoint(x, y, clamped);
+   }
+
+   private void drawCCIPPipper(double x, double y, boolean clamped) {
+      int color = clamped ? 0x9955FF66 : 0xEE55FF66;
+      double r = 7.0D;
+      this.drawLine(new double[]{x - r, y, x - 2.5D, y, x + 2.5D, y, x + r, y, x, y - r, x, y - 2.5D, x, y + 2.5D, x, y + r}, color);
+      this.drawLine(new double[]{x - r, y - r, x + r, y - r, x + r, y + r, x - r, y + r, x - r, y - r}, color, 2);
+      this.drawString("CCIP", (int)x + 9, (int)y - 4, color);
+   }
+
+   private static class ScreenPoint {
+      final double x; final double y; final boolean clamped; final boolean visible = true;
+      ScreenPoint(double x, double y, boolean clamped) { this.x = x; this.y = y; this.clamped = clamped; }
    }
 
    public void drawKeybind(MCP_EntityPlane plane, EntityPlayer player, int seatID) {

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -1,0 +1,86 @@
+package mcheli.plane;
+
+import mcheli.weapon.MCH_WeaponBase;
+import mcheli.weapon.MCH_WeaponInfo;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
+
+public final class MCP_PlaneCCIPHelper {
+   public static final int MAX_STEPS = 260;
+   private MCP_PlaneCCIPHelper() {}
+
+   public static Result predict(World world, MCH_WeaponInfo info, Vec3 releasePos, Vec3 initialVelocity) {
+      Result r = new Result();
+      r.valid = false;
+      r.reasonInvalid = "not_run";
+      if(world == null || info == null || releasePos == null || initialVelocity == null) {
+         r.reasonInvalid = "missing_input";
+         return r;
+      }
+
+      Vec3 pos = Vec3.createVectorHelper(releasePos.xCoord, releasePos.yCoord, releasePos.zCoord);
+      Vec3 vel = Vec3.createVectorHelper(initialVelocity.xCoord, initialVelocity.yCoord, initialVelocity.zCoord);
+      r.initialVelocity = Vec3.createVectorHelper(vel.xCoord, vel.yCoord, vel.zCoord);
+
+      int max = info.timeFuse > 0 ? Math.min(MAX_STEPS, info.timeFuse) : MAX_STEPS;
+      for(int i = 0; i < max; ++i) {
+         Vec3 prev = Vec3.createVectorHelper(pos.xCoord, pos.yCoord, pos.zCoord);
+         if(info.speedFactor != 0.0F && i > info.speedFactorStartTick && i < info.speedFactorEndTick) {
+            double speed = Math.sqrt(vel.xCoord * vel.xCoord + vel.yCoord * vel.yCoord + vel.zCoord * vel.zCoord);
+            if(speed > 1.0E-7D) {
+               vel.xCoord += vel.xCoord / speed * (double)info.speedFactor;
+               vel.yCoord += vel.yCoord / speed * (double)info.speedFactor;
+               vel.zCoord += vel.zCoord / speed * (double)info.speedFactor;
+            }
+         }
+         vel.yCoord += (double)info.gravity;
+         if(isBombLike(info)) {
+            vel.xCoord *= 0.999D;
+            vel.zCoord *= 0.999D;
+         }
+         pos.xCoord += vel.xCoord;
+         pos.yCoord += vel.yCoord;
+         pos.zCoord += vel.zCoord;
+         MovingObjectPosition hit = world.rayTraceBlocks(prev, pos, false, true, false);
+         r.ticksSimulated = i + 1;
+         if(hit != null && hit.hitVec != null) {
+            r.valid = true;
+            r.impact = hit.hitVec;
+            r.finalVelocity = Vec3.createVectorHelper(vel.xCoord, vel.yCoord, vel.zCoord);
+            r.impactDistance = releasePos.distanceTo(r.impact);
+            r.releaseAltitude = releasePos.yCoord - r.impact.yCoord;
+            r.reasonInvalid = "";
+            return r;
+         }
+         if(pos.yCoord < -64.0D || !world.blockExists((int)pos.xCoord, Math.max(0, (int)pos.yCoord), (int)pos.zCoord)) {
+            r.reasonInvalid = "out_of_world";
+            break;
+         }
+      }
+      r.finalVelocity = Vec3.createVectorHelper(vel.xCoord, vel.yCoord, vel.zCoord);
+      if("not_run".equals(r.reasonInvalid)) r.reasonInvalid = "no_collision";
+      return r;
+   }
+
+   public static boolean isBombWeapon(MCH_WeaponBase weapon) {
+      return weapon != null && isBombLike(weapon.getInfo());
+   }
+
+   public static boolean isBombLike(MCH_WeaponInfo info) {
+      if(info == null || info.type == null) return false;
+      return info.type.equalsIgnoreCase("bomb") || info.type.equalsIgnoreCase("dispenser")
+            || (info.gravity < 0.0F && info.acceleration <= 1.0F && info.explosion > 0);
+   }
+
+   public static class Result {
+      public boolean valid;
+      public Vec3 impact;
+      public int ticksSimulated;
+      public double impactDistance;
+      public double releaseAltitude;
+      public Vec3 initialVelocity;
+      public Vec3 finalVelocity;
+      public String reasonInvalid;
+   }
+}


### PR DESCRIPTION
### Motivation

- Provide a way for plane configs to opt into an on-screen computed-collision CCIP (bomb impact) reticle and enable client-side bomb aiming assistance. 
- Expose a simple config flag so specific aircraft can opt into the ballistic computer behavior without touching HUD code per-aircraft.

### Description

- Added a new boolean field `hasBallisticComputer` to `MCH_BaseVehicleInfo` and extended the config parser to accept `HasBallisticComputer` or `EnableBallisticComputer` keys. 
- Implemented a new helper `MCP_PlaneCCIPHelper` that simulates projectile/bomb trajectories and exposes a `predict` API and utility checks for bomb-like weapons. 
- Updated the plane HUD in `MCP_GuiPlane` to call `drawPlaneCCIPReticle`, which uses the helper to predict impacts and renders a CCIP pipper and guidance line on-screen; helper functions `projectWorldToHud`, `drawCCIPPipper`, and debug output were added. 
- Enabled the ballistic computer for many plane config files by adding `HasBallisticComputer = true` entries to relevant `configreference/planes/*.txt` files. 

### Testing

- Performed a full project build and ensured the modified sources compile successfully with no compile errors reported. 
- No new automated unit tests were added as part of this change and existing test suites (if any) were left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dce787c48832998c268c1eb7a25cc)