### PR TITLE
Fix New UAV station fake-player rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Fixed New UAV station pilot rendering so the station keeps showing the operator fake player after control transfers to an active New UAV.
+
 - Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries or lag spikes by recreating missing server seat entities on interaction, clearing stale client seat slots, and resyncing authoritative seat occupant IDs.
 
 - Cached 3D vehicle item icon model rendering in OpenGL display lists so inventories, held items, and dropped item icons reuse compiled geometry instead of re-submitting full vehicle models every frame.

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -1214,8 +1214,10 @@ public class MCH_EntityUavStation
       }
 
       private void updateNewUavPilotProfile() {
-           Entity pilot = this.controlAircraft != null && this.controlAircraft.isNewUAV()
-                 ? this.controlAircraft.getRiddenByEntity() : null;
+           MCH_EntityBaseVehicle activeNewUav = this.controlAircraft != null && this.controlAircraft.isNewUAV()
+                 ? this.controlAircraft : MCH_UavRegistry.findLoadedByUuid(this.worldObj, this.linkedUavEntityUUID);
+           Entity pilot = activeNewUav != null && activeNewUav.isNewUAV()
+                 && activeNewUav.isLinkedToStation(this) ? activeNewUav.getRiddenByEntity() : null;
            setNewUavPilotProfile(pilot instanceof EntityPlayer ? (EntityPlayer)pilot : null);
          }
 


### PR DESCRIPTION
### Motivation
- Ensure the station continues rendering the operator fake-player when control transfers to an active New UAV, because clearing station-side `controlAircraft` during handoff made the fake player disappear.

### Description
- Updated `updateNewUavPilotProfile` to resolve the actual active New UAV via `MCH_UavRegistry.findLoadedByUuid` when `controlAircraft` is not present and to use that resolved vehicle's rider when appropriate.
- Added an extra check that the resolved New UAV `isLinkedToStation(this)` before using its rider to avoid showing incorrect profiles.
- Updated `CHANGELOG.md` with an Unreleased entry describing the fix.

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues, test passed.
- Verified workspace status with `git status --short` to confirm only intended files were modified, check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5034eaa2648323a9f7b17757af66bf)