### PR TITLE
Use TV guidance for guided torpedoes

### DIFF
--- a/src/main/java/mcheli/weapon/MCH_EntityTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityTorpedo.java
@@ -1,19 +1,16 @@
 package mcheli.weapon;
 
-import net.minecraft.entity.Entity;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
+import net.minecraft.block.material.Material;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-import java.util.List;
-
-public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
+public class MCH_EntityTorpedo extends MCH_EntityTvMissile {
 
    public double targetPosX;
    public double targetPosY;
    public double targetPosZ;
    public double accelerationInWater = 2.0D;
-
-   private Entity homingTarget;
 
 
    public MCH_EntityTorpedo(World par1World) {
@@ -21,6 +18,13 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
       this.targetPosX = 0.0D;
       this.targetPosY = 0.0D;
       this.targetPosZ = 0.0D;
+      this.isSpawnParticle = false;
+   }
+
+   public void onUpdateMotion() {
+      // Guided torpedoes intentionally apply the TV-missile steering from
+      // onUpdateGuided() only while submerged, so the inherited TV missile
+      // update cannot steer them through air or out of the water.
    }
 
    public void onUpdate() {
@@ -65,23 +69,7 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
 
    private void onUpdateGuided() {
       if(!super.worldObj.isRemote && this.isInWater()) {
-         if(this.homingTarget == null || this.homingTarget.isDead || !this.homingTarget.isInWater()) {
-            this.homingTarget = this.findTorpedoTarget();
-         }
-
-         double tx;
-         double ty;
-         double tz;
-
-         if(this.homingTarget != null) {
-            tx = this.homingTarget.posX;
-            ty = this.homingTarget.posY + this.homingTarget.height * 0.5D;
-            tz = this.homingTarget.posZ;
-         } else {
-            tx = this.targetPosX;
-            ty = this.targetPosY;
-            tz = this.targetPosZ;
-         }
+         this.applyTvGuidanceInWater();
 
          if(super.acceleration < this.accelerationInWater) {
             super.acceleration += 0.1D;
@@ -89,16 +77,14 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
             super.acceleration -= 0.1D;
          }
 
-         double dx = tx - super.posX;
-         double dy = ty - super.posY;
-         double dz = tz - super.posZ;
-         double d = MathHelper.sqrt_double(dx * dx + dy * dy + dz * dz);
-
+         double d = MathHelper.sqrt_double(super.motionX * super.motionX + super.motionY * super.motionY + super.motionZ * super.motionZ);
          if(d > 0.001D) {
-            super.motionX = dx * super.acceleration / d;
-            super.motionY = dy * super.acceleration / d;
-            super.motionZ = dz * super.acceleration / d;
+            super.motionX = super.motionX * super.acceleration / d;
+            super.motionY = super.motionY * super.acceleration / d;
+            super.motionZ = super.motionZ * super.acceleration / d;
          }
+
+         this.keepGuidedTorpedoInWater();
       }
 
       if(this.isInWater()) {
@@ -110,60 +96,47 @@ public class MCH_EntityTorpedo extends MCH_EntityBaseBullet {
       }
    }
 
-   private Entity findTorpedoTarget() {
-      double range = 96.0D;
-
-      List list = super.worldObj.getEntitiesWithinAABBExcludingEntity(
-              this,
-              super.boundingBox.expand(range, range * 0.5D, range)
-      );
-
-      Entity best = null;
-      double bestScore = Double.MAX_VALUE;
-
-      for(int i = 0; i < list.size(); ++i) {
-         Entity e = (Entity)list.get(i);
-
-         if(e == null || e.isDead || e == super.shootingEntity) {
-            continue;
-         }
-
-         if(!e.isInWater()) {
-            continue;
-         }
-
-         if(!(e instanceof mcheli.ship.MCH_EntityShip) && !(e instanceof mcheli.aircraft.MCH_EntityBaseVehicle)) {
-            continue;
-         }
-
-         double dx = e.posX - super.posX;
-         double dy = e.posY - super.posY;
-         double dz = e.posZ - super.posZ;
-         double distSq = dx * dx + dy * dy + dz * dz;
-
-         // Front-cone check so torpedoes do not instantly 180-degree lock.
-         double motionLen = Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY + super.motionZ * super.motionZ);
-         double targetLen = Math.sqrt(dx * dx + dy * dy + dz * dz);
-
-         if(motionLen > 0.001D && targetLen > 0.001D) {
-            double dot = (super.motionX * dx + super.motionY * dy + super.motionZ * dz) / (motionLen * targetLen);
-
-            if(dot < 0.25D) {
-               continue;
-            }
-         }
-
-         if(distSq < bestScore) {
-            bestScore = distSq;
-            best = e;
-         }
+   private void applyTvGuidanceInWater() {
+      if(this.getInfo() == null || this.getInfo().laserGuidance) {
+         return;
       }
 
-      return best;
+      if(super.shootingEntity != null && !super.shootingEntity.isDead) {
+         MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(super.shootingEntity);
+         if(ac != null && ac.getTVMissile() == this) {
+            float yaw = super.shootingEntity.rotationYaw;
+            float pitch = super.shootingEntity.rotationPitch;
+            double tX = -MathHelper.sin(yaw / 180.0F * (float)Math.PI) * MathHelper.cos(pitch / 180.0F * (float)Math.PI);
+            double tZ = MathHelper.cos(yaw / 180.0F * (float)Math.PI) * MathHelper.cos(pitch / 180.0F * (float)Math.PI);
+            double tY = -MathHelper.sin(pitch / 180.0F * (float)Math.PI);
+            this.setMotion(tX, tY, tZ);
+            this.setRotation(yaw, pitch);
+         }
+      }
+   }
+
+   private void keepGuidedTorpedoInWater() {
+      if(!this.isWaterAt(super.posX + super.motionX, super.posY + super.motionY, super.posZ + super.motionZ)) {
+         super.motionY = Math.min(super.motionY, -0.05D);
+
+         if(!this.isWaterAt(super.posX + super.motionX, super.posY + super.motionY, super.posZ + super.motionZ)) {
+            super.motionX *= 0.25D;
+            super.motionZ *= 0.25D;
+         }
+      }
+   }
+
+   private boolean isWaterAt(double x, double y, double z) {
+      return super.worldObj.getBlock(
+              MathHelper.floor_double(x),
+              MathHelper.floor_double(y),
+              MathHelper.floor_double(z)
+      ).getMaterial() == Material.water;
    }
 
    public MCH_EntityTorpedo(World par1World, double posX, double posY, double posZ, double targetX, double targetY, double targetZ, float yaw, float pitch, double acceleration) {
       super(par1World, posX, posY, posZ, targetX, targetY, targetZ, yaw, pitch, acceleration);
+      this.isSpawnParticle = false;
    }
 
    public MCH_BulletModel getDefaultBulletModel() {

--- a/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
@@ -1,17 +1,16 @@
 package mcheli.weapon;
 
-import mcheli.MCH_Lib;
-import mcheli.weapon.MCH_EntityTorpedo;
-import mcheli.weapon.MCH_WeaponBase;
-import mcheli.weapon.MCH_WeaponInfo;
-import mcheli.weapon.MCH_WeaponParam;
-import mcheli.wrapper.W_WorldFunc;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.aircraft.MCH_PacketNotifyTVMissileEntity;
+import mcheli.wrapper.W_Entity;
 import net.minecraft.util.MathHelper;
-import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public class MCH_WeaponTorpedo extends MCH_WeaponBase {
+
+   protected MCH_EntityTorpedo lastShotGuidedTorpedo = null;
+   protected net.minecraft.entity.Entity lastShotEntity = null;
 
    public MCH_WeaponTorpedo(World w, Vec3 v, float yaw, float pitch, String nm, MCH_WeaponInfo wi) {
       super(w, v, yaw, pitch, nm, wi);
@@ -23,6 +22,28 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
          super.interval -= 10;
       }
 
+   }
+
+
+   public void update(int countWait) {
+      super.update(countWait);
+
+      if(!super.worldObj.isRemote) {
+         if(super.tick <= 9 && this.lastShotGuidedTorpedo != null && this.lastShotEntity != null) {
+            if(super.tick % 3 == 0 && !this.lastShotGuidedTorpedo.isDead && !this.lastShotEntity.isDead) {
+               MCH_PacketNotifyTVMissileEntity.send(W_Entity.getEntityId(this.lastShotEntity), W_Entity.getEntityId(this.lastShotGuidedTorpedo));
+            }
+
+            if(super.tick == 9) {
+               this.lastShotEntity = null;
+               this.lastShotGuidedTorpedo = null;
+            }
+         }
+
+         if(super.tick <= 2 && this.lastShotEntity instanceof MCH_EntityBaseVehicle) {
+            ((MCH_EntityBaseVehicle)this.lastShotEntity).setTVMissile(this.lastShotGuidedTorpedo);
+         }
+      }
    }
 
    public boolean shot(MCH_WeaponParam prm) {
@@ -56,63 +77,31 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
    }
 
    protected boolean shotGuided(MCH_WeaponParam prm) {
+      if(super.worldObj.isRemote) {
+         return true;
+      }
+
       float yaw = prm.user.rotationYaw;
       float pitch = prm.user.rotationPitch;
-      Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -prm.rotRoll);
-      double tX = v.xCoord;
-      double tZ = v.zCoord;
-      double tY = v.yCoord;
-      double dist = (double)MathHelper.sqrt_double(tX * tX + tY * tY + tZ * tZ);
-      if(dist < 0.001D) {
-         return false;
-      }
+      double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
+      double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
+      double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
+      mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
+      my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
+      mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
+      super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
 
-      if(super.worldObj.isRemote) {
-         tX = tX * 100.0D / dist;
-         tY = tY * 100.0D / dist;
-         tZ = tZ * 100.0D / dist;
-      } else {
-         tX = tX * 150.0D / dist;
-         tY = tY * 150.0D / dist;
-         tZ = tZ * 150.0D / dist;
-      }
-
-      Vec3 src = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX, prm.user.posY, prm.user.posZ);
-      Vec3 dst = W_WorldFunc.getWorldVec3(super.worldObj, prm.user.posX + tX, prm.user.posY + tY, prm.user.posZ + tZ);
-      MovingObjectPosition m = W_WorldFunc.clip(super.worldObj, src, dst);
-
-      if(!super.worldObj.isRemote) {
-         double targetX = dst.xCoord;
-         double targetY = dst.yCoord;
-         double targetZ = dst.zCoord;
-
-         if(m != null && m.hitVec != null) {
-            targetX = m.hitVec.xCoord;
-            targetY = m.hitVec.yCoord;
-            targetZ = m.hitVec.zCoord;
-         }
-
-         double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
-         double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
-         double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-         mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
-         my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
-         mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
-         super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
-         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ, yaw, 0.0F, (double)super.acceleration);
-         e.setName(super.name);
-         e.setParameterFromWeapon(this, prm.entity, prm.user);
-         e.targetPosX = targetX;
-         e.targetPosY = targetY;
-         e.targetPosZ = targetZ;
-         e.motionX = mx;
-         e.motionY = my;
-         e.motionZ = mz;
-         e.accelerationInWater = this.getInfo() != null?(double)this.getInfo().accelerationInWater:1.0D;
-         super.worldObj.spawnEntityInWorld(e);
-         this.playSound(prm.entity);
-      }
-
+      MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, pitch, (double)super.acceleration);
+      e.setName(super.name);
+      e.setParameterFromWeapon(this, prm.entity, prm.user);
+      e.motionX = mx;
+      e.motionY = my;
+      e.motionZ = mz;
+      e.accelerationInWater = this.getInfo() != null?(double)this.getInfo().accelerationInWater:1.0D;
+      this.lastShotEntity = prm.entity;
+      this.lastShotGuidedTorpedo = e;
+      super.worldObj.spawnEntityInWorld(e);
+      this.playSound(prm.entity);
       return true;
    }
 }


