### PR TITLE
Fix bomb CCIP aircraft speed prediction

### DIFF
--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -534,7 +534,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          Vec3 planePos = this.getInterpolatedEntityPos(plane, partialTicks);
          Vec3 release = Vec3.createVectorHelper(planePos.xCoord + shotOfs.xCoord, planePos.yCoord + shotOfs.yCoord, planePos.zCoord + shotOfs.zCoord);
          ReleaseKinematics releaseKinematics = this.getInitialBombVelocity(plane, weapon, aircraftMotion, partialTicks);
-         result = MCP_PlaneCCIPHelper.predict(plane.worldObj, weapon.getInfo(), release, releaseKinematics.initialVelocity);
+         result = MCP_PlaneCCIPHelper.predict(plane.worldObj, weapon.getInfo(), release, releaseKinematics.initialVelocity, aircraftMotion);
          result.releaseMode = releaseKinematics.releaseMode;
          result.ejectionVelocity = releaseKinematics.ejectionVelocity;
          result.initialVelocityDeltaFromAircraft = releaseKinematics.initialVelocityDeltaFromAircraft;
@@ -639,10 +639,14 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       String msg3 = String.format("aircraftMotion=%s ejectionVelocity=%s initialBombVelocity=%s deltaFromAircraft=%s",
             this.formatVec(aircraftMotion), this.formatVec(result != null ? result.ejectionVelocity : null),
             this.formatVec(result != null ? result.initialVelocity : null), this.formatVec(result != null ? result.initialVelocityDeltaFromAircraft : null));
