### PR TITLE
Fix remote ship bounding-box side collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Fix remote ship bounding-box side collision
+
+- Returned the composite ship collision resolver with the expanded extra-box search bounds for entity collision boxes, so player movement discovers and resolves side contact on ship BoundingBox volumes far from the vehicle origin without making the broad-phase enclosure solid.
+
 ## Fix ship bounding-box collision jitter
 
 - Kept ship broad-phase lookup expanded to all configured extra boxes while returning the composite collision resolver, preventing the enclosing search AABB from becoming a physical jitter source during jumping, deck walking, or side contact.

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -978,11 +978,12 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
     @Override
     public AxisAlignedBB getCollisionBox(Entity entity) {
-        // Return the composite vehicle collision resolver, not the broad-phase
-        // search box itself. MCH_BaseVehicleBoundingBox resolves movement
-        // against each configured ship BoundingBox, giving their sides solid
-        // wall-like collision while preserving the precise deck-top support path.
-        return super.boundingBox;
+        // Vanilla player movement only adds an entity collision box when that
+        // box intersects the player's movement AABB. Use the full ship extra-box
+        // enclosure for that broad-phase intersection while returning the
+        // composite resolver type, so remote BoundingBox sides are discoverable
+        // without making the enclosing AABB itself physically solid.
+        return this.getCompositeCollisionSearchBox();
     }
 
     @Override
@@ -991,6 +992,10 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         // keep the returned box as the composite vehicle resolver. Returning the
         // raw search AABB makes vanilla movement resolve against the enclosing
         // volume itself, which reintroduces jump/deck and side-contact jitter.
+        return this.getCompositeCollisionSearchBox();
+    }
+
+    private AxisAlignedBB getCompositeCollisionSearchBox() {
         AxisAlignedBB search = this.getDeckSearchBox();
         if(super.boundingBox instanceof MCH_BaseVehicleBoundingBox) {
             return ((MCH_BaseVehicleBoundingBox)super.boundingBox).NewAABB(search.minX, search.minY, search.minZ,


### PR DESCRIPTION
### Motivation

- Players could pass through ship side bounding boxes when those boxes were positioned far from the vehicle origin because vanilla movement broad-phase lookups did not discover remote rotated extra boxes while the enclosing AABB could become a physical collision source.

### Description

- `MCH_EntityShip#getCollisionBox` now returns a composite collision search box helper so vanilla player movement can discover remote extra-box side contacts while still resolving collisions against the composite resolver type.
- `MCH_EntityShip#getBoundingBox` was changed to reuse the same composite search helper so the broad-phase enclosure is exposed for lookups without becoming a solid enclosing AABB.
- Added a private helper `getCompositeCollisionSearchBox()` that composes the deck search AABB and, when applicable, returns a `MCH_BaseVehicleBoundingBox`-based composite AABB.
- Documented the fix at the top of `CHANGELOG.md` describing the remote bounding-box side collision resolution.

### Testing

- Repository pre-check `git diff --check` was executed and reported no issues.
- No runtime or compile was performed as part of this change set (no binary builds were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a38760f0c832385a3808e30fafa1b)