### PR TITLE
Use oriented vehicle boxes for projectile hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Converted extra vehicle bounding-box projectile hit processing to use vehicle-rotated oriented boxes while preserving existing damage-factor armor behavior.
+
 ### Documentation
 
 - Rewrote `README.md` with a modern project overview, feature list, installation steps, compatibility/client-server requirements, configuration overview, command examples, troubleshooting, FAQ, and confirmed resource links.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -80,7 +80,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 **How it differs from original MCHeli:** The ship entity now searches for players standing on its calculated deck surfaces, rotates their relative position with ship yaw changes, and adjusts vertical placement to prevent one-tick freezing or clipping when water bobbing moves the deck.
 
-**Configuration:** Pack makers create useful deck surfaces with normal body dimensions plus `BoundingBox` entries. Large ships should define broad, flat extra boxes for decks and collision. `PreventWaterBobbing = true` can stabilize ship vertical movement for smoother walking and carrier operations.
+**Configuration:** Pack makers create useful deck surfaces with normal body dimensions plus `BoundingBox` entries. Extra boxes retain their configured damage factors and armor behavior, and projectile hit processing ray-traces them as vehicle-rotated oriented boxes instead of unrotated AABBs. Large ships should define broad, flat extra boxes for decks and collision. `PreventWaterBobbing = true` can stabilize ship vertical movement for smoother walking and carrier operations.
 
 ### Aircraft carrier and vehicle-on-vehicle interaction
 

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -74,7 +74,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `EntityHeight` | All | float | 1.0 | entity bounding height |
 | `EntityPitch` | All | float | 0.0 | rendered entity pitch offset |
 | `EntityRoll` | All | float | 0.0 | rendered entity roll offset |
