### PR TITLE
Fix remote ship side collision for players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@
 - Expanded the ship collision broad-phase box to include rotated extra-box deck extents so far-from-origin OBB decks are considered for player collision instead of falling back to nearby base AABB behavior.
 
 
+## Fix remote ship side bounding-box player collision
+
+- Added a server-side player separation pass for ship extra bounding-box side contacts so players cannot phase through hull or wall boxes that are far from the ship vehicle origin.
+- Added an OBB horizontal push-out helper for ship bounding boxes without changing damage-factor or projectile hit behavior.
+
 ## Unreleased
 
 ### Changed

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -205,6 +205,35 @@ public class MCH_BoundingBox {
               && local.zCoord >= -halfWidth && local.zCoord <= halfWidth;
    }
 
+   public Vec3 getHorizontalPushOut(AxisAlignedBB entityBox, double epsilon) {
+      Vec3 localCenter = this.toLocal(Vec3.createVectorHelper(
+              (entityBox.minX + entityBox.maxX) / 2.0D,
+              (entityBox.minY + entityBox.maxY) / 2.0D,
+              (entityBox.minZ + entityBox.maxZ) / 2.0D));
+      double halfEntityX = (entityBox.maxX - entityBox.minX) / 2.0D;
+      double halfEntityY = (entityBox.maxY - entityBox.minY) / 2.0D;
+      double halfEntityZ = (entityBox.maxZ - entityBox.minZ) / 2.0D;
+      double halfWidth = (double)this.width / 2.0D;
+      double halfHeight = (double)this.height / 2.0D;
+
+      if(Math.abs(localCenter.yCoord) >= halfHeight + halfEntityY
+              || Math.abs(localCenter.xCoord) >= halfWidth + halfEntityX
+              || Math.abs(localCenter.zCoord) >= halfWidth + halfEntityZ) {
+         return null;
+      }
+
+      double pushX = halfWidth + halfEntityX - Math.abs(localCenter.xCoord);
+      double pushZ = halfWidth + halfEntityZ - Math.abs(localCenter.zCoord);
+      Vec3 localPush;
+      if(pushX < pushZ) {
+         localPush = Vec3.createVectorHelper((localCenter.xCoord < 0.0D ? -pushX - epsilon : pushX + epsilon), 0.0D, 0.0D);
+      } else {
+         localPush = Vec3.createVectorHelper(0.0D, 0.0D, (localCenter.zCoord < 0.0D ? -pushZ - epsilon : pushZ + epsilon));
+      }
+      return MCH_Lib.RotVec3(localPush, -this.lastYaw, -this.lastPitch, -this.lastRoll);
+   }
+
+
    public MovingObjectPosition calculateIntercept(Vec3 start, Vec3 end) {
       Vec3 localStart = this.toLocal(start);
       Vec3 localEnd = this.toLocal(end);

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -959,6 +959,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
         this.moveEntity(super.motionX, super.motionY, super.motionZ);
         this.finishDeckMovement(deckEntities, oldYaw);
+        this.resolvePlayerSideCollisions();
         //super.motionY *= 0.95D;
 
         if(this.getAcInfo().throttleUpDown > 0.0F) {
@@ -1017,6 +1018,46 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
             this.surfaceCenterX = surfaceCenter.xCoord;
             this.surfaceTopY = surfaceTopY;
             this.surfaceCenterZ = surfaceCenter.zCoord;
+        }
+    }
+
+
+    private void resolvePlayerSideCollisions() {
+        if(super.worldObj.isRemote || this.getAcInfo() == null) {
+            return;
+        }
+
+        AxisAlignedBB search = this.getDeckSearchBox();
+        MCH_BoundingBox[] shipBoxes = this.getCalculatedExtraBoundingBoxes();
+        for(Object value : super.worldObj.playerEntities) {
+            EntityPlayer player = (EntityPlayer)value;
+            if(player == this.getRiddenByEntity() || player.ridingEntity != null || player.isDead
+                    || !player.boundingBox.intersectsWith(search)) {
+                continue;
+            }
+
+            Vec3 push = null;
+            double bestPushSq = Double.MAX_VALUE;
+            for(MCH_BoundingBox shipBox : shipBoxes) {
+                if(this.isOnTopOf(player.boundingBox, shipBox)) {
+                    continue;
+                }
+
+                Vec3 candidate = shipBox.getHorizontalPushOut(player.boundingBox, 1.0E-4D);
+                if(candidate != null) {
+                    double pushSq = candidate.xCoord * candidate.xCoord + candidate.zCoord * candidate.zCoord;
+                    if(pushSq < bestPushSq) {
+                        push = candidate;
+                        bestPushSq = pushSq;
+                    }
+                }
+            }
+
+            if(push != null) {
+                player.moveEntity(push.xCoord, 0.0D, push.zCoord);
+                player.motionX = 0.0D;
+                player.motionZ = 0.0D;
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

- Players could phase through ship extra bounding-box side walls when those OBBs were far from the ship origin, because vanilla broad-phase lookups used only an enclosing AABB around the vehicle origin and deck support used legacy AABBs; this change prevents side-phasing while preserving existing damage behavior.
- The fix must not touch damage or projectile hit handling and should keep deck/on-top behavior intact.

### Description

- Added `MCH_BoundingBox.getHorizontalPushOut(AxisAlignedBB, double)` to compute a minimal horizontal push vector from an oriented box (OBB) to a player `AxisAlignedBB` in world space, using the box local coordinates and rotating the push back into world coordinates.
- Added `resolvePlayerSideCollisions()` to `MCH_EntityShip` and call it after ship movement so the server scans nearby players using the deck search AABB and separates any players intersecting an extra ship OBB on the side (skipping deck-top contacts), applying the horizontal push and zeroing player horizontal motion.
- Kept all damage and projectile-hit code unchanged and preserved existing deck/on-top checks by skipping boxes where an entity is considered on top; updated `CHANGELOG.md` to record the fix.

### Testing

- Ran `git diff --check` to ensure no whitespace/patch issues and it passed.
- No compile/build was performed per repository instructions not to compile binaries, and no automated unit tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a3af52b44832385be45b14befe656)