### PR TITLE
Apply interpolated roll to debug extra bounding-box rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed debug extra bounding-box roll translation so rendered boxes use the same interpolated yaw, pitch, and roll as the vehicle model instead of leaving their vertical offsets visually static during roll.
+
 - Fixed plane free-look steering so A/D turn input is still sent and applied while free look is active in both mouse flight-sim and regular control modes.
 
 - Added a first-person bomber reticle mode for plane gunner view, toggled by the new `KeyBombReticleMode` keybind, using the existing ballistic bomb-impact predictor for accurate impact placement. The key now appears in the in-game key binding list, and its HUD hint is shown at bottom-center to avoid overlapping flap prompts.

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -75,7 +75,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `EntityHeight` | All | float | 1.0 | entity bounding height |
 | `EntityPitch` | All | float | 0.0 | rendered entity pitch offset |
 | `EntityRoll` | All | float | 0.0 | rendered entity roll offset |
-| `BoundingBox` | All | list | none | extra damage/collision OBB; existing `x,y,z,width,height[,damageFactor]` syntax is preserved, and `x,y,z,width,height,depth,damageFactor` enables rectangular OBB footprints that rotate with vehicle yaw/pitch/roll |
+| `BoundingBox` | All | list | none | extra damage/collision OBB; existing `x,y,z,width,height[,damageFactor]` syntax is preserved, and `x,y,z,width,height,depth,damageFactor` enables rectangular OBB footprints that rotate with vehicle yaw/pitch/roll. Debug rendering now also applies the interpolated vehicle roll to the box offset so rolled vehicles show boxes moving vertically with the model. |
 | `SetWheelPos` | All | vec3 | family default wheel list | wheel contact point; repeatable |
 | `StepHeight` | All | float | 0.0 (intended plane/tank/ship helper returns 0.6 but is private) | block step height |
 | `maxhp` | All | int | 50 | health |

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -497,7 +497,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       return prevRot + (rot - prevRot) * tickTime;
    }
 
