### PR TITLE
Add TextureOverlay item support and skinoverlays texture path

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -16,6 +16,8 @@ import mcheli.flare.MCH_Chaff;
 import mcheli.flare.MCH_Flare;
 import mcheli.flare.MCH_Maintenance;
 import mcheli.helicopter.MCH_EntityHeli;
+import mcheli.item.MCH_ItemInfo;
+import mcheli.item.MCH_ItemInfoManager;
 import mcheli.multiplay.MCH_Multiplay;
 import mcheli.parachute.MCH_EntityParachute;
 import mcheli.particles.MCH_ParticleParam;
@@ -4183,6 +4185,17 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
    }
 
+   public static String getSkinOverlayTextureName(String name) {
+      return name != null && name.startsWith("skinoverlays/") ? name : "skinoverlays/" + name;
+   }
+
+   public static String getTexturePath(String directory, String textureName) {
+      if(textureName != null && textureName.startsWith("skinoverlays/")) {
+         return "textures/" + textureName + ".png";
+      }
+      return "textures/" + directory + "/" + textureName + ".png";
+   }
+
    public MCH_EntityBaseVehicle setTextureName(String name) {
       if(name != null && !name.isEmpty()) {
          this.getDataWatcher().updateObject(21, String.valueOf(name));
@@ -6959,6 +6972,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             switchNextTextureName();
          }
          return this.rejectInteraction(player, "wrench_action");
+      }
+      if(itemStack != null) {
+         MCH_ItemInfo itemInfo = MCH_ItemInfoManager.get(itemStack.getItem());
+         if(itemInfo != null && itemInfo.textureOverlay) {
+            if(!this.worldObj.isRemote) {
+               this.setTextureName(getSkinOverlayTextureName(itemInfo.name));
+               if(!player.capabilities.isCreativeMode) {
+                  --itemStack.stackSize;
+                  if(itemStack.stackSize <= 0) {
+                     player.inventory.setInventorySlotContents(player.inventory.currentItem, (ItemStack)null);
+                  }
+               }
+            }
+            return true;
+         }
       }
       if(itemStack != null && itemStack.getItem() instanceof mcheli.mob.MCH_ItemSpawnGunner) {
          return this.rejectInteraction(player, "gunner_item");

--- a/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
@@ -32,7 +32,7 @@ public class MCH_RenderHeli extends MCH_RenderBaseVehicle {
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);
             GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
             GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
-            this.bindTexture("textures/helicopters/" + heli.getTextureName() + ".png", heli);
+            this.bindTexture(MCH_EntityBaseVehicle.getTexturePath("helicopters", heli.getTextureName()), heli);
             renderBody(heliInfo.model);
             this.drawModelBlade(heli, heliInfo, tickTime);
          }

