### PR TITLE
Use OBBs for ship walkability instead of AABBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Use OBBs for ship walkability instead of using the AABBs
+
+- Changed ship moving-deck detection and carry anchors for extra bounding boxes to use the rotated OBB support surface instead of the legacy unrotated AABB.
+- Added reusable OBB deck helpers on `MCH_BoundingBox` for top-center, top-height, and entity-on-top checks.
+
+
 ## Unreleased
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MCHeli Overdrive+ is a combined-arms vehicle, weapon, and warfare framework for 
 
 ### Naval warfare
 
-- **Walkable moving ships:** large ships can use their collision/extra bounding boxes as moving deck surfaces, letting players stand on and move with ships.
+- **Walkable moving ships:** large ships can use their collision/rotated extra bounding-box OBBs as moving deck surfaces, letting players stand on and move with ships.
 - **Aircraft carrier operations:** carrier-style rack slots, `RideRack` compatibility, aircraft attachment/parking, launch assistance, and temporary launch no-collision grace support deck operations.
 - **Submarine behavior:** ship-based submarine mode supports diving, underwater ascend/descend controls, bounded vertical acceleration, depth-control HUD prompts, and normal ship behavior when diving is off.
 

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -74,7 +74,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 ### Walkable and moving ship decks
 
-**What it does:** Ships use their base and extra bounding boxes as deck surfaces. Players standing on a moving or turning ship are carried with the deck, receive small clearance corrections when the deck moves upward, keep grounded state, and have fall distance reset while standing on the surface.
+**What it does:** Ships use their base box and rotated extra bounding-box OBBs as deck surfaces. Players standing on a moving or turning ship are carried with the deck, receive small clearance corrections when the deck moves upward, keep grounded state, and have fall distance reset while standing on the surface.
 
 **Why it exists:** Original MCHeli did not provide a robust moving-deck experience for large ships. Overdrive makes ships more useful as mobile platforms instead of decorative or single-seat vehicles.
 

--- a/docs/vehicle-config/ships.md
+++ b/docs/vehicle-config/ships.md
@@ -20,7 +20,7 @@ Ships are an existing vehicle category in this codebase. They inherit shared key
 
 ## Overdrive naval, carrier, and submarine behavior
 
-Ships are more than static boats in Overdrive. Large ship configs can use `BoundingBox` entries as walkable deck surfaces: the ship entity detects players standing on the base box or extra boxes, carries them with ship movement/yaw changes, corrects small upward deck movements, and keeps fall distance reset while the player remains on the deck. Use broad, flat extra boxes for carrier decks and set `PreventWaterBobbing = true` when a stable carrier surface is more important than visible buoyancy.
+Ships are more than static boats in Overdrive. Large ship configs can use `BoundingBox` entries as walkable deck surfaces: the ship entity detects players standing on the base box or rotated extra-box OBBs, carries them with ship movement/yaw changes, corrects small upward deck movements, and keeps fall distance reset while the player remains on the deck. Use broad, flat extra boxes for carrier decks and set `PreventWaterBobbing = true` when a stable carrier surface is more important than visible buoyancy.
 
 Carrier and vehicle-on-vehicle behavior uses the shared rack system. Parent ships define compatible parking/launch slots with `AddRack`, and child aircraft or vehicles can opt into specific parent racks with `RideRack`. Ship racks launch carried aircraft with forward/vertical assist and temporary no-collision grace against the carrier; non-launch dismounts can fall back to parachute behavior when there is no safe surface below.
 

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -73,6 +73,29 @@ public class MCH_BoundingBox {
       this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
    }
 
