### PR TITLE
Fix HBM mine dispenser placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.
+
 - Added the `EnableHandheld` config toggle for disabling Stinger, Javelin, RPG, and matching ammunition crafting recipes.
 
 - Fixed debug extra bounding-box rendering to use the vehicle model transform before box offsets, so boxes roll with the vehicle instead of staying visually upright while only their centers move.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -24,7 +24,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 **How it differs from original MCHeli:** Overdrive adds or documents richer missile guidance behavior, torpedo/dispenser paths, lockable entity synchronization, RWR/radar identity, flares/chaff separation, active protection support, and HBM-compatible explosion hooks.
 
-**Configuration:** Pack makers configure weapon stations with `AddWeapon`, `AddTurretWeapon`, and weapon-part keys, and tune weapon definitions through MCHeli-style weapon files. Vehicle combat/support keys include `RadarType`, `RWRType`, `Stealth`, `FlareType`, `FlareOption`, `HasChaff`, `ChaffUseTime`, `ChaffWaitTime`, `HasAPS`, `APSUseTime`, `APSWaitTime`, `APSRange`, `AmmoSupplyRange`, and `RepairOtherVehicles`.
+**Configuration:** Pack makers configure weapon stations with `AddWeapon`, `AddTurretWeapon`, and weapon-part keys, and tune weapon definitions through MCHeli-style weapon files. `Type = Dispenser` weapons can use `DispenseItem` for block or item payloads; HBM mine block payloads named like `hbm:tile.mine_he` and `hbm:tile.mine_ap` are placed directly as mine blocks on impact when a valid air space exists above the struck block, avoiding unreliable fake-player block-item use. Vehicle combat/support keys include `RadarType`, `RWRType`, `Stealth`, `FlareType`, `FlareOption`, `HasChaff`, `ChaffUseTime`, `ChaffWaitTime`, `HasAPS`, `APSUseTime`, `APSWaitTime`, `APSRange`, `AmmoSupplyRange`, and `RepairOtherVehicles`.
 
 ### Warnings, countermeasures, and protection
 

--- a/src/main/java/mcheli/weapon/MCH_EntityDispensedItem.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityDispensedItem.java
@@ -174,6 +174,8 @@ public class MCH_EntityDispensedItem extends MCH_EntityBaseBullet {
             info.delayFuse = 0;
             entity.setInfo(info);
             worldObj.spawnEntityInWorld(entity);
+         } else if (this.placeHbmMineBlock(x, y, z, item, itemDamage)) {
+            System.out.println("[DispensedItem] Placed HBM mine block");
          } else {
             System.out.println("[DispensedItem] Using generic item");
             ItemStack stack = new ItemStack(item, 1, itemDamage);
@@ -191,6 +193,25 @@ public class MCH_EntityDispensedItem extends MCH_EntityBaseBullet {
             }
          }
       }
+   }
+
+   private boolean placeHbmMineBlock(int x, int y, int z, Item item, int itemDamage) {
+      String itemName = W_Item.getNameForItem(item);
+      if(itemName == null || !itemName.startsWith("hbm:tile.mine")) {
+         return false;
+      }
+
+      Block mineBlock = Block.getBlockFromItem(item);
+      if(mineBlock == null || mineBlock == Blocks.air) {
+         return false;
+      }
+
+      int placeY = y + 1;
+      if(placeY < 0 || placeY >= 256 || !super.worldObj.isAirBlock(x, placeY, z) || !mineBlock.canPlaceBlockAt(super.worldObj, x, placeY, z)) {
+         return false;
+      }
+
+      return super.worldObj.setBlock(x, placeY, z, mineBlock, itemDamage, 3);
    }
 
    public void sprinkleBomblet() {


### PR DESCRIPTION
### Motivation
- Dispenser-type weapons using HBM mine items (for example `DispenseItem = hbm:tile.mine_he`) sometimes failed to place mines because the fake-player item-use path is unreliable for HBM block-items, so a direct placement path was needed.

### Description
- Added a direct placement branch in `MCH_EntityDispensedItem.onImpact` that calls a new helper `placeHbmMineBlock(...)` before the generic fake-player item-use fallback. 
- Implemented `placeHbmMineBlock(int x, int y, int z, Item item, int itemDamage)` to detect `hbm:tile.mine*` item names, resolve the block with `Block.getBlockFromItem(...)`, validate space and placement via `canPlaceBlockAt(...)`, and call `world.setBlock(...)` to place the mine block above the impacted block. 
- Preserved existing behavior for throwable items and the generic fake-player `onItemUse`/`onItemRightClick` fallback when the direct block placement path is not applicable. 
- Updated documentation in `docs/overdrive-features.md` to describe dispenser handling for HBM mine block payloads and added an entry to `CHANGELOG.md` noting the fix. 

### Testing
- Ran `git diff --check` to validate the working tree changes and whitespace issues, which completed without errors. 
- No automated unit tests exist or were run for this change; behavior relies on in-game testing to validate mine placement at runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4082a02c83239f20a78eb5a4efb2)