-      String msg4 = String.format("predictedGravity=%.4f predictedDrag=%.4f predictedTimestep=%.1f initialVelocityUpDot=%.3f initialVelocitySideDot=%.3f",
+      String msg4 = String.format("predictedGravity=%.4f predictedDrag=%.4f predictedTimestep=%.1f speedDependsAircraft=%s speedAddedFromAircraft=%.4f",
             Double.valueOf(result != null ? result.gravity : 0.0D), Double.valueOf(result != null ? result.horizontalDrag : 0.0D), Double.valueOf(result != null ? result.simulationTimeStep : 0.0D),
-            Double.valueOf(result != null ? result.initialVelocityUpDot : 0.0D), Double.valueOf(result != null ? result.initialVelocitySideDot : 0.0D));
-      String msg5 = String.format("warningImpossibleLaunch=%s cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
+            Boolean.valueOf(result != null && result.speedDependsAircraft), Double.valueOf(result != null ? result.speedAddedFromAircraft : 0.0D));
+      String msg5 = String.format("predictedAcceleration before/after=%.4f/%.4f speedDependsApplied=%s initialVelocityUpDot=%.3f initialVelocitySideDot=%.3f",
+            Double.valueOf(result != null ? result.predictedAccelerationBeforeAircraft : 0.0D), Double.valueOf(result != null ? result.predictedAccelerationAfterAircraft : 0.0D),
+            Boolean.valueOf(result != null && result.speedDependsAircraftApplied), Double.valueOf(result != null ? result.initialVelocityUpDot : 0.0D),
+            Double.valueOf(result != null ? result.initialVelocitySideDot : 0.0D));
+      String msg6 = String.format("warningImpossibleLaunch=%s cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
             Boolean.valueOf(result != null && result.warningImpossibleLaunch),
             Float.valueOf(camera != null ? camera.rotationYaw : 0.0F), Float.valueOf(camera != null ? camera.rotationPitch : 0.0F),
             Float.valueOf(plane.rotationYaw), Float.valueOf(plane.rotationPitch), Float.valueOf(plane.getRotRoll()));
@@ -651,6 +655,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       this.drawString(msg3, super.centerX - 170, super.centerY + 90, 0xFF55FF66);
       this.drawString(msg4, super.centerX - 170, super.centerY + 100, 0xFF55FF66);
       this.drawString(msg5, super.centerX - 170, super.centerY + 110, 0xFF55FF66);
+      this.drawString(msg6, super.centerX - 170, super.centerY + 120, 0xFF55FF66);
    }
 
    private String formatVec(Vec3 v) {

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -11,11 +11,21 @@ public final class MCP_PlaneCCIPHelper {
    private MCP_PlaneCCIPHelper() {}
 
    public static Result predict(World world, MCH_WeaponInfo info, Vec3 releasePos, Vec3 initialVelocity) {
+      return predict(world, info, releasePos, initialVelocity, null);
+   }
+
+   public static Result predict(World world, MCH_WeaponInfo info, Vec3 releasePos, Vec3 initialVelocity, Vec3 aircraftMotion) {
       Result r = new Result();
       r.valid = false;
       r.reasonInvalid = "not_run";
       r.releasePos = copy(releasePos);
       r.initialVelocity = copy(initialVelocity);
+      r.aircraftMotion = copy(aircraftMotion);
+      r.speedDependsAircraft = info != null && info.speedDependsAircraft;
+      r.predictedAccelerationBeforeAircraft = info != null ? (double)info.acceleration : 0.0D;
+      r.predictedAccelerationAfterAircraft = r.predictedAccelerationBeforeAircraft;
+      r.speedAddedFromAircraft = 0.0D;
+      r.speedDependsAircraftApplied = false;
       r.gravity = info != null ? (double)info.gravity : 0.0D;
       r.horizontalDrag = info != null && isBombLike(info) ? 0.999D : 1.0D;
       r.simulationTimeStep = 1.0D;
@@ -26,6 +36,8 @@ public final class MCP_PlaneCCIPHelper {
 
       Vec3 pos = copy(releasePos);
       Vec3 vel = copy(initialVelocity);
+
+      applySpeedDependsAircraftFirstTick(info, aircraftMotion, vel, r);
 
       int max = info.timeFuse > 0 ? Math.min(MAX_STEPS, info.timeFuse) : MAX_STEPS;
       for(int i = 0; i < max; ++i) {
@@ -67,6 +79,27 @@ public final class MCP_PlaneCCIPHelper {
       return r;
    }
 
+   private static void applySpeedDependsAircraftFirstTick(MCH_WeaponInfo info, Vec3 aircraftMotion, Vec3 vel, Result r) {
+      if(info == null || aircraftMotion == null || vel == null || r == null || !info.speedDependsAircraft || !isBombLike(info)) {
+         return;
+      }
+
+      double speedAdded = Math.sqrt(aircraftMotion.xCoord * aircraftMotion.xCoord + aircraftMotion.yCoord * aircraftMotion.yCoord + aircraftMotion.zCoord * aircraftMotion.zCoord);
+      double speed = Math.sqrt(vel.xCoord * vel.xCoord + vel.yCoord * vel.yCoord + vel.zCoord * vel.zCoord);
+      if(speed <= 1.0E-7D) {
+         return;
+      }
+
+      r.speedAddedFromAircraft = speedAdded;
+      r.predictedAccelerationBeforeAircraft = (double)info.acceleration;
+      r.predictedAccelerationAfterAircraft = r.predictedAccelerationBeforeAircraft + speedAdded;
+      vel.xCoord = vel.xCoord * r.predictedAccelerationAfterAircraft / speed;
+      vel.yCoord = vel.yCoord * r.predictedAccelerationAfterAircraft / speed;
+      vel.zCoord = vel.zCoord * r.predictedAccelerationAfterAircraft / speed;
+      r.initialVelocity = copy(vel);
+      r.speedDependsAircraftApplied = true;
+   }
+
    private static Vec3 copy(Vec3 v) {
       return v != null ? Vec3.createVectorHelper(v.xCoord, v.yCoord, v.zCoord) : null;
    }
@@ -90,9 +123,15 @@ public final class MCP_PlaneCCIPHelper {
       public double releaseAltitude;
       public Vec3 initialVelocity;
       public Vec3 finalVelocity;
+      public Vec3 aircraftMotion;
       public double gravity;
       public double horizontalDrag;
       public double simulationTimeStep;
+      public boolean speedDependsAircraft;
+      public boolean speedDependsAircraftApplied;
+      public double speedAddedFromAircraft;
+      public double predictedAccelerationBeforeAircraft;
+      public double predictedAccelerationAfterAircraft;
       public Vec3 ejectionVelocity;
       public Vec3 initialVelocityDeltaFromAircraft;
       public double initialVelocityUpDot;


### PR DESCRIPTION
### Motivation
- Ensure plane CCIP predictions treat `MCH_WeaponInfo.speedDependsAircraft` consistently for bomb-like weapons and avoid applying aircraft speed twice for normal gravity bombs. 
- Either disable `speedDependsAircraft` in the predictor path for bomb-like weapons or simulate the same first-tick behavior that `MCH_EntityBaseBullet` applies; this change implements the latter so the predictor matches runtime behavior.

### Description
- Pass aircraft motion into the predictor by adding an overload `predict(..., Vec3 aircraftMotion)` and update the CCIP call site to pass `aircraftMotion` from `MCP_GuiPlane`. 
- Simulate the first-server-tick aircraft-speed effect for bomb-like weapons when `info.speedDependsAircraft == true` with a new helper `applySpeedDependsAircraftFirstTick` that adds aircraft speed magnitude to the predicted acceleration, renormalizes velocity, and sets the result `speedDependsAircraftApplied` flag. 
- Add debug/result fields to `MCP_PlaneCCIPHelper.Result` (`speedDependsAircraft`, `speedDependsAircraftApplied`, `speedAddedFromAircraft`, `predictedAccelerationBeforeAircraft`, `predictedAccelerationAfterAircraft`, and `aircraftMotion`) and populate them during prediction. 
- Expand the CCIP HUD debug output in `MCP_GuiPlane` to display `speedDependsAircraft`, `speedAddedFromAircraft`, predicted acceleration before/after, and whether the adjustment was applied for easier troubleshooting.

### Testing
- Ran `git diff --check` to validate diffs and whitespace issues and it completed successfully. 
- Attempted a Java build with `bash ./gradlew compileJava` but the Gradle distribution download failed due to an external proxy returning `HTTP/1.1 403 Forbidden`, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef776b144832390c17bf8b352c552)