### PR TITLE
Fix seats becoming non-interactable after lag/chunk reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Bomb reticle mode now forces the first-person gunner camera to look directly at the predicted bomb impact point while active.
 - Replaced the bomber sight drawing with a large black bomb-sight reticle instead of reusing the green CCIP pipper.
 
+## Seat Interaction Recovery Fix
+- Fixed stale client-side seat occupants left behind by lag spikes or chunk reloads so vehicle seats become interactable again without requiring a relog.
+
 ## Unreleased
 
 ### Changed

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5449,23 +5449,29 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          if(seat == null) {
             MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=seat_reference_null vehicle=%s seat=%d",
                     new Object[]{this.debugEntity(this), Integer.valueOf(i)});
-         } else if(seat.riddenByEntity != null) {
-            MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=occupied vehicle=%s seat=%d occupant=%s",
-                    new Object[]{this.debugEntity(this), Integer.valueOf(i), this.debugEntity(seat.riddenByEntity)});
-         } else if(this.isMountedEntity(player)) {
-            MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=player_already_mounted vehicle=%s seat=%d",
-                    new Object[]{this.debugEntity(this), Integer.valueOf(i)});
-         } else if(!this.canRideSeatOrRack(seatId, player)) {
-            MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=seat_exclusion vehicle=%s seat=%d",
-                    new Object[]{this.debugEntity(this), Integer.valueOf(i)});
          } else {
-            if(!super.worldObj.isRemote) {
-               this.clearPlacementMotionLock();
-               player.mountEntity(seat);
+            if(this.clearInvalidSeatOccupant(seat, i, "vehicle_interact_search")) {
+               MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-REPAIRED] vehicle=%s seat=%d",
+                       new Object[]{this.debugEntity(this), Integer.valueOf(i)});
             }
-            MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-ACCEPT] vehicle=%s seat=%d player=%s",
-                    new Object[]{this.debugEntity(this), Integer.valueOf(i), this.debugEntity(player)});
-            return true;
+            if(seat.riddenByEntity != null) {
+               MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=occupied vehicle=%s seat=%d occupant=%s",
+                       new Object[]{this.debugEntity(this), Integer.valueOf(i), this.debugEntity(seat.riddenByEntity)});
+            } else if(this.isMountedEntity(player)) {
+               MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=player_already_mounted vehicle=%s seat=%d",
+                       new Object[]{this.debugEntity(this), Integer.valueOf(i)});
+            } else if(!this.canRideSeatOrRack(seatId, player)) {
+               MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SKIP] reason=seat_exclusion vehicle=%s seat=%d",
+                       new Object[]{this.debugEntity(this), Integer.valueOf(i)});
+            } else {
+               if(!super.worldObj.isRemote) {
+                  this.clearPlacementMotionLock();
+                  player.mountEntity(seat);
+               }
+               MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-ACCEPT] vehicle=%s seat=%d player=%s",
+                       new Object[]{this.debugEntity(this), Integer.valueOf(i), this.debugEntity(player)});
+               return true;
+            }
          }
       }
       MCH_Lib.DbgLog(super.worldObj, "[MCH-INTERACT][SEAT-SEARCH-REJECT] reason=no_available_seat vehicle=%s player=%s",
@@ -6985,16 +6991,24 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          super.riddenByEntity = null;
       }
       for(int i = 0; i < this.getSeats().length; ++i) {
-         MCH_EntitySeat seat = this.getSeats()[i];
-         if(seat != null && seat.riddenByEntity != null
-                 && (seat.riddenByEntity.isDead || seat.riddenByEntity.ridingEntity != seat
-                 || !super.worldObj.loadedEntityList.contains(seat.riddenByEntity))) {
-            MCH_Lib.DbgLog(super.worldObj,
-                    "[MCH-STATE][REPAIR] context=%s reason=invalid_seat_occupant_backreference vehicle=%s seat=%d staleOccupant=%s",
-                    new Object[]{context, this.debugEntity(this), Integer.valueOf(i), this.debugEntity(seat.riddenByEntity)});
-            seat.riddenByEntity = null;
-         }
+         this.clearInvalidSeatOccupant(this.getSeats()[i], i, context);
       }