-   public void renderDebugHitBox(MCH_EntityBaseVehicle e, double x, double y, double z, float yaw, float pitch) {
+   public void renderDebugHitBox(MCH_EntityBaseVehicle e, double x, double y, double z, float yaw, float pitch, float roll) {
       MCH_Config var10000 = MCH_MOD.config;
       if(MCH_Config.TestMode.prmBool && debugModel != null) {
          GL11.glPushMatrix();
@@ -514,10 +514,11 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          for(int i$ = 0; i$ < len$; ++i$) {
             MCH_BoundingBox bb = arr$[i$];
             GL11.glPushMatrix();
-            GL11.glTranslated(bb.rotatedOffset.xCoord, bb.rotatedOffset.yCoord, bb.rotatedOffset.zCoord);
-            GL11.glRotatef(-e.getRotYaw(), 0.0F, 1.0F, 0.0F);
-            GL11.glRotatef(-e.getRotPitch(), 1.0F, 0.0F, 0.0F);
-            GL11.glRotatef(-e.getRotRoll(), 0.0F, 0.0F, 1.0F);
+            Vec3 rotatedOffset = MCH_Lib.RotVec3(bb.offsetX, bb.offsetY, bb.offsetZ, -yaw, -pitch, -roll);
+            GL11.glTranslated(rotatedOffset.xCoord, rotatedOffset.yCoord, rotatedOffset.zCoord);
+            GL11.glRotatef(-yaw, 0.0F, 1.0F, 0.0F);
+            GL11.glRotatef(-pitch, 1.0F, 0.0F, 0.0F);
+            GL11.glRotatef(-roll, 0.0F, 0.0F, 1.0F);
             GL11.glPushMatrix();
             GL11.glScalef(bb.width, bb.height, bb.depth);
             this.bindTexture("textures/bounding_box.png");

--- a/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
@@ -26,7 +26,7 @@ public class MCH_RenderHeli extends MCH_RenderBaseVehicle {
          MCH_EntityHeli heli = (MCH_EntityHeli)entity;
          heliInfo = heli.getHeliInfo();
          if(heliInfo != null) {
-            this.renderDebugHitBox(heli, posX, posY, posZ, yaw, pitch);
+            this.renderDebugHitBox(heli, posX, posY, posZ, yaw, pitch, roll);
             this.renderDebugPilotSeat(heli, posX, posY, posZ, yaw, pitch, roll);
             GL11.glTranslated(posX, posY, posZ);
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);

--- a/src/main/java/mcheli/plane/MCP_RenderPlane.java
+++ b/src/main/java/mcheli/plane/MCP_RenderPlane.java
@@ -26,7 +26,7 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
          MCP_EntityPlane plane = (MCP_EntityPlane)entity;
          planeInfo = plane.getPlaneInfo();
          if(planeInfo != null) {
-            this.renderDebugHitBox(plane, posX, posY, posZ, yaw, pitch);
+            this.renderDebugHitBox(plane, posX, posY, posZ, yaw, pitch, roll);
             this.renderDebugPilotSeat(plane, posX, posY, posZ, yaw, pitch, roll);
             GL11.glTranslated(posX, posY, posZ);
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);

--- a/src/main/java/mcheli/ship/MCH_RenderShip.java
+++ b/src/main/java/mcheli/ship/MCH_RenderShip.java
@@ -22,7 +22,7 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
             MCH_EntityShip ship = (MCH_EntityShip)entity;
             shipInfo = ship.getShipInfo();
             if(shipInfo != null) {
-                this.renderDebugHitBox(ship, posX, posY, posZ, yaw, pitch);
+                this.renderDebugHitBox(ship, posX, posY, posZ, yaw, pitch, roll);
                 this.renderDebugPilotSeat(ship, posX, posY, posZ, yaw, pitch, roll);
                 GL11.glTranslated(posX, posY, posZ);
                 GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -30,7 +30,7 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
          tankInfo = tank.getTankInfo();
          if(tankInfo != null) {
             this.renderWheel(tank, posX, posY, posZ);
-            this.renderDebugHitBox(tank, posX, posY, posZ, yaw, pitch);
+            this.renderDebugHitBox(tank, posX, posY, posZ, yaw, pitch, roll);
             this.renderDebugPilotSeat(tank, posX, posY, posZ, yaw, pitch, roll);
             GL11.glTranslated(posX, posY, posZ);
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -38,7 +38,7 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
                vehicle.lastRiderPitch = vehicle.rotationPitch;
             }
 
-            this.renderDebugHitBox(vehicle, posX, posY, posZ, yaw, pitch);
+            this.renderDebugHitBox(vehicle, posX, posY, posZ, yaw, pitch, roll);
             this.renderDebugPilotSeat(vehicle, posX, posY, posZ, yaw, pitch, roll);
             GL11.glTranslated(posX, posY, posZ);
             GL11.glRotatef(yaw, 0.0F, -1.0F, 0.0F);


### PR DESCRIPTION
### Motivation
- Debug bounding boxes stayed visually static in vertical offset when vehicles rolled because the debug renderer used precomputed rotated offsets instead of the same interpolated yaw/pitch/roll as the rendered model. 
- The change aligns debug visuals with actual vehicle transforms so hit/collision boxes move correctly while rolling and improve debugging accuracy.

### Description
- Changed the debug hit-box API to accept interpolated roll by updating `renderDebugHitBox` to `renderDebugHitBox(..., float roll)` in `MCH_RenderBaseVehicle` and relevant renderers. 
- Recompute box offsets at render time using `MCH_Lib.RotVec3(bb.offsetX, bb.offsetY, bb.offsetZ, -yaw, -pitch, -roll)` and apply the interpolated `yaw`, `pitch`, and `roll` when drawing each `MCH_BoundingBox`. 
- Updated all vehicle renderer call sites that draw debug boxes to pass the interpolated `roll` (`MCH_RenderHeli`, `MCP_RenderPlane`, `MCH_RenderShip`, `MCH_RenderTank`, `MCH_RenderTurret`). 
- Documented the fix in `CHANGELOG.md` and updated `docs/vehicle-config-reference.md` to note that debug rendering applies interpolated roll to box offsets.

### Testing
- Verified call-site and signature updates with a repository search (`rg`) to ensure all `renderDebugHitBox` invocations now include `roll` and there were no missing references. 
- Ran `git diff --check` to validate there are no whitespace or trivial diff-check issues, which completed with no errors. 
- Performed file-level inspection of the modified render paths to confirm `MCH_Lib.RotVec3` is used for the debug offset computation and the interpolated `roll` is applied during debug rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3160b9a483238350ee03616a3737)