### PR TITLE
Fix helicopter speed scaling

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `PreventingBroken` | `false` | Prevents breakage behavior where implemented. |
 | `DropItemInCreativeMode` | `false` | Allows item drops in creative mode for applicable actions. |
 | `BreakableOnlyPickaxe` | `false` | Restricts breakability to pickaxe behavior where implemented. |
-| `AllHeliSpeed` | `1.5` | Global helicopter speed scalar; clamped between 0 and 1000. |
+| `AllHeliSpeed` | `3.4` | Global helicopter speed scalar; clamped between 0 and 1000. |
 | `AllPlaneSpeed` | `1000.0` | Global plane speed scalar/clamp value; clamped between 0 and 1000. Plane config speeds use `(mph / 1000) * 1.74` before this scalar is applied. AA-missile launch speed uses the matching normalized scale, `AllPlaneSpeed / 1000 * 1.74`, so the default makes AA missiles 1.74 times their configured `Acceleration`. |
 | `NewFlightGravity` | `0.008` | Global per-tick downward acceleration for new-flight-model aircraft; individual vehicle configs can override with `NewFlightGravity`, `FlightGravity`, or `GravityOverride`. |
 | `AllShipSpeed` | `2.0` | Global ship speed scalar; clamped between 0 and 1000. |

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -279,7 +279,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `enablefoldblade` | Helicopter | boolean | false | blade folding support |
 | `addrotor` | Helicopter | `bladeNum,bladeRot,x,y,z,rx,ry,rz[,fold]` | none | rotor render/animation |
 | `addrotorold` | Helicopter | same as `addrotor` | none | legacy rotor renderer |
-| `Speed` | Helicopter | mph / 100 | inherited | authored helicopter top speed; after `AllHeliSpeed`, physics converts to internal blocks/tick and HUD reports actual km/h |
+| `Speed` | Helicopter | internal speed | inherited | authored helicopter top speed; after `AllHeliSpeed`, physics uses the scaled internal value directly and HUD reports actual km/h |
 | `HelicopterLateralThrustScale` | Helicopter | float >= 0 | 0.45 | new-heli-only roll-generated lateral acceleration multiplier |
 | `HelicopterLateralDrag` | Helicopter | float >= 0 | 0.055 | new-heli-only drag on right/left velocity component |
 | `HelicopterMaxLateralSpeedScale` | Helicopter | float >= 0 | 0.45 | new-heli-only cap for lateral speed component |

--- a/docs/vehicle-config/helicopters.md
+++ b/docs/vehicle-config/helicopters.md
@@ -1,6 +1,6 @@
 # Helicopter config values and rotorcraft lift model
 
-Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys are small; most helicopter behavior is controlled by shared `speed`, `gravity`, `MotionFactor`, mobility, throttle, and ceiling values. Helicopter `speed` values are authored as real-world mph divided by 100; runtime top-speed caps convert them to internal motion with `speed * 100 mph * 1.609344 / 72`, while HUD speed is shown as actual km/h.
+Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys are small; most helicopter behavior is controlled by shared `speed`, `gravity`, `MotionFactor`, mobility, throttle, and ceiling values. Helicopter `speed` values are authored as MCHeli internal horizontal speed units and are multiplied by `AllHeliSpeed` during validation; runtime top-speed caps use the same scaled internal value, while HUD speed is shown as km/h from actual motion.
 
 ## Helicopter-only keys
 
@@ -40,7 +40,7 @@ Helicopters inherit all shared keys from `base.md`. Helicopter-only parser keys 
 - Default `SoundRange = 80`.
 - Default `camerazoom = 8`.
 - HUD defaults are `heli`, `heli_gnr`, then `gunner`.
