### PR TITLE
Fix CCIP static bomb reticle projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 - Added `docs/commands.md` with source-verified `/mcheli` command syntax, permission model, examples, and safety notes.
 - Added `docs/server-administration.md` with server installation, safe survival defaults, permission guidance, runtime reloads, diagnostics, and performance notes.
 - Added `docs/documentation-audit.md` listing discovered undocumented systems and remaining documentation gaps.
+
+## CCIP Static Bomb Reticle Fix
+- Fixed the plane CCIP pipper so it draws directly at the predicted bomb impact projection instead of smoothing toward a look-following cursor.
+- Documented that CCIP is projected in the aircraft body frame and is not driven by player freelook or mouse aim.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,7 +225,7 @@ Tuning guidance:
 
 ## New-flight plane mouse aim controls (currently in development)
 
-Mouse aim is currently in development as a control foundation for fixed-wing planes using `UseNewMobilitySystem = true` only. It is disabled by default and does not affect legacy aircraft. When enabled globally, pilots can toggle it in a qualifying new-flight plane with `KeyPlaneMouseAim`; the mouse moves a separate desired aim yaw/pitch and the aircraft nose chases that aim through the existing new-flight authority, stall, energy, pitch-suppression, damping, and rotation-limit path. Advanced lead/CCIP HUD polish is intentionally left for a later pass.
+Mouse aim is currently in development as a control foundation for fixed-wing planes using `UseNewMobilitySystem = true` only. It is disabled by default and does not affect legacy aircraft. When enabled globally, pilots can toggle it in a qualifying new-flight plane with `KeyPlaneMouseAim`; the mouse moves a separate desired aim yaw/pitch and the aircraft nose chases that aim through the existing new-flight authority, stall, energy, pitch-suppression, damping, and rotation-limit path. Advanced lead HUD polish is intentionally left for a later pass. Plane CCIP, where enabled by the aircraft ballistic computer, is a static ballistic bomb-impact pipper projected from the aircraft body frame and does not follow player freelook or mouse aim.
 
 This first implementation uses global client config keys. Per-plane mouse-aim overrides are not wired yet, so pack authors should tune conservatively.
 

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -603,8 +603,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          if(result.valid) {
             ScreenPoint projected = this.projectWorldToAircraftHud(plane, result.impact);
             if(projected != null && projected.visible) {
-               ScreenPoint p = this.smoothCCIPScreenPoint(projected, result.impact, weapon);
-               this.drawCCIPPipper(p.x, p.y, p.clamped);
+               // Draw the pipper directly at the predicted impact projection. Do not steer or
+               // smooth the CCIP toward the player's view/mouse aim; gravity bombs fall from
+               // the aircraft's current release point and velocity, so the HUD must remain a
+               // deterministic bomb-fall solution instead of a look-following cursor.
+               this.drawCCIPPipper(projected.x, projected.y, projected.clamped);
             } else {
                this.resetCCIPSmoothing();
             }
@@ -744,6 +747,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       float yaw = plane.calcRotYaw(partialTicks);
       float pitch = plane.calcRotPitch(partialTicks);
       float roll = plane.calcRotRoll(partialTicks);
+      // Project into the aircraft body frame, not the player/camera frame. This keeps CCIP
+      // as a fixed ballistic impact cue for the selected bomb rather than a freelook or
+      // mouse-aim reticle.
       Vec3 forward = mcheli.MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -roll);
       Vec3 right = mcheli.MCH_Lib.RotVec3(1.0D, 0.0D, 0.0D, -yaw, -pitch, -roll);
       Vec3 up = mcheli.MCH_Lib.RotVec3(0.0D, 1.0D, 0.0D, -yaw, -pitch, -roll);
@@ -751,27 +757,16 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       if(localForward <= 0.05D) {
          return null;
       }
-     // double localRight = this.dot(toImpact, right);
-     // double localUp = this.dot(toImpact, up);
-     // double scale = (double)super.height * 0.75D / localForward;
-     // // Match the existing HUD convention: positive aircraft-right offsets draw toward screen-left.
-     // double x = (double)super.centerX - localRight * scale;
-     // double y = (double)super.centerY - localUp * scale;
       double localRight = toImpact.dotProduct(right);
       double localUp = toImpact.dotProduct(up);
       double scale = (double)super.height * 0.75D / localForward;
+      // Match the existing HUD convention: positive aircraft-right offsets draw toward screen-left.
       double x = (double)super.centerX - localRight * scale;
       double y = (double)super.centerY - localUp * scale;
-      //fucking pick one
       if(x < 0.0D || x > (double)super.width || y < 0.0D || y > (double)super.height) {
          return null;
       }
 
-      //double localRight = toImpact.dotProduct(right);
-      //double localUp = toImpact.dotProduct(up);
-      //double scale = (double)super.height * 0.75D / localForward;
-      //double x = (double)super.centerX - localRight * scale;
-      //double y = (double)super.centerY - localUp * scale;
       double clampedX = MathHelper.clamp_double(x, 0.0D, (double)super.width);
       double clampedY = MathHelper.clamp_double(y, 0.0D, (double)super.height);
       return new ScreenPoint(clampedX, clampedY, x != clampedX || y != clampedY);


### PR DESCRIPTION
### Motivation
- The CCIP HUD was drifting/steering toward the player's freelook/mouse-aim and therefore did not represent a deterministic bomb-impact point.  
- CCIP must represent the ballistic impact computed from the aircraft release point/velocity, not the camera or mouse orientation.  
- The change restores a static bomb reticle that reliably shows where the bomb will land given the current aircraft/weapon state.

### Description
- Draw the CCIP pipper directly at the predicted impact projection by calling `drawCCIPPipper(projected.x, projected.y, ...)` instead of smoothing toward the player's view with `smoothCCIPScreenPoint`.  
- Make `projectWorldToAircraftHud` explicit about projecting into the aircraft body frame so CCIP is not driven by freelook/camera orientation.  
- Update `docs/configuration.md` to document that CCIP is a static ballistic bomb-impact pipper projected from the aircraft body frame and does not follow freelook/mouse aim.  
- Add a `CHANGELOG.md` entry describing the CCIP static bomb reticle fix.

### Testing
- Ran `git diff --check` to ensure there are no trivial whitespace/index issues and it completed successfully.  
- Ran `git status --short` to verify only the intended files were modified and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6e5923b083238ee5a011464f7aaf)