### PR TITLE
Keep New UAV station chunks loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Active New UAVs now keep their linked UAV station chunk loaded while piloted so the station continue flow can resolve the tied drone outside spawn chunks.
+
 - Fixed New UAV station pilot rendering so the station keeps showing the operator fake player after control transfers to an active New UAV.
 
 - Fixed passenger seats becoming non-enterable after vehicles cross chunk load boundaries or lag spikes by recreating missing server seat entities on interaction, clearing stale client seat slots, and resyncing authoritative seat occupant IDs.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -132,7 +132,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 **Why it exists:** Original MCHeli UAV behavior is fragile around restarts and station control. Overdrive adds persistence and duplicate-detection infrastructure so NewUAV/NewSmallUAV content can survive common server lifecycle events more safely.
 
-**How it differs from original MCHeli:** Overdrive stores NewUAV station/location data in `data/mcheli_new_uavs.json`, tracks destroyed stations, restores item identity/damage, and resolves duplicate live entities through canonical selection instead of blindly deleting potentially recoverable vehicles.
+**How it differs from original MCHeli:** Overdrive stores NewUAV station/location data in `data/mcheli_new_uavs.json`, tracks destroyed stations, restores item identity/damage, keeps the linked station chunk loaded while an active NewUAV is piloted, and resolves duplicate live entities through canonical selection instead of blindly deleting potentially recoverable vehicles.
 
 **Configuration:** Pack makers use shared `UAV`, `SmallUAV`, `NewUAV`, `NewSmallUAV`, and `TargetDrone` flags. Server owners should preserve the world `data/` folder with normal backups because it contains the NewUAV JSON persistence file.
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -85,6 +85,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private static final int NEW_UAV_SAFE_RETURN_MIN_TICKS = 20;
    private static MCH_EntityBaseVehicle aircraft;
     private ForgeChunkManager.Ticket chunkTicket;
+   private ForgeChunkManager.Ticket newUavStationChunkTicket;
+   private ChunkCoordIntPair newUavForcedStationChunk;
    //MCH_EntityBaseVehicle ac = null;
    private static final int DATAWT_ID_DAMAGE = 19;
    private static final int DATAWT_ID_TYPE = 20;
@@ -5811,6 +5813,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setDead(boolean dropItems) {
+      releaseNewUavStationChunk("vehicle-dead");
       if(!super.worldObj.isRemote && this.isNewUAV() && this.isDestroyed() && !this.newUavShiftExitInProgress) {
          notifyLinkedStationNewUavRemoved();
          Entity pilot = super.riddenByEntity != null ? super.riddenByEntity : this.lastRiddenByEntity;
@@ -8163,6 +8166,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
             //System.out.println("everything is WORKING");
          } else if(this.uavStation != null) {
+            updateNewUavStationChunkLoading();
             double udx1 = super.posX - this.uavStation.posX;
             double udz = super.posZ - this.uavStation.posZ;
 
@@ -8184,6 +8188,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             }
             //this.forceChunkLoading();
             //System.out.println("everything is working, now chunk loading");
+         } else {
+            releaseNewUavStationChunk("station-cleared");
          }
          //System.out.println("everything is working 2");
 
@@ -8192,8 +8198,52 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             this.uavStation = null;
          }
 
+      } else {
+         releaseNewUavStationChunk("not-uav");
       }
       //System.out.println("working 3");
+   }
+
+   private void updateNewUavStationChunkLoading() {
+      if(super.worldObj.isRemote || !this.isNewUAV() || this.uavStation == null || this.uavStation.isDead
+            || this.getRiddenByEntity() == null) {
+         releaseNewUavStationChunk("inactive-new-uav");
+         return;
+      }
+
+      ChunkCoordIntPair stationChunk = new ChunkCoordIntPair(
+            MathHelper.floor_double(this.uavStation.posX) >> 4,
+            MathHelper.floor_double(this.uavStation.posZ) >> 4);
+
+      if(this.newUavStationChunkTicket != null && stationChunk.equals(this.newUavForcedStationChunk)) {
+         return;
+      }
+
+      releaseNewUavStationChunk("station-chunk-changed");
+      this.newUavStationChunkTicket = ForgeChunkManager.requestTicket(MCH_MOD.instance, super.worldObj,
+            ForgeChunkManager.Type.NORMAL);
+      if(this.newUavStationChunkTicket == null) {
+         MCH_Lib.Log((Entity)this, "Unable to request New UAV station chunk ticket", new Object[0]);
+         return;
+      }
+
+      this.newUavForcedStationChunk = stationChunk;
+      ForgeChunkManager.forceChunk(this.newUavStationChunkTicket, this.newUavForcedStationChunk);
+      super.worldObj.getChunkFromChunkCoords(stationChunk.chunkXPos, stationChunk.chunkZPos);
+   }
+
+   private void releaseNewUavStationChunk(String reason) {
+      if(this.newUavStationChunkTicket == null) {
+         this.newUavForcedStationChunk = null;
+         return;
+      }
+      if(this.newUavForcedStationChunk != null) {
+         ForgeChunkManager.unforceChunk(this.newUavStationChunkTicket, this.newUavForcedStationChunk);
+      }
+      ForgeChunkManager.releaseTicket(this.newUavStationChunkTicket);
+      this.newUavStationChunkTicket = null;
+      this.newUavForcedStationChunk = null;
+      MCH_Lib.Log((Entity)this, "Released New UAV station chunk ticket: %s", new Object[] { reason });
    }
 
    public void switchGunnerMode(boolean mode) {


### PR DESCRIPTION
### Motivation
- Continue/resume control (the station "continue" flow) could only resolve NewUAVs when the station chunk was in spawn-loaded area, causing "continue" to fail for piloted NewUAVs outside spawn chunks. The goal is to keep station chunk loading behavior limited to NewUAVs actively piloted so continue/reconnect logic works reliably without changing other behavior.

### Description
- Added per-vehicle ticket tracking fields `newUavStationChunkTicket` and `newUavForcedStationChunk` and a chunk-management lifecycle so an actively piloted NewUAV forces its linked station chunk to remain loaded via `ForgeChunkManager.forceChunk` (new methods `updateNewUavStationChunkLoading` and `releaseNewUavStationChunk`).
- Hooked the new chunk-loading logic into `updateUAV()` so the station chunk is requested while the NewUAV is active and the player is mounted, and released when the UAV becomes inactive, the station is cleared, the vehicle stops being a NewUAV, or the vehicle dies.
- Added a defensive early release on vehicle death by calling `releaseNewUavStationChunk("vehicle-dead")` from `setDead(boolean)`.
- Documented the change in `CHANGELOG.md` and updated `docs/overdrive-features.md` to describe that linked station chunks are kept loaded while an active NewUAV is piloted.

### Testing
- Ran static verification `git diff --check`, which completed without errors.
- Verified the change compiles locally was intentionally not performed per repository rules; only source edits, changelog, and docs updates were made and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a503afb1be883239082670df70069e2)