### PR TITLE
Queue 3D vehicle item icon builds to reduce creative-tab lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries or lag spikes by recreating missing server seat entities on interaction, clearing stale client seat slots, and resyncing authoritative seat occupant IDs.
 
 - Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.
+- Queued 3D vehicle item icon display-list builds so scrolling large creative vehicle tabs compiles models gradually instead of freezing while every visible icon loads at once.
 
 - Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The mod writes `config/mcheli.cfg` on startup. Important options include:
 - `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed` - global speed multipliers/clamps.
 - `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` - control long-distance vehicle model rendering.
 - `Override3DItemIcon` - globally disables 3D vehicle item icons when set to `true`; `false` allows per-vehicle 3D item icon settings.
-- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type. Vehicle item models are cached after first render to reduce inventory and held-item lag.
+- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type. Vehicle item models are queued and cached after first render to reduce inventory and held-item lag without compiling every visible creative-tab model at once.
 - `MultiThreadedModelLoading` - toggles threaded model loading on the client.
 - `CommandPermission` entries - grant specific `/mcheli` subcommands to named non-operator players.
 - `Key*` entries - default key and mouse bindings for MCHeli controls.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `Ship3DItemIconScale` | `1.0` | Global scale multiplier for ship 3D item icons. |
 | `Tank3DItemIconScale` | `1.0` | Global scale multiplier for tank 3D item icons. |
 | `Turret3DItemIconScale` | `1.0` | Global scale multiplier for turret/static vehicle 3D item icons. |
-| 3D item icon rendering | n/a | Vehicle item models are cached client-side in OpenGL display lists after first render to reduce inventory/held-item lag while keeping the same config toggles. |
+| 3D item icon rendering | n/a | Vehicle item models are queued and cached client-side in OpenGL display lists after first render, preventing large creative tabs from compiling every visible model in the same frame while keeping the same config toggles. |
 | `HideKeybind` | `false` | Hides keybind display/help where implemented. |
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -7,8 +7,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IModelCustom;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Map;
+import java.util.Set;
 import org.lwjgl.opengl.GL11;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
@@ -19,10 +23,20 @@ import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
 public class MCH_VehicleItemModelRender implements IItemRenderer {
 
    private static final Map MODEL_DISPLAY_LISTS = new HashMap();
+   private static final LinkedList MODEL_BUILD_QUEUE = new LinkedList();
+   private static final Set QUEUED_MODELS = new HashSet();
+   private static final long MODEL_BUILD_INTERVAL_MS = 25L;
+   private static long nextModelBuildTime;
 
    public boolean handleRenderType(ItemStack item, ItemRenderType type) {
       MCH_BaseVehicleInfo info = getInfo(item);
-      return info != null && info.model != null && is3DIconEnabled(info);
+      if(info == null || info.model == null || !is3DIconEnabled(info)) {
+         return false;
+      }
+
+      queueModelBuild(info);
+      processQueuedModelBuild();
+      return isModelCached(info);
    }
 
    public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
@@ -32,6 +46,12 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
    public void renderItem(ItemRenderType type, ItemStack item, Object ... data) {
       MCH_BaseVehicleInfo info = getInfo(item);
       if(info == null || info.model == null || !is3DIconEnabled(info)) {
+         return;
+      }
+
+      queueModelBuild(info);
+      processQueuedModelBuild();
+      if(!isModelCached(info)) {
          return;
       }
 
@@ -53,14 +73,40 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
 
    private static void renderCachedModel(MCH_BaseVehicleInfo info) {
       CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
-      if(cached == null || cached.model != info.model) {
-         if(cached != null) {
-            cached.delete();
-         }
-         cached = new CachedDisplayList(info.model);
-         MODEL_DISPLAY_LISTS.put(info, cached);
+      if(cached != null && cached.model == info.model) {
+         cached.render();
       }
-      cached.render();
+   }
+
+   private static boolean isModelCached(MCH_BaseVehicleInfo info) {
+      CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+      return cached != null && cached.model == info.model;
+   }
+
+   private static void queueModelBuild(MCH_BaseVehicleInfo info) {
+      CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+      if(cached != null && cached.model != info.model) {
+         cached.delete();
+         MODEL_DISPLAY_LISTS.remove(info);
+         cached = null;
+      }
+      if(cached == null && QUEUED_MODELS.add(info)) {
+         MODEL_BUILD_QUEUE.add(info);
+      }
+   }
+
+   private static void processQueuedModelBuild() {
+      long now = Minecraft.getSystemTime();
+      if(now < nextModelBuildTime || MODEL_BUILD_QUEUE.isEmpty()) {
+         return;
+      }
+
+      MCH_BaseVehicleInfo info = (MCH_BaseVehicleInfo)MODEL_BUILD_QUEUE.removeFirst();
+      QUEUED_MODELS.remove(info);
+      if(info != null && info.model != null && is3DIconEnabled(info)) {
+         MODEL_DISPLAY_LISTS.put(info, new CachedDisplayList(info.model));
+         nextModelBuildTime = now + MODEL_BUILD_INTERVAL_MS;
+      }
    }
 
    private static class CachedDisplayList {


### PR DESCRIPTION
### Motivation

- Scrolling large creative tabs with many vehicle 3D icons caused the client to compile every visible model in one frame and temporarily drop FPS to zero. 
- The change limits per-frame work by throttling display-list compilation so regular item rendering can continue while models are compiled in the background.

### Description

- Added a throttled build queue to `MCH_VehicleItemModelRender` by introducing `MODEL_BUILD_QUEUE`, `QUEUED_MODELS`, `MODEL_BUILD_INTERVAL_MS`, and `nextModelBuildTime`, and imported `LinkedList`/`HashSet`/`Minecraft` for timing and queue management. 
- Modified `handleRenderType` and `renderItem` to `queueModelBuild(info)` and `processQueuedModelBuild()` and to only use the 3D renderer when `isModelCached(info)` returns true. 
- Implemented `queueModelBuild`, `processQueuedModelBuild`, and `isModelCached`, and adjusted `renderCachedModel` to only draw existing cached display lists while queued builds are compiled incrementally. 
- Updated documentation and changelog (`CHANGELOG.md`, `README.md`, `docs/configuration.md`) to describe the queued-and-cached 3D icon behavior and added a changelog entry for the improvement.

### Testing

- Ran `git diff --check` to validate whitespace and diff sanity, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f591a472c8323872b1400310c68c3)