### PR TITLE
Disable non-bomber gunner bombsights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Config Reference Non-Bomber Gunner Bombsights
+
+- Disabled `HasBombSight` for non-bomber fixed-wing config references that use pilot gunner mode, including gunships, drones, fighters, transports, and reconnaissance aircraft, while confirming the AC-130 remains opted out via `EnableBombSight = false`.
+
 ## Config Reference Plane Carrier Eligibility
 
 - Added explicit `CanMountShip` entries to every plane config reference. Oversized bombers, strategic aircraft, large transports, AWACS/tanker, and other large non-carrier aircraft are set to `false`; remaining plane references are set to `true` to preserve carrier rack compatibility.

--- a/configreference/planes/ac-47.txt
+++ b/configreference/planes/ac-47.txt
@@ -104,6 +104,7 @@ CameraPosition = 1.8, 4.40, -7.42
 CameraZoom = 1
 EnableNightVision = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 ;FlareType = 2
 ;sorry kid

--- a/configreference/planes/au23.txt
+++ b/configreference/planes/au23.txt
@@ -23,6 +23,7 @@ CameraPosition = 1.13, 2.29, -0.32, false
 EnableNightVision = false
 EnableEntityRadar = false
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 MaxFuel         = 2120
 FuelConsumption = 1.767

--- a/configreference/planes/bayraktar tb 2.txt
+++ b/configreference/planes/bayraktar tb 2.txt
@@ -22,6 +22,7 @@ EnableEntityRadar = true
 RadarType = MODERN_AA
 HasChaff = true
 EnableGunnerMode = true
+HasBombSight = false
 NewUAV = true
 HideEntity = true
 AutoPilotRot = -0.06

--- a/configreference/planes/c5m.txt
+++ b/configreference/planes/c5m.txt
@@ -21,6 +21,7 @@ MaxFuel         = 603260
 FuelConsumption = 109.168
 InventorySize = 64
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = 0
 FlareType = 2
 EnableNightVision = true

--- a/configreference/planes/e767.txt
+++ b/configreference/planes/e767.txt
@@ -25,6 +25,7 @@ EnableEntityRadar = true
 RWRType = DIGITAL
 RadarType = MODERN_AA
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 FlareType = 2
 HasChaff = true

--- a/configreference/planes/eurofighter_typhoon_2.txt
+++ b/configreference/planes/eurofighter_typhoon_2.txt
@@ -18,6 +18,7 @@ RadarType = MODERN_AA
 EnableEjectionSeat = true
 Speed = 4.0
 EnableGunnerMode = true
+HasBombSight = false
 FlareType = 4
 HasChaff = true
 MaxFuel         = 20000

--- a/configreference/planes/eurofighter_typhoon_2_t.txt
+++ b/configreference/planes/eurofighter_typhoon_2_t.txt
@@ -21,6 +21,7 @@ Speed = 4.0
 ;1.5k mph
 
 EnableGunnerMode = true
+HasBombSight = false
 FlareType = 4
 HasChaff = true
 MaxFuel         = 20000

--- a/configreference/planes/f-15e.txt
+++ b/configreference/planes/f-15e.txt
@@ -101,6 +101,7 @@ MaxFuel         = 24400
 FuelConsumption = 6.256
 CameraPosition = 0.0, 0.70, 1.6
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = 0
 ThrottleUpDown = 0.3
 

--- a/configreference/planes/f-15s_mtd.txt
+++ b/configreference/planes/f-15s_mtd.txt
@@ -27,6 +27,7 @@ MaxFuel         = 24400
 FuelConsumption = 6.256
 CameraPosition = 0.0, 0.70, 1.6
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = 0
 ThrottleUpDown = 0.3
 

--- a/configreference/planes/f14.txt
+++ b/configreference/planes/f14.txt
@@ -18,6 +18,7 @@ RWRType = DIGITAL
 RadarType = MODERN_AA
 EnableEjectionSeat = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 Speed = 4.0
 Sound = tomcat

--- a/configreference/planes/f22a.txt
+++ b/configreference/planes/f22a.txt
@@ -30,6 +30,7 @@ CameraPosition = 0.0, 0.70, -2.18
 ;CameraPosition = 5.0, 5.70, -22.18, false, 90, 40
 ;CameraPosition = 0.0, 5.70, -12.18, false, 30, 40
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = 0
 ThrottleUpDown = 0.3
 

--- a/configreference/planes/kf-21.txt
+++ b/configreference/planes/kf-21.txt
@@ -110,6 +110,7 @@ MobilityRoll = 2.520
 ;OnGroundPitch = 3
 
 EnableGunnerMode = true
+HasBombSight = false
 CameraPosition = 0.0, 0.7, -1.0
 AutoPilotRot = 0
 

--- a/configreference/planes/mc130.txt
+++ b/configreference/planes/mc130.txt
@@ -22,6 +22,7 @@ EnableNightVision = true
 EnableEntityRadar = false
 HasBallisticComputer = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 FlareType = 2
 InventorySize = 18

