### PR TITLE
Fix vehicle seat entry after chunk reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries by recreating missing seat entities immediately when an interaction occurs in a loaded chunk.
+
 - Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.
 
 - Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -6927,7 +6927,50 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       MCH_Lib.DbgLog(super.worldObj,
               "[MCH-STATE][SEAT-RESOLVE-FAIL] context=%s vehicle=%s index=%d reason=no_loaded_seat_with_parent_id",
               new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
-      return current;
+      MCH_EntitySeat recreated = this.recreateSeatInLoadedChunk(seatIndex, context);
+      if(recreated != null) {
+         return recreated;
+      }
+      return current != null && !current.isDead && current.worldObj == super.worldObj
+              && current.seatID == seatIndex && current.getParent() == this?current:null;
+   }
+
+   private MCH_EntitySeat recreateSeatInLoadedChunk(int seatIndex, String context) {
+      if(super.worldObj.isRemote || this.getAcInfo() == null || this.getCommonUniqueId().isEmpty()
+              || seatIndex < 0 || seatIndex >= this.seats.length) {
+         return null;
+      }
+      MCH_SeatInfo seatInfo = this.getSeatInfo(seatIndex + 1);
+      if(seatInfo == null) {
+         return null;
+      }
+      Vec3 position = this.getTransformedPosition(seatInfo.pos);
+      if(!super.worldObj.blockExists(MathHelper.floor_double(position.xCoord),
+              MathHelper.floor_double(position.yCoord), MathHelper.floor_double(position.zCoord))) {
+         MCH_Lib.DbgLog(super.worldObj,
+                 "[MCH-STATE][SEAT-RECREATE-SKIP] context=%s vehicle=%s index=%d reason=seat_chunk_not_loaded",
+                 new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
+         return null;
+      }
+      MCH_EntitySeat seat = new MCH_EntitySeat(super.worldObj);
+      seat.parentUniqueID = this.getCommonUniqueId();
+      seat.seatID = seatIndex;
+      seat.setParent(this);
+      seat.setPosition(position.xCoord, position.yCoord, position.zCoord);
+      seat.prevPosX = position.xCoord;
+      seat.prevPosY = position.yCoord;
+      seat.prevPosZ = position.zCoord;
+      if(super.worldObj.spawnEntityInWorld(seat)) {
+         this.setSeat(seatIndex, seat);
+         MCH_Lib.DbgLog(super.worldObj,
+                 "[MCH-STATE][SEAT-RECREATE] context=%s vehicle=%s index=%d seat=%s",
+                 new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex), this.debugEntity(seat)});
+         return seat;
+      }
+      MCH_Lib.DbgLog(super.worldObj,
+              "[MCH-STATE][SEAT-RECREATE-FAIL] context=%s vehicle=%s index=%d reason=spawn_rejected",
+              new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
+      return null;
    }
 
    private void repairInvalidOccupantsForInteraction(String context) {


### PR DESCRIPTION
### Motivation
- Passenger seats could become non-enterable after a vehicle crossed chunk load boundaries because seat entity references were lost and not recreated when interaction occurred in a loaded chunk.
- The goal is to ensure players can enter vehicles immediately after chunks load by recreating missing seat entities on-demand and avoid returning stale/dead seat references.

### Description
- Added `recreateSeatInLoadedChunk(int seatIndex, String context)` to `MCH_EntityBaseVehicle` to attempt reconstruction and spawning of a missing `MCH_EntitySeat` when the seat's target chunk is loaded.
- Updated `resolveSeatReferenceForInteraction` to call the recreator when no loaded seat entity is found and to avoid returning stale/dead seat objects by returning `null` unless a valid seat is verified or successfully recreated.
- Wrote a short changelog entry in `CHANGELOG.md` documenting the fix.

### Testing
- Ran repository code-checks with `git diff --check` to ensure there are no whitespace or diff issues, which passed.
- Applied the patch and verified the modified files (`src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java` and `CHANGELOG.md`) were updated without errors using the project tooling used in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f528229488323838f4016af5595a0)