--- a/src/main/java/mcheli/item/MCH_ItemInfo.java
+++ b/src/main/java/mcheli/item/MCH_ItemInfo.java
@@ -27,6 +27,7 @@ public class MCH_ItemInfo extends MCH_BaseInfo {
     public List recipe;
     public boolean isShapedRecipe;
     public int stackSize;
+    public boolean textureOverlay;
 
     public List<String> oreDictNames = new ArrayList<String>();
 
@@ -41,6 +42,7 @@ public class MCH_ItemInfo extends MCH_BaseInfo {
         this.recipe = new ArrayList();
         this.isShapedRecipe = true;
         this.stackSize = 1;
+        this.textureOverlay = false;
     }
 
     public void loadItemData(String item, String data) {
@@ -59,6 +61,9 @@ public class MCH_ItemInfo extends MCH_BaseInfo {
 
         } else if (item.equalsIgnoreCase("StackSize")) {
             this.stackSize = this.toInt(data, 1, 64);
+
+        } else if (item.equalsIgnoreCase("textureoverlay")) {
+            this.textureOverlay = this.toBool(data);
         //OREDICTS
         } else if (item.equalsIgnoreCase("oredict")) {
             this.oreDictNames.add(data.trim());

--- a/src/main/java/mcheli/plane/MCP_RenderPlane.java
+++ b/src/main/java/mcheli/plane/MCP_RenderPlane.java
@@ -33,7 +33,7 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
             GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
             GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
             try {
-            this.bindTexture("textures/planes/" + plane.getTextureName() + ".png", plane);
+            this.bindTexture(MCH_EntityBaseVehicle.getTexturePath("planes", plane.getTextureName()), plane);
             } catch (Exception var15) {
                System.out.println("Texture not found : " + plane.getTextureName());
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));

--- a/src/main/java/mcheli/ship/MCH_RenderShip.java
+++ b/src/main/java/mcheli/ship/MCH_RenderShip.java
@@ -29,7 +29,7 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
                 GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
                 GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
                 try {
-                    this.bindTexture("textures/ships/" + ship.getTextureName() + ".png",
+                    this.bindTexture(MCH_EntityBaseVehicle.getTexturePath("ships", ship.getTextureName()),
                                      ship);
                 } catch (Exception var15) {
                     System.out.println("Texture not found : " + ship.getTextureName());

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -37,7 +37,7 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
             GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
             GL11.glRotatef(roll, 0.0F, 0.0F, 1.0F);
             try {
-            this.bindTexture("textures/tanks/" + tank.getTextureName() + ".png", tank);
+            this.bindTexture(MCH_EntityBaseVehicle.getTexturePath("tanks", tank.getTextureName()), tank);
             } catch (Exception var15) {
                System.out.println("Texture not found : " + tank.getTextureName());
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -44,7 +44,7 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);
             GL11.glRotatef(pitch, 1.0F, 0.0F, 0.0F);
             try {
-            this.bindTexture("textures/" + turretInfo.getDirectoryName() + "/" + vehicle.getTextureName() + ".png", vehicle);
+            this.bindTexture(MCH_EntityBaseVehicle.getTexturePath(turretInfo.getDirectoryName(), vehicle.getTextureName()), vehicle);
             } catch (Exception var15) {
                System.out.println("Texture not found : " + vehicle.getTextureName());
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));


### PR DESCRIPTION
### Motivation
- Provide a way for simple item configs to act as texture overlays so players can apply skins from a dedicated folder to vehicles by clicking them. 
- Keep existing vehicle texture resolution unchanged while allowing overlay textures to be sourced from a new `skinoverlays` directory. 
- Consume one overlay item when applied (except in creative) to behave like a single-use skin applicator.

### Description
- Added a new boolean flag `textureOverlay` to item metadata and parsed `textureoverlay` in `MCH_ItemInfo.loadItemData` so items can be configured with `TextureOverlay = true` (file: `src/main/java/mcheli/item/MCH_ItemInfo.java`).
- Added helper functions `getSkinOverlayTextureName` and `getTexturePath` to `MCH_EntityBaseVehicle` to resolve overlay textures from `textures/skinoverlays/<name>.png` while preserving existing per-vehicle folder paths (file: `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`).
- Hooked vehicle interaction in `MCH_EntityBaseVehicle.interactFirst` to detect `TextureOverlay` items via `MCH_ItemInfoManager.get`, set the vehicle texture to the overlay name and decrement the item stack (skip consumption in creative) (file: `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`).
- Updated all vehicle renderers so they use the shared texture-path helper (`getTexturePath`) to support overlay textures: tank, heli, plane, ship and turret renderers were changed to call `MCH_EntityBaseVehicle.getTexturePath(...)` instead of hardcoded folder paths (files: `src/main/java/mcheli/tank/MCH_RenderTank.java`, `src/main/java/mcheli/helicopter/MCH_RenderHeli.java`, `src/main/java/mcheli/plane/MCP_RenderPlane.java`, `src/main/java/mcheli/ship/MCH_RenderShip.java`, `src/main/java/mcheli/vehicle/MCH_RenderTurret.java`).

### Testing
- Ran `git diff --check`, which reported no whitespace/patch errors and completed successfully. 
- Attempted to compile with the Gradle wrapper using `./gradlew compileJava`, but the wrapper is not executable in this environment so it could not be run. 
- Attempted to run `bash gradlew compileJava` and `gradle compileJava`; the build failed due to remote dependency resolution for ForgeGradle returning HTTP 403 (repository/network restrictions), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a444324449883238bb33fb06f18d5d8)