### PR TITLE
Recreate missing seat entities and sync rider IDs to fix passenger desyncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries or lag spikes by recreating missing server seat entities on interaction, clearing stale client seat slots, and resyncing authoritative seat occupant IDs.
+
 - Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.
 
 - Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -311,8 +311,18 @@ public class MCH_BaseVehiclePacketHandler {
                         seat.seatID = i;
                         seat.setParent(ac);
                         seat.parentUniqueID = ac.getCommonUniqueId();
+                        if(seatList.riderEntityID == null || seatList.riderEntityID.length <= i || seatList.riderEntityID[i] <= 0) {
+                           seat.riddenByEntity = null;
+                        } else {
+                           Entity rider = player.worldObj.getEntityByID(seatList.riderEntityID[i]);
+                           if(rider != null) {
+                              seat.riddenByEntity = rider;
+                              rider.ridingEntity = seat;
+                           }
+                        }
                         ac.setSeat(i, seat);
                      } else {
+                        ac.setSeat(i, null);
                         MCH_Lib.DbgLog(player.worldObj, "[MCH-SYNC][SEAT-APPLY-FAIL] reason=seat_entity_missing_or_wrong_type aircraftId=%d index=%d requestedSeatId=%d resolved=%s",
                                 new Object[]{Integer.valueOf(seatList.entityID_AC), Integer.valueOf(i), Integer.valueOf(seatList.seatEntityID[i]), entity});
                      }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -6927,7 +6927,50 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       MCH_Lib.DbgLog(super.worldObj,
               "[MCH-STATE][SEAT-RESOLVE-FAIL] context=%s vehicle=%s index=%d reason=no_loaded_seat_with_parent_id",
               new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
-      return current;
+      MCH_EntitySeat recreated = this.recreateSeatInLoadedChunk(seatIndex, context);
+      if(recreated != null) {
+         return recreated;
+      }
+      return current != null && !current.isDead && current.worldObj == super.worldObj
+              && current.seatID == seatIndex && current.getParent() == this?current:null;
+   }
+
+   private MCH_EntitySeat recreateSeatInLoadedChunk(int seatIndex, String context) {
+      if(super.worldObj.isRemote || this.getAcInfo() == null || this.getCommonUniqueId().isEmpty()
+              || seatIndex < 0 || seatIndex >= this.seats.length) {
+         return null;
+      }
+      MCH_SeatInfo seatInfo = this.getSeatInfo(seatIndex + 1);
+      if(seatInfo == null) {
+         return null;
+      }
+      Vec3 position = this.getTransformedPosition(seatInfo.pos);
+      if(!super.worldObj.blockExists(MathHelper.floor_double(position.xCoord),
+              MathHelper.floor_double(position.yCoord), MathHelper.floor_double(position.zCoord))) {
+         MCH_Lib.DbgLog(super.worldObj,
+                 "[MCH-STATE][SEAT-RECREATE-SKIP] context=%s vehicle=%s index=%d reason=seat_chunk_not_loaded",
+                 new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
+         return null;
+      }
+      MCH_EntitySeat seat = new MCH_EntitySeat(super.worldObj);
+      seat.parentUniqueID = this.getCommonUniqueId();
+      seat.seatID = seatIndex;
+      seat.setParent(this);
+      seat.setPosition(position.xCoord, position.yCoord, position.zCoord);
+      seat.prevPosX = position.xCoord;
+      seat.prevPosY = position.yCoord;
+      seat.prevPosZ = position.zCoord;
+      if(super.worldObj.spawnEntityInWorld(seat)) {
+         this.setSeat(seatIndex, seat);
+         MCH_Lib.DbgLog(super.worldObj,
+                 "[MCH-STATE][SEAT-RECREATE] context=%s vehicle=%s index=%d seat=%s",
+                 new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex), this.debugEntity(seat)});
+         return seat;
+      }
+      MCH_Lib.DbgLog(super.worldObj,
+              "[MCH-STATE][SEAT-RECREATE-FAIL] context=%s vehicle=%s index=%d reason=spawn_rejected",
+              new Object[]{context, this.debugEntity(this), Integer.valueOf(seatIndex)});
+      return null;
    }
 
    private void repairInvalidOccupantsForInteraction(String context) {

--- a/src/main/java/mcheli/aircraft/MCH_PacketSeatListResponse.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketSeatListResponse.java
@@ -15,6 +15,7 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
    public int entityID_AC = -1;
    public int seatNum = -1;
    public int[] seatEntityID = new int[]{-1};
+   public int[] riderEntityID = new int[]{-1};
 
 
    public int getMessageID() {
@@ -27,9 +28,11 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
          this.seatNum = data.readShort();
          if(this.seatNum > 0) {
             this.seatEntityID = new int[this.seatNum];
+            this.riderEntityID = new int[this.seatNum];
 
             for(int e = 0; e < this.seatNum; ++e) {
                this.seatEntityID[e] = data.readInt();
+               this.riderEntityID[e] = data.readInt();
             }
          }
       } catch (Exception var3) {
@@ -41,11 +44,13 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
    public void writeData(DataOutputStream dos) {
       try {
          dos.writeInt(this.entityID_AC);
-         if(this.seatNum > 0 && this.seatEntityID != null && this.seatEntityID.length == this.seatNum) {
+         if(this.seatNum > 0 && this.seatEntityID != null && this.seatEntityID.length == this.seatNum
+                 && this.riderEntityID != null && this.riderEntityID.length == this.seatNum) {
             dos.writeShort(this.seatNum);
 
             for(int e = 0; e < this.seatNum; ++e) {
                dos.writeInt(this.seatEntityID[e]);
+               dos.writeInt(this.riderEntityID[e]);
             }
          } else {
             dos.writeShort(-1);
@@ -72,12 +77,17 @@ public class MCH_PacketSeatListResponse extends MCH_Packet {
          this.seatNum = ac.getSeats().length;
          if(this.seatNum > 0) {
             this.seatEntityID = new int[this.seatNum];
+            this.riderEntityID = new int[this.seatNum];
 
             for(int i = 0; i < this.seatNum; ++i) {
-               this.seatEntityID[i] = W_Entity.getEntityId(ac.getSeat(i));
+               MCH_EntitySeat seat = ac.getSeat(i);
+               this.seatEntityID[i] = W_Entity.getEntityId(seat);
+               this.riderEntityID[i] = seat != null && seat.riddenByEntity != null
+                       && seat.riddenByEntity.ridingEntity == seat?W_Entity.getEntityId(seat.riddenByEntity):-1;
             }
          } else {
             this.seatEntityID = new int[]{-1};
+            this.riderEntityID = new int[]{-1};
          }
 
       }


### PR DESCRIPTION
### Motivation

- Passenger seats could become non-enterable after vehicles cross chunk load boundaries or during lag spikes because server-side seat entities were missing and clients retained stale seat slots.
- The seat list packet did not convey authoritative occupant IDs so clients could not fully resync seat occupant backreferences.

### Description

- Add a `riderEntityID[]` field to `MCH_PacketSeatListResponse` and serialize/deserialize it so seat occupant entity IDs are sent with the seat list.
- Update `setParameter`/`writeData`/`readData` in `MCH_PacketSeatListResponse` to populate and validate `riderEntityID` alongside `seatEntityID`.
- In `MCH_BaseVehiclePacketHandler.onPacketSeatListResponse` restore `seat.riddenByEntity` and `rider.ridingEntity` when rider IDs are present, and set missing seats to `null` when entity resolution fails.
- Implement `MCH_EntityBaseVehicle.recreateSeatInLoadedChunk` and adjust seat resolution logic to spawn missing `MCH_EntitySeat` server-side when the seat's chunk is loaded, and return a validated seat reference only if it is valid and belongs to this vehicle.
- Update `CHANGELOG.md` to describe the fix for passenger seats becoming non-enterable.

### Testing

- Verified the project builds successfully with `./gradlew build`.
- Ran `./gradlew test` and observed no failing automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f528229488323838f4016af5595a0)