### PR TITLE
Add `/mcheli enablenukes` command with HBM/NTM sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Added `/mcheli enablenukes [true|false]` for MCHeli nuclear-weapon gating, with status/updates mirrored to HBM NTM's `/ntmenablenukes` command when that mod command is available.
+
 - Added the `CanMountShip` vehicle config key so pack makers can prevent oversized aircraft, such as heavy bombers, from mounting ship/carrier racks while preserving existing behavior by default.
 
 - Added chain towing weight checks for configured vehicles with `MaximumExternalPayloadCapacity` and `Weight` content-pack keys, including an in-game warning when a vehicle exceeds the towing vehicle's payload capacity.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Common examples:
 /mcheli reconfig
 /mcheli status entity 5
 /mcheli showboundingbox true
+/mcheli enablenukes false
 /mcheli title 5 2 {"text":"Mission start"}
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,6 +43,7 @@ Permissions are per subcommand. Granting `status` does not grant `fill` or `kill
 | `removeentity` | `/mcheli removeentity <entityClassNameFragment>` | Marks matching loaded non-player entities dead by setting `isDead = true`. |
 | `attackentity` | `/mcheli attackentity <entityClassNameFragment> <damage> [damageSource]` | Damages matching loaded non-player entities. |
 | `showboundingbox` | `/mcheli showboundingbox <true|false>` | Toggles MCHeli debug bounding boxes and broadcasts server settings. This does not save the config file. |
+| `enablenukes` | `/mcheli enablenukes [true|false]` | Shows or changes whether MCHeli HBM-style nuclear weapon effects are enabled. When HBM/NTM registers `/ntmenablenukes`, this subcommand mirrors that command's current status and forwards changes back to HBM. |
 
 ## `attackentity` damage sources
 

--- a/src/main/java/mcheli/MCH_HBMUtil.java
+++ b/src/main/java/mcheli/MCH_HBMUtil.java
@@ -28,6 +28,154 @@ public class MCH_HBMUtil {
         }
     }
 
+    private static final String HBM_ENABLE_NUKES_COMMAND = "ntmenablenukes";
+    private static boolean mcheliNukesEnabled = true;
+
+    public static boolean areNukesEnabled() {
+        Boolean hbmEnabled = getHBMNukesEnabled();
+        if (hbmEnabled != null) {
+            mcheliNukesEnabled = hbmEnabled.booleanValue();
+        }
+        return mcheliNukesEnabled;
+    }
+
+    public static void setMCHeliNukesEnabled(boolean enabled) {
+        mcheliNukesEnabled = enabled;
+        setHBMNukesEnabled(enabled);
+    }
+
+    public static boolean hasHBMEnableNukesCommand() {
+        return getHBMEnableNukesCommand() != null;
+    }
+
+    public static void syncHBMEnableNukesCommand(net.minecraft.command.ICommandSender sender, boolean enabled) {
+        try {
+            net.minecraft.command.ICommand command = getHBMEnableNukesCommand();
+            if (command != null) {
+                command.processCommand(sender, new String[]{String.valueOf(enabled)});
+                setHBMNukesEnabled(enabled);
+            }
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static net.minecraft.command.ICommand getHBMEnableNukesCommand() {
+        try {
+            net.minecraft.server.MinecraftServer server = net.minecraft.server.MinecraftServer.getServer();
+            if (server != null && server.getCommandManager() != null) {
+                java.lang.reflect.Method getCommands = server.getCommandManager().getClass().getMethod("getCommands", new Class[0]);
+                Object commands = getCommands.invoke(server.getCommandManager(), new Object[0]);
+                if (commands instanceof java.util.Map) {
+                    Object command = ((java.util.Map)commands).get(HBM_ENABLE_NUKES_COMMAND);
+                    if (command instanceof net.minecraft.command.ICommand) {
+                        return (net.minecraft.command.ICommand)command;
+                    }
+                }
+            }
+        } catch (Throwable ignored) {
+        }
+        return null;
+    }
+
+    private static Boolean getHBMNukesEnabled() {
+        Object command = getHBMEnableNukesCommand();
+        Boolean enabled = getBooleanField(command, "enableNukes", "enabled", "nukes", "allowNukes");
+        if (enabled != null) {
+            return enabled;
+        }
+        return getBooleanFieldFromClasses(new String[]{"com.hbm.config.BombConfig", "com.hbm.config.GeneralConfig", "com.hbm.config.WeaponConfig"}, new String[]{"enableNukes", "enabledNukes", "nukes", "allowNukes"});
+    }
+
+    private static void setHBMNukesEnabled(boolean enabled) {
+        Object command = getHBMEnableNukesCommand();
+        setBooleanField(command, enabled, "enableNukes", "enabled", "nukes", "allowNukes");
+        setBooleanFieldInClasses(new String[]{"com.hbm.config.BombConfig", "com.hbm.config.GeneralConfig", "com.hbm.config.WeaponConfig"}, enabled, new String[]{"enableNukes", "enabledNukes", "nukes", "allowNukes"});
+    }
+
+    private static Boolean getBooleanField(Object target, String... names) {
+        if (target == null) {
+            return null;
+        }
+        for (String name : names) {
+            try {
+                java.lang.reflect.Field field = target.getClass().getDeclaredField(name);
+                field.setAccessible(true);
+                if (field.getType() == Boolean.TYPE) {
+                    return Boolean.valueOf(field.getBoolean(target));
+                }
+                if (field.getType() == Boolean.class) {
+                    return (Boolean)field.get(target);
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static Boolean getBooleanFieldFromClasses(String[] classNames, String[] fieldNames) {
+        for (String className : classNames) {
+            try {
+                Class<?> clazz = Class.forName(className);
+                for (String fieldName : fieldNames) {
+                    try {
+                        java.lang.reflect.Field field = clazz.getDeclaredField(fieldName);
+                        field.setAccessible(true);
+                        if (field.getType() == Boolean.TYPE) {
+                            return Boolean.valueOf(field.getBoolean(null));
+                        }
+                        if (field.getType() == Boolean.class) {
+                            return (Boolean)field.get(null);
+                        }
+                    } catch (Throwable ignored) {
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static void setBooleanField(Object target, boolean value, String... names) {
+        if (target == null) {
+            return;
+        }
+        for (String name : names) {
+            try {
+                java.lang.reflect.Field field = target.getClass().getDeclaredField(name);
+                field.setAccessible(true);
+                if (field.getType() == Boolean.TYPE) {
+                    field.setBoolean(target, value);
+                } else if (field.getType() == Boolean.class) {
+                    field.set(target, Boolean.valueOf(value));
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+
+    private static void setBooleanFieldInClasses(String[] classNames, boolean value, String[] fieldNames) {
+        for (String className : classNames) {
+            try {
+                Class<?> clazz = Class.forName(className);
+                for (String fieldName : fieldNames) {
+                    try {
+                        java.lang.reflect.Field field = clazz.getDeclaredField(fieldName);
+                        field.setAccessible(true);
+                        if (field.getType() == Boolean.TYPE) {
+                            field.setBoolean(null, value);
+                        } else if (field.getType() == Boolean.class) {
+                            field.set(null, Boolean.valueOf(value));
+                        }
+                    } catch (Throwable ignored) {
+                    }
+                }
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+
+
     public static Object EntityNukeExplosionMK5_statFac(World world, int r, double posX, double posY, double posZ) {
         try {
             if (nukeExplosionMK5Class != null) {

--- a/src/main/java/mcheli/command/MCH_Command.java
+++ b/src/main/java/mcheli/command/MCH_Command.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import mcheli.MCH_Config;
 import mcheli.MCH_MOD;
+import mcheli.MCH_HBMUtil;
 import mcheli.MCH_PacketNotifyServerSettings;
 import mcheli.command.MCH_PacketTitle;
 import mcheli.multiplay.MCH_MultiplayPacketHandler;
@@ -57,7 +58,8 @@ public class MCH_Command extends CommandBase {
    public static final String CMD_ATTACK_ENTITY = "attackentity";
    public static final String CMD_SHOW_BB = "showboundingbox";
    public static final String CMD_LIST = "list";
-   public static String[] ALL_COMMAND = new String[]{"sendss", "modlist", "reconfig", "title", "fill", "status", "killentity", "removeentity", "attackentity", "showboundingbox", "list"};
+   public static final String CMD_ENABLE_NUKES = "enablenukes";
+   public static String[] ALL_COMMAND = new String[]{"sendss", "modlist", "reconfig", "title", "fill", "status", "killentity", "removeentity", "attackentity", "showboundingbox", "enablenukes", "list"};
    public static MCH_Command instance = new MCH_Command();
 
 
@@ -99,6 +101,13 @@ public class MCH_Command extends CommandBase {
    }
 
    public static void onCommandEvent(CommandEvent event) {
+      if(event.command != null && "ntmenablenukes".equalsIgnoreCase(event.command.getCommandName()) && event.parameters.length > 0) {
+         try {
+            MCH_HBMUtil.setMCHeliNukesEnabled(parseBoolean(event.sender, event.parameters[0]));
+         } catch(Throwable ignored) {
+         }
+      }
+
       if(event.command instanceof MCH_Command) {
          if(event.parameters.length > 0 && event.parameters[0].length() > 0) {
             if(!checkCommandPermission(event.sender, event.parameters[0])) {
@@ -225,6 +234,8 @@ public class MCH_Command extends CommandBase {
                      MCH_PacketNotifyServerSettings.sendAll();
                      sender.addChatMessage(new ChatComponentText("Enabled bounding box [F3 + b]"));
                   }
+               } else if(prm[0].equalsIgnoreCase("enablenukes")) {
+                  this.executeEnableNukes(sender, prm);
                } else {
                   if(!prm[0].equalsIgnoreCase("list")) {
                      throw new CommandException("Unknown mcheli command. please type /mcheli list", new Object[0]);
@@ -244,6 +255,27 @@ public class MCH_Command extends CommandBase {
             }
 
          }
+      }
+   }
+
+   private void executeEnableNukes(ICommandSender sender, String[] args) {
+      if(args.length > 2) {
+         throw new CommandException("Parameter error! : /mcheli enablenukes [true|false]", new Object[0]);
+      }
+
+      if(args.length == 2) {
+         boolean enabled = parseBoolean(sender, args[1]);
+         MCH_HBMUtil.setMCHeliNukesEnabled(enabled);
+         if(MCH_HBMUtil.hasHBMEnableNukesCommand()) {
+            MCH_HBMUtil.syncHBMEnableNukesCommand(sender, enabled);
+         }
+         sender.addChatMessage(new ChatComponentText("MCHeli nukes " + (MCH_HBMUtil.areNukesEnabled() ? "enabled" : "disabled") + "."));
+      } else {
+         sender.addChatMessage(new ChatComponentText("MCHeli nukes are " + (MCH_HBMUtil.areNukesEnabled() ? "enabled" : "disabled") + "."));
+      }
+
+      if(MCH_HBMUtil.hasHBMEnableNukesCommand()) {
+         sender.addChatMessage(new ChatComponentText("Linked to HBM /ntmenablenukes command."));
       }
    }
 
@@ -559,6 +591,8 @@ public class MCH_Command extends CommandBase {
                   return getListOfStringsMatchingLastWord(prm, new String[]{"player", "inFire", "onFire", "lava", "inWall", "drown", "starve", "cactus", "fall", "outOfWorld", "generic", "magic", "wither", "anvil", "fallingBlock"});
                }
             } else if(prm[0].equalsIgnoreCase("showboundingbox") && prm.length == 2) {
+               return getListOfStringsMatchingLastWord(prm, new String[]{"true", "false"});
+            } else if(prm[0].equalsIgnoreCase("enablenukes") && prm.length == 2) {
                return getListOfStringsMatchingLastWord(prm, new String[]{"true", "false"});
             }
          }

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -1534,7 +1534,7 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
             result = MCH_Explosion.newExplosionInWater(super.worldObj, this, this.shootingEntity, x, y, z, exp, expBlock, this.isBomblet == 1 ? super.rand.nextInt(3) == 0 : true, true, this.getInfo().flaming, true, 0, this.getInfo() != null ? this.getInfo().damageFactor : null);
         }
 
-        if(this.getInfo().nukeYield > 0) {
+        if(this.getInfo().nukeYield > 0 && MCH_HBMUtil.areNukesEnabled()) {
             if(!this.getInfo().nukeEffectOnly) {
                 worldObj.spawnEntityInWorld((Entity) MCH_HBMUtil.EntityNukeExplosionMK5_statFac(super.worldObj, this.getInfo().nukeYield, this.posX + 0.5, this.posY + 0.5, this.posZ + 0.5));
             }


### PR DESCRIPTION
### Motivation
- Provide a server/admin command to view and change whether MCHeli emits HBM-style nuclear effects and keep that state aligned with HBM/NTM when present.
- Make MCHeli respect a single shared enable/disable state so content packs and server operators can safely gate nuclear effects.
- Update documentation and changelog to record the new admin command and behavior.

### Description
- Added `/mcheli enablenukes [true|false]` handling, permission checks, and tab-completion in `src/main/java/mcheli/command/MCH_Command.java` and added the new command name to the command list.
- Implemented reflection helpers and shared state in `src/main/java/mcheli/MCH_HBMUtil.java` to discover HBM/NTM's `/ntmenablenukes` command, read/write enable flags (via fields or config classes), forward changes to HBM, and detect when HBM's command runs to keep MCHeli synchronized.
- Gate nuclear explosion behavior in `src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java` by checking `MCH_HBMUtil.areNukesEnabled()` before spawning HBM nuke effects.
- Documented the new subcommand in `docs/commands.md` and `README.md` and added an entry to `CHANGELOG.md`.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch-format issues and it completed without errors.
- Performed repository search/inspection to verify references and tab-completion (`rg`/code review) and committed the change; no runtime/unit tests were present or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f01d8dcd483239243f44fbd1b3975)