### PR TITLE
Fix ship bounding-box side collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix ship bounding-box side collision
+
+- Restored ship `BoundingBox` side collision by returning the composite vehicle collision resolver for ship entity collision checks.
+- Re-exposed the ship extra-box enclosure for broad-phase lookup so player movement can discover remote ship collision boxes while resolving against the precise configured boxes instead of the enclosing search volume.
+
 ## Fix ship-origin deck bounding-box jitter
 
 - Stopped returning the composite ship deck-search AABB from `MCH_EntityShip.getBoundingBox()` so vanilla player movement no longer treats the broad-phase deck search volume as a physical collision box near the ship origin.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MCHeli Overdrive+ is a combined-arms vehicle, weapon, and warfare framework for 
 
 ### Naval warfare
 
-- **Walkable moving ships:** large ships can use their collision/rotated extra bounding-box OBBs as moving deck surfaces, letting players stand on and move with ships.
+- **Walkable and solid moving ships:** large ships can use their collision/rotated extra bounding-box OBBs as moving deck surfaces and solid side walls, letting players stand on ships without walking through configured hull or wall boxes.
 - **Aircraft carrier operations:** carrier-style rack slots, `RideRack` compatibility, aircraft attachment/parking, launch assistance, and temporary launch no-collision grace support deck operations.
 - **Submarine behavior:** ship-based submarine mode supports diving, underwater ascend/descend controls, bounded vertical acceleration, depth-control HUD prompts, and normal ship behavior when diving is off.
 

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -978,29 +978,20 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
     @Override
     public AxisAlignedBB getCollisionBox(Entity entity) {
-        // Ships expose a large composite deck search AABB so broad-phase entity
-        // lookups can discover remote OBB decks. That search volume must not be
-        // returned to vanilla entity movement as a physical collision box: near
-        // the ship origin, players can collide with the enclosing search AABB
-        // instead of the precise deck OBB, causing vertical jitter and horizontal
-        // movement cancellation while walking or jumping. Ship walkability is
-        // resolved by getEntitiesStandingOnDeck()/finishDeckMovement() and the
-        // OBB helpers below, so vanilla entity collision should ignore the ship
-        // itself.
-        return null;
+        // Return the composite vehicle collision resolver, not the broad-phase
+        // search box itself. MCH_BaseVehicleBoundingBox resolves movement
+        // against each configured ship BoundingBox, giving their sides solid
+        // wall-like collision while preserving the precise deck-top support path.
+        return super.boundingBox;
     }
 
     @Override
     public AxisAlignedBB getBoundingBox() {
-        // Do not expose the composite deck-search volume as the ship entity's
-        // vanilla bounding box. Player movement adds other entities' bounding
-        // boxes before consulting getCollisionBox(), so returning the deck
-        // search AABB here still creates a physical wall/floor near the ship
-        // origin even when getCollisionBox() returns null. Keep vanilla entity
-        // collision effectively empty; ship deck carry and damage use the
-        // explicit OBB search helpers instead.
-        return AxisAlignedBB.getBoundingBox(super.posX, super.posY, super.posZ,
-                super.posX, super.posY, super.posZ);
+        // Expose the full extra-box enclosure for broad-phase entity lookups so
+        // vanilla movement can discover remote ship BoundingBoxes. Physical
+        // resolution is handled by getCollisionBox()'s composite resolver, which
+        // avoids treating this enclosing search volume as a solid block.
+        return this.getDeckSearchBox();
     }
 
     private static class DeckContact {


### PR DESCRIPTION
### Motivation

- Ships had their vanilla collision path disabled (returned `null` from `getCollisionBox()` and an empty point from `getBoundingBox()`), allowing players to walk through configured hull/wall boxes instead of colliding with them.  

### Description

- Restore ship-side collision by returning the entity bounding box in `MCH_EntityShip.getCollisionBox()` (which is the composite vehicle resolver set up by the vehicle base), so configured extra `BoundingBox` entries resolve as solid walls.  
- Re-expose the ship extra-box enclosure by returning `getDeckSearchBox()` from `MCH_EntityShip.getBoundingBox()` so broad-phase lookups can discover remote ship collision boxes while physical resolution remains precise.  
- Update `README.md` to document ships as walkable and solid moving ships and add a new `CHANGELOG.md` entry describing the fix.  

### Testing

- Ran `git diff --check` to validate the working tree and formatting, which succeeded.  
- Changes were committed and a pull request was created; no compilation or runtime test was executed per project instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a32036394832396e90a5bb8d31f84)