### PR TITLE
Render placeable vehicle items with their 3D models and add per-type/per-vehicle scaling/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Added 3D vehicle item rendering so placeable helicopters, planes, ships, tanks, and turret/static vehicles use their loaded vehicle models in inventories, held views, and dropped item form instead of relying on flat item icons. Added `Override3DItemIcon`, per-type global scale settings, and per-vehicle `Enable3DItemIcon` / `ItemIconScaleFactor` content-pack keys.
+
 - Replaced vehicle extra bounding-box narrow-phase checks with oriented bounding boxes while retaining enclosing AABBs for vanilla broad-phase compatibility. Added optional rectangular `depth` syntax for diagonal/rotated OBB footprints.
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For development asset testing, the build/run setup expects assets in `build/run/
 
 1. Open the MCHeli creative tabs (`MCHeliO Item`, `MCHeliO Helicopters`, `MCHeliO Planes`, `MCHeliO Ships`, `MCHeliO Tanks`, `MCHeliO Vehicles`, and `MCHeliO Recipe Items`).
 2. Place or craft a **Drafting Table** to access recipes when recipes are enabled.
-3. Use vehicle item icons to place vehicles. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
+3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
 4. Enter vehicles, use the configured movement/weapon keys, and refuel/repair according to the content pack's vehicle definitions.
 5. Server operators can use `/mcheli list` to discover available administrative subcommands.
 
@@ -130,6 +130,8 @@ The mod writes `config/mcheli.cfg` on startup. Important options include:
 - `InfinityAmmo` and `InfinityFuel` - enable unlimited ammunition/fuel globally.
 - `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed` - global speed multipliers/clamps.
 - `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` - control long-distance vehicle model rendering.
+- `Override3DItemIcon` - globally disables 3D vehicle item icons when set to `true`; `false` allows per-vehicle 3D item icon settings.
+- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type.
 - `MultiThreadedModelLoading` - toggles threaded model loading on the client.
 - `CommandPermission` entries - grant specific `/mcheli` subcommands to named non-operator players.
 - `Key*` entries - default key and mouse bindings for MCHeli controls.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,12 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `SwitchWeaponWithMouseWheel` | `true` | Allows mouse-wheel weapon switching. |
 | `LWeaponAutoFire` | `false` | Auto-fire behavior for light weapons. |
 | `DisableItemRender` | `1` | Valid range noted in source: `0 ~ 3`; `1` recommended. |
+| `Override3DItemIcon` | `false` | Global 3D vehicle item icon override. `true` forces 3D item icons off; `false` allows per-vehicle `Enable3DItemIcon` settings. |
+| `Heli3DItemIconScale` | `1.0` | Global scale multiplier for helicopter 3D item icons. |
+| `Plane3DItemIconScale` | `1.0` | Global scale multiplier for plane 3D item icons. |
+| `Ship3DItemIconScale` | `1.0` | Global scale multiplier for ship 3D item icons. |
+| `Tank3DItemIconScale` | `1.0` | Global scale multiplier for tank 3D item icons. |
+| `Turret3DItemIconScale` | `1.0` | Global scale multiplier for turret/static vehicle 3D item icons. |
 | `HideKeybind` | `false` | Hides keybind display/help where implemented. |
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |
@@ -108,6 +114,15 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `ReplaceRenderViewEntity` | `true` | Replaces render-view entity for MCHeli camera behavior. |
 | `ItemRecipe_*` | See generated config/source defaults | Recipe strings for core MCHeli items. |
 | `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
+
+## Vehicle content-pack keys
+
+Vehicle `.txt` definitions can opt individual items into or out of 3D item rendering and tune their own size after the global type scale is applied:
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `Enable3DItemIcon` | `true` | Per-vehicle toggle. Set `false` to keep that vehicle on the normal flat item icon even when the global override allows 3D icons. |
+| `ItemIconScaleFactor` | `1.0` | Per-vehicle 3D item icon scale multiplier, clamped to `0.01` through `100.0`. Alias: `3DItemIconScaleFactor`. |
 
 ## Hidden/advanced options initialized in source
 

--- a/examples/vehicle-configs/plane_minimal.txt
+++ b/examples/vehicle-configs/plane_minimal.txt
@@ -1,6 +1,8 @@
 displayname = Minimal Plane
 Category = EXAMPLE.PLANE
 addtexture = minimal_plane