--- a/configreference/planes/mc130j.txt
+++ b/configreference/planes/mc130j.txt
@@ -21,6 +21,7 @@ CameraPosition = 2.0, 1.40, -4.0
 EnableNightVision = true
 EnableEntityRadar = false
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 FlareType = 2
 InventorySize = 36

--- a/configreference/planes/mq-9.txt
+++ b/configreference/planes/mq-9.txt
@@ -22,6 +22,7 @@ EnableEntityRadar = true
 RadarType = MODERN_AA
 HasChaff = true
 EnableGunnerMode = true
+HasBombSight = false
 ;;NewUAV = true
 ;;soon
 ;;blud really used java comments

--- a/configreference/planes/mq-9debug.txt
+++ b/configreference/planes/mq-9debug.txt
@@ -26,6 +26,7 @@ EnableEntityRadar = true
 RadarType = MODERN_AA
 HasChaff = true
 EnableGunnerMode = true
+HasBombSight = false
 NewUAV = true
 ;;soon
 ;;ahh hell nah blud used slash comments in the txt

--- a/configreference/planes/q-5d.txt
+++ b/configreference/planes/q-5d.txt
@@ -30,6 +30,7 @@ HasChaff = true
 EnableEjectionSeat = true
 EnableSeaSurfaceParticle = true
 EnableGunnerMode = true
+HasBombSight = false
 CameraPosition = 0.0, 0.45, 2.0
 AutoPilotRot = 0.0
 ParticlesScale = 0.7

--- a/configreference/planes/skylark.txt
+++ b/configreference/planes/skylark.txt
@@ -17,6 +17,7 @@ EnableEntityRadar = true
 RadarType = MODERN_AA
 HasChaff = true
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = -0.04
 CameraPosition = 0.0, 0.40, 0.34
 ThrottleUpDown = 1.0

--- a/configreference/planes/sr71.txt
+++ b/configreference/planes/sr71.txt
@@ -19,6 +19,7 @@ EnableEjectionSeat = true
 
 AutoPilotRot = 0.00
 EnableGunnerMode = true
+HasBombSight = false
 
 Speed = 4.0
 FlareType = 4

--- a/configreference/planes/su34.txt
+++ b/configreference/planes/su34.txt
@@ -16,6 +16,7 @@ RWRType = DIGITAL
 RadarType = MODERN_AS
 EnableEjectionSeat = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 Speed = 3.306
 FlareType = 4

--- a/configreference/planes/su34b.txt
+++ b/configreference/planes/su34b.txt
@@ -17,6 +17,7 @@ RadarType = MODERN_AS
 HasBallisticComputer = true
 EnableEjectionSeat = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 Speed = 3.306
 FlareType = 4

--- a/configreference/planes/su34n.txt
+++ b/configreference/planes/su34n.txt
@@ -16,6 +16,7 @@ RWRType = DIGITAL
 RadarType = MODERN_AA
 EnableEjectionSeat = true
 EnableGunnerMode = true
+HasBombSight = false
 ConcurrentGunnerMode = true
 Speed = 3.306
 FlareType = 4

--- a/configreference/planes/su57.txt
+++ b/configreference/planes/su57.txt
@@ -28,6 +28,7 @@ FuelConsumption = 11.771
 Stealth = 0.43
 CameraPosition = 0.0, 1.25, 0.00
 EnableGunnerMode = true
+HasBombSight = false
 AutoPilotRot = 0
 
 sound = pakfa

--- a/configreference/planes/x-47b.txt
+++ b/configreference/planes/x-47b.txt
@@ -24,6 +24,7 @@ RWRType = DIGITAL
 RadarType = MODERN_AA
 HasChaff = true
 EnableGunnerMode = true
+HasBombSight = false
 NewUAV = true
 HideEntity = true
 AutoPilotRot = -0.06


### PR DESCRIPTION
### Motivation

- Non-bomber fixed-wing vehicles that enable pilot/gunner mode should not present a first-person bomber sight by default, so gunships, drones, fighters, transports, and reconnaissance aircraft need an explicit opt-out for the bombsight feature.

### Description

- Added `HasBombSight = false` to a set of fixed-wing config reference files that contain `EnableGunnerMode = true` to disable the first-person bomber sight for non-bomber platforms. 
- Confirmed the AC-130 remains opted out using its existing `EnableBombSight = false` entry and was not changed.
- Documented the update in `CHANGELOG.md` under a new `Config Reference Non-Bomber Gunner Bombsights` entry. 

### Testing

- Ran a Python audit that enumerated plane configs with `EnableGunnerMode = true` and verified the new `HasBombSight = false` opt-outs were present, which succeeded. 
- Ran `python3 tools/validate_plane_config_surface.py`, which exercised config validation but failed on an unrelated preexisting issue in `configreference/planes/b-21.txt` (removed keys `ClimbEnergyLoss`, `DiveEnergyGain`, `TakeoffDistanceMultiplier`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a509046887083239b28c6dcae3685a9)