-| `BoundingBox` | All | list | none | extra damage/collision box |
+| `BoundingBox` | All | list | none | extra damage/collision box; projectile hit processing uses the vehicle-rotated oriented box while retaining the same damage factor/armor behavior |
 | `SetWheelPos` | All | vec3 | family default wheel list | wheel contact point; repeatable |
 | `StepHeight` | All | float | 0.0 (intended plane/tank/ship helper returns 0.6 but is private) | block step height |
 | `maxhp` | All | int | 50 | health |

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -266,7 +266,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
 
       for(int i$ = 0; i$ < len$; ++i$) {
          MCH_BoundingBox bb = arr$[i$];
-         MovingObjectPosition mop2 = bb.boundingBox.calculateIntercept(v1, v2);
+         MovingObjectPosition mop2 = bb.calculateIntercept(v1, v2);
          if(mop2 != null) {
             double dist2 = v1.distanceTo(mop2.hitVec);
             if(dist2 < dist) {

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -1,7 +1,9 @@
 package mcheli.aircraft;
 
 import mcheli.MCH_Lib;
+import mcheli.wrapper.W_Vec3;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 
 public class MCH_BoundingBox {
@@ -18,6 +20,9 @@ public class MCH_BoundingBox {
    public Vec3 prevPos;
    public final float damegeFactor;
    public EnumBoundingBoxType boundingBoxType = EnumBoundingBoxType.DEFAULT;
+   private float lastYaw;
+   private float lastPitch;
+   private float lastRoll;
 
 
    public MCH_BoundingBox(double x, double y, double z, float w, float h, float df) {
@@ -36,14 +41,21 @@ public class MCH_BoundingBox {
 
 
    public MCH_BoundingBox copy() {
-      return new MCH_BoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      MCH_BoundingBox copy = new MCH_BoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      copy.boundingBoxType = this.boundingBoxType;
+      return copy;
    }
 
    public wheelBoundingBox copy2() {
-      return new wheelBoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      wheelBoundingBox copy = new wheelBoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      copy.boundingBoxType = this.boundingBoxType;
+      return copy;
    }
 
    public void updatePosition(double posX, double posY, double posZ, float yaw, float pitch, float roll) {
+      this.lastYaw = yaw;
+      this.lastPitch = pitch;
+      this.lastRoll = roll;
       Vec3 v = Vec3.createVectorHelper(this.offsetX, this.offsetY, this.offsetZ);
       this.rotatedOffset = MCH_Lib.RotVec3(v, -yaw, -pitch, -roll);
       float w = this.width;
@@ -59,5 +71,49 @@ public class MCH_BoundingBox {
       this.nowPos.zCoord = z;
       this.backupBoundingBox.setBB(this.boundingBox);
       this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+   }
+
+   public MovingObjectPosition calculateIntercept(Vec3 start, Vec3 end) {
+      Vec3 localStart = this.toLocal(start);
+      Vec3 localEnd = this.toLocal(end);
+      double dx = localEnd.xCoord - localStart.xCoord;
+      double dy = localEnd.yCoord - localStart.yCoord;
+      double dz = localEnd.zCoord - localStart.zCoord;
+      double halfWidth = (double)this.width / 2.0D;
+      double halfHeight = (double)this.height / 2.0D;
+      double[] interval = new double[] {0.0D, 1.0D};
+
+      if(!this.clipAxis(localStart.xCoord, dx, -halfWidth, halfWidth, interval)) return null;
+      if(!this.clipAxis(localStart.yCoord, dy, -halfHeight, halfHeight, interval)) return null;
+      if(!this.clipAxis(localStart.zCoord, dz, -halfWidth, halfWidth, interval)) return null;
+
+      Vec3 hit = start.addVector((end.xCoord - start.xCoord) * interval[0], (end.yCoord - start.yCoord) * interval[0], (end.zCoord - start.zCoord) * interval[0]);
+      return new MovingObjectPosition(0, 0, 0, 0, hit);
+   }
+
+   private Vec3 toLocal(Vec3 world) {
+      Vec3 relative = Vec3.createVectorHelper(world.xCoord - this.nowPos.xCoord, world.yCoord - this.nowPos.yCoord, world.zCoord - this.nowPos.zCoord);
+      relative.rotateAroundY(this.lastYaw / 180.0F * 3.1415927F);
+      relative.rotateAroundX(this.lastPitch / 180.0F * 3.1415927F);
+      W_Vec3.rotateAroundZ(this.lastRoll / 180.0F * 3.1415927F, relative);
+      return relative;
+   }
+
+   private boolean clipAxis(double start, double delta, double min, double max, double[] interval) {
+      if(Math.abs(delta) < 1.0E-7D) {
+         return start >= min && start <= max;
+      }
+
+      double t1 = (min - start) / delta;
+      double t2 = (max - start) / delta;
+      if(t1 > t2) {
+         double tmp = t1;
+         t1 = t2;
+         t2 = tmp;
+      }
+
+      if(t1 > interval[0]) interval[0] = t1;
+      if(t2 < interval[1]) interval[1] = t2;
+      return interval[0] <= interval[1];
    }
 }


### PR DESCRIPTION
### Motivation
- Projectile hit detection should respect vehicle orientation so tank/ship/plane extra boxes register hits in the correct rotated locations while keeping existing armor/damage behavior.
- Runtime copies of configured AABB boxes must continue to carry the same damage factors and bounding-box type metadata so armor logic is unchanged.

### Description
- Added an oriented-box ray intersection method `calculateIntercept(Vec3 start, Vec3 end)` to `MCH_BoundingBox` that transforms rays into box-local space using the vehicle yaw/pitch/roll and clips against the rotated box extents. 
- Preserved `boundingBoxType` when copying configured boxes in `MCH_BoundingBox.copy()` and `copy2()` so runtime boxes keep the same damage/armor metadata. 
- Switched composite vehicle ray tracing to call `bb.calculateIntercept(...)` instead of the raw AABB path in `MCH_BaseVehicleBoundingBox` so projectile checks use oriented boxes. 
- Updated documentation entries in `docs/vehicle-config-reference.md` and `docs/overdrive-features.md` and added a changelog note in `CHANGELOG.md` describing the behavior change for `BoundingBox` entries.

### Testing
- Repository diff/style check (`git diff --check`) was executed and returned no errors. 
- No unit tests were available for the new code path in-tree, and no build/test run was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49eb893574832380249ab254537fe0)