-- `speed` is multiplied by global `AllHeliSpeed` during validation. Helicopter physics then treats the resulting value as mph/100 for top-speed purposes, so `Speed = 1.82` caps around 182 mph / 293 km/h instead of 1.82 internal blocks/tick.
+- `speed` is multiplied by global `AllHeliSpeed` during validation. Helicopter physics uses that scaled internal value directly for top-speed purposes, so low legacy asset speeds such as `Speed = 0.5` become usable when the default `AllHeliSpeed = 3.4` raises them to about `1.7` internal speed.
 
 ## New helicopter flight-model foundation
 

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -518,7 +518,7 @@ public class MCH_Config {
       NewPlaneWeaponHudY = new MCH_ConfigPrm("NewPlaneWeaponHudY", 42);
       NewPlaneWeaponHudY.desc = ";Right-side new-plane weapon HUD Y offset in scaled GUI pixels.";
       SwitchWeaponWithMouseWheel = new MCH_ConfigPrm("SwitchWeaponWithMouseWheel", true);
-      AllHeliSpeed = new MCH_ConfigPrm("AllHeliSpeed", 1.5D);
+      AllHeliSpeed = new MCH_ConfigPrm("AllHeliSpeed", 3.4D);
       AllPlaneSpeed = new MCH_ConfigPrm("AllPlaneSpeed", 1000.00D);
       NewFlightGravity = new MCH_ConfigPrm("NewFlightGravity", 0.008D);
       NewFlightGravity.desc = ";Default per-tick downward acceleration for new-flight-model aircraft. Vehicle configs can override with NewFlightGravity, FlightGravity, or GravityOverride.";

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -113,24 +113,16 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
    private static final float NEW_HELI_GROUNDED_YAW_DAMPING = 0.35F;
    private static final double LEGACY_HELI_REGULAR_FORWARD_ACCEL = 0.50D;
    private static final double LEGACY_HELI_HOVER_TRANSLATION_ACCEL = 0.0015D;
-   private static final double HELI_CONFIG_SPEED_MPH_SCALE = 100.0D;
-   private static final double MPH_TO_KMH = 1.609344D;
-   private static final double INTERNAL_SPEED_TO_KMH = 72.0D;
    private static final double NEW_HELI_HOVER_HORIZONTAL_SPEED_SCALE = 0.35D;
 
 
    /**
-    * Helicopter content speeds are authored as real-world top speed in mph divided by 100
-    * (for example, Speed = 1.82 means roughly 182 mph). Convert that value back into
-    * MCHeli internal blocks/tick so physics caps match the authored real-world speed
-    * instead of treating the mph-derived number as an already-converted km/h value.
+    * Helicopter Speed values are MCHeli internal horizontal speed units after validation.
+    * Use the globally-scaled value here so legacy and new helicopter caps both honor
+    * AllHeliSpeed instead of falling back to the unscaled authored value.
     */
    private static double calculateConfiguredHelicopterTopSpeed(MCH_BaseVehicleInfo info) {
-      if(info == null) {
-         return 0.0D;
-      }
-      double authoredSpeed = info instanceof MCH_HeliInfo?(double)((MCH_HeliInfo)info).authoredSpeed:(double)info.speed;
-      return Math.max(0.0D, authoredSpeed * HELI_CONFIG_SPEED_MPH_SCALE * MPH_TO_KMH / INTERNAL_SPEED_TO_KMH);
+      return info != null?Math.max(0.0D, (double)info.speed):0.0D;
    }
 
    private double getConfiguredHelicopterTopSpeed() {


### PR DESCRIPTION
### Motivation
- Helicopters authored with low legacy `Speed` values were capping far too low and made many rotorcraft (e.g., Mi-24 variants) unusable, so top-speed calculation and the global helicopter scalar needed to be adjusted to place typical helis into a usable internal speed range (~1.5–1.8).
- Ensure both legacy and new helicopter flight caps consistently honor the globally-validated internal speed (`AllHeliSpeed`) instead of falling back to an unscaled authored-to-mph conversion path.

### Description
- Change `calculateConfiguredHelicopterTopSpeed` in `src/main/java/mcheli/helicopter/MCH_EntityHeli.java` to use the validated internal `info.speed` value so helicopter caps honor the `AllHeliSpeed` scalar. 
- Remove the old mph-to-internal conversion path and associated constants used only by the previous authored-speed conversion. 
- Increase the default `AllHeliSpeed` in `src/main/java/mcheli/MCH_Config.java` from `1.5` to `3.4` so low legacy `Speed` values (for example `Speed = 0.5`) produce usable internal speeds (≈1.7) by default. 
- Update documentation in `docs/configuration.md`, `docs/vehicle-config/helicopters.md`, and `docs/vehicle-config-reference.md` to describe the new internal-unit semantics and the updated default `AllHeliSpeed` value.

### Testing
- Ran `git diff --check`, which completed without problems. 
- Attempted `./gradlew test` but the Gradle wrapper download failed due to a network/proxy error (`HTTP/1.1 403 Forbidden`), so unit/integration tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f33969da883238e4edaf4b0146224)