### PR TITLE
Add `EnableHandheld` config toggle to disable handheld weapon crafting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Added the `EnableHandheld` config toggle for disabling Stinger, Javelin, RPG, and matching ammunition crafting recipes.
+
 - Fixed debug extra bounding-box rendering to use the vehicle model transform before box offsets, so boxes roll with the vehicle instead of staying visually upright while only their centers move.
 
 - Fixed plane free-look steering so A/D turn input is still sent and applied while free look is active in both mouse flight-sim and regular control modes.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `AutoThrottleDownTank` | `false` | Auto-throttle-down behavior for tanks. |
 | `SwitchWeaponWithMouseWheel` | `true` | Allows mouse-wheel weapon switching. |
 | `LWeaponAutoFire` | `false` | Auto-fire behavior for light weapons. |
+| `EnableHandheld` | `true` | Enables crafting recipes for hand-held weapons and their ammunition (`Stinger`, `Javelin`, and `RPG`). Set to `false` to prevent those recipes from registering. |
 | `DisableItemRender` | `1` | Valid range noted in source: `0 ~ 3`; `1` recommended. |
 | `Override3DItemIcon` | `false` | Global 3D vehicle item icon override. `true` forces 3D item icons off; `false` allows per-vehicle `Enable3DItemIcon` settings. |
 | `Heli3DItemIconScale` | `1.0` | Global scale multiplier for helicopter 3D item icons. |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -113,6 +113,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm Collision_EntityDamage;
    public static MCH_ConfigPrm Collision_EntityTankDamage;
    public static MCH_ConfigPrm LWeaponAutoFire;
+   public static MCH_ConfigPrm EnableHandheld;
    public static MCH_ConfigPrm DismountAll;
    public static MCH_ConfigPrm MountMinecartHeli;
    public static MCH_ConfigPrm MountMinecartPlane;
@@ -434,6 +435,7 @@ public class MCH_Config {
       Collision_EntityDamage = new MCH_ConfigPrm("Collision_EntityDamage", true);
       Collision_EntityTankDamage = new MCH_ConfigPrm("Collision_EntityTankDamage", false);
       LWeaponAutoFire = new MCH_ConfigPrm("LWeaponAutoFire", false);
+      EnableHandheld = new MCH_ConfigPrm("EnableHandheld", true);
       DismountAll = new MCH_ConfigPrm("DismountAll", false);
       MountMinecartHeli = new MCH_ConfigPrm("MountMinecartHeli", true);
       MountMinecartPlane = new MCH_ConfigPrm("MountMinecartPlane", true);
@@ -791,6 +793,7 @@ public class MCH_Config {
               AutoThrottleDownTank,
               SwitchWeaponWithMouseWheel,
               LWeaponAutoFire,
+              EnableHandheld,
               DisableItemRender,
               Override3DItemIcon,
               Heli3DItemIconScale,

--- a/src/main/java/mcheli/MCH_ItemRecipe.java
+++ b/src/main/java/mcheli/MCH_ItemRecipe.java
@@ -90,23 +90,26 @@ public class MCH_ItemRecipe implements MCH_IRecipeList {
       var10001 = MCH_MOD.config;
       addRecipeList(addRecipe(MCH_MOD.itemRangeFinder, MCH_Config.ItemRecipe_RangeFinder.prmString));
       GameRegistry.addRecipe(new MCH_RecipeReloadRangeFinder());
-      var10001 = MCH_MOD.config;
-      addRecipeList(addRecipe(MCH_MOD.itemStinger, MCH_Config.ItemRecipe_Stinger.prmString));
-      MCH_ItemLightWeaponBullet var1 = MCH_MOD.itemStingerBullet;
-      StringBuilder var3 = (new StringBuilder()).append("2,");
-      MCH_Config var10002 = MCH_MOD.config;
-      addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_StingerMissile.prmString).toString()));
-      var10001 = MCH_MOD.config;
-      addRecipeList(addRecipe(MCH_MOD.itemJavelin, MCH_Config.ItemRecipe_Javelin.prmString));
-      var1 = MCH_MOD.itemJavelinBullet;
-      var3 = (new StringBuilder()).append("2,");
-      var10002 = MCH_MOD.config;
-      addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_JavelinMissile.prmString).toString()));
+      if(MCH_Config.EnableHandheld.prmBool) {
+         var10001 = MCH_MOD.config;
+         addRecipeList(addRecipe(MCH_MOD.itemStinger, MCH_Config.ItemRecipe_Stinger.prmString));
+         MCH_ItemLightWeaponBullet var1 = MCH_MOD.itemStingerBullet;
+         StringBuilder var3 = (new StringBuilder()).append("2,");
+         MCH_Config var10002 = MCH_MOD.config;
+         addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_StingerMissile.prmString).toString()));
+         var10001 = MCH_MOD.config;
+         addRecipeList(addRecipe(MCH_MOD.itemJavelin, MCH_Config.ItemRecipe_Javelin.prmString));
+         var1 = MCH_MOD.itemJavelinBullet;
+         var3 = (new StringBuilder()).append("2,");
+         var10002 = MCH_MOD.config;
+         addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_JavelinMissile.prmString).toString()));
+         addRecipeList(addRecipe(MCH_MOD.itemRpg, MCH_Config.ItemRecipe_Rpg.prmString));
+         var1 = MCH_MOD.itemRpgBullet;
+         var3 = (new StringBuilder()).append("2,");
+         addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_RpgMissile.prmString).toString()));
+      }
+
       Item var2 = W_Item.getItemFromBlock(MCH_MOD.blockDraftingTable);
-      addRecipeList(addRecipe(MCH_MOD.itemRpg, MCH_Config.ItemRecipe_Rpg.prmString));
-      var1 = MCH_MOD.itemRpgBullet;
-      var3 = (new StringBuilder()).append("2,");
-      addRecipeList(addRecipe(var1, var3.append(MCH_Config.ItemRecipe_RpgMissile.prmString).toString()));
       var10001 = MCH_MOD.config;
       addRecipeList(addRecipe(var2, MCH_Config.ItemRecipe_DraftingTable.prmString));
    }


### PR DESCRIPTION
### Motivation
- Provide a simple server/config toggle to disable MCHeli's hand-held weapon crafting and matching ammunition registration so pack authors or server admins can remove Stinger/Javelin/RPG recipes without patching code.

### Description
- Added a new config parameter `EnableHandheld` (`MCH_ConfigPrm`) to `MCH_Config` with a default value of `true` so it is generated and persisted to `mcheli.cfg` via the existing config system.
- Gated registration of the Stinger, Javelin, RPG and their ammunition recipes inside `MCH_ItemRecipe.registerCommonItemRecipe` with `if (MCH_Config.EnableHandheld.prmBool)` so setting it to `false` prevents those recipes from being added.
- Updated `docs/configuration.md` to document the new `EnableHandheld` key and added an entry to `CHANGELOG.md` describing the new toggle.

### Testing
- Ran `git diff --check` to validate there are no whitespace/format problems and it completed successfully.
- Ran `git status --short` to verify the intended files were modified and it reported the expected changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3e9f55ac8323bb3eab1e567c73de)