### PR TITLE
Restrict NewUAV linking/Continue to the station that placed them

### DIFF
--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -226,6 +226,11 @@ public class MCH_EntityUavStation
                       this.linkedUavEntityUUID.toString() });
                 return false;
            }
+           if(!isUavLinkedToThisStation(ac)) {
+                MCH_Lib.Log((Entity)this, "Rejected UAV %d because it belongs to another UAV station", new Object[] {
+                      Integer.valueOf(W_Entity.getEntityId((Entity)ac)) });
+                return false;
+           }
            MCH_UavRegistry.register(ac);
            if(ac.isDead) {
                 return false;
@@ -748,16 +753,42 @@ public class MCH_EntityUavStation
 
       public MCH_EntityBaseVehicle findLinkedUavEntity(World world) {
            if(this.assignedUav != null && !this.assignedUav.isDead
-                 && MCH_UavRegistry.isPresentInLoadedEntityList(world, this.assignedUav)) {
+                 && MCH_UavRegistry.isPresentInLoadedEntityList(world, this.assignedUav)
+                 && isUavLinkedToThisStation(this.assignedUav)) {
                 return this.assignedUav;
            }
            this.assignedUav = null;
-           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+           if(!hasStableLinkedUavIdentity()) {
+                return null;
+           }
+           UUID lookupUuid = this.linkedUavEntityUUID != null ? this.linkedUavEntityUUID : parseUavUUID(this.assignedUavUUID);
+           if(lookupUuid == null && (this.linkedUavCommonId == null || this.linkedUavCommonId.isEmpty())) {
+                return null;
+           }
+           MCH_EntityBaseVehicle ac = MCH_UavRegistry.findLinkedUav(world, lookupUuid, this.linkedUavCommonId, null);
            if(ac == null) {
                 loadLinkedUavChunk(world);
-                ac = MCH_UavRegistry.findLinkedUav(world, this.linkedUavEntityUUID, this.linkedUavCommonId, this.ownerUUID);
+                ac = MCH_UavRegistry.findLinkedUav(world, lookupUuid, this.linkedUavCommonId, null);
            }
-           return ac;
+           return isUavLinkedToThisStation(ac) ? ac : null;
+         }
+
+      private boolean hasStableLinkedUavIdentity() {
+           return this.linkedUavEntityUUID != null ||
+                 (this.linkedUavCommonId != null && !this.linkedUavCommonId.isEmpty()) ||
+                 (this.assignedUavUUID != null && !this.assignedUavUUID.isEmpty());
+      }
+
+      private boolean isUavLinkedToThisStation(MCH_EntityBaseVehicle ac) {
+           if(ac == null) {
+                return false;
+           }
+           MCH_EntityUavStation station = ac.getUavStation();
+           if(station != null && station != this) {
+                return false;
+           }
+           UUID linkedStationUuid = ac.getLinkedUavStationUUID();
+           return linkedStationUuid == null || linkedStationUuid.equals(this.getUniqueID());
          }
 
       private boolean pinReconnectChunks(EntityPlayerMP player) {
@@ -880,12 +911,20 @@ public class MCH_EntityUavStation
                 return false;
            }
            if(player != null) {
-                setOwnerUUID(player.getUniqueID());
+                if(this.ownerUUID != null && !this.ownerUUID.equals(player.getUniqueID())) {
+                     return false;
+                }
                 if(ac.getOwnerUUID() != null && !ac.getOwnerUUID().equals(player.getUniqueID())) {
                      return false;
                 }
+                if(this.ownerUUID == null) {
+                     setOwnerUUID(player.getUniqueID());
+                }
            }
            if(this.linkedUavDimension != 0 && ac.dimension != this.linkedUavDimension) {
+                return false;
+           }
+           if(!isUavLinkedToThisStation(ac)) {
                 return false;
            }
            return ac.isUAV() || ac.isNewUAV();
@@ -1566,7 +1605,7 @@ public class MCH_EntityUavStation
 
       public boolean interactFirst(EntityPlayer player) {
 
-          if(player != null) {
+          if(player != null && this.ownerUUID == null && !hasContinuableUavLink()) {
               this.setOwnerUUID(player.getUniqueID());
           }
 

--- a/src/main/java/mcheli/uav/MCH_ItemUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_ItemUavStation.java
@@ -84,6 +84,7 @@ public class MCH_ItemUavStation extends W_Item {
                int var33 = movingobjectposition.blockY;
                int var34 = movingobjectposition.blockZ;
                MCH_EntityUavStation var35 = this.createUavStation(par2World, (double)((float)i + 0.5F), (double)((float)var33 + 1.0F), (double)((float)var34 + 0.5F), this.UavStationKind);
+               var35.setOwnerUUID(par3EntityPlayer.getUniqueID());
                int rot = (int)(MCH_Lib.getRotate360((double)par3EntityPlayer.rotationYaw) + 45.0D);
                var35.rotationYaw = (float)(rot / 90 * 90 - 180);
                var35.initUavPostion();


### PR DESCRIPTION
### Motivation
- Prevent stations from acquiring or continuing control of NewUAVs placed by other stations or by other players, and ensure the player who placed a station is considered its owner for linking/continue semantics.
- Avoid accidental cross-station Continue transfers and duplicate UAV reassignments when multiple stations share the same player owner.

### Description
- Set the station owner UUID at placement time by calling `setOwnerUUID` in `MCH_ItemUavStation.createUavStation` so newly placed stations remember their placer.
- Tighten `linkUav` in `MCH_EntityUavStation` to reject UAVs that are not linked to this station via a new `isUavLinkedToThisStation` check.
- Restrict `findLinkedUavEntity`/relink logic to require a stable linked UAV identity (via `hasStableLinkedUavIdentity`) and to only return UAVs that are linked to this station.
- Harden validation in `isValidLinkedUav` so a player cannot reassign a continuable station owned by another player and ensure the station owner is set only when appropriate.

### Testing
- Ran `git diff --check` and inspected diffs of `src/main/java/mcheli/uav/MCH_EntityUavStation.java` and `src/main/java/mcheli/uav/MCH_ItemUavStation.java` (succeeded).
- Attempted `bash ./gradlew compileJava` but the Gradle wrapper download failed due to an external network/proxy HTTP 403, so the wrapper run could not complete.
- Attempted `gradle compileJava` which failed to resolve ForgeGradle/Maven metadata due to external network/proxy HTTP 403, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f810ba3c88323987ef021b59c4ee4)