### PR TITLE
Disable AABB collisions for ships — use oriented OBBs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Disable ship AABBs entirely
+
+- Forced ship debug hit-box rendering to draw configured extra bounding boxes as OBBs, independent of the single-player OBB debug toggle.
+- Filtered ship entity collision damage against ship OBBs instead of applying broad-phase AABB hits from their enclosing search boxes.
+- Updated ship hit detection so ship extra bounding boxes use oriented-box intersection checks rather than their legacy axis-aligned boxes.
+
 ## Disable ship AABB collision
 
 - Disabled ship base AABB collision, ray hits, and broad-phase damage/pushback so ships no longer use the vanilla axis-aligned body box as a physical collision volume.

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -171,8 +171,8 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          MCH_BoundingBox bb = arr$[i$];
          //wheelBoundingBox wb = arr$[i$];
 
-         if(bb.boundingBox.intersectsWith(aabb)) {
-            double dist2 = this.getDistSq(aabb, bb.boundingBox);
+         if((this.isShip() ? bb.intersectsAABB(aabb) : bb.boundingBox.intersectsWith(aabb))) {
+            double dist2 = this.getDistSq(aabb, this.isShip() ? bb.getEnclosingAABB() : bb.boundingBox);
             if(dist2 < dist) {
                dist = dist2;
                this.ac.lastBBDamageFactor = bb.damegeFactor;

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -151,6 +151,60 @@ public class MCH_BoundingBox {
       return candidate > offset ? candidate : offset;
    }
 
+
+   public boolean intersectsAABB(AxisAlignedBB aabb) {
+      if(!this.getEnclosingAABB().intersectsWith(aabb)) {
+         return false;
+      }
+
+      double centerX = (aabb.minX + aabb.maxX) / 2.0D;
+      double centerY = (aabb.minY + aabb.maxY) / 2.0D;
+      double centerZ = (aabb.minZ + aabb.maxZ) / 2.0D;
+      if(this.containsWorldPoint(centerX, centerY, centerZ)) {
+         return true;
+      }
+
+      for(int x = 0; x <= 1; ++x) {
+         for(int y = 0; y <= 1; ++y) {
+            for(int z = 0; z <= 1; ++z) {
+               if(this.containsWorldPoint(x == 0 ? aabb.minX : aabb.maxX, y == 0 ? aabb.minY : aabb.maxY, z == 0 ? aabb.minZ : aabb.maxZ)) {
+                  return true;
+               }
+            }
+         }
+      }
+
+      double halfWidth = (double)this.width / 2.0D;
+      double halfHeight = (double)this.height / 2.0D;
+      for(int x = -1; x <= 1; x += 2) {
+         for(int y = -1; y <= 1; y += 2) {
+            for(int z = -1; z <= 1; z += 2) {
+               Vec3 corner = Vec3.createVectorHelper((double)x * halfWidth, (double)y * halfHeight, (double)z * halfWidth);
+               corner = MCH_Lib.RotVec3(corner, -this.lastYaw, -this.lastPitch, -this.lastRoll);
+               double worldX = this.nowPos.xCoord + corner.xCoord;
+               double worldY = this.nowPos.yCoord + corner.yCoord;
+               double worldZ = this.nowPos.zCoord + corner.zCoord;
+               if(worldX >= aabb.minX && worldX <= aabb.maxX
+                       && worldY >= aabb.minY && worldY <= aabb.maxY
+                       && worldZ >= aabb.minZ && worldZ <= aabb.maxZ) {
+                  return true;
+               }
+            }
+         }
+      }
+
+      return false;
+   }
+
+   private boolean containsWorldPoint(double x, double y, double z) {
+      Vec3 local = this.toLocal(Vec3.createVectorHelper(x, y, z));
+      double halfWidth = (double)this.width / 2.0D;
+      double halfHeight = (double)this.height / 2.0D;
+      return local.xCoord >= -halfWidth && local.xCoord <= halfWidth
+              && local.yCoord >= -halfHeight && local.yCoord <= halfHeight
+              && local.zCoord >= -halfWidth && local.zCoord <= halfWidth;
+   }
+
    public MovingObjectPosition calculateIntercept(Vec3 start, Vec3 end) {
       Vec3 localStart = this.toLocal(start);
       Vec3 localEnd = this.toLocal(end);

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_ClientEventHook;
 import mcheli.MCH_Config;
+import mcheli.ship.MCH_EntityShip;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
 import mcheli.flare.MCH_EntityChaff;
@@ -508,7 +509,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          GL11.glPopMatrix();
          GL11.glPushMatrix();
          GL11.glTranslated(x, y, z);
-         boolean drawObb = Minecraft.getMinecraft().isSingleplayer() && MCH_Config.DebugDrawOBB.prmBool;
+         boolean drawObb = e instanceof MCH_EntityShip || Minecraft.getMinecraft().isSingleplayer() && MCH_Config.DebugDrawOBB.prmBool;
          MCH_BoundingBox[] arr$ = e.getCalculatedExtraBoundingBoxes();
          int len$ = arr$.length;
 

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -1120,8 +1120,9 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         }
     }
 
-    private void collisionEntity(AxisAlignedBB bb) {
-        if (bb != null) {
+    private void collisionEntity(MCH_BoundingBox shipBox) {
+        if (shipBox != null) {
+            AxisAlignedBB bb = shipBox.getEnclosingAABB();
             // Calculate speed
             double speed = Math.sqrt(super.motionX * super.motionX + super.motionY * super.motionY + super.motionZ * super.motionZ);
 
@@ -1136,7 +1137,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                         ? ((MCH_EntitySeat) super.ridingEntity).getParent()
                         : null);
 
-                // Get a list of entities within the bounding box
+                // Get a broad-phase entity list from the OBB enclosure, then filter each hit by the ship OBB.
                 List<Entity> list = super.worldObj.getEntitiesWithinAABBExcludingEntity(this, bb.expand(0.3D, 0.3D, 0.3D), new IEntitySelector() {
                     @Override
                     public boolean isEntityApplicable(Entity e) {
@@ -1166,7 +1167,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
                 // Process each entity within the bounding box
                 for (Entity e : list) {
-                    if (this.shouldCollisionDamage(e)) {
+                    if (this.shouldCollisionDamage(e) && shipBox.intersectsAABB(e.boundingBox)) {
                         double dx = e.posX - super.posX;
                         double dz = e.posZ - super.posZ;
                         double dist = Math.sqrt(dx * dx + dz * dz);
@@ -1251,7 +1252,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 if(super.rand.nextInt(3) == 0) {
                     var10000 = MCH_MOD.config;
 
-                    this.collisionEntity(bb.boundingBox);
+                    this.collisionEntity(bb);
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Ships should not use axis-aligned body AABBs for collision/hit detection and pushback; only configured extra oriented bounding boxes (OBBs) must define ship collision and walkable decks.
- Preserve broad-phase efficiency while ensuring narrow-phase checks use the true rotated box geometry to avoid false-positive AABB hits and incorrect damage/pushback.

### Description
- Added an oriented intersection helper `intersectsAABB(AxisAlignedBB)` and a `containsWorldPoint(...)` helper on `MCH_BoundingBox` so rotated OBBs can be tested against an AABB broad-phase box before precise checks. (modified `src/main/java/mcheli/aircraft/MCH_BoundingBox.java`)
- Switched composite vehicle hit detection to test ship extra boxes using the new OBB intersection helper when the vehicle is a ship, and continue using legacy AABB checks for non-ship vehicles. (modified `src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java`)
- Reworked ship collision processing to accept an `MCH_BoundingBox` (OBB) for narrow-phase handling, use the box enclosure for the broad-phase entity query, and apply damage/pushback only when the ship OBB intersects the entity's AABB. (modified `src/main/java/mcheli/ship/MCH_EntityShip.java`)
- Forced ship debug hit-box rendering to show extra boxes as OBBs for ships independent of the single-player `DebugDrawOBB` toggle so ships no longer display legacy AABB-style debug boxes. (modified `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`)
- Documented the change in `CHANGELOG.md` to note that ships no longer expose base AABB collisions and that extra `BoundingBox` OBBs are now the authoritative collision volumes.

### Testing
- Ran `git diff --check` to validate whitespace and patch issues; it completed without errors.
- Searched the codebase with `rg` for affected patterns to verify updated callsites: `rg -n "bb\.boundingBox\.intersectsWith|collisionEntity\(bb\.boundingBox\)|DebugDrawOBB"` and confirmed the new helpers and ship-only checks are present; the search returned the updated files.
- No compilation or binary builds were executed per repository constraints; all checks were limited to static edits and repository searches and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a257583548323b4fb92033d9b61c0)