### PR TITLE
Fix distant LOD model and skin overlay rendering

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -319,15 +319,19 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    }
 
    private static void beginSkinOverlayRender(MCH_BaseVehicleInfo info, MCH_EntityBaseVehicle ac) {
+      beginSkinOverlayRender(info.getDirectoryName(), ac.getTextureName());
+   }
+
+   public static void beginSkinOverlayRender(String directory, String textureName) {
       activeSkinOverlayTexture = null;
       activeBaseTexture = null;
-      String overlayTextureName = getSkinOverlayTextureName(ac.getTextureName());
+      String overlayTextureName = getSkinOverlayTextureName(textureName);
       if(overlayTextureName != null && !overlayTextureName.isEmpty()) {
-         activeSkinOverlayTexture = new ResourceLocation(W_MOD.DOMAIN, MCH_EntityBaseVehicle.getTexturePath(info.getDirectoryName(), overlayTextureName));
+         activeSkinOverlayTexture = new ResourceLocation(W_MOD.DOMAIN, MCH_EntityBaseVehicle.getTexturePath(directory, overlayTextureName));
       }
    }
 
-   private static void endSkinOverlayRender() {
+   public static void endSkinOverlayRender() {
       activeSkinOverlayTexture = null;
       activeBaseTexture = null;
    }
@@ -359,9 +363,14 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       void render();
    }
 
-   private static String getBaseTexturePath(String path) {
-      int overlaySeparator = path.indexOf("|skinoverlays/");
+   public static String getBaseTexturePath(String path) {
+      int overlaySeparator = path != null ? path.indexOf("|skinoverlays/") : -1;
       return overlaySeparator >= 0 ? path.substring(0, overlaySeparator) + ".png" : path;
+   }
+
+   public static String getBaseTextureName(String textureName) {
+      int overlaySeparator = textureName != null ? textureName.indexOf("|skinoverlays/") : -1;
+      return overlaySeparator >= 0 ? textureName.substring(0, overlaySeparator) : textureName;
    }
 
    private static String getSkinOverlayTextureName(String textureName) {
@@ -578,6 +587,18 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          renderSkinOverlayPass(new RenderRunnable() {
             public void render() {
                renderBodyModel(model);
+            }
+         });
+      }
+
+   }
+
+   public static void renderAllModel(final IModelCustom model) {
+      if(model != null) {
+         model.renderAll();
+         renderSkinOverlayPass(new RenderRunnable() {
+            public void render() {
+               model.renderAll();
             }
          });
       }

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -152,9 +152,15 @@ public final class MCH_VehicleLODManager {
             GL11.glRotatef(interpolateAngle(display.previousPitch, display.pitch, interpolation), 1.0F, 0.0F, 0.0F);
             GL11.glRotatef(interpolateAngle(display.previousRoll, display.roll, interpolation), 0.0F, 0.0F, 1.0F);
             GL11.glScalef(display.scale, display.scale, display.scale);
-            Minecraft.getMinecraft().renderEngine.bindTexture(
-                new ResourceLocation(W_MOD.DOMAIN, "textures/" + textureFolder + "/" + display.textureName + ".png"));
-            MCH_RenderBaseVehicle.renderBody(info.model);
+            MCH_RenderBaseVehicle.beginSkinOverlayRender(textureFolder, display.textureName);
+            try {
+                Minecraft.getMinecraft().renderEngine.bindTexture(
+                    new ResourceLocation(W_MOD.DOMAIN, "textures/" + textureFolder + "/"
+                        + MCH_RenderBaseVehicle.getBaseTextureName(display.textureName) + ".png"));
+                MCH_RenderBaseVehicle.renderAllModel(info.model);
+            } finally {
+                MCH_RenderBaseVehicle.endSkinOverlayRender();
+            }
         } finally {
             GL11.glPopMatrix();
             RENDER_STATE.end();


### PR DESCRIPTION
### Motivation
- Distant LOD snapshots were rendering only the model `$body` helper, producing incomplete silhouettes at range. 
- The new skinoverlay feature produced missing or incorrect overlay textures when used by non-entity render paths (LODs). 
- Provide a small, reusable API so LOD rendering can reuse the same base+overlay texture pipeline used by entity renderers.

### Description
- Added public skin-overlay setup/teardown API and overload: `beginSkinOverlayRender(String directory, String textureName)` and `endSkinOverlayRender()`, and made overlay helpers null-safe so non-entity renderers can initialize overlays correctly. 
- Introduced `getBaseTextureName(String)` (and made `getBaseTexturePath` null-safe) to strip `|skinoverlays/...` from texture names for the base texture binding. 
- Added `renderAllModel(IModelCustom)` which renders the full model and applies the skin-overlay pass, so LOD code can draw the complete model instead of `$body` only. 
- Updated `MCH_VehicleLODManager` to use the new API: it now calls `beginSkinOverlayRender(...)`, binds the stripped base texture, calls `renderAllModel(...)`, and ensures `endSkinOverlayRender()` runs in a `finally` block to clean up render state.

### Testing
- Ran `git diff --check` and local repository checks (no style/whitespace issues reported). 
- Attempted to run `./gradlew compileJava` to verify compilation, but the Gradle wrapper download failed due to an external proxy returning `HTTP/1.1 403 Forbidden`, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49dd8d562083239d62fbaa7db24700)