### PR TITLE
Add vehicle weight and maximumExternalPayloadCapacity for chain towing limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Added chain towing weight checks for configured vehicles with `MaximumExternalPayloadCapacity` and `Weight` content-pack keys, including an in-game warning when a vehicle exceeds the towing vehicle's payload capacity.
+
 - Added 3D vehicle item rendering so placeable helicopters, planes, ships, tanks, and turret/static vehicles use their loaded vehicle models in inventories, held views, and dropped item form instead of relying on flat item icons. Added `Override3DItemIcon`, per-type global scale settings, and per-vehicle `Enable3DItemIcon` / `ItemIconScaleFactor` content-pack keys.
 
 - Replaced vehicle extra bounding-box narrow-phase checks with oriented bounding boxes while retaining enclosing AABBs for vanilla broad-phase compatibility. Added optional rectangular `depth` syntax for diagonal/rotated OBB footprints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,8 @@ Vehicle `.txt` definitions can opt individual items into or out of 3D item rende
 | --- | --- | --- |
 | `Enable3DItemIcon` | `true` | Per-vehicle toggle. Set `false` to keep that vehicle on the normal flat item icon even when the global override allows 3D icons. |
 | `ItemIconScaleFactor` | `1.0` | Per-vehicle 3D item icon scale multiplier, clamped to `0.01` through `100.0`. Alias: `3DItemIconScaleFactor`. |
+| `MaximumExternalPayloadCapacity` | `0` | Maximum vehicle weight, in pounds, that this vehicle can lift/tow with a chain. A value of `0` prevents chain-towing other configured vehicles by default. |
+| `Weight` | `50000` | Vehicle weight, in pounds, used when another vehicle attempts to chain-tow it. |
 
 ## Hidden/advanced options initialized in source
 

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -114,6 +114,7 @@ Visual keys do not usually affect physics unless explicitly noted.
 
 - Weapons: `AddWeapon`, `AddTurretWeapon`, `AddPartWeapon`, `AddPartRotWeapon`, `AddPartTurretWeapon`, `AddPartTurretRotWeapon`, `AddPartWeaponChild`, `AddPartWeaponMissile`, `AddPartWeaponBay`, `AddPartSlideWeaponBay`.
 - Racks/hooks: `AddRack`, `RideRack`, `MobDropOption`, `AddRepellingHook`.
+- Chain towing limits: `MaximumExternalPayloadCapacity` sets how much vehicle weight this vehicle can chain-tow in pounds, and `Weight` sets this vehicle's own chain-tow weight in pounds. Defaults are `0` lb capacity and `50000` lb weight, so vehicles cannot chain-lift other configured vehicles unless a payload capacity is explicitly configured.
 - Part animation: `AddPartHatch`, `AddPartSlideHatch`, `AddPartCanopy`, `AddPartSlideCanopy`, `AddPartLG`, `AddPartLGRev`, `AddPartLGHatch`, `AddPartSlideRotLG`, `AddPartThrottle`, `AddPartRotation`, `AddPartLightHatch`.
 - Ground visuals: `SetWheelPos`, `AddCrawlerTrack`, `AddTrackRoller`, `TrackRollerRot`, `AddPartWheel`, `PartWheelRot`, `AddPartSteeringWheel`.
 - Effects/sound/render: `AddParticleSplash`, `particlesscale`, `EnableSeaSurfaceParticle`, `Sound`, `SoundRange`, `SoundVolume`, `SoundPitch`, `hideentity`, `SmoothShading`, `AddSearchLight`, `AddFixedSearchLight`, `AddSteeringSearchLight`, `RotorSpeed`.

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -32,6 +32,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public boolean hasalert = true;
    /** Enables client-side CCIP bomb impact reticle for plane HUDs. */
    public boolean hasBallisticComputer = false;
+   public double maximumExternalPayloadCapacity;
+   public double weight;
    public List recipeString;
    public List recipe;
    public boolean isShapedRecipe;
@@ -263,6 +265,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
       this.displayName = this.name;
       this.displayNameLang = new HashMap();
       this.itemID = 0;
+      this.maximumExternalPayloadCapacity = 0.0D;
+      this.weight = 50000.0D;
       this.recipeString = new ArrayList();
       this.recipe = new ArrayList();
       this.isShapedRecipe = true;
