### PR TITLE
Fix plane free-look A/D turning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed plane free-look steering so A/D turn input is still sent and applied while free look is active in both mouse flight-sim and regular control modes.
+
 - Added a first-person bomber reticle mode for plane gunner view, toggled by the new `KeyBombReticleMode` keybind, using the existing ballistic bomb-impact predictor for accurate impact placement. The key now appears in the in-game key binding list, and its HUD hint is shown at bottom-center to avoid overlapping flap prompts.
 
 - Added `/mcheli enablenukes [true|false]` for MCHeli nuclear-weapon gating, with usage/status output when run without an argument, colored broadcast messages, Wither spawn sound feedback, and status/updates mirrored to HBM NTM's `/ntmenablenukes` command when that mod command is available.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,7 +183,7 @@ The standard chase camera is intentionally stable: it stays behind the aircraft 
 
 * **Free Look** (`KeyFreeLook`, default Left Control): by default this remains the original toggle action, including in regular third person, so the view does not snap back when the key is released. Enabling **Hold Free Look** in the controls menu changes it to a held action that turns off on key release.
 * **Hold Plane Look Ahead** (`KeyPlaneLookAhead`, default Left Alt): while held, the camera focus blends forward along the aircraft facing direction while the camera remains behind the aircraft at normal chase distance. Releasing the key smoothly returns to centered framing.
-* **Interaction:** the new third-person chase camera no longer consumes freelook mouse movement for a custom orbit path, so freelook uses the shared aircraft freelook state instead of injecting camera-orbit deltas into flight controls.
+* **Interaction:** the new third-person chase camera no longer consumes freelook mouse movement for a custom orbit path, so freelook uses the shared aircraft freelook state instead of injecting camera-orbit deltas into flight controls. While free look is active, plane pilots can still use **A/D** to turn the aircraft in both regular controls and mouse flight-sim mode.
 
 Recommended bindings: keep **Free Look** on a comfortable key such as Left Control, enable **Hold Free Look** only if you prefer hold-to-use behavior, and bind **Plane Look Ahead** to Left Alt, a thumb mouse button, or another hold key that can be pressed briefly during target tracking.
 

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -256,13 +256,8 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
             }
             pc.throttleDown = ac.throttleDown = this.KeyDown.isKeyPress();
             pc.throttleUp = ac.throttleUp = this.KeyUp.isKeyPress();
-            if(ac instanceof MCP_EntityPlane && ac.isFreeLookMode()) {
-               pc.moveRight = ac.moveRight = false;
-               pc.moveLeft = ac.moveLeft = false;
-            } else {
-               pc.moveRight = ac.moveRight = this.KeyRight.isKeyPress();
-               pc.moveLeft = ac.moveLeft = this.KeyLeft.isKeyPress();
-            }
+            pc.moveRight = ac.moveRight = this.KeyRight.isKeyPress();
+            pc.moveLeft = ac.moveLeft = this.KeyLeft.isKeyPress();
          }
       }
       if (!ac.isDestroyed() && this.KeyFlare.isKeyDown()) {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -2717,11 +2717,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                }
             }
 
-            if(!this.isFreeLookMode() && super.moveLeft && !super.moveRight) {
+            if(super.moveLeft && !super.moveRight) {
                this.setRotYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
             }
 
-            if(!this.isFreeLookMode() && super.moveRight && !super.moveLeft) {
+            if(super.moveRight && !super.moveLeft) {
                this.setRotYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
             }
          }


### PR DESCRIPTION
### Motivation

- Free-look decouples the camera from pilot input but previously prevented A/D (left/right) keys from turning planes while freelook was active. 
- Ensure pilots can still steer with A/D in both regular and mouse flight-sim control modes while freelook is enabled.

### Description

- Stop clearing left/right movement input for planes in the client input handler by leaving `moveLeft`/`moveRight` set from `KeyLeft`/`KeyRight` in `MCH_BaseVehicleClientTickHandler`.
- Apply yaw from A/D in the plane free-look update path by allowing the existing `moveLeft`/`moveRight` checks to affect `setRotYaw` in `MCP_EntityPlane` even while freelook is active.
- Add a changelog entry describing the fix in `CHANGELOG.md` and update the camera/config docs in `docs/configuration.md` to document that A/D turning still works during free look.

### Testing

- Ran `git diff --check` to validate the working tree and whitespace issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2cad8a4c83238ebc5de962dcf761)