### PR TITLE
Fix helicopter speed conversion and HUD display

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -279,6 +279,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `enablefoldblade` | Helicopter | boolean | false | blade folding support |
 | `addrotor` | Helicopter | `bladeNum,bladeRot,x,y,z,rx,ry,rz[,fold]` | none | rotor render/animation |
 | `addrotorold` | Helicopter | same as `addrotor` | none | legacy rotor renderer |
+| `Speed` | Helicopter | mph / 100 | inherited | authored helicopter top speed; after `AllHeliSpeed`, physics converts to internal blocks/tick and HUD reports actual km/h |
 | `HelicopterLateralThrustScale` | Helicopter | float >= 0 | 0.45 | new-heli-only roll-generated lateral acceleration multiplier |
 | `HelicopterLateralDrag` | Helicopter | float >= 0 | 0.055 | new-heli-only drag on right/left velocity component |
 | `HelicopterMaxLateralSpeedScale` | Helicopter | float >= 0 | 0.45 | new-heli-only cap for lateral speed component |

--- a/docs/vehicle-config/helicopters.md
+++ b/docs/vehicle-config/helicopters.md
@@ -1,6 +1,6 @@
 # Helicopter config values and rotorcraft lift model
 
-Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys are small; most helicopter behavior is controlled by shared `speed`, `gravity`, `MotionFactor`, mobility, throttle, and ceiling values.
+Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys are small; most helicopter behavior is controlled by shared `speed`, `gravity`, `MotionFactor`, mobility, throttle, and ceiling values. Helicopter `speed` values are authored as real-world mph divided by 100; runtime top-speed caps convert them to internal motion with `speed * 100 mph * 1.609344 / 72`, while HUD speed is shown as actual km/h.
 
 ## Helicopter-only keys
 
@@ -40,7 +40,7 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 - Default `SoundRange = 80`.
 - Default `camerazoom = 8`.
 - HUD defaults are `heli`, `heli_gnr`, then `gunner`.
-- `speed` is multiplied by global `AllHeliSpeed` during validation.
+- `speed` is multiplied by global `AllHeliSpeed` during validation. Helicopter physics then treats the resulting value as mph/100 for top-speed purposes, so `Speed = 1.82` caps around 182 mph / 293 km/h instead of 1.82 internal blocks/tick.
 
 ## New helicopter flight-model foundation
 

--- a/src/main/java/mcheli/aircraft/MCH_HudShared.java
+++ b/src/main/java/mcheli/aircraft/MCH_HudShared.java
@@ -10,7 +10,7 @@ import net.minecraft.util.MathHelper;
 
 public final class MCH_HudShared {
 
-   public static final double HUD_HELI_SPEED_MULTIPLIER = 3.5D;
+   public static final double HUD_HELI_SPEED_MULTIPLIER = 1.0D;
    public static final double HUD_PLANE_SPEED_MULTIPLIER = 2.0D;
 
    private MCH_HudShared() {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -113,9 +113,25 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private static final float NEW_HELI_GROUNDED_YAW_DAMPING = 0.35F;
    private static final double LEGACY_HELI_REGULAR_FORWARD_ACCEL = 0.50D;
    private static final double LEGACY_HELI_HOVER_TRANSLATION_ACCEL = 0.0015D;
-   private static final double NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE = 4.0D;
+   private static final double HELI_CONFIG_SPEED_MPH_SCALE = 100.0D;
+   private static final double MPH_TO_KMH = 1.609344D;
+   private static final double INTERNAL_SPEED_TO_KMH = 72.0D;
    private static final double NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE = 0.35D;
 
+
+   /**
+    * Helicopter content speeds are authored as real-world top speed in mph divided by 100
+    * (for example, Speed = 1.82 means roughly 182 mph). Convert that value back into
+    * MCHeli internal blocks/tick so physics caps match the authored real-world speed
+    * instead of treating the mph-derived number as an already-converted km/h value.
+    */
+   private double getConfiguredHelicopterTopSpeed() {
+      MCH_AircraftInfo info = this.getAcInfo();
+      if(info == null) {
+         return 0.0D;
+      }
+      return Math.max(0.0D, (double)info.speed * HELI_CONFIG_SPEED_MPH_SCALE * MPH_TO_KMH / INTERNAL_SPEED_TO_KMH);
+   }
 
    public MCH_EntityHeli(World world) {
       super(world);
@@ -1660,10 +1676,8 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       forwardVelocity = dampedForwardVelocity;
       lateralVelocity = dampedLateralVelocity;
 
-      double configuredSpeed = (double)this.getAcInfo().speed;
-      double speedScale = this.isHoveringMode()?NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE:NEW_HELI_REGULAR_HORIZONTAL_SPEED_SCALE;
-      double minimumSafetyLimit = this.isHoveringMode()?0.35D:4.0D;
-      double safetyLimit = Math.max(configuredSpeed * speedScale, minimumSafetyLimit);
+      double configuredTopSpeed = this.getConfiguredHelicopterTopSpeed();
+      double safetyLimit = this.isHoveringMode()?Math.max(configuredTopSpeed * NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE, 0.35D):configuredTopSpeed;
       float lateralLimit = (float)(safetyLimit * (double)(this.heliInfo != null?MathHelper.clamp_float(this.heliInfo.helicopterMaxLateralSpeedScale, 0.0F, 1000.0F):0.45F));
       this.lateralSpeedCapped = lateralLimit > 0.0F && MathHelper.abs(lateralVelocity) > lateralLimit;
       if(this.lateralSpeedCapped) {
@@ -1923,7 +1937,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       }
 
       motion = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
-      speedLimit = this.getAcInfo().speed;
+      speedLimit = (float)this.getConfiguredHelicopterTopSpeed();
       if(!this.newHeliFlightModelEnabled && motion > (double)speedLimit) {
          super.motionX *= (double)speedLimit / motion;
          super.motionZ *= (double)speedLimit / motion;


### PR DESCRIPTION
### Motivation
- Helicopter `Speed` values were authored as real-world mph/100 but were being treated as internal speed units, producing abnormally slow helicopters and incorrect HUD readings.
- The intent is to interpret authored helicopter `Speed` as mph/100 for physics and to display actual km/h on the HUD so in-game performance matches real-world top speeds.

### Description
- Convert authored helicopter `Speed` (mph/100) into internal blocks/tick top-speed with a new `getConfiguredHelicopterTopSpeed()` helper and apply it to both new-model safety limits and legacy motion clamps in `src/main/java/mcheli/helicopter/MCH_EntityHeli.java`.
- Replace the previous heuristic horizontal-speed scale with a direct configured top-speed conversion and use it for lateral/backward caps and safety clamping in `MCH_EntityHeli`.
- Change helicopter HUD behavior by removing the extra 3.5x display multiplier and using `HUD_HELI_SPEED_MULTIPLIER = 1.0` so HUD shows actual km/h in `src/main/java/mcheli/aircraft/MCH_HudShared.java`.
- Document the authoring and runtime conversion behavior in `docs/vehicle-config/helicopters.md` and `docs/vehicle-config-reference.md` so pack authors understand that `Speed` is mph/100 and is converted to internal units and displayed as km/h.

### Testing
- Attempted `./gradlew compileJava` but the Gradle wrapper download failed due to proxy/HTTP 403, so the wrapper build could not run.
- Attempted `gradle compileJava` but dependency resolution for ForgeGradle failed with HTTP 403 from remote repositories, blocking the automated build.
- No unit tests or in-repo automated tests were executed because compilation was blocked by external repository/proxy errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f2ce2f84883239b9160cae7b2bdb3)