### PR TITLE
Cache 3D vehicle item icon models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.
+
 - Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.
 
 - Added the `EnableHandheld` config toggle for disabling Stinger, Javelin, RPG, and matching ammunition crafting recipes.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The mod writes `config/mcheli.cfg` on startup. Important options include:
 - `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed` - global speed multipliers/clamps.
 - `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` - control long-distance vehicle model rendering.
 - `Override3DItemIcon` - globally disables 3D vehicle item icons when set to `true`; `false` allows per-vehicle 3D item icon settings.
-- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type.
+- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type. Vehicle item models are cached after first render to reduce inventory and held-item lag.
 - `MultiThreadedModelLoading` - toggles threaded model loading on the client.
 - `CommandPermission` entries - grant specific `/mcheli` subcommands to named non-operator players.
 - `Key*` entries - default key and mouse bindings for MCHeli controls.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `Ship3DItemIconScale` | `1.0` | Global scale multiplier for ship 3D item icons. |
 | `Tank3DItemIconScale` | `1.0` | Global scale multiplier for tank 3D item icons. |
 | `Turret3DItemIconScale` | `1.0` | Global scale multiplier for turret/static vehicle 3D item icons. |
+| 3D item icon rendering | n/a | Vehicle item models are cached client-side in OpenGL display lists after first render to reduce inventory/held-item lag while keeping the same config toggles. |
 | `HideKeybind` | `false` | Hides keybind display/help where implemented. |
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -4,6 +4,10 @@ import mcheli.MCH_Config;
 import mcheli.MCH_ConfigPrm;
 import mcheli.wrapper.W_McClient;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.client.model.IModelCustom;
+
+import java.util.HashMap;
+import java.util.Map;
 import org.lwjgl.opengl.GL11;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
@@ -13,6 +17,8 @@ import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
  * Renders placeable vehicle items with their loaded 3D vehicle model instead of the flat item icon.
  */
 public class MCH_VehicleItemModelRender implements IItemRenderer {
+
+   private static final Map MODEL_DISPLAY_LISTS = new HashMap();
 
    public boolean handleRenderType(ItemStack item, ItemRenderType type) {
       MCH_BaseVehicleInfo info = getInfo(item);
@@ -36,13 +42,54 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
       W_McClient.MOD_bindTexture("textures/" + info.getDirectoryName() + "/" + MCH_RenderBaseVehicle.getBaseTextureName(info.name) + ".png");
       MCH_RenderBaseVehicle.beginSkinOverlayRender(info.getDirectoryName(), info.name);
       try {
-         MCH_RenderBaseVehicle.renderAllModel(info.model);
+         renderCachedModel(info);
       } finally {
          MCH_RenderBaseVehicle.endSkinOverlayRender();
          GL11.glPopMatrix();
       }
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
       GL11.glEnable(3042);
+   }
+
+   private static void renderCachedModel(MCH_BaseVehicleInfo info) {
+      CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+      if(cached == null || cached.model != info.model) {
+         if(cached != null) {
+            cached.delete();
+         }
+         cached = new CachedDisplayList(info.model);
+         MODEL_DISPLAY_LISTS.put(info, cached);
+      }
+      cached.render();
+   }
+
+   private static class CachedDisplayList {
+      private final IModelCustom model;
+      private final int displayList;
+
+      private CachedDisplayList(IModelCustom model) {
+         this.model = model;
+         this.displayList = GL11.glGenLists(1);
+         if(this.displayList != 0) {
+            GL11.glNewList(this.displayList, GL11.GL_COMPILE);
+            MCH_RenderBaseVehicle.renderAllModel(model);
+            GL11.glEndList();
+         }
+      }
+
+      private void render() {
+         if(this.displayList != 0) {
+            GL11.glCallList(this.displayList);
+         } else {
+            MCH_RenderBaseVehicle.renderAllModel(this.model);
+         }
+      }
+
+      private void delete() {
+         if(this.displayList != 0) {
+            GL11.glDeleteLists(this.displayList, 1);
+         }
+      }
    }
 
    private static MCH_BaseVehicleInfo getInfo(ItemStack item) {


### PR DESCRIPTION
### Motivation

- Reduce lag when rendering 3D vehicle item icons in inventories, held item views, and dropped items by avoiding repeated full-model submissions to OpenGL every frame. 

### Description

- Add a per-vehicle cache of compiled OpenGL display lists in `src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java` to reuse compiled geometry instead of calling `renderAll` on every render. 
- Rebuild and delete a cached display list when the `IModelCustom` instance changes so model reloads remain safe. 
- Update documentation to mention the new client-side caching behavior in `CHANGELOG.md`, `README.md`, and `docs/configuration.md`. 

### Testing

- Ran `git diff --check` which returned no whitespace/patch errors and completed successfully. 
- Changes were committed (4 files: `MCH_VehicleItemModelRender.java`, `CHANGELOG.md`, `README.md`, `docs/configuration.md`) and no automated build or runtime rendering tests were executed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4675e3e48323bad62ed4cca0341b)