### PR TITLE
Replace extra vehicle AABBs with oriented OBBs (preserve AABB compatibility)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Replaced vehicle extra bounding-box narrow-phase checks with oriented bounding boxes while retaining enclosing AABBs for vanilla broad-phase compatibility.
+
 ### Documentation
 
 - Rewrote `README.md` with a modern project overview, feature list, installation steps, compatibility/client-server requirements, configuration overview, command examples, troubleshooting, FAQ, and confirmed resource links.

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -74,7 +74,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `EntityHeight` | All | float | 1.0 | entity bounding height |
 | `EntityPitch` | All | float | 0.0 | rendered entity pitch offset |
 | `EntityRoll` | All | float | 0.0 | rendered entity roll offset |
-| `BoundingBox` | All | list | none | extra damage/collision box |
+| `BoundingBox` | All | list | none | extra damage/collision OBB; existing `x,y,z,width,height[,damageFactor]` syntax is preserved while runtime collision rotates with vehicle yaw/pitch/roll |
 | `SetWheelPos` | All | vec3 | family default wheel list | wheel contact point; repeatable |
 | `StepHeight` | All | float | 0.0 (intended plane/tank/ship helper returns 0.6 but is private) | block step height |
 | `maxhp` | All | int | 50 | health |

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleBoundingBox.java
@@ -140,7 +140,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
          MCH_BoundingBox bb = arr$[i$];
          //wheelBoundingBox wb = arr$[i$];
 
