### PR TITLE
Calibrate CCIP bomb prediction physics and add calibration/debug logging

### DIFF
--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -635,10 +635,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       String msg3 = String.format("aircraftMotion=%s ejectionVelocity=%s initialBombVelocity=%s deltaFromAircraft=%s",
             this.formatVec(aircraftMotion), this.formatVec(result != null ? result.ejectionVelocity : null),
             this.formatVec(result != null ? result.initialVelocity : null), this.formatVec(result != null ? result.initialVelocityDeltaFromAircraft : null));
-      String msg4 = String.format("initialVelocityUpDot=%.3f initialVelocitySideDot=%.3f warningImpossibleLaunch=%s",
-            Double.valueOf(result != null ? result.initialVelocityUpDot : 0.0D), Double.valueOf(result != null ? result.initialVelocitySideDot : 0.0D),
-            Boolean.valueOf(result != null && result.warningImpossibleLaunch));
-      String msg5 = String.format("cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
+      String msg4 = String.format("predictedGravity=%.4f predictedDrag=%.4f predictedTimestep=%.1f initialVelocityUpDot=%.3f initialVelocitySideDot=%.3f",
+            Double.valueOf(result != null ? result.gravity : 0.0D), Double.valueOf(result != null ? result.horizontalDrag : 0.0D), Double.valueOf(result != null ? result.simulationTimeStep : 0.0D),
+            Double.valueOf(result != null ? result.initialVelocityUpDot : 0.0D), Double.valueOf(result != null ? result.initialVelocitySideDot : 0.0D));
+      String msg5 = String.format("warningImpossibleLaunch=%s cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
+            Boolean.valueOf(result != null && result.warningImpossibleLaunch),
             Float.valueOf(camera != null ? camera.rotationYaw : 0.0F), Float.valueOf(camera != null ? camera.rotationPitch : 0.0F),
             Float.valueOf(plane.rotationYaw), Float.valueOf(plane.rotationPitch), Float.valueOf(plane.getRotRoll()));
       this.drawString(msg1, super.centerX - 170, super.centerY + 70, 0xFF55FF66);

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -16,6 +16,9 @@ public final class MCP_PlaneCCIPHelper {
       r.reasonInvalid = "not_run";
       r.releasePos = copy(releasePos);
       r.initialVelocity = copy(initialVelocity);
+      r.gravity = info != null ? (double)info.gravity : 0.0D;
+      r.horizontalDrag = info != null && isBombLike(info) ? 0.999D : 1.0D;
+      r.simulationTimeStep = 1.0D;
       if(world == null || info == null || releasePos == null || initialVelocity == null) {
          r.reasonInvalid = "missing_input";
          return r;
@@ -36,14 +39,14 @@ public final class MCP_PlaneCCIPHelper {
             }
          }
          vel.yCoord += (double)info.gravity;
-         if(isBombLike(info)) {
-            vel.xCoord *= 0.999D;
-            vel.zCoord *= 0.999D;
-         }
          pos.xCoord += vel.xCoord;
          pos.yCoord += vel.yCoord;
          pos.zCoord += vel.zCoord;
          MovingObjectPosition hit = world.rayTraceBlocks(prev, pos);
+         if(isBombLike(info)) {
+            vel.xCoord *= 0.999D;
+            vel.zCoord *= 0.999D;
+         }
          r.ticksSimulated = i + 1;
          if(hit != null && hit.hitVec != null) {
             r.valid = true;
@@ -87,6 +90,9 @@ public final class MCP_PlaneCCIPHelper {
       public double releaseAltitude;
       public Vec3 initialVelocity;
       public Vec3 finalVelocity;
+      public double gravity;
+      public double horizontalDrag;
+      public double simulationTimeStep;
       public Vec3 ejectionVelocity;
       public Vec3 initialVelocityDeltaFromAircraft;
       public double initialVelocityUpDot;

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -1214,6 +1214,10 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
             //System.out.println("Extra chunk loader activated.");
         }
 
+        if(this instanceof MCH_EntityBomb) {
+            ((MCH_EntityBomb)this).onCCIPCalibrationImpact(hit);
+        }
+
         if(hit.entityHit instanceof MCH_EntityBaseVehicle) {
 
             MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle) hit.entityHit;

--- a/src/main/java/mcheli/weapon/MCH_EntityBomb.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBomb.java
@@ -1,6 +1,8 @@
 package mcheli.weapon;
 
 import java.util.List;
+import mcheli.MCH_Config;
+import mcheli.plane.MCP_PlaneCCIPHelper;
 import mcheli.weapon.MCH_BulletModel;
 import mcheli.weapon.MCH_DefaultBulletModels;
 import mcheli.weapon.MCH_EntityBaseBullet;
@@ -11,6 +13,12 @@ import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public class MCH_EntityBomb extends MCH_EntityBaseBullet {
+
+   private MCP_PlaneCCIPHelper.Result ccipCalibration;
+   private Vec3 ccipAircraftMotion;
+   private Vec3 ccipWeaponReleaseParam;
+   private Vec3 ccipRealInitialPos;
+   private Vec3 ccipRealInitialMotion;
 
    public MCH_EntityBomb(World par1World) {
       super(par1World);
@@ -48,6 +56,44 @@ public class MCH_EntityBomb extends MCH_EntityBaseBullet {
       }
 
       this.onUpdateBomblet();
+   }
+
+   public void setCCIPCalibration(MCP_PlaneCCIPHelper.Result prediction, Vec3 aircraftMotion, Vec3 weaponReleaseParam) {
+      this.ccipCalibration = prediction;
+      this.ccipAircraftMotion = copyVec(aircraftMotion);
+      this.ccipWeaponReleaseParam = copyVec(weaponReleaseParam);
+      this.ccipRealInitialPos = Vec3.createVectorHelper(super.posX, super.posY, super.posZ);
+      this.ccipRealInitialMotion = Vec3.createVectorHelper(super.motionX, super.motionY, super.motionZ);
+   }
+
+   protected void onCCIPCalibrationImpact(MovingObjectPosition hit) {
+      if((MCH_Config.PlaneMouseAimReticleDebug.prmBool || MCH_Config.DebugFlightControl.prmBool) && this.ccipCalibration != null) {
+         Vec3 real = hit != null && hit.hitVec != null ? hit.hitVec : Vec3.createVectorHelper(super.posX, super.posY, super.posZ);
+         Vec3 predicted = this.ccipCalibration.impact;
+         double dx = predicted != null ? real.xCoord - predicted.xCoord : 0.0D;
+         double dy = predicted != null ? real.yCoord - predicted.yCoord : 0.0D;
+         double dz = predicted != null ? real.zCoord - predicted.zCoord : 0.0D;
+         double horizontal = Math.sqrt(dx * dx + dz * dz);
+         double total = Math.sqrt(dx * dx + dy * dy + dz * dz);
+         double vx = this.ccipAircraftMotion != null ? this.ccipAircraftMotion.xCoord : 0.0D;
+         double vz = this.ccipAircraftMotion != null ? this.ccipAircraftMotion.zCoord : 0.0D;
+         double vh = Math.sqrt(vx * vx + vz * vz);
+         double ahead = vh > 1.0E-7D ? (dx * vx + dz * vz) / vh : 0.0D;
+         double right = vh > 1.0E-7D ? (dx * vz - dz * vx) / vh : 0.0D;
+         Vec3 predVel = this.ccipCalibration.initialVelocity;
+         double ivErr = predVel != null && this.ccipRealInitialMotion != null ? this.ccipRealInitialMotion.distanceTo(predVel) : 0.0D;
+         double relErr = this.ccipCalibration.releasePos != null && this.ccipRealInitialPos != null ? this.ccipRealInitialPos.distanceTo(this.ccipCalibration.releasePos) : 0.0D;
+         System.out.println(String.format("[CCIP_BOMB_CALIBRATION] weapon=%s predictedImpact=%s realImpact=%.6f,%.6f,%.6f horizontalError=%.6f verticalError=%.6f totalError=%.6f aheadBehindError=%.6f leftRightError=%.6f ticksPredicted=%d ticksReal=%d initialVelocityError=%.6f releasePositionError=%.6f realInitialPos=%s weaponReleaseParam=%s",
+               this.getName(), formatVec(predicted), real.xCoord, real.yCoord, real.zCoord, horizontal, dy, total, ahead, right, Integer.valueOf(this.ccipCalibration.ticksSimulated), Integer.valueOf(this.getCountOnUpdate()), ivErr, relErr, formatVec(this.ccipRealInitialPos), formatVec(this.ccipWeaponReleaseParam)));
+      }
+   }
+
+   private static Vec3 copyVec(Vec3 v) {
+      return v != null ? Vec3.createVectorHelper(v.xCoord, v.yCoord, v.zCoord) : null;
+   }
+
+   private static String formatVec(Vec3 v) {
+      return v != null ? String.format("%.6f,%.6f,%.6f", v.xCoord, v.yCoord, v.zCoord) : "-";
    }
 
    public void sprinkleBomblet() {

--- a/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
@@ -1,6 +1,8 @@
 package mcheli.weapon;
 
+import mcheli.MCH_Config;
 import mcheli.MCH_Explosion;
+import mcheli.plane.MCP_PlaneCCIPHelper;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.weapon.MCH_EntityBomb;
@@ -51,6 +53,16 @@ public class MCH_WeaponBomb extends MCH_WeaponBase {
          e.motionX = prm.entity.motionX;
          e.motionY = prm.entity.motionY;
          e.motionZ = prm.entity.motionZ;
+         if(MCH_Config.PlaneMouseAimReticleDebug.prmBool || MCH_Config.DebugFlightControl.prmBool) {
+            double hs = Math.sqrt(prm.entity.motionX * prm.entity.motionX + prm.entity.motionZ * prm.entity.motionZ);
+            System.out.println(String.format("[CCIP_BOMB_SPAWN] weapon=%s aircraftMotion=%.6f,%.6f,%.6f aircraftHorizontalSpeed=%.6f aircraftYawPitchRoll=%.2f,%.2f,%.2f releaseParam=%.6f,%.6f,%.6f bombPos=%.6f,%.6f,%.6f bombMotion=%.6f,%.6f,%.6f deltaFromAircraft=%.6f,%.6f,%.6f gravity=%.6f dragXZ=0.999000 ejection=0.000000,0.000000,0.000000 speedDependsAircraft=%s accelerationConfig=%.6f",
+                  super.name, prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ, hs, prm.entity.rotationYaw, prm.entity.rotationPitch, prm.entity instanceof mcheli.aircraft.MCH_EntityBaseVehicle ? ((mcheli.aircraft.MCH_EntityBaseVehicle)prm.entity).getRotRoll() : 0.0F,
+                  prm.posX, prm.posY, prm.posZ, e.posX, e.posY, e.posZ, e.motionX, e.motionY, e.motionZ, e.motionX - prm.entity.motionX, e.motionY - prm.entity.motionY, e.motionZ - prm.entity.motionZ, this.getInfo().gravity, Boolean.valueOf(this.getInfo().speedDependsAircraft), this.getInfo().acceleration));
+            MCP_PlaneCCIPHelper.Result ccip = MCP_PlaneCCIPHelper.predict(super.worldObj, this.getInfo(), Vec3.createVectorHelper(e.posX, e.posY, e.posZ), Vec3.createVectorHelper(e.motionX, e.motionY, e.motionZ));
+            e.setCCIPCalibration(ccip, Vec3.createVectorHelper(prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ), Vec3.createVectorHelper(prm.posX, prm.posY, prm.posZ));
+            System.out.println(String.format("[CCIP_BOMB_PREDICT] weapon=%s predictedRelease=%.6f,%.6f,%.6f predictedInitialVelocity=%.6f,%.6f,%.6f predictedGravity=%.6f predictedDrag=%.6f predictedEjection=0.000000,0.000000,0.000000 predictedTimestep=%.1f predictedImpact=%s ticks=%d valid=%s reason=%s",
+                  super.name, e.posX, e.posY, e.posZ, e.motionX, e.motionY, e.motionZ, ccip.gravity, ccip.horizontalDrag, ccip.simulationTimeStep, ccip.impact != null ? String.format("%.6f,%.6f,%.6f", ccip.impact.xCoord, ccip.impact.yCoord, ccip.impact.zCoord) : "-", Integer.valueOf(ccip.ticksSimulated), Boolean.valueOf(ccip.valid), ccip.reasonInvalid));
+         }
          super.worldObj.spawnEntityInWorld(e);
       }
 


### PR DESCRIPTION
### Motivation
- Align client CCIP prediction with the server bomb physics so the HUD reticle matches real bomb impacts more closely and provide observability to diagnose remaining errors.
- Capture the real bomb initial state and end-of-flight differences so we can determine whether mismatches come from initial velocity, release position, gravity, drag, or timing.

### Description
- Change CCIP simulator step order to apply gravity before movement/collision and apply horizontal drag after the movement step to match `MCH_EntityBomb` update behavior (modified `MCP_PlaneCCIPHelper`).
- Add predicted physics metadata (`gravity`, `horizontalDrag`, `simulationTimeStep`) to `MCP_PlaneCCIPHelper.Result` and surface those values on the CCIP HUD debug overlay (modified `MCP_PlaneCCIPHelper` and `MCP_GuiPlane`).
- Add debug-only server logging at actual bomb spawn to print aircraft motion, weapon/release parameters, spawned bomb initial position/motion, delta from aircraft, per-weapon gravity/drag/acceleration flags, and run an immediate CCIP prediction for comparison (modified `MCH_WeaponBomb`).
- Attach a calibration record to `MCH_EntityBomb` at spawn and log a calibration summary at impact including predicted vs real impact positions, horizontal/vertical/total error, ahead/behind and left/right errors, predicted vs actual ticks, initial velocity error, and release position error; invoke the calibration report from the base impact handler (modified `MCH_EntityBomb` and `MCH_EntityBaseBullet`).
- Preserve shared CCIP calculator usage so both legacy and new-flight planes continue to use the same predictor and no gating by `UseNewMobilitySystem` was added.

### Testing
- Ran `git diff --check` to ensure there are no whitespace/merge conflicts (passed).
- Verified working tree status with `git status --short` to confirm the intended files were modified (expected changes present).
- Java compilation and runtime integration tests were intentionally not run per the instruction not to compile `.class` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dddcdcfd483299dc5071fccdb9caa)