+   }
+
+   private boolean clearInvalidSeatOccupant(MCH_EntitySeat seat, int seatIndex, String context) {
+      if(seat == null || seat.riddenByEntity == null) {
+         return false;
+      }
+      Entity occupant = seat.riddenByEntity;
+      if(!occupant.isDead && occupant.ridingEntity == seat
+              && (super.worldObj.isRemote || super.worldObj.loadedEntityList.contains(occupant))) {
+         return false;
+      }
+      MCH_Lib.DbgLog(super.worldObj,
+              "[MCH-STATE][REPAIR] context=%s reason=invalid_seat_occupant_backreference side=%s vehicle=%s seat=%d staleOccupant=%s",
+              new Object[]{context, super.worldObj.isRemote?"CLIENT":"SERVER", this.debugEntity(this), Integer.valueOf(seatIndex), this.debugEntity(occupant)});
+      seat.riddenByEntity = null;
+      return true;
    }
 
    private boolean rejectInteraction(EntityPlayer player, String reason) {

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -301,12 +301,10 @@ public class MCH_EntitySeat extends W_Entity implements IEntityAdditionalSpawnDa
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=team_check_failed seatId=%d", new Object[]{Integer.valueOf(this.seatID)});
          return false;
       }
-      if(!this.worldObj.isRemote && this.riddenByEntity != null
-              && (this.riddenByEntity.isDead || this.riddenByEntity.ridingEntity != this
-              || !this.worldObj.loadedEntityList.contains(this.riddenByEntity))) {
+      if(this.riddenByEntity != null && isInvalidSeatOccupant(this.riddenByEntity)) {
          MCH_Lib.DbgLog(this.worldObj,
-                 "[MCH-STATE][REPAIR] context=seat_interact reason=invalid_seat_occupant_backreference seatId=%d staleOccupantId=%d staleOccupantUuid=%s dead=%s",
-                 new Object[]{Integer.valueOf(this.seatID), Integer.valueOf(this.riddenByEntity.getEntityId()),
+                 "[MCH-STATE][REPAIR] context=seat_interact reason=invalid_seat_occupant_backreference side=%s seatId=%d staleOccupantId=%d staleOccupantUuid=%s dead=%s",
+                 new Object[]{this.worldObj.isRemote?"CLIENT":"SERVER", Integer.valueOf(this.seatID), Integer.valueOf(this.riddenByEntity.getEntityId()),
                          this.riddenByEntity.getUniqueID(), Boolean.valueOf(this.riddenByEntity.isDead)});
          this.riddenByEntity = null;
       }
@@ -330,6 +328,11 @@ public class MCH_EntitySeat extends W_Entity implements IEntityAdditionalSpawnDa
       }
       player.mountEntity(this);
       return true;
+   }
+
+   private boolean isInvalidSeatOccupant(Entity occupant) {
+      return occupant == null || occupant.isDead || occupant.ridingEntity != this
+              || (!this.worldObj.isRemote && !this.worldObj.loadedEntityList.contains(occupant));
    }
 
    public MCH_EntityBaseVehicle getParent() {


### PR DESCRIPTION
### Motivation

- Players could be prevented from entering passenger seats after lag spikes or when entering/exiting the area around a vehicle because seat entities retained stale occupant backreferences, often forcing a relog to recover.

### Description

- Added `isInvalidSeatOccupant(Entity)` to `MCH_EntitySeat` and use it in `interactFirst` to clear a stale `riddenByEntity` before rejecting an interaction so client-side stale occupants don't block entry.
- Added `clearInvalidSeatOccupant(MCH_EntitySeat,int,String)` to `MCH_EntityBaseVehicle` and replaced inline repair logic with calls to that helper to centralize and standardize invalid-occupant detection and cleanup.
- Reused the new cleanup path inside `interactFirstSeat`/seat search so stale occupants are cleared during seat lookup, allowing recovered seats to be mounted immediately instead of staying unusable.
- Updated `CHANGELOG.md` with a short entry under a new “Seat Interaction Recovery Fix” section describing the change.

### Testing

- Ran `git diff --check` to ensure no whitespace/indexing issues and the repository diff shows only the intended source and changelog edits (success).
- Attempted `./gradlew test`, but the Gradle run failed in this environment because the wrapper cannot determine Java version `25.0.2`, so automated JVM tests were not executed (environment failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5d2bf47483239339323dfb87c362)