### PR TITLE
Fix New UAV inventory restore on station destruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Destroying a UAV station now unlinks the live UAV and returns any active operator to the station position instead of destroying the UAV and dismounting the player at the aircraft.
+- Destroying a UAV station while its operator is controlling a linked New UAV now restores the operator's stored inventory immediately after returning them to the station.
 
 - Active New UAVs now keep their linked UAV station chunk loaded while piloted so the station continue flow can resolve the tied drone outside spawn chunks.
 

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -132,7 +132,7 @@ This page summarizes the major project-wide systems that distinguish MCHeli Over
 
 **Why it exists:** Original MCHeli UAV behavior is fragile around restarts and station control. Overdrive adds persistence and duplicate-detection infrastructure so NewUAV/NewSmallUAV content can survive common server lifecycle events more safely.
 
-**How it differs from original MCHeli:** Overdrive stores NewUAV station/location data in `data/mcheli_new_uavs.json`, tracks destroyed stations, restores item identity/damage, keeps the linked station chunk loaded while an active NewUAV is piloted, and resolves duplicate live entities through canonical selection instead of blindly deleting potentially recoverable vehicles.
+**How it differs from original MCHeli:** Overdrive stores NewUAV station/location data in `data/mcheli_new_uavs.json`, tracks destroyed stations, restores item identity/damage, restores a NewUAV operator inventory if the linked station is destroyed mid-control, keeps the linked station chunk loaded while an active NewUAV is piloted, and resolves duplicate live entities through canonical selection instead of blindly deleting potentially recoverable vehicles.
 
 **Configuration:** Pack makers use shared `UAV`, `SmallUAV`, `NewUAV`, `NewSmallUAV`, and `TargetDrone` flags. Server owners should preserve the world `data/` folder with normal backups because it contains the NewUAV JSON persistence file.
 

--- a/src/main/java/mcheli/uav/MCH_EntityUavStation.java
+++ b/src/main/java/mcheli/uav/MCH_EntityUavStation.java
@@ -440,8 +440,12 @@ public class MCH_EntityUavStation
                 double z = this.posZ + Math.cos(this.rotationYaw * Math.PI / 180.0D) * 0.9D;
                 double y = this.posY + getMountedYOffset() + rider.getYOffset();
                 if(rider instanceof EntityPlayerMP) {
-                     W_EntityPlayer.closeScreen(rider);
-                     ((EntityPlayerMP)rider).setPositionAndUpdate(x, y, z);
+                     EntityPlayerMP player = (EntityPlayerMP)rider;
+                     W_EntityPlayer.closeScreen(player);
+                     player.setPositionAndUpdate(x, y, z);
+                     if(linkedUav.isNewUAV()) {
+                          MCH_UavInventory.restorePilotInventory(player, "station_destroyed");
+                     }
                 } else {
                      rider.setPosition(x, y, z);
                 }


### PR DESCRIPTION
### Motivation
- Fix a bug where a New UAV operator's stored inventory was not restored when the linked UAV station was destroyed while the operator remained mounted to the drone.

### Description
- Call `MCH_UavInventory.restorePilotInventory(player, "station_destroyed")` after unmounting and teleporting a player in `detachLinkedUavForStationDestruction` so stored inventories are restored immediately when destroying a station tied to a `NewUAV`.
- Clear and unlink the station as before; the fix only adds an immediate inventory restore for `EntityPlayerMP` riders of `NewUAV` entities.
- Document the behavior in `CHANGELOG.md` and update `docs/overdrive-features.md` to mention that operator inventories are restored if the linked station is destroyed mid-control.

### Testing
- Ran static checks with `git diff --check` which returned no issues.
- Performed repository text searches to verify the new `restorePilotInventory` call and updated documentation lines were applied.
- No build or runtime compilation was performed as requested by project contribution rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5043a5568083238cb1746c74954746)