### PR TITLE
Composite vehicle skin overlays over base textures to avoid overriding/invisible skins

### DIFF
--- a/src/main/java/mcheli/MCH_SkinOverlayTextureManager.java
+++ b/src/main/java/mcheli/MCH_SkinOverlayTextureManager.java
@@ -1,0 +1,61 @@
+package mcheli;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.util.ResourceLocation;
+
+public final class MCH_SkinOverlayTextureManager {
+   private static final Map CACHE = new HashMap();
+
+   private MCH_SkinOverlayTextureManager() {}
+
+   public static ResourceLocation getOrCreate(String basePath, String overlayPath) throws IOException {
+      String key = basePath + "|" + overlayPath;
+      ResourceLocation cached = (ResourceLocation)CACHE.get(key);
+      if(cached != null) {
+         return cached;
+      }
+
+      Minecraft mc = Minecraft.getMinecraft();
+      BufferedImage base = readImage(mc, new ResourceLocation("mcheli", basePath));
+      BufferedImage overlay = readImage(mc, new ResourceLocation("mcheli", overlayPath));
+      BufferedImage combined = new BufferedImage(base.getWidth(), base.getHeight(), BufferedImage.TYPE_INT_ARGB);
+      Graphics2D graphics = combined.createGraphics();
+      try {
+         graphics.drawImage(base, 0, 0, null);
+         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+         graphics.drawImage(overlay, 0, 0, base.getWidth(), base.getHeight(), null);
+      } finally {
+         graphics.dispose();
+      }
+
+      TextureManager textureManager = mc.getTextureManager();
+      ResourceLocation location = textureManager.getDynamicTextureLocation("mcheli_skin_overlay", new DynamicTexture(combined));
+      CACHE.put(key, location);
+      return location;
+   }
+
+   private static BufferedImage readImage(Minecraft mc, ResourceLocation location) throws IOException {
+      IResource resource = mc.getResourceManager().getResource(location);
+      InputStream stream = resource.getInputStream();
+      try {
+         BufferedImage image = ImageIO.read(stream);
+         if(image == null) {
+            throw new IOException("Unsupported image format: " + location);
+         }
+         return image;
+      } finally {
+         stream.close();
+      }
+   }
+}

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -4185,8 +4185,14 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
    }
 
-   public static String getSkinOverlayTextureName(String name) {
-      return name != null && name.startsWith("skinoverlays/") ? name : "skinoverlays/" + name;
+   public static String getSkinOverlayTextureName(String baseName, String overlayName) {
+      String overlay = overlayName != null && overlayName.startsWith("skinoverlays/") ? overlayName : "skinoverlays/" + overlayName;
+      String base = baseName;
+      int overlaySeparator = base != null ? base.indexOf("|skinoverlays/") : -1;
+      if(overlaySeparator >= 0) {
+         base = base.substring(0, overlaySeparator);
+      }
+      return (base != null && !base.isEmpty() && !base.startsWith("skinoverlays/") ? base : "") + "|" + overlay;
    }
 
    public static String getTexturePath(String directory, String textureName) {
@@ -4210,7 +4216,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void switchNextTextureName() {
       if(this.getAcInfo() != null) {
-         this.setTextureName(this.getAcInfo().getNextTextureName(this.getTextureName()));
+         String currentTexture = this.getTextureName();
+         int overlaySeparator = currentTexture != null ? currentTexture.indexOf("|skinoverlays/") : -1;
+         if(overlaySeparator >= 0) {
+            currentTexture = currentTexture.substring(0, overlaySeparator);
+         }
+         this.setTextureName(this.getAcInfo().getNextTextureName(currentTexture));
       }
 
    }
@@ -6977,7 +6988,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          MCH_ItemInfo itemInfo = MCH_ItemInfoManager.get(itemStack.getItem());
          if(itemInfo != null && itemInfo.textureOverlay) {
             if(!this.worldObj.isRemote) {
-               this.setTextureName(getSkinOverlayTextureName(itemInfo.name));
+               this.setTextureName(getSkinOverlayTextureName(this.getTextureName(), itemInfo.name));
                if(!player.capabilities.isCreativeMode) {
                   --itemStack.stackSize;
                   if(itemStack.stackSize <= 0) {

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -8,6 +8,7 @@ import mcheli.MCH_ClientEventHook;
 import mcheli.MCH_Config;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
+import mcheli.MCH_SkinOverlayTextureManager;
 import mcheli.flare.MCH_EntityChaff;
 import mcheli.flare.MCH_EntityFlare;
 import mcheli.gui.MCH_Gui;
@@ -300,8 +301,15 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          super.bindTexture(new ResourceLocation(W_MOD.DOMAIN, "textures/test.png"));
       }else {
          try {
-            super.bindTexture(new ResourceLocation(W_MOD.DOMAIN,
-                                                   path));
+            int overlaySeparator = path.indexOf("|skinoverlays/");
+            if(overlaySeparator >= 0) {
+               String basePath = path.substring(0, overlaySeparator) + ".png";
+               String overlayPath = "textures/" + path.substring(overlaySeparator + 1) + ".png";
+               super.bindTexture(MCH_SkinOverlayTextureManager.getOrCreate(basePath, overlayPath));
+            } else {
+               super.bindTexture(new ResourceLocation(W_MOD.DOMAIN,
+                                                      path));
+            }
          } catch (Exception var4) {
             System.out.println("Error loading texture: " + path + " (" + var4.getMessage() + ")"); //why the fuck is this happening
             super.bindTexture(new ResourceLocation(W_MOD.DOMAIN, "textures/test.png"));


### PR DESCRIPTION
### Motivation
- Skin overlay items currently replace the vehicle texture with the overlay file, causing full overrides or invisible skins when overlay sizes differ from base textures.
- Overlays must be composited on top of the vehicle's base texture and scaled to the base texture to preserve the underlying skin and visual fidelity.

### Description
- Added `MCH_SkinOverlayTextureManager` which loads the base texture and overlay, scales the overlay to the base size with nearest-neighbor interpolation, composites them into a `DynamicTexture`, and caches the result (`src/main/java/mcheli/MCH_SkinOverlayTextureManager.java`).
- Preserve the base skin when applying an overlay by encoding both base and overlay in the texture name via `getSkinOverlayTextureName(base, overlay)` and update overlay application to use `this.setTextureName(getSkinOverlayTextureName(this.getTextureName(), itemInfo.name))` (`src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`).
- Detect encoded overlay names in `bindTexture` and bind the composited dynamic texture using `MCH_SkinOverlayTextureManager.getOrCreate(...)` instead of binding the overlay file directly (`src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`).
- Ensure normal skin cycling with the wrench still works by stripping overlay metadata before calling `getNextTextureName` in `switchNextTextureName` (`src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`).

### Testing
- Attempted to run `bash ./gradlew compileJava` to validate compilation, but the Gradle wrapper download was blocked by the environment proxy (HTTP 403) and the compile could not complete.
- Performed local code edits and committed changes (`Fix vehicle skin overlay compositing`), no further automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ca43397c832397a15bda3bbabd54)