### PR TITLE
Fix new helicopter lateral and backward speed scaling

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -115,6 +115,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private static final double LEGACY_HELI_HOVER_TRANSLATION_ACCEL = 0.0015D;
    private static final double NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE = 4.0D;
    private static final double NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE = 0.35D;
+   private static final float NEW_HELI_LATERAL_SPEED_TUNING_MULTIPLIER = 2.0F;
+   private static final float NEW_HELI_BACKWARD_TUNING_MULTIPLIER = 2.0F;
 
 
    public MCH_EntityHeli(World world) {
@@ -1630,8 +1632,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       float rightZ = -MathHelper.sin(yawRadians);
 
       float horizontalThrustScale = this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.horizontalRotorThrustScale, 0.0F, 1000.0F):0.35F;
-      float lateralThrustScale = this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterLateralThrustScale, 0.0F, 1000.0F):0.45F;
-      float backwardThrustScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterBackwardThrustScale)?MathHelper.clamp_float(this.heliInfo.helicopterBackwardThrustScale, 0.0F, 1000.0F):1.0F;
+      float lateralThrustScale = (this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterLateralThrustScale, 0.0F, 1000.0F):0.45F) * NEW_HELI_LATERAL_SPEED_TUNING_MULTIPLIER;
+      float backwardThrustScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterBackwardThrustScale)?MathHelper.clamp_float(this.heliInfo.helicopterBackwardThrustScale, 0.0F, 1000.0F) * NEW_HELI_BACKWARD_TUNING_MULTIPLIER:1.0F;
       float attitudeTiltForward = MathHelper.clamp_float(MathHelper.sin(this.getRotPitch() / 180.0F * 3.1415927F), -0.75F, 0.75F);
       float attitudeTiltRight = MathHelper.clamp_float(-MathHelper.sin(this.getRotRoll() / 180.0F * 3.1415927F), -0.75F, 0.75F);
       float effectiveTiltForward = MathHelper.clamp_float(this.rotorTiltForward + attitudeTiltForward, -1.0F, 1.0F);
@@ -1664,12 +1666,12 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       double speedScale = this.isHoveringMode()?NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE:NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE;
       double minimumSafetyLimit = this.isHoveringMode()?0.35D:4.0D;
       double safetyLimit = Math.max(configuredSpeed * speedScale, minimumSafetyLimit);
-      float lateralLimit = (float)(safetyLimit * (double)(this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterMaxLateralSpeedScale, 0.0F, 1000.0F):0.45F));
+      float lateralLimit = (float)(safetyLimit * (double)((this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterMaxLateralSpeedScale, 0.0F, 1000.0F):0.45F) * NEW_HELI_LATERAL_SPEED_TUNING_MULTIPLIER));
       this.lateralSpeedCapped = lateralLimit > 0.0F && MathHelper.abs(lateralVelocity) > lateralLimit;
       if(this.lateralSpeedCapped) {
          lateralVelocity = MathHelper.clamp_float(lateralVelocity, -lateralLimit, lateralLimit);
       }
-      float backwardLimitScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterMaxBackwardSpeedScale)?MathHelper.clamp_float(this.heliInfo.helicopterMaxBackwardSpeedScale, 0.0F, 1000.0F):1.0F;
+      float backwardLimitScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterMaxBackwardSpeedScale)?MathHelper.clamp_float(this.heliInfo.helicopterMaxBackwardSpeedScale, 0.0F, 1000.0F) * NEW_HELI_BACKWARD_TUNING_MULTIPLIER:1.0F;
       float backwardLimit = (float)(safetyLimit * (double)backwardLimitScale);
       this.backwardSpeedCapped = forwardVelocity < -backwardLimit && MathHelper.abs(backwardLimitScale - 1.0F) > 0.0001F;
       if(this.backwardSpeedCapped) {


### PR DESCRIPTION
### Motivation
- Helicopter lateral and backward movement felt artificially slow because runtime lateral/backward scales were not aligned with the speed displayed in TXT configs and HUD readouts. 
- The intent is to respect configured helicopter speed while making lateral/backward feel consistent with forward tuning.

### Description
- Added two new constants `NEW_HELI_LATERAL_SPEED_TUNING_MULTIPLIER` and `NEW_HELI_BACKWARD_TUNING_MULTIPLIER` (both `2.0F`) in `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` to provide a global tuning boost. 
- Multiplied the lateral thrust scale and lateral speed cap by `NEW_HELI_LATERAL_SPEED_TUNING_MULTIPLIER` so sideways acceleration and caps reflect the configured TXT speed. 
- Multiplied the configured backward thrust and backward speed-cap values by `NEW_HELI_BACKWARD_TUNING_MULTIPLIER` while preserving compatibility for helicopters that omit the optional backward-scale fields. 
- Changes affect the new helicopter flight model paths in `applyNewHelicopterCyclicThrust` (thrust calculation and speed-cap enforcement) so display readouts and internal motion use consistent bases.

### Testing
- Attempted to run the automated test target with `./gradlew test`, but `gradlew` is not executable in the environment so the wrapper did not run. 
- Attempted `bash ./gradlew test` to invoke the wrapper bootstrap, but the Gradle wrapper download failed due to a proxy HTTP 403 error, preventing the build/test run from completing. 
- No unit/integration test results are available from this checkout due to the environment restrictions above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2415b5d88323bfc61bd7ee5bf3c7)