### PR TITLE
Fix guided torpedo behavior and simplify guided launch/target selection

### DIFF
--- a/src/main/java/mcheli/weapon/MCH_EntityTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityTorpedo.java
@@ -61,23 +61,19 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
    }
 
    private void onUpdateGuided() {
-      if(!super.worldObj.isRemote && this.isInWater()) {
+      if(!this.isInWater()) {
+         this.onUpdateNoGuided();
+         return;
+      }
+
+      if(!super.worldObj.isRemote) {
          if(this.isInvalidTorpedoTarget(super.targetEntity)) {
             this.setTargetEntity(this.findTorpedoTarget());
          }
 
-         double tx;
-         double ty;
-         double tz;
-
-         if(super.targetEntity != null) {
-            tx = super.targetEntity.posX;
-            ty = this.getGuidanceDepth(super.targetEntity);
-            tz = super.targetEntity.posZ;
-         } else {
-            tx = this.targetPosX;
-            ty = Math.min(this.targetPosY, this.getGuidanceDepth((Entity)null));
-            tz = this.targetPosZ;
+         if(super.targetEntity == null) {
+            this.onUpdateNoGuided();
+            return;
          }
 
          if(super.acceleration < this.accelerationInWater) {
@@ -86,9 +82,9 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
             super.acceleration -= 0.1D;
          }
 
-         double dx = tx - super.posX;
-         double dy = ty - super.posY;
-         double dz = tz - super.posZ;
+         double dx = super.targetEntity.posX - super.posX;
+         double dy = this.getGuidanceDepth(super.targetEntity) - super.posY;
+         double dz = super.targetEntity.posZ - super.posZ;
          double d = MathHelper.sqrt_double(dx * dx + dy * dy + dz * dz);
 
          if(d > 0.001D) {
@@ -101,13 +97,11 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
          }
       }
 
-      if(this.isInWater()) {
-         double yaw = (double)((float)Math.atan2(super.motionZ, super.motionX));
-         super.rotationYaw = (float)(yaw * 180.0D / Math.PI) - 90.0F;
+      double yaw = (double)((float)Math.atan2(super.motionZ, super.motionX));
+      super.rotationYaw = (float)(yaw * 180.0D / Math.PI) - 90.0F;
 
-         double h = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
-         super.rotationPitch = -((float)(Math.atan2(super.motionY, h) * 180.0D / Math.PI));
-      }
+      double h = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
+      super.rotationPitch = -((float)(Math.atan2(super.motionY, h) * 180.0D / Math.PI));
    }
 
    private Entity findTorpedoTarget() {
@@ -132,18 +126,6 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
          double dy = e.posY - super.posY;
          double dz = e.posZ - super.posZ;
          double distSq = dx * dx + dy * dy + dz * dz;
-
-         // Front-cone check so torpedoes do not instantly 180-degree lock.
-         double motionLen = Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY + super.motionZ * super.motionZ);
-         double targetLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-         if(motionLen > 0.001D && targetLen > 0.001D) {
-            double dot = (super.motionX * dx + super.motionY * dy + super.motionZ * dz) / (motionLen * targetLen);
-
-            if(dot < 0.25D) {
-               continue;
-            }
-         }
 
          if(distSq < bestScore) {
             bestScore = distSq;

--- a/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
@@ -1,14 +1,11 @@
 package mcheli.weapon;
 
-import mcheli.MCH_Lib;
 import mcheli.weapon.MCH_EntityTorpedo;
 import mcheli.weapon.MCH_WeaponBase;
 import mcheli.weapon.MCH_WeaponInfo;
 import mcheli.weapon.MCH_WeaponParam;
-import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.MathHelper;
-import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -57,42 +54,11 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
    }
 
    protected boolean shotGuided(MCH_WeaponParam prm) {
-      float yaw = prm.user.rotationYaw;
-      float pitch = prm.user.rotationPitch;
-      Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -prm.rotRoll);
-      double tX = v.xCoord;
-      double tZ = v.zCoord;
-      double tY = v.yCoord;
-      double dist = (double)MathHelper.sqrt_double(tX * tX + tY * tY + tZ * tZ);
-      if(dist < 0.001D) {
-         return false;
-      }
-
       if(super.worldObj.isRemote) {
-         tX = tX * 100.0D / dist;
-         tY = tY * 100.0D / dist;
-         tZ = tZ * 100.0D / dist;
+         return true;
       } else {
-         tX = tX * 150.0D / dist;
-         tY = tY * 150.0D / dist;
-         tZ = tZ * 150.0D / dist;
-      }
-
-      Vec3 src = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX, prm.user.posY, prm.user.posZ);
-      Vec3 dst = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX + tX, prm.user.posY + tY, prm.user.posZ + tZ);
-      MovingObjectPosition m = W_WorldFunc.clip(super.worldObj, src, dst);
-
-      if(!super.worldObj.isRemote) {
-         double targetX = dst.xCoord;
-         double targetY = dst.yCoord;
-         double targetZ = dst.zCoord;
-
-         if(m != null && m.hitVec != null) {
-            targetX = m.hitVec.xCoord;
-            targetY = m.hitVec.yCoord;
-            targetZ = m.hitVec.zCoord;
-         }
-
+         float yaw = prm.rotYaw;
+         float pitch = prm.rotPitch;
          double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
          double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
          double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
@@ -100,14 +66,11 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
          my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
          mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
          super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
-         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ, yaw, 0.0F, (double)super.acceleration);
+         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, 0.0F, (double)super.acceleration);
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
-         e.targetPosX = targetX;
-         e.targetPosY = targetY;
-         e.targetPosZ = targetZ;
          Entity tgtEnt = prm.user != null ? prm.user.worldObj.getEntityByID(prm.option1) : null;
-         if(tgtEnt != null && !tgtEnt.isDead && tgtEnt != prm.entity && tgtEnt != prm.user) {
+         if(tgtEnt != null && !tgtEnt.isDead && tgtEnt != prm.entity && tgtEnt != prm.user && tgtEnt.isInWater()) {
             e.setTargetEntity(tgtEnt);
          }
          e.motionX = mx;
@@ -116,8 +79,7 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
          e.accelerationInWater = this.getInfo() != null?(double)this.getInfo().accelerationInWater:1.0D;
          super.worldObj.spawnEntityInWorld(e);
          this.playSound(prm.entity);
+         return true;
       }
-
-      return true;
    }
 }


### PR DESCRIPTION
### Motivation
- Ensure guided torpedoes behave correctly when not submerged and avoid invalid or airborne targets, while simplifying launch and targeting logic for maintainability.

### Description
- In `MCH_EntityTorpedo.onUpdateGuided()` return to the non-guided update when the torpedo is not in water, require a valid `targetEntity` before guided logic proceeds, and always update rotation calculations outside the water-check.
- Use the `targetEntity` position directly for guidance and clamp vertical motion with `clamp(...)`, removing the old `targetPosX/Y/Z` fallback logic.
- Simplify `findTorpedoTarget()` by removing the front-cone dot-product check so the nearest valid in-water target is chosen, and keep existing invalid-target checks in `isInvalidTorpedoTarget()`.
- In `MCH_WeaponTorpedo.shotGuided()` remove the previous raytrace/clip calculations and compute the guided launch vector using the weapon/weapon-info acceleration (`mx,my,mz`), only set `targetEntity` if `tgtEnt.isInWater()`, and clean up unused imports.

### Testing
- Built the project with `./gradlew build` and the build completed successfully.
- Ran `./gradlew test` and automated tests (if present) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a472e8007408323a68199b72cf37898)