### PR TITLE
Fix plane CCIP projection basis

### DIFF
--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -540,7 +540,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          result.initialVelocitySideDot = releaseKinematics.initialVelocitySideDot;
          result.warningImpossibleLaunch = releaseKinematics.warningImpossibleLaunch;
          if(result.valid) {
-            ScreenPoint projected = this.projectWorldToHud(result.impact, plane, true);
+            ScreenPoint projected = this.projectWorldToHud(result.impact, plane, false);
             if(projected != null && projected.visible) {
                ScreenPoint p = this.smoothCCIPScreenPoint(projected, result.impact, weapon);
                this.drawCCIPPipper(p.x, p.y, p.clamped);
@@ -654,21 +654,29 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    }
 
    private ScreenPoint projectWorldToHud(Vec3 pos, MCP_EntityPlane plane, boolean clamp) {
-      Entity camera = super.mc.renderViewEntity != null ? super.mc.renderViewEntity : super.mc.thePlayer;
-      if(pos == null || plane == null || camera == null) {
+      if(pos == null || plane == null) {
          return null;
       }
-      double dx = pos.xCoord - camera.posX;
-      double dy = pos.yCoord - (camera.posY + (double)camera.getEyeHeight());
-      double dz = pos.zCoord - camera.posZ;
-      // CCIP is aircraft fire-control symbology, so project its impact point through the
-      // airframe attitude instead of the freelook/render camera attitude. This keeps the
-      // pipper tied to where the plane is pointed while the pilot looks around.
-      Vec3 local = mcheli.MCH_Lib.RotVec3(dx, dy, dz, plane.rotationYaw, plane.rotationPitch, plane.getRotRoll());
-      if(local.zCoord <= 0.05D) return null;
-      double scale = (double)super.height * 0.75D / local.zCoord;
-      double x = (double)super.centerX - local.xCoord * scale;
-      double y = (double)super.centerY - local.yCoord * scale;
+
+      // CCIP is aircraft fire-control symbology, not camera symbology.  Use the
+      // airframe as both the origin and the attitude basis so freelook/chase-camera
+      // movement cannot drag the pipper around the screen.  Build an explicit
+      // orthonormal aircraft basis instead of reusing RotVec3 as an inverse rotation;
+      // RotVec3 applies Z->X->Y, so simply changing signs does not produce the
+      // correct world-to-aircraft transform once pitch and roll are present.
+      double dx = pos.xCoord - plane.posX;
+      double dy = pos.yCoord - (plane.posY + (double)plane.height * 0.5D);
+      double dz = pos.zCoord - plane.posZ;
+      Vec3 right = mcheli.MCH_Lib.RotVec3(1.0D, 0.0D, 0.0D, -plane.rotationYaw, -plane.rotationPitch, -plane.getRotRoll());
+      Vec3 up = mcheli.MCH_Lib.RotVec3(0.0D, 1.0D, 0.0D, -plane.rotationYaw, -plane.rotationPitch, -plane.getRotRoll());
+      Vec3 forward = mcheli.MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -plane.rotationYaw, -plane.rotationPitch, -plane.getRotRoll());
+      double localX = dx * right.xCoord + dy * right.yCoord + dz * right.zCoord;
+      double localY = dx * up.xCoord + dy * up.yCoord + dz * up.zCoord;
+      double localZ = dx * forward.xCoord + dy * forward.yCoord + dz * forward.zCoord;
+      if(localZ <= 0.05D) return null;
+      double scale = (double)super.height * 0.75D / localZ;
+      double x = (double)super.centerX + localX * scale;
+      double y = (double)super.centerY - localY * scale;
       boolean clamped = false;
       if(clamp) {
          double margin = 14.0D;
@@ -676,6 +684,8 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          double cy = MathHelper.clamp_double(y, margin, (double)super.height - margin);
          clamped = cx != x || cy != y;
          x = cx; y = cy;
+      } else if(x < -32.0D || x > (double)super.width + 32.0D || y < -32.0D || y > (double)super.height + 32.0D) {
+         return null;
       }
       return new ScreenPoint(x, y, clamped);
    }


### PR DESCRIPTION
### Motivation
- CCIP pipper was being projected through the render/freelook camera so it moved with the player look instead of remaining fixed to the airframe. 
- The previous inverse-rotation shortcut did not correctly account for aircraft pitch and roll, producing CCIP markers that could appear in the sky or misaligned with the actual bomb impact. 
- Screen-edge clamping forced off-screen impacts onto the HUD edge, hiding invalid/behind-airframe results and confusing the user.

### Description
- Changed CCIP projection to compute the world-to-aircraft transform using the aircraft position and an explicit orthonormal basis (`right`, `up`, `forward`) derived with `MCH_Lib.RotVec3` so pitch and roll are handled correctly. 
- Stopped using the render camera as the projection origin and instead use the plane origin (release basis) for CCIP projection by updating `projectWorldToHud` in `MCP_GuiPlane`. 
- Updated the CCIP drawing call to request an unclamped projection (`clamp=false`) so off-screen/behind-airframe impacts are rejected rather than pinned to the HUD edge. 
- Added a small off-screen rejection region so unclamped results outside the visible area return `null`, preserving the previous clamped behavior when explicitly requested.

### Testing
- Ran `git diff --check` to verify there are no whitespace/merge issues and it completed successfully. 
- Attempted to run `./gradlew compileJava` to do a full compile, but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so a local compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed034d5448323b8f680364189aea8)