### PR TITLE
Project CCIP reticle in aircraft frame and use aircraft-forward for visibility/scale

### DIFF
--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -542,7 +542,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          result.initialVelocitySideDot = releaseKinematics.initialVelocitySideDot;
          result.warningImpossibleLaunch = releaseKinematics.warningImpossibleLaunch;
          if(result.valid) {
-            ScreenPoint projected = this.projectWorldToHud(result.impact);
+            ScreenPoint projected = this.projectWorldToAircraftHud(plane, result.impact);
             if(projected != null && projected.visible) {
                ScreenPoint p = this.smoothCCIPScreenPoint(projected, result.impact, weapon);
                this.drawCCIPPipper(p.x, p.y, p.clamped);
@@ -670,27 +670,37 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       return mcheli.MCH_Lib.RotVec3(weapon.position, -yaw, -pitch, -roll);
    }
 
-   private ScreenPoint projectWorldToHud(Vec3 pos) {
-      Entity camera = super.mc.renderViewEntity != null ? super.mc.renderViewEntity : super.mc.thePlayer;
-      if(pos == null || camera == null) {
+   private ScreenPoint projectWorldToAircraftHud(MCP_EntityPlane plane, Vec3 pos) {
+      if(plane == null || pos == null) {
          return null;
       }
       float partialTicks = this.smoothCamPartialTicks;
-      Vec3 cameraPos = this.getInterpolatedEntityPos(camera, partialTicks);
-      double dx = pos.xCoord - cameraPos.xCoord;
-      double dy = pos.yCoord - (cameraPos.yCoord + (double)camera.getEyeHeight());
-      double dz = pos.zCoord - cameraPos.zCoord;
-      float yaw = camera.prevRotationYaw + MathHelper.wrapAngleTo180_float(camera.rotationYaw - camera.prevRotationYaw) * partialTicks;
-      float pitch = camera.prevRotationPitch + (camera.rotationPitch - camera.prevRotationPitch) * partialTicks;
-      Vec3 local = mcheli.MCH_Lib.RotVec3(dx, dy, dz, yaw, pitch);
-      if(local.zCoord <= 0.05D) return null;
-      double scale = (double)super.height * 0.75D / local.zCoord;
-      double x = (double)super.centerX - local.xCoord * scale;
-      double y = (double)super.centerY - local.yCoord * scale;
+      Vec3 planePos = this.getInterpolatedEntityPos(plane, partialTicks);
+      Vec3 toImpact = Vec3.createVectorHelper(pos.xCoord - planePos.xCoord, pos.yCoord - planePos.yCoord, pos.zCoord - planePos.zCoord);
+      float yaw = plane.calcRotYaw(partialTicks);
+      float pitch = plane.calcRotPitch(partialTicks);
+      float roll = plane.calcRotRoll(partialTicks);
+      Vec3 forward = mcheli.MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -roll);
+      Vec3 right = mcheli.MCH_Lib.RotVec3(1.0D, 0.0D, 0.0D, -yaw, -pitch, -roll);
+      Vec3 up = mcheli.MCH_Lib.RotVec3(0.0D, 1.0D, 0.0D, -yaw, -pitch, -roll);
+      double localForward = this.dot(toImpact, forward);
+      if(localForward <= 0.05D) {
+         return null;
+      }
+      double localRight = this.dot(toImpact, right);
+      double localUp = this.dot(toImpact, up);
+      double scale = (double)super.height * 0.75D / localForward;
+      // Match the existing HUD convention: positive aircraft-right offsets draw toward screen-left.
+      double x = (double)super.centerX - localRight * scale;
+      double y = (double)super.centerY - localUp * scale;
       if(x < 0.0D || x > (double)super.width || y < 0.0D || y > (double)super.height) {
          return null;
       }
       return new ScreenPoint(x, y, false);
+   }
+
+   private double dot(Vec3 a, Vec3 b) {
+      return a.xCoord * b.xCoord + a.yCoord * b.yCoord + a.zCoord * b.zCoord;
    }
 
    private void drawCCIPPipper(double x, double y, boolean clamped) {


### PR DESCRIPTION
### Motivation
- The CCIP pipper was being projected and hidden using camera-space coordinates, which made free-look affect CCIP visibility and scale.
- Move the behind-HUD / near-plane test into an aircraft-frame projection so the HUD pipper is tied to aircraft geometry instead of the camera.

### Description
- Replaced the camera-space projection call with `projectWorldToAircraftHud(plane, impact)` and added the new method in `MCP_GuiPlane.java` that projects impacts into aircraft-local axes.
- Compute aircraft-frame components `localForward = dot(toImpact, forward)`, `localRight = dot(toImpact, right)`, and `localUp = dot(toImpact, up)` and only hide CCIP when `localForward <= 0.05D`.
- Use `scale = height * 0.75D / localForward` and compute screen coordinates with `x = centerX - localRight * scale` and `y = centerY - localUp * scale`, preserving the existing HUD horizontal sign convention.
- Added a small `dot(Vec3, Vec3)` helper and retained existing CCIP smoothing and clamping behavior.

### Testing
- Ran `git diff --check` which succeeded and confirmed the single modified file staged.  
- Attempted `./gradlew compileJava` but the wrapper is not executable in this environment so it could not be run.  
- Attempted `bash ./gradlew compileJava` but the Gradle distribution download failed due to an external proxy (HTTP 403), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef7309b5c8323bd6eeb4e541e6a2f)