### PR TITLE
Chunked, queued OpenGL display-list builds for 3D vehicle item icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries or lag spikes by recreating missing server seat entities on interaction, clearing stale client seat slots, and resyncing authoritative seat occupant IDs.
 
 - Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.
+- Queued 3D vehicle item icon display-list builds in small face batches so scrolling large creative vehicle tabs compiles models gradually without single-model display-list spikes dropping FPS to zero.
 
 - Fixed dispenser weapons using HBM mine block items such as `hbm:tile.mine_he` to place the mine block directly on impact when vanilla-style fake-player item use does not handle the block item reliably.
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The mod writes `config/mcheli.cfg` on startup. Important options include:
 - `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed` - global speed multipliers/clamps.
 - `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` - control long-distance vehicle model rendering.
 - `Override3DItemIcon` - globally disables 3D vehicle item icons when set to `true`; `false` allows per-vehicle 3D item icon settings.
-- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type. Vehicle item models are cached after first render to reduce inventory and held-item lag.
+- `Heli3DItemIconScale`, `Plane3DItemIconScale`, `Ship3DItemIconScale`, `Tank3DItemIconScale`, and `Turret3DItemIconScale` - global scale multipliers for 3D item icons by vehicle type. Vehicle item models are queued, compiled into display-list chunks, and cached after first render to reduce inventory and held-item lag without compiling every visible creative-tab model or full vehicle mesh in one frame.
 - `MultiThreadedModelLoading` - toggles threaded model loading on the client.
 - `CommandPermission` entries - grant specific `/mcheli` subcommands to named non-operator players.
 - `Key*` entries - default key and mouse bindings for MCHeli controls.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,7 +87,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `Ship3DItemIconScale` | `1.0` | Global scale multiplier for ship 3D item icons. |
 | `Tank3DItemIconScale` | `1.0` | Global scale multiplier for tank 3D item icons. |
 | `Turret3DItemIconScale` | `1.0` | Global scale multiplier for turret/static vehicle 3D item icons. |
-| 3D item icon rendering | n/a | Vehicle item models are cached client-side in OpenGL display lists after first render to reduce inventory/held-item lag while keeping the same config toggles. |
+| 3D item icon rendering | n/a | Vehicle item models are queued and cached client-side in chunked OpenGL display lists after first render, preventing large creative tabs from compiling every visible model or full vehicle mesh in the same frame while keeping the same config toggles. |
 | `HideKeybind` | `false` | Hides keybind display/help where implemented. |
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -3,12 +3,20 @@ package mcheli.aircraft;
 import mcheli.MCH_Config;
 import mcheli.MCH_ConfigPrm;
 import mcheli.wrapper.W_McClient;
+import mcheli.wrapper.modelloader.W_MetasequoiaObject;
+import mcheli.wrapper.modelloader.W_WavefrontObject;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.client.model.IModelCustom;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.lwjgl.opengl.GL11;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.client.IItemRenderer;
 import net.minecraftforge.client.IItemRenderer.ItemRenderType;
 import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