-         if(bb.boundingBox.intersectsWith(aabb)) {
+         if(bb.intersectsWith(aabb)) {
             double dist2 = this.getDistSq(aabb, bb.boundingBox);
             if(dist2 < dist) {
                dist = dist2;
@@ -266,7 +266,7 @@ public class MCH_BaseVehicleBoundingBox extends AxisAlignedBB {
 
       for(int i$ = 0; i$ < len$; ++i$) {
          MCH_BoundingBox bb = arr$[i$];
-         MovingObjectPosition mop2 = bb.boundingBox.calculateIntercept(v1, v2);
+         MovingObjectPosition mop2 = bb.calculateIntercept(v1, v2);
          if(mop2 != null) {
             double dist2 = v1.distanceTo(mop2.hitVec);
             if(dist2 < dist) {

--- a/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
+++ b/src/main/java/mcheli/aircraft/MCH_BoundingBox.java
@@ -2,10 +2,12 @@ package mcheli.aircraft;
 
 import mcheli.MCH_Lib;
 import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 
 public class MCH_BoundingBox {
 
+   /** Broad-phase compatibility AABB containing the oriented box. */
    public final AxisAlignedBB boundingBox;
    public final AxisAlignedBB backupBoundingBox;
    public final double offsetX;
@@ -18,7 +20,11 @@ public class MCH_BoundingBox {
    public Vec3 prevPos;
    public final float damegeFactor;
    public EnumBoundingBoxType boundingBoxType = EnumBoundingBoxType.DEFAULT;
-
+   private Vec3 axisX = Vec3.createVectorHelper(1.0D, 0.0D, 0.0D);
+   private Vec3 axisY = Vec3.createVectorHelper(0.0D, 1.0D, 0.0D);
+   private Vec3 axisZ = Vec3.createVectorHelper(0.0D, 0.0D, 1.0D);
+   private final double halfWidth;
+   private final double halfHeight;
 
    public MCH_BoundingBox(double x, double y, double z, float w, float h, float df) {
       this.offsetX = x;
@@ -26,28 +32,34 @@ public class MCH_BoundingBox {
       this.offsetZ = z;
       this.width = w;
       this.height = h;
+      this.halfWidth = (double)(w / 2.0F);
+      this.halfHeight = (double)(h / 2.0F);
       this.damegeFactor = df;
-      this.boundingBox = AxisAlignedBB.getBoundingBox(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
-      this.backupBoundingBox = AxisAlignedBB.getBoundingBox(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+      this.boundingBox = AxisAlignedBB.getBoundingBox(x - this.halfWidth, y - this.halfHeight, z - this.halfWidth, x + this.halfWidth, y + this.halfHeight, z + this.halfWidth);
+      this.backupBoundingBox = AxisAlignedBB.getBoundingBox(x - this.halfWidth, y - this.halfHeight, z - this.halfWidth, x + this.halfWidth, y + this.halfHeight, z + this.halfWidth);
       this.nowPos = Vec3.createVectorHelper(x, y, z);
       this.prevPos = Vec3.createVectorHelper(x, y, z);
       this.updatePosition(0.0D, 0.0D, 0.0D, 0.0F, 0.0F, 0.0F);
    }
 
-
    public MCH_BoundingBox copy() {
-      return new MCH_BoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      MCH_BoundingBox copy = new MCH_BoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      copy.boundingBoxType = this.boundingBoxType;
+      return copy;
    }
 
    public wheelBoundingBox copy2() {
-      return new wheelBoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      wheelBoundingBox copy = new wheelBoundingBox(this.offsetX, this.offsetY, this.offsetZ, this.width, this.height, this.damegeFactor);
+      copy.boundingBoxType = this.boundingBoxType;
+      return copy;
    }
 
    public void updatePosition(double posX, double posY, double posZ, float yaw, float pitch, float roll) {
       Vec3 v = Vec3.createVectorHelper(this.offsetX, this.offsetY, this.offsetZ);
       this.rotatedOffset = MCH_Lib.RotVec3(v, -yaw, -pitch, -roll);
-      float w = this.width;
-      float h = this.height;
+      this.axisX = MCH_Lib.RotVec3(Vec3.createVectorHelper(1.0D, 0.0D, 0.0D), -yaw, -pitch, -roll).normalize();
+      this.axisY = MCH_Lib.RotVec3(Vec3.createVectorHelper(0.0D, 1.0D, 0.0D), -yaw, -pitch, -roll).normalize();
+      this.axisZ = MCH_Lib.RotVec3(Vec3.createVectorHelper(0.0D, 0.0D, 1.0D), -yaw, -pitch, -roll).normalize();
       double x = posX + this.rotatedOffset.xCoord;
       double y = posY + this.rotatedOffset.yCoord;
       double z = posZ + this.rotatedOffset.zCoord;
@@ -58,6 +70,94 @@ public class MCH_BoundingBox {
       this.nowPos.yCoord = y;
       this.nowPos.zCoord = z;
       this.backupBoundingBox.setBB(this.boundingBox);
-      this.boundingBox.setBounds(x - (double)(w / 2.0F), y - (double)(h / 2.0F), z - (double)(w / 2.0F), x + (double)(w / 2.0F), y + (double)(h / 2.0F), z + (double)(w / 2.0F));
+      this.updateEnclosingAabb();
+   }
+
+   public boolean contains(Vec3 point) {
+      Vec3 d = Vec3.createVectorHelper(point.xCoord - this.nowPos.xCoord, point.yCoord - this.nowPos.yCoord, point.zCoord - this.nowPos.zCoord);
+      return Math.abs(dot(d, this.axisX)) <= this.halfWidth
+              && Math.abs(dot(d, this.axisY)) <= this.halfHeight
+              && Math.abs(dot(d, this.axisZ)) <= this.halfWidth;
+   }
+
+   public boolean intersectsWith(AxisAlignedBB aabb) {
+      if(aabb == null || !this.boundingBox.intersectsWith(aabb)) {
+         return false;
+      }
+      Vec3 aabbCenter = Vec3.createVectorHelper((aabb.minX + aabb.maxX) / 2.0D, (aabb.minY + aabb.maxY) / 2.0D, (aabb.minZ + aabb.maxZ) / 2.0D);
+      double[] a = new double[]{this.halfWidth, this.halfHeight, this.halfWidth};
+      double[] b = new double[]{(aabb.maxX - aabb.minX) / 2.0D, (aabb.maxY - aabb.minY) / 2.0D, (aabb.maxZ - aabb.minZ) / 2.0D};
+      Vec3[] u = new Vec3[]{this.axisX, this.axisY, this.axisZ};
+      Vec3[] v = new Vec3[]{Vec3.createVectorHelper(1.0D, 0.0D, 0.0D), Vec3.createVectorHelper(0.0D, 1.0D, 0.0D), Vec3.createVectorHelper(0.0D, 0.0D, 1.0D)};
+      return intersectsObb(aabbCenter, a, b, u, v);
+   }
+
+   public MovingObjectPosition calculateIntercept(Vec3 start, Vec3 end) {
+      if(this.boundingBox.calculateIntercept(start, end) == null && !this.contains(start)) {
+         return null;
+      }
+      Vec3 dir = Vec3.createVectorHelper(end.xCoord - start.xCoord, end.yCoord - start.yCoord, end.zCoord - start.zCoord);
+      Vec3 p = Vec3.createVectorHelper(start.xCoord - this.nowPos.xCoord, start.yCoord - this.nowPos.yCoord, start.zCoord - this.nowPos.zCoord);
+      double[] s = new double[]{dot(p, this.axisX), dot(p, this.axisY), dot(p, this.axisZ)};
+      double[] d = new double[]{dot(dir, this.axisX), dot(dir, this.axisY), dot(dir, this.axisZ)};
+      double[] e = new double[]{this.halfWidth, this.halfHeight, this.halfWidth};
+      double tMin = 0.0D;
+      double tMax = 1.0D;
+      for(int i = 0; i < 3; ++i) {
+         if(Math.abs(d[i]) < 1.0E-7D) {
+            if(s[i] < -e[i] || s[i] > e[i]) return null;
+         } else {
+            double t1 = (-e[i] - s[i]) / d[i];
+            double t2 = (e[i] - s[i]) / d[i];
+            if(t1 > t2) { double tmp = t1; t1 = t2; t2 = tmp; }
+            if(t1 > tMin) tMin = t1;
+            if(t2 < tMax) tMax = t2;
+            if(tMin > tMax) return null;
+         }
+      }
+      Vec3 hit = Vec3.createVectorHelper(start.xCoord + dir.xCoord * tMin, start.yCoord + dir.yCoord * tMin, start.zCoord + dir.zCoord * tMin);
+      return new MovingObjectPosition(0, 0, 0, 0, hit);
+   }
+
+   private void updateEnclosingAabb() {
+      Vec3[] corners = this.getCorners();
+      double minX = corners[0].xCoord, minY = corners[0].yCoord, minZ = corners[0].zCoord;
+      double maxX = minX, maxY = minY, maxZ = minZ;
+      for(int i = 1; i < corners.length; ++i) {
+         minX = Math.min(minX, corners[i].xCoord); minY = Math.min(minY, corners[i].yCoord); minZ = Math.min(minZ, corners[i].zCoord);
+         maxX = Math.max(maxX, corners[i].xCoord); maxY = Math.max(maxY, corners[i].yCoord); maxZ = Math.max(maxZ, corners[i].zCoord);
+      }
+      this.boundingBox.setBounds(minX, minY, minZ, maxX, maxY, maxZ);
+   }
+
+   public Vec3[] getCorners() {
+      Vec3[] corners = new Vec3[8];
+      int i = 0;
+      for(int sx = -1; sx <= 1; sx += 2) for(int sy = -1; sy <= 1; sy += 2) for(int sz = -1; sz <= 1; sz += 2) {
+         corners[i++] = Vec3.createVectorHelper(this.nowPos.xCoord + this.axisX.xCoord * this.halfWidth * sx + this.axisY.xCoord * this.halfHeight * sy + this.axisZ.xCoord * this.halfWidth * sz,
+                 this.nowPos.yCoord + this.axisX.yCoord * this.halfWidth * sx + this.axisY.yCoord * this.halfHeight * sy + this.axisZ.yCoord * this.halfWidth * sz,
+                 this.nowPos.zCoord + this.axisX.zCoord * this.halfWidth * sx + this.axisY.zCoord * this.halfHeight * sy + this.axisZ.zCoord * this.halfWidth * sz);
+      }
+      return corners;
+   }
+
+   private boolean intersectsObb(Vec3 centerB, double[] a, double[] b, Vec3[] u, Vec3[] v) {
+      double[][] r = new double[3][3];
+      double[][] absR = new double[3][3];
+      for(int i = 0; i < 3; ++i) for(int j = 0; j < 3; ++j) { r[i][j] = dot(u[i], v[j]); absR[i][j] = Math.abs(r[i][j]) + 1.0E-7D; }
+      Vec3 tVec = Vec3.createVectorHelper(centerB.xCoord - this.nowPos.xCoord, centerB.yCoord - this.nowPos.yCoord, centerB.zCoord - this.nowPos.zCoord);
+      double[] t = new double[]{dot(tVec, u[0]), dot(tVec, u[1]), dot(tVec, u[2])};
+      for(int i = 0; i < 3; ++i) if(Math.abs(t[i]) > a[i] + b[0] * absR[i][0] + b[1] * absR[i][1] + b[2] * absR[i][2]) return false;
+      for(int j = 0; j < 3; ++j) if(Math.abs(t[0] * r[0][j] + t[1] * r[1][j] + t[2] * r[2][j]) > b[j] + a[0] * absR[0][j] + a[1] * absR[1][j] + a[2] * absR[2][j]) return false;
+      for(int i = 0; i < 3; ++i) for(int j = 0; j < 3; ++j) {
+         double ra = a[(i + 1) % 3] * absR[(i + 2) % 3][j] + a[(i + 2) % 3] * absR[(i + 1) % 3][j];
+         double rb = b[(j + 1) % 3] * absR[i][(j + 2) % 3] + b[(j + 2) % 3] * absR[i][(j + 1) % 3];
+         if(Math.abs(t[(i + 2) % 3] * r[(i + 1) % 3][j] - t[(i + 1) % 3] * r[(i + 2) % 3][j]) > ra + rb) return false;
+      }
+      return true;
+   }
+
+   private static double dot(Vec3 a, Vec3 b) {
+      return a.xCoord * b.xCoord + a.yCoord * b.yCoord + a.zCoord * b.zCoord;
    }
 }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -3033,10 +3033,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    /**
     * Returns the current calculated extra collision / hit boxes for this vehicle.
     *
-    * This method intentionally still produces the same AxisAlignedBB-backed MCH_BoundingBox
-    * data as the legacy path.  It centralizes the transform calculation and caches stationary
-    * vehicles so future yaw/pitch/roll oriented box math can be added in one place without
-    * making every collision, damage, and debug-render caller rebuild box geometry independently.
+    * This method returns oriented MCH_BoundingBox instances with enclosing AxisAlignedBBs
+    * for vanilla broad-phase compatibility. It centralizes transform calculation and caches
+    * stationary vehicles so collision, damage, and debug-render callers share the same geometry.
     */
    public MCH_BoundingBox[] getCalculatedExtraBoundingBoxes() {
       return this.vehicleBoxCache.getBoxes(this);

--- a/src/main/java/mcheli/aircraft/MCH_VehicleBoxCache.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleBoxCache.java
@@ -7,10 +7,9 @@ import mcheli.MCH_Lib;
 /**
  * Caches calculated vehicle collision / hit box positions.
  *
- * The current MCHeli collision path still consumes AxisAlignedBB-backed MCH_BoundingBox objects.
- * This cache is deliberately behavior-preserving: it updates those same boxes only when the
- * vehicle transform or source definitions change.  It is the abstraction boundary where future
- * rotating/oriented vehicle box calculations should be implemented.
+ * MCH_BoundingBox now stores oriented box geometry and maintains an enclosing
+ * AxisAlignedBB for vanilla broad-phase compatibility. This cache updates those OBB transforms
+ * only when the vehicle transform or source definitions change.
  */
 public class MCH_VehicleBoxCache {
    private static final double POSITION_EPSILON = 1.0E-4D;

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -424,7 +424,7 @@ public class MCP_PlaneChaseCamera {
       MCH_BoundingBox[] boxes = plane.getCalculatedExtraBoundingBoxes();
       for(int i = 0; i < boxes.length; ++i) {
          MCH_BoundingBox box = boxes[i];
-         if(box != null && this.isPointInsideAabb(point, box.boundingBox)) {
+         if(box != null && box.contains(point)) {
             return "partBB#" + i;
          }
       }
@@ -445,13 +445,23 @@ public class MCP_PlaneChaseCamera {
       return Math.sqrt(dx * dx + dy * dy + dz * dz);
    }
 
+   private double distanceToObb(Vec3 point, MCH_BoundingBox box) {
+      if(box == null) {
+         return Double.MAX_VALUE;
+      }
+      if(box.contains(point)) {
+         return 0.0D;
+      }
+      return this.distanceToAabb(point, box.boundingBox);
+   }
+
    private double nearestAircraftBoxDistance(MCP_EntityPlane plane, Vec3 point) {
       double nearest = this.distanceToAabb(point, plane.boundingBox);
       MCH_BoundingBox[] boxes = plane.getCalculatedExtraBoundingBoxes();
       for(int i = 0; i < boxes.length; ++i) {
          MCH_BoundingBox box = boxes[i];
          if(box != null) {
-            nearest = Math.min(nearest, this.distanceToAabb(point, box.boundingBox));
+            nearest = Math.min(nearest, this.distanceToObb(point, box));
          }
       }
       return nearest;


### PR DESCRIPTION
### Motivation

- Improve collision/damage/raycast accuracy for vehicle extra boxes by treating them as oriented bounding boxes (OBBs) while keeping existing broad-phase behavior. 
- Make vehicle box math rotation-aware so extra boxes follow vehicle yaw/pitch/roll and eliminate incorrect narrow-phase AABB checks. 
- Preserve compatibility with vanilla systems and other code paths that expect an enclosing `AxisAlignedBB` for broad-phase queries.

### Description

- Added oriented-box state and math to `MCH_BoundingBox`, including local rotated axes, `contains(Vec3)`, OBB narrow-phase SAT-based `intersectsWith(AxisAlignedBB)`, OBB ray `calculateIntercept`, corner generation, and an enclosing AABB update via `updateEnclosingAabb()` to maintain broad-phase compatibility. 
- Updated composite vehicle hit and ray tracing to call the new OBB-aware helpers (`bb.intersectsWith(...)`, `bb.calculateIntercept(...)`) in `MCH_BaseVehicleBoundingBox` so damage/raycast selection prefers oriented geometry. 
- Updated chase-camera proximity and point tests in `MCP_PlaneChaseCamera` to use `box.contains(point)` and a new `distanceToObb(...)` helper that falls back to the enclosing AABB for distance metrics. 
- Documented the change in `docs/vehicle-config-reference.md` (note that `BoundingBox` entries now operate as OBBs at runtime while preserving existing `x,y,z,width,height[,damageFactor]` config syntax) and added a changelog entry in `CHANGELOG.md`; clarified `MCH_VehicleBoxCache` comment to reflect OBB caching.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems. 
- Ran repository searches with `rg` to validate code paths were updated to use the new OBB helpers and to ensure no remaining direct AABB narrow-phase calls remained for extra boxes. 
- Did not run a full compile/build to avoid generating binary artifacts per repository instructions, so runtime integration testing was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d610f583c83239386e94e3f2a88b4)