### PR TITLE
Fix server-side camera class loading crash

### DIFF
--- a/src/main/java/mcheli/MCH_Camera.java
+++ b/src/main/java/mcheli/MCH_Camera.java
@@ -1,6 +1,5 @@
 package mcheli;
 
-import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.wrapper.W_Entity;
 import mcheli.wrapper.W_EntityRenderer;
 import mcheli.wrapper.W_Lib;
@@ -132,7 +131,6 @@ public class MCH_Camera {
       this.posX = x;
       this.posY = y;
       this.posZ = z;
-      MCP_PlaneChaseCamera.logCameraWrite("MCH_Camera.setPosition", String.format("pos=(%.3f,%.3f,%.3f)", Double.valueOf(x), Double.valueOf(y), Double.valueOf(z)));
    }
 
    public void setCameraZoom(float z) {


### PR DESCRIPTION
### Motivation
- Prevent dedicated servers from loading client-only classes (which caused `NoClassDefFoundError: net/minecraft/client/multiplayer/WorldClient`) when UAV stations spawn aircraft such as the MQ-8 by removing a client-only dependency from the shared camera code.

### Description
- Removed the client-only `MCP_PlaneChaseCamera` usage and debug log call from `MCH_Camera#setPosition` in `src/main/java/mcheli/MCH_Camera.java` so the server-side camera class no longer references client-only code.

### Testing
- Ran `git diff --check`, which passed without warnings. 
- Attempted `bash ./gradlew compileJava` but the Gradle wrapper download failed due to an external proxy returning `HTTP/1.1 403 Forbidden`, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f84851a208323bedcaafdc21f7ea1)