### PR TITLE
Add first-person bomber reticle mode (KeyBombReticleMode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Added a first-person bomber reticle mode for plane gunner view, toggled by the new `KeyBombReticleMode` keybind, using the existing ballistic bomb-impact predictor for accurate impact placement.
+
 - Added `/mcheli enablenukes [true|false]` for MCHeli nuclear-weapon gating, with usage/status output when run without an argument, colored broadcast messages, Wither spawn sound feedback, and status/updates mirrored to HBM NTM's `/ntmenablenukes` command when that mod command is available.
 
 - Added the `CanMountShip` vehicle config key so pack makers can prevent oversized aircraft, such as heavy bombers, from mounting ship/carrier racks while preserving existing behavior by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,7 +242,7 @@ Tuning guidance:
 
 ## New-flight plane mouse aim controls (currently in development)
 
-Mouse aim is currently in development as a control foundation for fixed-wing planes using `UseNewMobilitySystem = true` only. It is disabled by default and does not affect legacy aircraft. When enabled globally, pilots can toggle it in a qualifying new-flight plane with `KeyPlaneMouseAim`; the mouse moves a separate desired aim yaw/pitch and the aircraft nose chases that aim through the existing new-flight authority, stall, energy, pitch-suppression, damping, and rotation-limit path. Advanced lead HUD polish is intentionally left for a later pass. Plane CCIP, where enabled by the aircraft ballistic computer, is a static ballistic bomb-impact pipper projected from the aircraft body frame and does not follow player freelook or mouse aim.
+Mouse aim is currently in development as a control foundation for fixed-wing planes using `UseNewMobilitySystem = true` only. It is disabled by default and does not affect legacy aircraft. When enabled globally, pilots can toggle it in a qualifying new-flight plane with `KeyPlaneMouseAim`; the mouse moves a separate desired aim yaw/pitch and the aircraft nose chases that aim through the existing new-flight authority, stall, energy, pitch-suppression, damping, and rotation-limit path. Advanced lead HUD polish is intentionally left for a later pass. Plane CCIP, where enabled by the aircraft ballistic computer, is a static ballistic bomb-impact pipper projected from the aircraft body frame and does not follow player freelook or mouse aim. In first-person pilot gunner mode, `KeyBombReticleMode` toggles a bomber sight that uses the same ballistic prediction and only appears while viewing from the gunner camera.
 
 This first implementation uses global client config keys. Per-plane mouse-aim overrides are not wired yet, so pack authors should tune conservatively.
 
@@ -250,6 +250,7 @@ This first implementation uses global client config keys. Per-plane mouse-aim ov
 | --- | --- | --- |
 | `EnableMouseAimControls` | `false` | Master enable for the active-development mode; new-flight-model planes only. |
 | `KeyPlaneMouseAim` | `49` | Toggle key while piloting a qualifying new-flight plane (N by default). |
+| `KeyBombReticleMode` | `37` | Toggle first-person gunner bomber sight for bomb-capable planes (K by default). |
 | `MouseAimSensitivity` | `0.18` | Scales raw mouse movement into desired aim yaw/pitch changes. |
 | `MouseAimSmoothing` | `0.30` | Smooths desired aim motion to reduce jitter without snapping. |
 | `MouseAimMaxPitchUp` | `70.0` | Nose-up aim clamp in degrees. |
@@ -298,6 +299,7 @@ The custom cursor is required because the vanilla Minecraft crosshair is locked 
 | `KeyFreeLook` | `29` | Left Control |
 | `KeyPlaneLookAhead` | `56` | Left Alt |
 | `KeyPlaneMouseAim` | `49` | N |
+| `KeyBombReticleMode` | `37` | K |
 | `KeyGUI` | `19` | R |
 | `KeyGearUpDown` | `48` | B |
 | `KeyPutToRack` | `36` | J |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -66,6 +66,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm KeyFreeLook;
    public static MCH_ConfigPrm KeyPlaneLookAhead;
    public static MCH_ConfigPrm KeyPlaneMouseAim;
+   public static MCH_ConfigPrm KeyBombReticleMode;
    public static MCH_ConfigPrm KeyGUI;
    public static MCH_ConfigPrm KeyGearUpDown;
    public static MCH_ConfigPrm KeyPutToRack;
@@ -364,6 +365,7 @@ public class MCH_Config {
       KeyFreeLook = new MCH_ConfigPrm("KeyFreeLook", 29);
       KeyPlaneLookAhead = new MCH_ConfigPrm("KeyPlaneLookAhead", 56);
       KeyPlaneMouseAim = new MCH_ConfigPrm("KeyPlaneMouseAim", 49);
+      KeyBombReticleMode = new MCH_ConfigPrm("KeyBombReticleMode", 37);
       KeyGUI = new MCH_ConfigPrm("KeyGUI", 19);
       KeyGearUpDown = new MCH_ConfigPrm("KeyGearUpDown", 48);
       KeyPutToRack = new MCH_ConfigPrm("KeyPutToRack", 36);
@@ -392,6 +394,7 @@ public class MCH_Config {
               KeyFreeLook,
               KeyPlaneLookAhead,
               KeyPlaneMouseAim,
+              KeyBombReticleMode,
               KeyGUI,
               KeyGearUpDown,
               KeyPutToRack,

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -22,7 +22,10 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
    public MCH_Key KeyEjectSeat;
    public MCH_Key KeyZoom;
    public MCH_Key KeyMouseAim;
+   public MCH_Key KeyBombReticleMode;
    public MCH_Key[] Keys;
+   private static int bombReticlePlaneEntityId = -1;
+   private static boolean bombReticleMode = false;
    private final MCP_PlaneChaseCamera chaseCamera = new MCP_PlaneChaseCamera();
    private boolean wasUsingChaseCamera = false;
 
@@ -38,7 +41,8 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.KeyEjectSeat = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyMouseAim = new MCH_Key(MCH_Config.KeyPlaneMouseAim.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.KeyBombReticleMode = new MCH_Key(MCH_Config.KeyBombReticleMode.prmInt);
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, this.KeyBombReticleMode, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCP_EntityPlane plane) {
@@ -102,6 +106,8 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
             this.playerControlInGUI(var7, var8, var9);
          }
 
+         this.updateBombReticleMode(var7, var8, var9);
+
          boolean hideHand = true;
          if(useChaseCamera) {
             this.chaseCamera.update(super.mc, var7, var8);
@@ -126,6 +132,7 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
             this.wasUsingChaseCamera = false;
          }
          super.isRiding = false;
+         resetBombReticleMode();
       }
 
       if(!super.isBeforeRiding && super.isRiding && var8 != null && !this.wasUsingChaseCamera) {
@@ -140,6 +147,28 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
          this.wasUsingChaseCamera = false;
       }
 
+   }
+
+   private void updateBombReticleMode(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
+      if(player == null || plane == null || !isPilot || !plane.getIsGunnerMode(player)
+            || super.mc == null || super.mc.gameSettings == null || super.mc.gameSettings.thirdPersonView != 0) {
+         resetBombReticleMode();
+         return;
+      }
+      if(this.KeyBombReticleMode.isKeyDown()) {
+         bombReticleMode = !bombReticleMode;
+         bombReticlePlaneEntityId = bombReticleMode ? plane.getEntityId() : -1;
+         playSoundOK();
+      }
+   }
+
+   public static boolean isBombReticleMode(MCP_EntityPlane plane) {
+      return plane != null && bombReticleMode && bombReticlePlaneEntityId == plane.getEntityId();
+   }
+
+   public static void resetBombReticleMode() {
+      bombReticleMode = false;
+      bombReticlePlaneEntityId = -1;
    }
 
    protected void playerControlInGUI(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -126,8 +126,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
          // CCIP is a world-space impact cue, not part of the optional full HUD.
          // Keep it available in third person even when DisplayHUDThirdPerson is disabled.
-         if(seatID == 0) {
-            this.drawPlaneCCIPReticle(plane, player);
+         if(seatID == 0 && (!plane.getIsGunnerMode(player) || (!isThirdPersonView && MCP_ClientPlaneTickHandler.isBombReticleMode(plane)))) {
+            this.drawPlaneCCIPReticle(plane, player, plane.getIsGunnerMode(player));
+         } else if(seatID == 0 && plane.getIsGunnerMode(player)) {
+            this.resetCCIPState();
          }
 
          this.drawHitBullet(plane, -14101432, seatID);
@@ -592,7 +594,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             x + r * 0.55D, y + r * 0.55D, x - r * 0.55D, y + r * 0.55D}, color, 2);
    }
 
