### PR TITLE
Add tilt-referenced speed matching and smoothing to new helicopter horizontal physics

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -115,6 +115,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private static final double LEGACY_HELI_HOVER_TRANSLATION_ACCEL = 0.0015D;
    private static final double NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE = 4.0D;
    private static final double NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE = 0.35D;
+   private static final float NEW_HELI_SPEED_MATCH_TILT_REFERENCE = 0.35F;
+   private static final float NEW_HELI_SPEED_MATCH_RESPONSE = 0.08F;
 
 
    public MCH_EntityHeli(World world) {
@@ -1664,12 +1666,22 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       double speedScale = this.isHoveringMode()?NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE:NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE;
       double minimumSafetyLimit = this.isHoveringMode()?0.35D:4.0D;
       double safetyLimit = Math.max(configuredSpeed * speedScale, minimumSafetyLimit);
+      float backwardLimitScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterMaxBackwardSpeedScale)?MathHelper.clamp_float(this.heliInfo.helicopterMaxBackwardSpeedScale, 0.0F, 1000.0F):1.0F;
+      float speedMatchResponse = MathHelper.clamp_float(NEW_HELI_SPEED_MATCH_RESPONSE * tickDelta, 0.0F, 1.0F);
+      float forwardSpeedCommand = MathHelper.clamp_float(effectiveTiltForward / NEW_HELI_SPEED_MATCH_TILT_REFERENCE, -1.0F, 1.0F);
+      float forwardTargetSpeed = (float)configuredSpeed * forwardSpeedCommand;
+      if(forwardTargetSpeed < 0.0F) {
+         forwardTargetSpeed *= backwardLimitScale;
+      }
+      forwardVelocity += (forwardTargetSpeed - forwardVelocity) * MathHelper.abs(forwardSpeedCommand) * speedMatchResponse;
       float lateralLimit = (float)(safetyLimit * (double)(this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterMaxLateralSpeedScale, 0.0F, 1000.0F):0.45F));
+      float lateralSpeedCommand = MathHelper.clamp_float(effectiveTiltRight / NEW_HELI_SPEED_MATCH_TILT_REFERENCE, -1.0F, 1.0F);
+      float lateralTargetSpeed = lateralLimit * lateralSpeedCommand;
+      lateralVelocity += (lateralTargetSpeed - lateralVelocity) * MathHelper.abs(lateralSpeedCommand) * speedMatchResponse;
       this.lateralSpeedCapped = lateralLimit > 0.0F && MathHelper.abs(lateralVelocity) > lateralLimit;
       if(this.lateralSpeedCapped) {
          lateralVelocity = MathHelper.clamp_float(lateralVelocity, -lateralLimit, lateralLimit);
       }
-      float backwardLimitScale = this.heliInfo != null && this.isFinite(this.heliInfo.helicopterMaxBackwardSpeedScale)?MathHelper.clamp_float(this.heliInfo.helicopterMaxBackwardSpeedScale, 0.0F, 1000.0F):1.0F;
       float backwardLimit = (float)(safetyLimit * (double)backwardLimitScale);
       this.backwardSpeedCapped = forwardVelocity < -backwardLimit && MathHelper.abs(backwardLimitScale - 1.0F) > 0.0001F;
       if(this.backwardSpeedCapped) {


### PR DESCRIPTION
### Motivation
- Reduce abrupt horizontal speed changes and improve control responsiveness in the new helicopter flight model by introducing tilt-referenced target speeds with smoothing.

### Description
- Introduce two new constants: `NEW_HELI_SPEED_MATCH_TILT_REFERENCE` and `NEW_HELI_SPEED_MATCH_RESPONSE` to define tilt-to-speed mapping and smoothing response.
- Compute forward and lateral speed commands from `effectiveTiltForward` and `effectiveTiltRight` normalized by the tilt reference, clamp them to `[-1, 1]`, and derive `forwardTargetSpeed` and `lateralTargetSpeed` accordingly. 
- Apply backward-speed scaling for negative forward targets using a clamped `backwardLimitScale`, and smoothly adjust `forwardVelocity` and `lateralVelocity` toward their targets via `velocity += (target - velocity) * abs(command) * speedMatchResponse` using a `tickDelta`-scaled response.
- Reordered and clamped `backwardLimitScale` computation and preserved existing lateral/backward capping and safety limit enforcement.

### Testing
- Built the project and ran the automated test suite; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2415b5d88323bfc61bd7ee5bf3c7)