### PR TITLE
Fix guided torpedo spawning and raycast fallback target

### DIFF
--- a/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
@@ -5,7 +5,6 @@ import mcheli.weapon.MCH_EntityTorpedo;
 import mcheli.weapon.MCH_WeaponBase;
 import mcheli.weapon.MCH_WeaponInfo;
 import mcheli.weapon.MCH_WeaponParam;
-import mcheli.wrapper.W_MovingObjectPosition;
 import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
@@ -59,12 +58,15 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
    protected boolean shotGuided(MCH_WeaponParam prm) {
       float yaw = prm.user.rotationYaw;
       float pitch = prm.user.rotationPitch;
-      //wtf is wrong with ts why doesn't it want to fire unless you're like looking at a block wtf
       Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -prm.rotRoll);
       double tX = v.xCoord;
       double tZ = v.zCoord;
       double tY = v.yCoord;
       double dist = (double)MathHelper.sqrt_double(tX * tX + tY * tY + tZ * tZ);
+      if(dist < 0.001D) {
+         return false;
+      }
+
       if(super.worldObj.isRemote) {
          tX = tX * 100.0D / dist;
          tY = tY * 100.0D / dist;
@@ -78,35 +80,39 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
       Vec3 src = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX, prm.user.posY, prm.user.posZ);
       Vec3 dst = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX + tX, prm.user.posY + tY, prm.user.posZ + tZ);
       MovingObjectPosition m = W_WorldFunc.clip(super.worldObj, src, dst);
-      //wont fire unless you're looking at a block which is fucking retarded, like why the fuck would I want a guided torpedo to not fire while not looking at a block wtf
-      //who's the retarded fucking crack head that wrote this shit
-      //if(m != null && W_MovingObjectPosition.isHitTypeTile(m) && MCH_Lib.isBlockInWater(super.worldObj, m.blockX, m.blockY, m.blockZ)) {
-         if(!super.worldObj.isRemote) {
-            double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
-            double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
-            double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-            mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
-            my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
-            mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
-            super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
-            MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ, yaw, 0.0F, (double)super.acceleration);
-            e.setName(super.name);
-            e.setParameterFromWeapon(this, prm.entity, prm.user);
-            e.targetPosX = m.hitVec.xCoord;
-            e.targetPosY = m.hitVec.yCoord;
-            e.targetPosZ = m.hitVec.zCoord;
-            e.motionX = mx;
-            e.motionY = my;
-            e.motionZ = mz;
-            e.accelerationInWater = this.getInfo() != null?(double)this.getInfo().accelerationInWater:1.0D;
-            super.worldObj.spawnEntityInWorld(e);
-            this.playSound(prm.entity);
+
+      if(!super.worldObj.isRemote) {
+         double targetX = dst.xCoord;
+         double targetY = dst.yCoord;
+         double targetZ = dst.zCoord;
+
+         if(m != null && m.hitVec != null) {
+            targetX = m.hitVec.xCoord;
+            targetY = m.hitVec.yCoord;
+            targetZ = m.hitVec.zCoord;
          }
 
-         return true;
-      //}
-      //else {
-      //   return false;
-      //}
+         double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
+         double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
+         double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
+         mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
+         my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
+         mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
+         super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
+         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ, yaw, 0.0F, (double)super.acceleration);
+         e.setName(super.name);
+         e.setParameterFromWeapon(this, prm.entity, prm.user);
+         e.targetPosX = targetX;
+         e.targetPosY = targetY;
+         e.targetPosZ = targetZ;
+         e.motionX = mx;
+         e.motionY = my;
+         e.motionZ = mz;
+         e.accelerationInWater = this.getInfo() != null?(double)this.getInfo().accelerationInWater:1.0D;
+         super.worldObj.spawnEntityInWorld(e);
+         this.playSound(prm.entity);
+      }
+
+      return true;
    }
 }


### PR DESCRIPTION
### Motivation
- Guided torpedoes could crash or not spawn when the player fired without a valid raycast hit because the code dereferenced a missing hit vector. 
- The intent is to allow guided torpedoes to be fired even when the aim ray doesn't hit a block by falling back to the ray end as the target and to avoid zero-length direction vectors.

### Description
- Added a zero-length guard for the guidance vector returned by `MCH_Lib.RotVec3` to return `false` early when the direction is effectively zero. 
- Use the ray end (`dst`) as a fallback target position and only override it with `m.hitVec` when a raycast hit exists, instead of dereferencing `m` unconditionally in `shotGuided` in `src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java`.
- Restructured the spawning block so the torpedo entity always receives a resolved `targetPosX/Y/Z` (ray-end or hit position) before `spawnEntityInWorld` and preserved existing motion/acceleration logic. 
- Removed reliance on the commented-out block-gated firing path and cleaned up an unused import.

### Testing
- Ran `git diff --check` which returned clean results. 
- Attempted `./gradlew compileJava` to compile the change, but the Gradle wrapper failed to download the distribution due to a network/proxy error (`HTTP 403`), so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47221356b88323b208d43dbc3ce156)