### PR TITLE
Fix ship-origin deck movement jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix ship-origin deck movement jitter
+
+- Prevented the ship composite deck search AABB from being used as a vanilla entity collision box, so players near the ship origin no longer collide with the broad-phase search volume while walking or jumping.
+- Kept ship walkability on the precise rotated extra bounding-box deck support path instead of reintroducing physical base/composite AABB collision.
+
 ## Disable ship AABBs entirely
 
 - Forced ship debug hit-box rendering to draw configured extra bounding boxes as OBBs, independent of the single-player OBB debug toggle.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -74,7 +74,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 ### Walkable and moving ship decks
 
-**What it does:** Ships use only rotated extra bounding-box OBBs as deck and physical collision surfaces; their base axis-aligned body box is not used for collision, ray hits, deck support, or damage/pushback broad-phase checks. The broad-phase deck search includes each extra OBB's rotated corner extents before the precise OBB top-contact check, so remote deck surfaces remain discoverable without reverting to a ship-origin AABB. Players standing on a moving or turning ship are detected and supported against those OBB deck tops, carried with the deck, receive small clearance corrections when the deck moves upward, keep grounded state, and have fall distance reset while standing on the surface.
+**What it does:** Ships use only rotated extra bounding-box OBBs as deck and physical collision surfaces; their base axis-aligned body box and composite deck search AABB are not used for vanilla entity collision, ray hits, deck support, or damage/pushback broad-phase checks. The broad-phase deck search includes each extra OBB's rotated corner extents before the precise OBB top-contact check, so remote deck surfaces remain discoverable without reverting to a ship-origin AABB. Players standing on a moving or turning ship are detected and supported against those OBB deck tops, carried with the deck, receive small clearance corrections when the deck moves upward, keep grounded state, and have fall distance reset while standing on the surface.
 
 **Why it exists:** Original MCHeli did not provide a robust moving-deck experience for large ships. Overdrive makes ships more useful as mobile platforms instead of decorative or single-seat vehicles.
 

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -977,6 +977,20 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
 
     @Override
+    public AxisAlignedBB getCollisionBox(Entity entity) {
+        // Ships expose a large composite deck search AABB so broad-phase entity
+        // lookups can discover remote OBB decks. That search volume must not be
+        // returned to vanilla entity movement as a physical collision box: near
+        // the ship origin, players can collide with the enclosing search AABB
+        // instead of the precise deck OBB, causing vertical jitter and horizontal
+        // movement cancellation while walking or jumping. Ship walkability is
+        // resolved by getEntitiesStandingOnDeck()/finishDeckMovement() and the
+        // OBB helpers below, so vanilla entity collision should ignore the ship
+        // itself.
+        return null;
+    }
+
+    @Override
     public AxisAlignedBB getBoundingBox() {
         if(this.getAcInfo() == null || super.extraBoundingBox == null || super.extraBoundingBox.length <= 0) {
             return AxisAlignedBB.getBoundingBox(super.posX, super.posY, super.posZ, super.posX, super.posY, super.posZ);


### PR DESCRIPTION
### Motivation
- Players were jittering upward/downward and losing horizontal movement when walking or jumping near a ship origin because the ship's composite deck search AABB was being treated as a vanilla entity collision box.
- The intent is to preserve precise rotated extra-bounding-box (OBB) deck support while preventing the broad-phase search volume from interfering with vanilla entity movement resolution.

### Description
- Added an override of `getCollisionBox(Entity)` in `src/main/java/mcheli/ship/MCH_EntityShip.java` to return `null`, so the composite deck search AABB is not exposed as a physical collision box to vanilla entity movement logic.
- Kept ship walking/carry behavior on the precise rotated extra bounding-box OBB path (`getEntitiesStandingOnDeck()` / `finishDeckMovement()`), so deck support, upward clearance corrections, and fall-distance resets are preserved.
- Updated `CHANGELOG.md` with a short entry summarizing the fix and clarified the behavior in `docs/overdrive-features.md` to note that the composite deck search AABB is not used for vanilla entity collision.

### Testing
- Ran `git diff --check` to validate whitespace and trivial diff issues, which completed without errors.
- No compile or runtime unit tests were executed in this change; behavior was limited to a focused entity-collision surface change and documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a284d6fb883238a035f7b857ebad0)