@@ -19,10 +27,21 @@ import net.minecraftforge.client.IItemRenderer.ItemRendererHelper;
 public class MCH_VehicleItemModelRender implements IItemRenderer {
 
    private static final Map MODEL_DISPLAY_LISTS = new HashMap();
+   private static final LinkedList MODEL_BUILD_QUEUE = new LinkedList();
+   private static final Set QUEUED_MODELS = new HashSet();
+   private static final int MODEL_BUILD_FACES_PER_STEP = 256;
+   private static final long MODEL_BUILD_INTERVAL_MS = 10L;
+   private static long nextModelBuildTime;
 
    public boolean handleRenderType(ItemStack item, ItemRenderType type) {
       MCH_BaseVehicleInfo info = getInfo(item);
-      return info != null && info.model != null && is3DIconEnabled(info);
+      if(info == null || info.model == null || !is3DIconEnabled(info)) {
+         return false;
+      }
+
+      queueModelBuild(info);
+      processQueuedModelBuild();
+      return hasRenderableModel(info);
    }
 
    public boolean shouldUseRenderHelper(ItemRenderType type, ItemStack item, ItemRendererHelper helper) {
@@ -32,6 +51,12 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
    public void renderItem(ItemRenderType type, ItemStack item, Object ... data) {
       MCH_BaseVehicleInfo info = getInfo(item);
       if(info == null || info.model == null || !is3DIconEnabled(info)) {
+         return;
+      }
+
+      queueModelBuild(info);
+      processQueuedModelBuild();
+      if(!hasRenderableModel(info)) {
          return;
       }
 
@@ -53,42 +78,120 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
 
    private static void renderCachedModel(MCH_BaseVehicleInfo info) {
       CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
-      if(cached == null || cached.model != info.model) {
-         if(cached != null) {
-            cached.delete();
-         }
-         cached = new CachedDisplayList(info.model);
-         MODEL_DISPLAY_LISTS.put(info, cached);
+      if(cached != null && cached.model == info.model) {
+         cached.render();
       }
-      cached.render();
+   }
+
+   private static boolean hasRenderableModel(MCH_BaseVehicleInfo info) {
+      CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+      return cached != null && cached.model == info.model && cached.hasRenderableChunks();
+   }
+
+   private static void queueModelBuild(MCH_BaseVehicleInfo info) {
+      CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+      if(cached != null && cached.model != info.model) {
+         cached.delete();
+         MODEL_DISPLAY_LISTS.remove(info);
+         cached = null;
+      }
+      if((cached == null || !cached.isComplete()) && QUEUED_MODELS.add(info)) {
+         MODEL_BUILD_QUEUE.add(info);
+      }
+   }
+
+   private static void processQueuedModelBuild() {
+      long now = Minecraft.getSystemTime();
+      if(now < nextModelBuildTime || MODEL_BUILD_QUEUE.isEmpty()) {
+         return;
+      }
+
+      MCH_BaseVehicleInfo info = (MCH_BaseVehicleInfo)MODEL_BUILD_QUEUE.removeFirst();
+      QUEUED_MODELS.remove(info);
+      if(info != null && info.model != null && is3DIconEnabled(info)) {
+         CachedDisplayList cached = (CachedDisplayList)MODEL_DISPLAY_LISTS.get(info);
+         if(cached == null || cached.model != info.model) {
+            cached = new CachedDisplayList(info.model);
+            MODEL_DISPLAY_LISTS.put(info, cached);
+         }
+         cached.buildNextChunk();
+         if(!cached.isComplete()) {
+            queueModelBuild(info);
+         }
+         nextModelBuildTime = now + MODEL_BUILD_INTERVAL_MS;
+      }
    }
 
    private static class CachedDisplayList {
       private final IModelCustom model;
-      private final int displayList;
+      private final List displayLists = new ArrayList();
+      private final int faceCount;
+      private int nextFace = 1;
+      private boolean complete;
 
       private CachedDisplayList(IModelCustom model) {
          this.model = model;
-         this.displayList = GL11.glGenLists(1);
-         if(this.displayList != 0) {
-            GL11.glNewList(this.displayList, GL11.GL_COMPILE);
-            MCH_RenderBaseVehicle.renderAllModel(model);
-            GL11.glEndList();
+         this.faceCount = getFaceCount(model);
+         this.complete = this.faceCount <= 0;
+      }
+
+      private boolean hasRenderableChunks() {
+         return !this.displayLists.isEmpty();
+      }
+
+      private boolean isComplete() {
+         return this.complete;
+      }
+
+      private void buildNextChunk() {
+         if(this.complete) {
+            return;
          }
+
+         int displayList = GL11.glGenLists(1);
+         if(displayList == 0) {
+            this.complete = true;
+            return;
+         }
+
+         int endFace = Math.min(this.nextFace + MODEL_BUILD_FACES_PER_STEP - 1, this.faceCount);
+         GL11.glNewList(displayList, GL11.GL_COMPILE);
+         renderModelRange(this.model, this.nextFace, endFace);
+         GL11.glEndList();
+         this.displayLists.add(Integer.valueOf(displayList));
+         this.nextFace = endFace + 1;
+         this.complete = this.nextFace > this.faceCount;
       }
 
       private void render() {
-         if(this.displayList != 0) {
-            GL11.glCallList(this.displayList);
-         } else {
-            MCH_RenderBaseVehicle.renderAllModel(this.model);
+         for(int i = 0; i < this.displayLists.size(); ++i) {
+            GL11.glCallList(((Integer)this.displayLists.get(i)).intValue());
          }
       }
 
       private void delete() {
-         if(this.displayList != 0) {
-            GL11.glDeleteLists(this.displayList, 1);
+         for(int i = 0; i < this.displayLists.size(); ++i) {
+            GL11.glDeleteLists(((Integer)this.displayLists.get(i)).intValue(), 1);
          }
+         this.displayLists.clear();
+      }
+   }
+
+   private static int getFaceCount(IModelCustom model) {
+      if(model instanceof W_WavefrontObject) {
+         return ((W_WavefrontObject)model).getFaceNum();
+      }
+      if(model instanceof W_MetasequoiaObject) {
+         return ((W_MetasequoiaObject)model).getFaceNum();
+      }
+      return 0;
+   }
+
+   private static void renderModelRange(IModelCustom model, int startFace, int endFace) {
+      if(model instanceof W_WavefrontObject) {
+         ((W_WavefrontObject)model).renderAll(startFace, endFace);
+      } else if(model instanceof W_MetasequoiaObject) {
+         ((W_MetasequoiaObject)model).renderAll(startFace, endFace);
       }
    }
 


### PR DESCRIPTION
### Motivation

- Prevent large creative tabs or many visible vehicle item models from compiling entire model display-lists in a single frame and causing FPS spikes or hangs. 
- Improve perceived responsiveness by incrementally compiling/model-caching vehicle item geometry across multiple frames while preserving existing 3D item icon behavior.

### Description

- Implemented a build queue and rate-limited processing in `MCH_VehicleItemModelRender` that schedules model compilation work and compiles models in small face-count chunks rather than a single full-model display-list. 
- Introduced `CachedDisplayList` chunked storage (multiple GL display lists), face-count-aware chunk construction, `queueModelBuild`/`processQueuedModelBuild` helpers, and `hasRenderableModel` checks so partially-built models can render available chunks while the remainder compiles asynchronously across frames. 
- Added model-type face counting and range rendering support for `W_WavefrontObject` and `W_MetasequoiaObject`, and added safeguards to avoid duplicate queue entries and to remove stale caches when models change. 
- Updated documentation and changelogs (`CHANGELOG.md`, `README.md`, `docs/configuration.md`) to describe the queued/chunked 3D item icon compilation behavior and the associated config implications.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f591a472c8323872b1400310c68c3)