### PR TITLE
Add 3D vehicle item icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Added 3D vehicle item rendering so placeable helicopters, planes, ships, tanks, and turret/static vehicles use their loaded vehicle models in inventories, held views, and dropped item form instead of relying on flat item icons.
+
 - Replaced vehicle extra bounding-box narrow-phase checks with oriented bounding boxes while retaining enclosing AABBs for vanilla broad-phase compatibility. Added optional rectangular `depth` syntax for diagonal/rotated OBB footprints.
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For development asset testing, the build/run setup expects assets in `build/run/
 
 1. Open the MCHeli creative tabs (`MCHeliO Item`, `MCHeliO Helicopters`, `MCHeliO Planes`, `MCHeliO Ships`, `MCHeliO Tanks`, `MCHeliO Vehicles`, and `MCHeliO Recipe Items`).
 2. Place or craft a **Drafting Table** to access recipes when recipes are enabled.
-3. Use vehicle item icons to place vehicles. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
+3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
 4. Enter vehicles, use the configured movement/weapon keys, and refuel/repair according to the content pack's vehicle definitions.
 5. Server operators can use `/mcheli list` to discover available administrative subcommands.
 

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -11,6 +11,7 @@ import mcheli.aircraft.MCH_EntityHide;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.aircraft.MCH_SoundUpdater;
+import mcheli.aircraft.MCH_VehicleItemModelRender;
 import mcheli.block.MCH_DraftingTableItemRender;
 import mcheli.block.MCH_DraftingTableRenderer;
 import mcheli.block.MCH_DraftingTableTileEntity;
@@ -128,6 +129,25 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemGLTD, new MCH_ItemGLTDRender());
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemWrench, new MCH_ItemRenderWrench());
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemRangeFinder, new MCH_ItemRenderRangeFinder());
+      this.registerVehicleItemRenderers();
+   }
+
+   private void registerVehicleItemRenderers() {
+      MCH_VehicleItemModelRender renderer = new MCH_VehicleItemModelRender();
+      registerVehicleItemRenderers(MCH_HeliInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCP_PlaneInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_ShipInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_TankInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_TurretInfoManager.map.values().iterator(), renderer);
+   }
+
+   private void registerVehicleItemRenderers(Iterator iterator, MCH_VehicleItemModelRender renderer) {
+      while(iterator.hasNext()) {
+         MCH_BaseVehicleInfo info = (MCH_BaseVehicleInfo)iterator.next();
+         if(info != null && info.getItem() != null) {
+            W_MinecraftForgeClient.registerItemRenderer(info.getItem(), renderer);
+         }
+      }
    }
 
    public void registerBlockRenderer() {

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -1,0 +1,83 @@
+package mcheli.aircraft;
+
+import mcheli.wrapper.W_McClient;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
+import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.IItemRenderer.ItemRenderType;
+import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
+
+/**
+ * Renders placeable vehicle items with their loaded 3D vehicle model instead of the flat item icon.
+ */
+public class MCH_VehicleItemModelRender implements IItemRenderer {
+
+   public boolean handleRenderType(ItemStack item, ItemRenderType type) {
+      return getInfo(item) != null;
+   }
+
+   public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
+      return true;
+   }
+
+   public void renderItem(ItemRenderType type, ItemStack item, Object ... data) {
+      MCH_BaseVehicleInfo info = getInfo(item);
+      if(info == null || info.model == null) {
+         return;
+      }
+
+      GL11.glPushMatrix();
+      GL11.glEnable('\u803a');
+      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+      transform(type, info);
+      W_McClient.MOD_bindTexture("textures/" + info.getDirectoryName() + "/" + MCH_RenderBaseVehicle.getBaseTextureName(info.name) + ".png");
+      MCH_RenderBaseVehicle.beginSkinOverlayRender(info.getDirectoryName(), info.name);
+      try {
+         MCH_RenderBaseVehicle.renderAllModel(info.model);
+      } finally {
+         MCH_RenderBaseVehicle.endSkinOverlayRender();
+         GL11.glPopMatrix();
+      }
+      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+      GL11.glEnable(3042);
+   }
+
+   private static MCH_BaseVehicleInfo getInfo(ItemStack item) {
+      return item != null && item.getItem() instanceof MCH_ItemBaseVehicle
+         ? ((MCH_ItemBaseVehicle)item.getItem()).getAircraftInfo() : null;
+   }
+
+   private static void transform(ItemRenderType type, MCH_BaseVehicleInfo info) {
+      switch(type) {
+      case ENTITY:
+         GL11.glTranslatef(0.0F, 0.35F, 0.0F);
+         GL11.glRotatef(35.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case EQUIPPED:
+         GL11.glTranslatef(0.25F, 0.45F, 0.55F);
+         GL11.glRotatef(25.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(135.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case EQUIPPED_FIRST_PERSON:
+         GL11.glTranslatef(0.65F, 0.35F, 0.35F);
+         GL11.glRotatef(20.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(125.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case INVENTORY:
+         GL11.glTranslatef(0.0F, -0.35F, 0.0F);
+         GL11.glRotatef(30.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      default:
+         break;
+      }
+
+      float largest = Math.max(Math.max(info.bodyWidth, info.bodyHeight), 1.0F);
+      float scale = type == ItemRenderType.INVENTORY ? 1.35F / largest : 0.75F / largest;
+      if(type == ItemRenderType.ENTITY) {
+         scale = 1.0F / largest;
+      }
+      GL11.glScalef(scale, scale, scale);
+   }
+}


### PR DESCRIPTION
### Motivation
- Replace flat 2D item icons for placeable vehicles with the vehicle's loaded 3D model so inventories, held views, and dropped items show the actual vehicle model and base texture instead of a static icon.

### Description
- Added a new Forge item renderer `MCH_VehicleItemModelRender` that draws a vehicle's `IModelCustom` and base texture for `INVENTORY`, `EQUIPPED`, `EQUIPPED_FIRST_PERSON`, and `ENTITY` item render contexts at `src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java`.
- Registered the renderer during client setup by adding `registerVehicleItemRenderers()` to `MCH_ClientProxy` which iterates the vehicle info managers and registers the new renderer for each vehicle item at `src/main/java/mcheli/MCH_ClientProxy.java`.
- Ensured safe render cleanup by wrapping model rendering in a `try`/`finally` to end overlay rendering and restore GL state.
- Updated user-facing docs to mention the new behavior in `README.md` and recorded the change in `CHANGELOG.md` under `Unreleased`.

### Testing
- Ran `git diff --check` which passed with no whitespace or index warnings.
- Attempted `./gradlew test` but it failed in this environment due to a Gradle/Java compatibility issue (`Gradle 4.4.1` could not determine Java version `25.0.2`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4edf9fb6e88323b53e793bd9f6f781)