@@ -619,6 +623,10 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
             this.category = data.toUpperCase().replaceAll("[,;:]", ".").replaceAll("[ \t]", "");
          } else if(item.equalsIgnoreCase("CanRide")) {
             this.canRide = this.toBool(data, true);
+         } else if(item.equalsIgnoreCase("MaximumExternalPayloadCapacity")) {
+            this.maximumExternalPayloadCapacity = Math.max(0.0D, Math.min(1000000000.0D, this.toDouble(data)));
+         } else if(item.equalsIgnoreCase("Weight")) {
+            this.weight = Math.max(0.0D, Math.min(1000000000.0D, this.toDouble(data)));
          } else if(item.equalsIgnoreCase("MaxFuel")) {
             this.maxFuel = this.toInt(data, 0, 100000000);
          } else if(item.equalsIgnoreCase("FuelConsumption")) {

--- a/src/main/java/mcheli/chain/MCH_ItemChain.java
+++ b/src/main/java/mcheli/chain/MCH_ItemChain.java
@@ -1,6 +1,8 @@
 package mcheli.chain;
 
 import java.util.List;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntityHitBox;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.chain.MCH_EntityChain;
@@ -15,6 +17,8 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 public class MCH_ItemChain extends W_Item {
@@ -74,6 +78,10 @@ public class MCH_ItemChain extends W_Item {
                return;
             }
 
+            if(!canTowEntity(entityTowed, entity, player)) {
+               return;
+            }
+
             MCH_EntityChain chain = new MCH_EntityChain(world, (entityTowed.posX + entity.posX) / 2.0D, (entityTowed.posY + entity.posY) / 2.0D, (entityTowed.posZ + entity.posZ) / 2.0D);
             chain.setChainLength((int)diff);
             chain.setTowEntity(entityTowed, entity);
@@ -86,6 +94,51 @@ public class MCH_ItemChain extends W_Item {
          }
       }
 
+   }
+
+   private static boolean canTowEntity(Entity towedEntity, Entity towEntity, EntityPlayer player) {
+      MCH_BaseVehicleInfo towedInfo = getVehicleInfo(towedEntity);
+      MCH_BaseVehicleInfo towInfo = getVehicleInfo(towEntity);
+      if(towedInfo == null) {
+         return true;
+      }
+
+      double towedWeight = Math.max(0.0D, towedInfo.weight);
+      double payloadCapacity = towInfo != null?Math.max(0.0D, towInfo.maximumExternalPayloadCapacity):0.0D;
+      if(towedWeight <= payloadCapacity) {
+         return true;
+      }
+
+      if(player != null) {
+         player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "Cannot attach chain: " + getEntityDisplayName(towedEntity) + " weighs " + formatPounds(towedWeight) + " lb, exceeding " + getEntityDisplayName(towEntity) + "'s external payload capacity of " + formatPounds(payloadCapacity) + " lb."));
+      }
+
+      return false;
+   }
+
+   private static MCH_BaseVehicleInfo getVehicleInfo(Entity entity) {
+      if(entity instanceof MCH_EntityBaseVehicle) {
+         return ((MCH_EntityBaseVehicle)entity).getAcInfo();
+      }
+
+      return null;
+   }
+
+   private static String getEntityDisplayName(Entity entity) {
+      MCH_BaseVehicleInfo info = getVehicleInfo(entity);
+      if(info != null && info.displayName != null && !info.displayName.isEmpty()) {
+         return info.displayName;
+      }
+
+      return entity != null?entity.getCommandSenderName():"entity";
+   }
+
+   private static String formatPounds(double pounds) {
+      if(Math.abs(pounds - (double)((long)pounds)) < 0.001D) {
+         return String.valueOf((long)pounds);
+      }
+
+      return String.format(java.util.Locale.ROOT, "%.1f", pounds);
    }
 
    public static void playConnectTowingEntity(Entity e) {


### PR DESCRIPTION
### Motivation
- Prevent vehicles from chaining/towing other configured vehicles when the towing vehicle cannot lift them, and display an in-game popup explaining the failure. 
- Expose two content-pack keys for vehicle authors: `MaximumExternalPayloadCapacity` (defaults to `0` lb) to control lift capability and `Weight` (defaults to `50000` lb) to represent vehicle weight used in towing checks.

### Description
- Added `maximumExternalPayloadCapacity` and `weight` fields to `MCH_BaseVehicleInfo` with defaults set in the constructor and parser support for `MaximumExternalPayloadCapacity` and `Weight` keys in `loadItemData` so vehicle `.txt` configs can set them. (file: `src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java`)
- Enforced the towing check in `MCH_ItemChain.interactEntity` by inserting a helper `canTowEntity(...)` that looks up `MCH_BaseVehicleInfo` for the tow/towed entities, compares `weight` against the towing vehicle's `maximumExternalPayloadCapacity`, and aborts chain creation when overweight. (file: `src/main/java/mcheli/chain/MCH_ItemChain.java`)
- When a tow attempt fails due to weight, the code now sends a red chat message to the player describing the towed entity, its weight in pounds, and the towing vehicle's external payload capacity. (file: `src/main/java/mcheli/chain/MCH_ItemChain.java`)
- Updated documentation and changelog to describe the new content-pack keys and defaults: `docs/configuration.md`, `docs/vehicle-config/base.md`, and `CHANGELOG.md`.

### Testing
- Ran static check `git diff --check` on the changes which completed successfully. 
- No runtime/unit tests were executed as part of this change; the modification is limited to config parsing, a runtime check on chain attach, and documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ef93b600083239a0e6a00709fd037)