### PR TITLE
UAV station destruction unlinks UAV and returns operator to station

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Destroying a UAV station now unlinks the live UAV and returns any active operator to the station position instead of destroying the UAV and dismounting the player at the aircraft.
+
 - Active New UAVs now keep their linked UAV station chunk loaded while piloted so the station continue flow can resolve the tied drone outside spawn chunks.
 
 - Fixed New UAV station pilot rendering so the station keeps showing the operator fake player after control transfers to an active New UAV.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -622,6 +622,19 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    }
 
+   public void unlinkUavStation() {
+      this.uavStation = null;
+      this.linkedUavStationUUID = null;
+      this.linkedUavStationDimension = 0;
+      this.linkedUavStationX = 0.0D;
+      this.linkedUavStationY = 0.0D;
+      this.linkedUavStationZ = 0.0D;
+      this.hasLinkedUavStationPosition = false;
+      if(!super.worldObj.isRemote) {
+         this.getDataWatcher().updateObject(22, Integer.valueOf(0));
+      }
+   }
+
    public UUID getUavPersistentUUID() {
       return getUavPersistentUUID(true);
    }

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -427,7 +427,48 @@ public class MCH_EntityUavStation
 
 
 
-             public void initUavPostion() {
+
+      private void detachLinkedUavForStationDestruction(MCH_EntityBaseVehicle linkedUav) {
+           if(this.worldObj.isRemote || linkedUav == null) {
+                return;
+           }
+
+           Entity rider = linkedUav.getRiddenByEntity();
+           if(rider != null) {
+                rider.mountEntity((Entity)null);
+                double x = this.posX - Math.sin(this.rotationYaw * Math.PI / 180.0D) * 0.9D;
+                double z = this.posZ + Math.cos(this.rotationYaw * Math.PI / 180.0D) * 0.9D;
+                double y = this.posY + getMountedYOffset() + rider.getYOffset();
+                if(rider instanceof EntityPlayerMP) {
+                     W_EntityPlayer.closeScreen(rider);
+                     ((EntityPlayerMP)rider).setPositionAndUpdate(x, y, z);
+                } else {
+                     rider.setPosition(x, y, z);
+                }
+                rider.fallDistance = 0.0F;
+           }
+
+           linkedUav.unlinkUavStation();
+           MCH_UavJsonStore.remove(this.worldObj, this);
+           releaseReconnectChunks("station-destroyed");
+           this.riddenByEntity = null;
+           this.lastRiddenByEntity = null;
+           this.assignedUav = null;
+           this.assignedUavId = -1;
+           this.assignedUavUUID = "";
+           this.linkedUavEntityUUID = null;
+           this.linkedUavCommonId = "";
+           this.hasStoredUavLink = false;
+           this.awaitingLoadedUav = false;
+           this.pendingContinueTicks = 0;
+           this.controlAircraft = null;
+           setLastControlAircraft((MCH_EntityBaseVehicle)null);
+           setLastControlAircraftEntityId(0);
+           setNewUavPilotProfile((EntityPlayer)null);
+           setContinuationState(CONTINUE_NONE);
+      }
+
+      public void initUavPostion() {
            int rt = (int)(MCH_Lib.getRotate360((this.rotationYaw + 45.0F)) / 90.0D);
            boolean D = true;
            this.posUavX = (rt != 0 && rt != 3) ? -12 : 12;
@@ -477,10 +518,7 @@ public class MCH_EntityUavStation
                          linkedUav = findLinkedUavEntity(this.worldObj);
                      }
                      if(linkedUav != null && !linkedUav.isDead) {
-                         // The aircraft owns the exact persisted return coordinates and always
-                         // detaches before teleporting, including when this station is destroyed.
-                         linkedUav.setUavStation(this);
-                         linkedUav.setDead();
+                         detachLinkedUavForStationDestruction(linkedUav);
                      }
 
                      // Handle station death


### PR DESCRIPTION
### Motivation
- Fix a bug where destroying a UAV station killed the linked UAV and left the player dismounted at the UAV instead of returning them to the station position. 
- The intended behavior is to preserve the live UAV entity and only dismount/return the player to the station when the station is destroyed. 

### Description
- Replace the previous station-death behavior that called `linkedUav.setDead()` with a new helper `detachLinkedUavForStationDestruction` in `src/main/java/mcheli/uav/MCH_EntityUavStation.java` that unmounts any rider, places the rider at the station position, clears station state, and unlinks the UAV. 
- Add `unlinkUavStation()` in `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java` to clear station references and update the data watcher without killing the aircraft. 
- Update `MCH_EntityUavStation.attackEntityFrom` to call the new detach helper instead of destroying the linked UAV. 
- Document the behavior change in `CHANGELOG.md` per repo changelog policy. 

### Testing
- Ran `git diff --check` to verify no trailing-whitespace or obvious diff issues and it passed. 
- Attempted `./gradlew testClasses` to compile/test, but the build was blocked by the environment's Java/Gradle mismatch (Gradle 4.4.1 could not determine Java version `25.0.2`), so no binaries were produced and JVM-based tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a503f8114e08323aae82a052c998e5e)