### PR DESCRIPTION
### Motivation
- Guided torpedo homing/target-selection was unreliable, so torpedoes should reuse the proven TV-missile steering path while enforcing water-only motion. 
- Ensure guided torpedoes integrate with existing TV-missile camera/packet plumbing so player control and HUD behavior work consistently.

### Description
- `MCH_EntityTorpedo` now extends `MCH_EntityTvMissile` and disables the inherited TV update in air by overriding `onUpdateMotion`, so steering is applied only while submerged. 
- Removed the old homing/target-search code and added `applyTvGuidanceInWater()`, `keepGuidedTorpedoInWater()` and `isWaterAt(...)` to apply TV-style steering while keeping the torpedo inside water. 
- Set `isSpawnParticle = false` for torpedoes and updated guided on-update logic to scale motion to `accelerationInWater`. 
- `MCH_WeaponTorpedo` now tracks the last guided torpedo (`lastShotGuidedTorpedo`) and its shooter (`lastShotEntity`), sends TV-missile notification packets during the initial ticks, and spawns torpedoes using the TV-like guided path instead of the previous raycast/target assignment logic.

### Testing
- Ran `git diff --check` to validate there are no whitespace/merge artifacts, which succeeded. 
- Attempted `bash ./gradlew compileJava` to compile the project, but the Gradle wrapper failed to download the distribution due to a network proxy returning `HTTP/1.1 403 Forbidden`, so compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a473c1cac3c83239c3533c2afe5234f)