+Enable3DItemIcon = true
+ItemIconScaleFactor = 1.0
 AddSeat = 0.0, 0.8, 0.0
 HUD = plane
 speed = 1.2

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -11,6 +11,7 @@ import mcheli.aircraft.MCH_EntityHide;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.aircraft.MCH_SoundUpdater;
+import mcheli.aircraft.MCH_VehicleItemModelRender;
 import mcheli.block.MCH_DraftingTableItemRender;
 import mcheli.block.MCH_DraftingTableRenderer;
 import mcheli.block.MCH_DraftingTableTileEntity;
@@ -128,6 +129,25 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemGLTD, new MCH_ItemGLTDRender());
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemWrench, new MCH_ItemRenderWrench());
       W_MinecraftForgeClient.registerItemRenderer(MCH_MOD.itemRangeFinder, new MCH_ItemRenderRangeFinder());
+      this.registerVehicleItemRenderers();
+   }
+
+   private void registerVehicleItemRenderers() {
+      MCH_VehicleItemModelRender renderer = new MCH_VehicleItemModelRender();
+      registerVehicleItemRenderers(MCH_HeliInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCP_PlaneInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_ShipInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_TankInfoManager.map.values().iterator(), renderer);
+      registerVehicleItemRenderers(MCH_TurretInfoManager.map.values().iterator(), renderer);
+   }
+
+   private void registerVehicleItemRenderers(Iterator iterator, MCH_VehicleItemModelRender renderer) {
+      while(iterator.hasNext()) {
+         MCH_BaseVehicleInfo info = (MCH_BaseVehicleInfo)iterator.next();
+         if(info != null && info.getItem() != null) {
+            W_MinecraftForgeClient.registerItemRenderer(info.getItem(), renderer);
+         }
+      }
    }
 
    public void registerBlockRenderer() {

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -124,6 +124,12 @@ public class MCH_Config {
 
    public static MCH_ConfigPrm AutoThrottleDownTank;
    public static MCH_ConfigPrm DisableItemRender;
+   public static MCH_ConfigPrm Override3DItemIcon;
+   public static MCH_ConfigPrm Heli3DItemIconScale;
+   public static MCH_ConfigPrm Plane3DItemIconScale;
+   public static MCH_ConfigPrm Ship3DItemIconScale;
+   public static MCH_ConfigPrm Tank3DItemIconScale;
+   public static MCH_ConfigPrm Turret3DItemIconScale;
    public static MCH_ConfigPrm RenderDistanceWeight;
    public static MCH_ConfigPrm EnableAircraftLODRender;
    public static MCH_ConfigPrm AircraftLODStartDistance;
@@ -437,6 +443,18 @@ public class MCH_Config {
       AutoThrottleDownTank = new MCH_ConfigPrm("AutoThrottleDownTank", false);
       DisableItemRender = new MCH_ConfigPrm("DisableItemRender", 1);
       DisableItemRender.desc = ";DisableItemRender = 0 ~ 3 (1 = Recommended)";
+      Override3DItemIcon = new MCH_ConfigPrm("Override3DItemIcon", false);
+      Override3DItemIcon.desc = ";Global 3D vehicle item icon override. true = force 3D icons off, false = allow per-vehicle 3D icon settings.";
+      Heli3DItemIconScale = new MCH_ConfigPrm("Heli3DItemIconScale", 1.0D);
+      Heli3DItemIconScale.desc = ";Global scale multiplier for helicopter 3D item icons.";
+      Plane3DItemIconScale = new MCH_ConfigPrm("Plane3DItemIconScale", 1.0D);
+      Plane3DItemIconScale.desc = ";Global scale multiplier for plane 3D item icons.";
+      Ship3DItemIconScale = new MCH_ConfigPrm("Ship3DItemIconScale", 1.0D);
+      Ship3DItemIconScale.desc = ";Global scale multiplier for ship 3D item icons.";
+      Tank3DItemIconScale = new MCH_ConfigPrm("Tank3DItemIconScale", 1.0D);
+      Tank3DItemIconScale.desc = ";Global scale multiplier for tank 3D item icons.";
+      Turret3DItemIconScale = new MCH_ConfigPrm("Turret3DItemIconScale", 1.0D);
+      Turret3DItemIconScale.desc = ";Global scale multiplier for turret/static vehicle 3D item icons.";
       RenderDistanceWeight = new MCH_ConfigPrm("RenderDistanceWeight", 1000.0D);
       EnableAircraftLODRender = new MCH_ConfigPrm("EnableAircraftLODRender", true);
       EnableAircraftLODRender.desc = ";Enable client-only far-distance model displays for aircraft, tanks, turrets, and ships.";
@@ -771,6 +789,12 @@ public class MCH_Config {
               SwitchWeaponWithMouseWheel,
               LWeaponAutoFire,
               DisableItemRender,
+              Override3DItemIcon,
+              Heli3DItemIconScale,
+              Plane3DItemIconScale,
+              Ship3DItemIconScale,
+              Tank3DItemIconScale,
+              Turret3DItemIconScale,
               HideKeybind,
               RenderDistanceWeight,
               EnableAircraftLODRender,

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -148,6 +148,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
     private List textureNameList;
    public int textureCount;
    public float particlesScale;
+   public boolean enable3DItemIcon;
+   public float itemIconScaleFactor;
    public boolean hideEntity;
    public boolean smoothShading;
    public String soundMove;
@@ -364,6 +366,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
       this.textureNameList.add(this.name);
       this.textureCount = 0;
       this.particlesScale = 1.0F;
+      this.enable3DItemIcon = true;
+      this.itemIconScaleFactor = 1.0F;
       this.enableSeaSurfaceParticle = false;
       this.hideEntity = false;
       this.smoothShading = true;
@@ -665,6 +669,10 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
             this.itemID = this.toInt(data, 0, '\uffff');
          } else if(item.compareTo("addtexture") == 0) {
             this.textureNameList.add(data.toLowerCase());
+         } else if(item.equalsIgnoreCase("Enable3DItemIcon")) {
+            this.enable3DItemIcon = this.toBool(data, true);
+         } else if(item.equalsIgnoreCase("ItemIconScaleFactor") || item.equalsIgnoreCase("3DItemIconScaleFactor")) {
+            this.itemIconScaleFactor = this.toFloat(data, 0.01F, 100.0F);
          } else if(item.compareTo("particlesscale") == 0) {
             this.particlesScale = this.toFloat(data, 0.0F, 50.0F);
          } else if(item.equalsIgnoreCase("EnableSeaSurfaceParticle")) {

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -1,0 +1,115 @@
+package mcheli.aircraft;
+
+import mcheli.MCH_Config;
+import mcheli.MCH_ConfigPrm;
+import mcheli.wrapper.W_McClient;
+import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
+import net.minecraftforge.client.IItemRenderer;
+import net.minecraftforge.client.IItemRenderer.ItemRenderType;
+import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
+
+/**
+ * Renders placeable vehicle items with their loaded 3D vehicle model instead of the flat item icon.
+ */
+public class MCH_VehicleItemModelRender implements IItemRenderer {
+
+   public boolean handleRenderType(ItemStack item, ItemRenderType type) {
+      MCH_BaseVehicleInfo info = getInfo(item);
+      return info != null && info.model != null && is3DIconEnabled(info);
+   }
+
+   public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
+      return true;
+   }
+
+   public void renderItem(ItemRenderType type, ItemStack item, Object ... data) {
+      MCH_BaseVehicleInfo info = getInfo(item);
+      if(info == null || info.model == null || !is3DIconEnabled(info)) {
+         return;
+      }
+
+      GL11.glPushMatrix();
+      GL11.glEnable('\u803a');
+      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+      transform(type, info);
+      W_McClient.MOD_bindTexture("textures/" + info.getDirectoryName() + "/" + MCH_RenderBaseVehicle.getBaseTextureName(info.name) + ".png");
+      MCH_RenderBaseVehicle.beginSkinOverlayRender(info.getDirectoryName(), info.name);
+      try {
+         MCH_RenderBaseVehicle.renderAllModel(info.model);
+      } finally {
+         MCH_RenderBaseVehicle.endSkinOverlayRender();
+         GL11.glPopMatrix();
+      }
+      GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+      GL11.glEnable(3042);
+   }
+
+   private static MCH_BaseVehicleInfo getInfo(ItemStack item) {
+      return item != null && item.getItem() instanceof MCH_ItemBaseVehicle
+         ? ((MCH_ItemBaseVehicle)item.getItem()).getAircraftInfo() : null;
+   }
+
+   private static boolean is3DIconEnabled(MCH_BaseVehicleInfo info) {
+      return info.enable3DItemIcon && (MCH_Config.Override3DItemIcon == null || !MCH_Config.Override3DItemIcon.prmBool);
+   }
+
+   private static void transform(ItemRenderType type, MCH_BaseVehicleInfo info) {
+      switch(type) {
+      case ENTITY:
+         GL11.glTranslatef(0.0F, 0.35F, 0.0F);
+         GL11.glRotatef(35.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case EQUIPPED:
+         GL11.glTranslatef(0.25F, 0.45F, 0.55F);
+         GL11.glRotatef(25.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(135.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case EQUIPPED_FIRST_PERSON:
+         GL11.glTranslatef(0.65F, 0.35F, 0.35F);
+         GL11.glRotatef(20.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(125.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      case INVENTORY:
+         GL11.glTranslatef(0.0F, -0.35F, 0.0F);
+         GL11.glRotatef(30.0F, 1.0F, 0.0F, 0.0F);
+         GL11.glRotatef(45.0F, 0.0F, 1.0F, 0.0F);
+         break;
+      default:
+         break;
+      }
+
+      float largest = Math.max(Math.max(info.bodyWidth, info.bodyHeight), 1.0F);
+      float scale = type == ItemRenderType.INVENTORY ? 1.35F / largest : 0.75F / largest;
+      if(type == ItemRenderType.ENTITY) {
+         scale = 1.0F / largest;
+      }
+      scale *= getTypeScale(info) * info.itemIconScaleFactor;
+      GL11.glScalef(scale, scale, scale);
+   }
+
+   private static float getTypeScale(MCH_BaseVehicleInfo info) {
+      String directory = info.getDirectoryName();
+      if("helicopters".equalsIgnoreCase(directory)) {
+         return getScale(MCH_Config.Heli3DItemIconScale);
+      }
+      if("planes".equalsIgnoreCase(directory)) {
+         return getScale(MCH_Config.Plane3DItemIconScale);
+      }
+      if("ships".equalsIgnoreCase(directory)) {
+         return getScale(MCH_Config.Ship3DItemIconScale);
+      }
+      if("tanks".equalsIgnoreCase(directory)) {
+         return getScale(MCH_Config.Tank3DItemIconScale);
+      }
+      if("vehicles".equalsIgnoreCase(directory) || "turrets".equalsIgnoreCase(directory)) {
+         return getScale(MCH_Config.Turret3DItemIconScale);
+      }
+      return 1.0F;
+   }
+
+   private static float getScale(MCH_ConfigPrm prm) {
+      return prm != null ? Math.max((float)prm.prmDouble, 0.01F) : 1.0F;
+   }
+}


### PR DESCRIPTION
### Motivation
- Replace flat item icons for placeable vehicles with their loaded 3D vehicle models so inventories, held-views, and dropped items match in-world visuals.
- Provide global and per-type overrides plus per-vehicle tuning so pack authors and server operators can control appearance and opt-out where needed.
- Update documentation and examples to expose the new configuration and vehicle content-pack keys.

### Description
- Added a new item renderer `MCH_VehicleItemModelRender` that draws placeable vehicle items using the vehicle's `IModelCustom` and applies per-type and per-vehicle scale factors. 
- Registered the renderer for all loaded vehicle types in `MCH_ClientProxy` via `registerVehicleItemRenderers()` so helicopters, planes, ships, tanks, and turrets use the 3D renderer. 
- Introduced configuration parameters in `MCH_Config`: `Override3DItemIcon`, `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale`, and exposed them to the generated config array. 
- Extended `MCH_BaseVehicleInfo` with `enable3DItemIcon` and `itemIconScaleFactor`, added parsing for `Enable3DItemIcon` and `ItemIconScaleFactor` (alias `3DItemIconScaleFactor`), and defaulted values to opt vehicles in by default. 
- Updated docs and examples: `CHANGELOG.md`, `README.md`, `docs/configuration.md`, and `examples/vehicle-configs/plane_minimal.txt` to document new options and example usage.

### Testing
- Performed a project build with `./gradlew build`, which completed successfully. 
- No automated unit tests were added; no failing automated tests were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4edf9fb6e88323b53e793bd9f6f781)