### PR TITLE
Use authored helicopter Speed for new-flight top-speed conversion

### DIFF
--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -125,12 +125,16 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
     * MCHeli internal blocks/tick so physics caps match the authored real-world speed
     * instead of treating the mph-derived number as an already-converted km/h value.
     */
-   private double getConfiguredHelicopterTopSpeed() {
-      MCH_BaseVehicleInfo info = this.getAcInfo();
+   private static double calculateConfiguredHelicopterTopSpeed(MCH_BaseVehicleInfo info) {
       if(info == null) {
          return 0.0D;
       }
-      return Math.max(0.0D, (double)info.speed * HELI_CONFIG_SPEED_MPH_SCALE * MPH_TO_KMH / INTERNAL_SPEED_TO_KMH);
+      double authoredSpeed = info instanceof MCH_HeliInfo?(double)((MCH_HeliInfo)info).authoredSpeed:(double)info.speed;
+      return Math.max(0.0D, authoredSpeed * HELI_CONFIG_SPEED_MPH_SCALE * MPH_TO_KMH / INTERNAL_SPEED_TO_KMH);
+   }
+
+   private double getConfiguredHelicopterTopSpeed() {
+      return calculateConfiguredHelicopterTopSpeed(this.getAcInfo());
    }
 
    public MCH_EntityHeli(World world) {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -12,6 +12,8 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
 
    public MCH_ItemHeli item = null;
    public boolean isEnableFoldBlade;
+   /** Raw authored Speed config before global AllHeliSpeed scaling is applied for legacy flight. */
+   public float authoredSpeed = 0.1F;
    /** Opt-in gate for the isolated helicopter flight-model rewrite. Default false keeps legacy lift/motion behavior. */
    public boolean useNewHelicopterFlightModel;
    /** Relative vehicle mass used by future helicopter physics. 1.0 matches current legacy scale. */
@@ -143,6 +145,9 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
 
    public void loadItemData(String item, String data) {
       super.loadItemData(item, data);
+      if(item.equalsIgnoreCase("Speed")) {
+         this.authoredSpeed = this.toFloat(data, 0.0F, this.getMaxSpeed());
+      }
       if(item.compareTo("enablefoldblade") == 0) {
          this.isEnableFoldBlade = this.toBool(data);
       } else if(item.equalsIgnoreCase("UseNewHelicopterFlightModel") || item.equalsIgnoreCase("EnableNewHelicopterFlightModel")) {


### PR DESCRIPTION
### Motivation
- Preserve the raw authored helicopter `Speed` value so the new helicopter flight-cap conversion can use the original authored number rather than the globally scaled `speed` used by legacy systems. 
- Keep legacy behavior intact by leaving the existing `AllHeliSpeed` scaling in place for code paths that rely on `speed` to avoid breaking existing flight logic.

### Description
- Add a new field `public float authoredSpeed = 0.1F;` to `MCH_HeliInfo` to capture the raw authored `Speed` value before global scaling. 
- In `MCH_HeliInfo.loadItemData(String item, String data)`, after delegating to `super.loadItemData(item, data)`, detect case-insensitive `Speed` and store the parsed raw value into `authoredSpeed` while leaving base parsing behavior unchanged. 
- Introduce `calculateConfiguredHelicopterTopSpeed(MCH_BaseVehicleInfo)` and change `getConfiguredHelicopterTopSpeed()` in `MCH_EntityHeli` to use `MCH_HeliInfo.authoredSpeed` when available (falling back to `info.speed` for non-helicopter info) and convert that authored value with `HELI_CONFIG_SPEED_MPH_SCALE * MPH_TO_KMH / INTERNAL_SPEED_TO_KMH`. 
- Leave `MCH_HeliInfo.isValidData()` scaling (`AllHeliSpeed`) unchanged so legacy users of `speed` continue to behave the same.

### Testing
- Ran `git diff --check` with no whitespace/error findings (succeeded). 
- Executed a numeric sanity check `python3` snippet confirming `2 * 100 * 1.609344 / 72` equals approximately `4.4704` (succeeded). 
- Attempted `./gradlew compileJava`, but build was blocked by environment network/proxy issues when the Gradle wrapper attempted to download its distribution (failed outside of code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f318aa32083238da26280046863ea)