-   private void drawPlaneCCIPReticle(MCP_EntityPlane plane, EntityPlayer player) {
+   private void drawPlaneCCIPReticle(MCP_EntityPlane plane, EntityPlayer player, boolean bomberMode) {
       MCP_PlaneInfo info = plane != null ? plane.getPlaneInfo() : null;
       if(plane == null || player == null || info == null || !info.hasBallisticComputer || plane.isDestroyed()) {
          this.resetCCIPState();
@@ -614,7 +616,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          if(result != null && result.valid && result.impact != null) {
             ScreenPoint projected = this.projectWorldToRenderCamera(result.impact, this.smoothCamPartialTicks);
             if(projected != null && projected.visible) {
-               this.drawCCIPPipper(projected.x, projected.y, false);
+               this.drawCCIPPipper(projected.x, projected.y, false, bomberMode);
             } else {
                this.resetCCIPSmoothing();
             }
@@ -986,7 +988,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       return Vec3.createVectorHelper(v.xCoord / length, v.yCoord / length, v.zCoord / length);
    }
 
-   private void drawCCIPPipper(double x, double y, boolean clamped) {
+   private void drawCCIPPipper(double x, double y, boolean clamped, boolean bomberMode) {
       int color = clamped ? 0xAA55FF66 : 0xF055FF66;
       double r = 10.0D * CCIP_PIPPER_SCALE;
       double tickInner = r + 2.0D * CCIP_PIPPER_SCALE;
@@ -1001,7 +1003,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       this.drawLine(new double[]{x - 2.0D, y, x + 2.0D, y, x, y - 2.0D, x, y + 2.0D,
             x - tickOuter, y, x - tickInner, y, x + tickInner, y, x + tickOuter, y,
             x, y - tickOuter, x, y - tickInner, x, y + tickInner, x, y + tickOuter}, color);
-      this.drawString("CCIP", (int)(x + r + 7.0D), (int)(y + r + 4.0D), color);
+      this.drawString(bomberMode ? "BOMB" : "CCIP", (int)(x + r + 7.0D), (int)(y + r + 4.0D), color);
    }
 
    private static class ReleaseKinematics {
@@ -1054,6 +1056,13 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
                   msg = var12.append(MCH_KeyName.getDescOrName(MCH_Config.KeySwitchMode.prmInt)).toString();
                   this.drawString(msg, RX, super.centerY - 70, c);
                }
+            }
+
+            if(seatID == 0 && plane.getIsGunnerMode(player) && !Keyboard.isKeyDown(MCH_Config.KeyFreeLook.prmInt)) {
+               boolean bombReticle = MCP_ClientPlaneTickHandler.isBombReticleMode(plane);
+               var12 = (new StringBuilder()).append(bombReticle ? "Bomb Sight Off : " : "Bomb Sight : ");
+               msg = var12.append(MCH_KeyName.getDescOrName(MCH_Config.KeyBombReticleMode.prmInt)).toString();
+               this.drawString(msg, RX, super.centerY - 60, colorActive);
             }
 
             if(seatID > 0 && plane.canSwitchGunnerModeOtherSeat(player)) {


### PR DESCRIPTION
### Motivation

- Provide a dedicated first-person bomber sight for pilots in gunner mode so they can toggle an accurate bomb impact reticle while looking through the gunner camera. 
- Reuse the existing deterministic ballistic CCIP predictor to ensure the reticle indicates where bombs will actually land.

### Description

- Added a new client config key `KeyBombReticleMode` (default `37`) and registered it in the key config array in `src/main/java/mcheli/MCH_Config.java`.
- Wired a new key and client-side state into `MCP_ClientPlaneTickHandler` by adding `KeyBombReticleMode`, boolean/ID state, and `updateBombReticleMode` logic that toggles the mode only while the pilot is in first-person gunner view and resets it when the view/state becomes invalid.
- Updated `MCP_GuiPlane` to accept a `bomberMode` flag, draw the existing CCIP prediction as a bomber sight when active, label the HUD pipper `BOMB` (instead of `CCIP`) for bomber mode, and render an in-HUD hint for the new keybind while in gunner mode.
- Updated documentation and changelog: `docs/configuration.md` documents the new `KeyBombReticleMode` and `CHANGELOG.md` records the feature addition.

### Testing

- Ran a code-style/consistency check (`git diff --check`) which returned no issues. 
- Performed automated source searches (`rg`) to verify references and that the new key/handlers and GUI calls are present and wired correctly. 
- Did not run a full Gradle compile/build to avoid producing binary artifacts, per repository instruction.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1311ea948323815516ed291c0e45)