+   public Vec3 getWorldTopCenter() {
+      Vec3 top = Vec3.createVectorHelper(0.0D, (double)this.height / 2.0D, 0.0D);
+      top = MCH_Lib.RotVec3(top, -this.lastYaw, -this.lastPitch, -this.lastRoll);
+      return Vec3.createVectorHelper(this.nowPos.xCoord + top.xCoord, this.nowPos.yCoord + top.yCoord, this.nowPos.zCoord + top.zCoord);
+   }
+
+   public boolean isEntityOnTop(AxisAlignedBB entityBox, double horizontalInset, double belowTolerance, double aboveTolerance) {
+      Vec3 feet = Vec3.createVectorHelper((entityBox.minX + entityBox.maxX) / 2.0D, entityBox.minY, (entityBox.minZ + entityBox.maxZ) / 2.0D);
+      Vec3 localFeet = this.toLocal(feet);
+      double halfWidth = (double)this.width / 2.0D;
+      double halfHeight = (double)this.height / 2.0D;
+      return localFeet.xCoord > -halfWidth + horizontalInset
+              && localFeet.xCoord < halfWidth - horizontalInset
+              && localFeet.zCoord > -halfWidth + horizontalInset
+              && localFeet.zCoord < halfWidth - horizontalInset
+              && localFeet.yCoord >= halfHeight - belowTolerance
+              && localFeet.yCoord <= halfHeight + aboveTolerance;
+   }
+
+   public double getTopSurfaceY() {
+      return this.getWorldTopCenter().yCoord;
+   }
+
    public MovingObjectPosition calculateIntercept(Vec3 start, Vec3 end) {
       Vec3 localStart = this.toLocal(start);
       Vec3 localEnd = this.toLocal(end);
@@ -91,7 +114,7 @@ public class MCH_BoundingBox {
       return new MovingObjectPosition(0, 0, 0, 0, hit);
    }
 
-   private Vec3 toLocal(Vec3 world) {
+   public Vec3 toLocal(Vec3 world) {
       Vec3 relative = Vec3.createVectorHelper(world.xCoord - this.nowPos.xCoord, world.yCoord - this.nowPos.yCoord, world.zCoord - this.nowPos.zCoord);
       relative.rotateAroundY(this.lastYaw / 180.0F * 3.1415927F);
       relative.rotateAroundX(this.lastPitch / 180.0F * 3.1415927F);

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -982,12 +982,12 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         public final double surfaceTopY;
         public final double surfaceCenterZ;
 
-        private DeckContact(Entity entity, int surfaceIndex, AxisAlignedBB surface) {
+        private DeckContact(Entity entity, int surfaceIndex, Vec3 surfaceCenter, double surfaceTopY) {
             this.entity = entity;
             this.surfaceIndex = surfaceIndex;
-            this.surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
-            this.surfaceTopY = surface.maxY;
-            this.surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
+            this.surfaceCenterX = surfaceCenter.xCoord;
+            this.surfaceTopY = surfaceTopY;
+            this.surfaceCenterZ = surfaceCenter.zCoord;
         }
     }
 
@@ -1004,7 +1004,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                     && entity.motionY < 0.3D && entity.boundingBox.intersectsWith(search)) {
                 int surfaceIndex = this.getDeckSurfaceIndex(entity.boundingBox);
                 if(surfaceIndex != Integer.MIN_VALUE) {
-                    standing.add(new DeckContact(entity, surfaceIndex, this.getDeckSurface(surfaceIndex)));
+                    standing.add(new DeckContact(entity, surfaceIndex, this.getDeckSurfaceCenter(surfaceIndex), this.getDeckSurfaceTopY(surfaceIndex)));
                 }
             }
         }
@@ -1026,10 +1026,11 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
         MCH_BoundingBox[] deckBoxes = this.getCalculatedExtraBoundingBoxes();
         for(int i = 0; i < deckBoxes.length; ++i) {
-            AxisAlignedBB deckBox = deckBoxes[i].boundingBox;
-            if(this.isOnTopOf(entityBox, deckBox) && deckBox.maxY > highestSurface) {
+            MCH_BoundingBox deckBox = deckBoxes[i];
+            double deckTopY = deckBox.getTopSurfaceY();
+            if(this.isOnTopOf(entityBox, deckBox) && deckTopY > highestSurface) {
                 surfaceIndex = i;
-                highestSurface = deckBox.maxY;
+                highestSurface = deckTopY;
             }
         }
         return surfaceIndex;
@@ -1047,9 +1048,25 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 && entityBox.minY <= deckBox.maxY + aboveTolerance;
     }
 
-    private AxisAlignedBB getDeckSurface(int surfaceIndex) {
-        return surfaceIndex < 0?super.boundingBox:this.getCalculatedExtraBoundingBoxes()[surfaceIndex].boundingBox;
+    private boolean isOnTopOf(AxisAlignedBB entityBox, MCH_BoundingBox deckBox) {
+        final double horizontalInset = 1.0E-4D;
+        final double aboveTolerance = 0.25D;
+        final double belowTolerance = 0.5D;
+        return deckBox.isEntityOnTop(entityBox, horizontalInset, belowTolerance, aboveTolerance);
     }
+
+    private Vec3 getDeckSurfaceCenter(int surfaceIndex) {
+        if(surfaceIndex < 0) {
+            return Vec3.createVectorHelper((super.boundingBox.minX + super.boundingBox.maxX) / 2.0D, super.boundingBox.maxY,
+                    (super.boundingBox.minZ + super.boundingBox.maxZ) / 2.0D);
+        }
+        return this.getCalculatedExtraBoundingBoxes()[surfaceIndex].getWorldTopCenter();
+    }
+
+    private double getDeckSurfaceTopY(int surfaceIndex) {
+        return surfaceIndex < 0?super.boundingBox.maxY:this.getCalculatedExtraBoundingBoxes()[surfaceIndex].getTopSurfaceY();
+    }
+
 
     private void finishDeckMovement(List<DeckContact> deckEntities, float oldYaw) {
         float yawChange = (float)MCH_Lib.getRotateDiff(oldYaw, this.getRotYaw());
@@ -1061,13 +1078,14 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         for(DeckContact contact : deckEntities) {
             Entity entity = contact.entity;
             if(!entity.isDead && entity.ridingEntity == null) {
-                AxisAlignedBB surface = this.getDeckSurface(contact.surfaceIndex);
                 double relativeX = entity.posX - contact.surfaceCenterX;
                 double relativeZ = entity.posZ - contact.surfaceCenterZ;
                 Vec3 rotated = MCH_Lib.RotVec3(relativeX, 0.0D, relativeZ, -yawChange, 0.0F);
-                double surfaceCenterX = (surface.minX + surface.maxX) / 2.0D;
-                double surfaceCenterZ = (surface.minZ + surface.maxZ) / 2.0D;
-                double deckDeltaY = surface.maxY - contact.surfaceTopY;
+                Vec3 surfaceCenter = this.getDeckSurfaceCenter(contact.surfaceIndex);
+                double surfaceCenterX = surfaceCenter.xCoord;
+                double surfaceCenterZ = surfaceCenter.zCoord;
+                double surfaceTopY = this.getDeckSurfaceTopY(contact.surfaceIndex);
+                double deckDeltaY = surfaceTopY - contact.surfaceTopY;
                 double carriedY = entity.posY + deckDeltaY;
 
                 // Carry by the measured deck delta, but never leave the feet
@@ -1078,8 +1096,8 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 if(deckDeltaY > 0.0D) {
                     final double deckClearance = 1.0E-4D;
                     double carriedMinY = entity.boundingBox.minY + deckDeltaY;
-                    if(carriedMinY < surface.maxY + deckClearance) {
-                        carriedY += surface.maxY + deckClearance - carriedMinY;
+                    if(carriedMinY < surfaceTopY + deckClearance) {
+                        carriedY += surfaceTopY + deckClearance - carriedMinY;
                     }
                 }
 


### PR DESCRIPTION
### Motivation

- Replace the legacy unrotated AABB-based deck detection with oriented bounding box (OBB) support so ship extra boxes behave correctly when rotated, improving walking/boarding accuracy on moving/turning ships. 
- Anchor carried players to the true rotated deck top (center and height) to prevent one-tick freeze/clipping and to preserve grounded state and fall-distance reset when decks move.

### Description

- Added OBB helper APIs to `MCH_BoundingBox` including `getWorldTopCenter()`, `getTopSurfaceY()`, and `isEntityOnTop(...)`, and exposed the local-space transform via `toLocal(...)` for reuse. 
- Updated `MCH_EntityShip` deck detection and carry logic to test extra boxes as rotated `MCH_BoundingBox` OBBs instead of their AxisAlignedBBs by using the new helpers, storing OBB top-center/top-Y in `DeckContact`, and anchoring player positions from the rotated top. 
- Kept base-box (ship hull) behavior unchanged while switching extra/extra-box handling to OBB-aware methods, and removed the now-unused AABB-based deck-surface accessor. 
- Updated documentation and changelog entries in `CHANGELOG.md`, `README.md`, `docs/overdrive-features.md`, and `docs/vehicle-config/ships.md` to describe the OBB-based deck surfaces.

### Testing

- Ran `git diff --check` to verify there are no whitespace/indexing issues, and it completed successfully. 
- No compile/build or runtime tests were executed in order to respect the instruction not to produce binary artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49f3d5401883238e261983c0b90a8a)