### PR TITLE
Restore ship side collision and prevent bounding-box collision jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Fix ship bounding-box collision jitter
+
+- Kept ship broad-phase lookup expanded to all configured extra boxes while returning the composite collision resolver, preventing the enclosing search AABB from becoming a physical jitter source during jumping, deck walking, or side contact.
+
+## Fix ship bounding-box side collision
+
+- Restored ship `BoundingBox` side collision by returning the composite vehicle collision resolver for ship entity collision checks.
+- Re-exposed the ship extra-box enclosure for broad-phase lookup so player movement can discover remote ship collision boxes while resolving against the precise configured boxes instead of the enclosing search volume.
+
 ## Fix ship-origin deck bounding-box jitter
 
 - Stopped returning the composite ship deck-search AABB from `MCH_EntityShip.getBoundingBox()` so vanilla player movement no longer treats the broad-phase deck search volume as a physical collision box near the ship origin.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MCHeli Overdrive+ is a combined-arms vehicle, weapon, and warfare framework for 
 
 ### Naval warfare
 
-- **Walkable moving ships:** large ships can use their collision/rotated extra bounding-box OBBs as moving deck surfaces, letting players stand on and move with ships.
+- **Walkable and solid moving ships:** large ships can use their collision/rotated extra bounding-box OBBs as moving deck surfaces and solid side walls, letting players stand on ships without walking through configured hull or wall boxes.
 - **Aircraft carrier operations:** carrier-style rack slots, `RideRack` compatibility, aircraft attachment/parking, launch assistance, and temporary launch no-collision grace support deck operations.
 - **Submarine behavior:** ship-based submarine mode supports diving, underwater ascend/descend controls, bounded vertical acceleration, depth-control HUD prompts, and normal ship behavior when diving is off.
 

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -978,29 +978,25 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
     @Override
     public AxisAlignedBB getCollisionBox(Entity entity) {
-        // Ships expose a large composite deck search AABB so broad-phase entity
-        // lookups can discover remote OBB decks. That search volume must not be
-        // returned to vanilla entity movement as a physical collision box: near
-        // the ship origin, players can collide with the enclosing search AABB
-        // instead of the precise deck OBB, causing vertical jitter and horizontal
-        // movement cancellation while walking or jumping. Ship walkability is
-        // resolved by getEntitiesStandingOnDeck()/finishDeckMovement() and the
-        // OBB helpers below, so vanilla entity collision should ignore the ship
-        // itself.
-        return null;
+        // Return the composite vehicle collision resolver, not the broad-phase
+        // search box itself. MCH_BaseVehicleBoundingBox resolves movement
+        // against each configured ship BoundingBox, giving their sides solid
+        // wall-like collision while preserving the precise deck-top support path.
+        return super.boundingBox;
     }
 
     @Override
     public AxisAlignedBB getBoundingBox() {
-        // Do not expose the composite deck-search volume as the ship entity's
-        // vanilla bounding box. Player movement adds other entities' bounding
-        // boxes before consulting getCollisionBox(), so returning the deck
-        // search AABB here still creates a physical wall/floor near the ship
-        // origin even when getCollisionBox() returns null. Keep vanilla entity
-        // collision effectively empty; ship deck carry and damage use the
-        // explicit OBB search helpers instead.
-        return AxisAlignedBB.getBoundingBox(super.posX, super.posY, super.posZ,
-                super.posX, super.posY, super.posZ);
+        // Expose the full extra-box enclosure for broad-phase entity lookups, but
+        // keep the returned box as the composite vehicle resolver. Returning the
+        // raw search AABB makes vanilla movement resolve against the enclosing
+        // volume itself, which reintroduces jump/deck and side-contact jitter.
+        AxisAlignedBB search = this.getDeckSearchBox();
+        if(super.boundingBox instanceof MCH_BaseVehicleBoundingBox) {
+            return ((MCH_BaseVehicleBoundingBox)super.boundingBox).NewAABB(search.minX, search.minY, search.minZ,
+                    search.maxX, search.maxY, search.maxZ);
+        }
+        return search;
     }
 
     private static class DeckContact {


### PR DESCRIPTION
### Motivation

- Prevent players from colliding with the broad-phase deck search AABB near the ship origin while restoring solid side-wall collision for configured ship extra bounding boxes.
- Ensure broad-phase lookups still discover remote oriented bounding-box (OBB) ship collision boxes so deck walkability and remote collision detection continue to work.

### Description

- Change `getCollisionBox()` to return the composite vehicle collision resolver (`super.boundingBox`) so movement is resolved against configured ship `BoundingBox` entries instead of the enclosing search AABB.
- Update `getBoundingBox()` to expose the deck-search enclosure for broad-phase discovery but return a composite resolver AABB via `MCH_BaseVehicleBoundingBox.NewAABB(...)` when available to avoid reintroducing physical search-box collisions.
- Update documentation and changelog entries to describe the restored side collisions and the approach taken to avoid jitter by keeping precise OBB resolution while exposing the search volume for discovery.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a32036394832396e90a5bb8d31f84)