### PR TITLE
Decouple plane CCIP HUD projection from camera view

### DIFF
--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -542,7 +542,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          result.initialVelocitySideDot = releaseKinematics.initialVelocitySideDot;
          result.warningImpossibleLaunch = releaseKinematics.warningImpossibleLaunch;
          if(result.valid) {
-            ScreenPoint projected = this.projectWorldToHud(result.impact);
+            ScreenPoint projected = this.projectWorldToAircraftHud(plane, result.impact, partialTicks);
             if(projected != null && projected.visible) {
                ScreenPoint p = this.smoothCCIPScreenPoint(projected, result.impact, weapon);
                this.drawCCIPPipper(p.x, p.y, p.clamped);
@@ -670,27 +670,58 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       return mcheli.MCH_Lib.RotVec3(weapon.position, -yaw, -pitch, -roll);
    }
 
-   private ScreenPoint projectWorldToHud(Vec3 pos) {
-      Entity camera = super.mc.renderViewEntity != null ? super.mc.renderViewEntity : super.mc.thePlayer;
-      if(pos == null || camera == null) {
+   private ScreenPoint projectWorldToAircraftHud(MCP_EntityPlane plane, Vec3 impact, float partialTicks) {
+      if(plane == null || impact == null) {
          return null;
       }
-      float partialTicks = this.smoothCamPartialTicks;
-      Vec3 cameraPos = this.getInterpolatedEntityPos(camera, partialTicks);
-      double dx = pos.xCoord - cameraPos.xCoord;
-      double dy = pos.yCoord - (cameraPos.yCoord + (double)camera.getEyeHeight());
-      double dz = pos.zCoord - cameraPos.zCoord;
-      float yaw = camera.prevRotationYaw + MathHelper.wrapAngleTo180_float(camera.rotationYaw - camera.prevRotationYaw) * partialTicks;
-      float pitch = camera.prevRotationPitch + (camera.rotationPitch - camera.prevRotationPitch) * partialTicks;
-      Vec3 local = mcheli.MCH_Lib.RotVec3(dx, dy, dz, yaw, pitch);
-      if(local.zCoord <= 0.05D) return null;
-      double scale = (double)super.height * 0.75D / local.zCoord;
-      double x = (double)super.centerX - local.xCoord * scale;
-      double y = (double)super.centerY - local.yCoord * scale;
-      if(x < 0.0D || x > (double)super.width || y < 0.0D || y > (double)super.height) {
+
+      float yaw = plane.calcRotYaw(partialTicks);
+      float pitch = plane.calcRotPitch(partialTicks);
+      float roll = plane.calcRotRoll(partialTicks);
+
+      Vec3 forward = this.normalizeVec(mcheli.MCH_Lib.Rot2Vec3(yaw, pitch));
+      Vec3 right = this.normalizeVec(mcheli.MCH_Lib.Rot2Vec3(yaw + 90.0F, 0.0F));
+      Vec3 up = this.normalizeVec(right.crossProduct(forward));
+      right = this.normalizeVec(forward.crossProduct(up));
+
+      double rollRad = Math.toRadians((double)roll);
+      double cosRoll = Math.cos(rollRad);
+      double sinRoll = Math.sin(rollRad);
+      Vec3 rolledRight = Vec3.createVectorHelper(right.xCoord * cosRoll + up.xCoord * sinRoll,
+            right.yCoord * cosRoll + up.yCoord * sinRoll,
+            right.zCoord * cosRoll + up.zCoord * sinRoll);
+      Vec3 rolledUp = Vec3.createVectorHelper(up.xCoord * cosRoll - right.xCoord * sinRoll,
+            up.yCoord * cosRoll - right.yCoord * sinRoll,
+            up.zCoord * cosRoll - right.zCoord * sinRoll);
+      right = this.normalizeVec(rolledRight);
+      up = this.normalizeVec(rolledUp);
+
+      Vec3 aircraftHudOrigin = this.getInterpolatedEntityPos(plane, partialTicks);
+      aircraftHudOrigin.yCoord += (double)plane.getEyeHeight();
+      Vec3 toImpact = Vec3.createVectorHelper(impact.xCoord - aircraftHudOrigin.xCoord,
+            impact.yCoord - aircraftHudOrigin.yCoord,
+            impact.zCoord - aircraftHudOrigin.zCoord);
+      double localForward = toImpact.dotProduct(forward);
+      if(localForward <= 0.05D) {
          return null;
       }
-      return new ScreenPoint(x, y, false);
+
+      double localRight = toImpact.dotProduct(right);
+      double localUp = toImpact.dotProduct(up);
+      double scale = (double)super.height * 0.75D / localForward;
+      double x = (double)super.centerX - localRight * scale;
+      double y = (double)super.centerY - localUp * scale;
+      double clampedX = MathHelper.clamp_double(x, 0.0D, (double)super.width);
+      double clampedY = MathHelper.clamp_double(y, 0.0D, (double)super.height);
+      return new ScreenPoint(clampedX, clampedY, x != clampedX || y != clampedY);
+   }
+
+   private Vec3 normalizeVec(Vec3 v) {
+      double length = v != null ? v.lengthVector() : 0.0D;
+      if(length < 1.0E-6D) {
+         return Vec3.createVectorHelper(0.0D, 0.0D, 0.0D);
+      }
+      return Vec3.createVectorHelper(v.xCoord / length, v.yCoord / length, v.zCoord / length);
    }
 
    private void drawCCIPPipper(double x, double y, boolean clamped) {


### PR DESCRIPTION
### Motivation
- Prevent the CCIP reticle from being affected by the free-look camera yaw/pitch and keep it fixed to the aircraft attitude. 
- Use the aircraft's own orientation (yaw/pitch/roll) so the HUD CCIP reflects aircraft attitude and stays stable during freelook.

### Description
- Replaced the camera-based call `projectWorldToHud(result.impact)` with a new `projectWorldToAircraftHud(plane, result.impact, partialTicks)` invocation in `drawPlaneCCIPReticle` so CCIP projection is driven by the plane. 
- Implemented `projectWorldToAircraftHud(MCP_EntityPlane plane, Vec3 impact, float partialTicks)` which uses `plane.calcRotYaw`, `plane.calcRotPitch`, `plane.calcRotRoll`, `mcheli.MCH_Lib.Rot2Vec3`, cross products, and roll rotation to build a stable orthonormal aircraft frame and project impact points via dot products. 
- The method computes an `aircraftHudOrigin` from `getInterpolatedEntityPos(plane, partialTicks)` plus `plane.getEyeHeight()`, treats impacts behind or too close as hidden, converts local right/up/forward coordinates into HUD screen coordinates using `centerX`/`centerY` and a depth-based scale, and clamps off-screen coordinates to the HUD edge. 
- Added a small `normalizeVec(Vec3)` helper for robust axis normalization, and avoided any reference to `mc.renderViewEntity.rotationYaw`/`rotationPitch` so free-look camera yaw/pitch will not affect CCIP placement.

### Testing
- Attempted to run `bash ./gradlew compileJava` but the Gradle wrapper failed to download Gradle due to a proxy error (`HTTP 403`), so a full compile could not be completed. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef7217cc08323af12d45457f83dd2)