### PR TITLE
Fix smooth ship AABB deck collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Smooth ship AABB deck collision
+
+- Kept ship base AABB deck collision enabled while matching the extra OBB deck support path for upward water-bob transitions.
+- Added previous-top Y support for floating ship AABB decks so players remain smoothly carried instead of being pushed sideways or jittering when the ship rises.
+
 ## Keep remote ship OBB decks walkable
 
 - Expanded ship deck broad-phase searches with the full rotated corner extents of each extra OBB, so deck collision remains discoverable even when the walkable OBB is far from the ship origin.

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -52,9 +52,33 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
       boolean overlapsPerpendicularAxis = movingOnX
               ? other.maxZ > deck.minZ && other.minZ < deck.maxZ
               : other.maxX > deck.minX && other.minX < deck.maxX;
-      return overlapsPerpendicularAxis
-              && other.minY >= deck.maxY - bobTolerance
+      return overlapsPerpendicularAxis && this.isBaseDeckVerticalContact(deck, other, bobTolerance);
+   }
+
+   private boolean isBaseDeckVerticalContact(AxisAlignedBB deck, AxisAlignedBB other, double bobTolerance) {
+      return other.minY >= deck.maxY - bobTolerance
               && other.minY <= deck.maxY + bobTolerance;
+   }
+
+   private boolean isBaseDeckTopContact(AxisAlignedBB other, double bobTolerance) {
+      return other.maxX > super.minX + 1.0E-4D
+              && other.minX < super.maxX - 1.0E-4D
+              && other.maxZ > super.minZ + 1.0E-4D
+              && other.minZ < super.maxZ - 1.0E-4D
+              && this.isBaseDeckVerticalContact(this, other, bobTolerance);
+   }
+
+   private double getPreviousBaseTopSurfaceY() {
+      return super.maxY - (this.ac.posY - this.ac.prevPosY);
+   }
+
+   private double calculatePreviousBaseDeckYOffset(AxisAlignedBB other, double offset, double supportTolerance) {
+      if(offset >= 0.0D || !this.isBaseDeckTopContact(other, supportTolerance)) {
+         return offset;
+      }
+
+      double candidate = this.getPreviousBaseTopSurfaceY() - other.minY;
+      return candidate > offset ? candidate : offset;
    }
 
    private boolean isDeckTopContact(MCH_BoundingBox deck, AxisAlignedBB other) {
@@ -85,7 +109,12 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          return offset;
       }
 
+      double previousBaseTopY = this.getPreviousBaseTopSurfaceY();
       offset = super.calculateYOffset(other, offset);
+      if(this.ac.canFloatWater() && super.maxY > previousBaseTopY) {
+         offset = this.calculatePreviousBaseDeckYOffset(other, offset, 0.6D);
+      }
+
       for(MCH_BoundingBox bb : this.ac.getCalculatedExtraBoundingBoxes()) {
          final double supportTolerance = 0.6D;
          double previousTopY = bb.getPreviousTopSurfaceY();


### PR DESCRIPTION
### Motivation

- Players standing on ship decks jitter or get pushed sideways when a ship (base AABB) rises because the legacy AABB path did not match the OBB upward-bob smoothing used for extra rotated boxes.  The base AABB must remain walkable and provide the same smoothing behavior as extra OBB decks without disabling AABB-player collisions.

### Description

- Added AABB deck-top helper primitives in `MCH_BaseVehicleBoundingBox.java`: `isBaseDeckVerticalContact`, `isBaseDeckTopContact`, `getPreviousBaseTopSurfaceY`, and `calculatePreviousBaseDeckYOffset` to centralize base-AABB deck contact and previous-top logic.  
- Updated `isDeckTopContact(...)` and the AABB Y resolver (`calculateYOffset`) to apply a previous-top Y adjustment for the base AABB when `canFloatWater()` detects an upward bob transition, matching the OBB smoothing path used by extra rotated boxes.  
- Kept the existing OBB-support code path for extra `MCH_BoundingBox` objects and applied the same previous-top handling for the base AABB so walking/carry behavior is consistent across base and extra boxes.  
- Documented the fix in `CHANGELOG.md` under a new "Smooth ship AABB deck collision" entry.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it completed without error.  
- Verified repository status with `git status --short` to confirm the intended files were modified.  
- No build/compile tasks were executed to avoid producing or modifying binary artifacts per repository policy.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a1df5c8848323835ba5b06cdadb3c)