### PR TITLE
Show non-zero vehicle weight and max payload in item tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Vehicle tooltip payload stats
+- Added vehicle item tooltip lines for non-zero configured `Weight` and `MaximumExternalPayloadCapacity` values so players can see vehicle weight and max payload capacity before spawning.
+
 ## Rack payload capacity cumulative enforcement
 - Updated rack mounting so `MaximumExternalPayloadCapacity` is checked against the total `Weight` already mounted on occupied rack seats plus the incoming vehicle, preventing the remaining payload capacity from ever going negative.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,8 +125,8 @@ Vehicle `.txt` definitions can opt individual items into or out of 3D item rende
 | --- | --- | --- |
 | `Enable3DItemIcon` | `true` | Per-vehicle toggle. Set `false` to keep that vehicle on the normal flat item icon even when the global override allows 3D icons. |
 | `ItemIconScaleFactor` | `1.0` | Per-vehicle 3D item icon scale multiplier, clamped to `0.01` through `100.0`. Alias: `3DItemIconScaleFactor`. |
-| `MaximumExternalPayloadCapacity` | `0` | Maximum total vehicle weight, in pounds, that this vehicle can lift/tow with a chain or carry across all occupied configured racks. Rack mounting subtracts already-mounted vehicle `Weight` plus the incoming vehicle `Weight`; the remaining capacity is never allowed below zero. A value of `0` prevents chain-towing or rack-carrying other configured vehicles by default. |
-| `Weight` | `50000` | Vehicle weight, in pounds, used when another vehicle attempts to chain-tow it or mount it on a rack. |
+| `MaximumExternalPayloadCapacity` | `0` | Maximum total vehicle weight, in pounds, that this vehicle can lift/tow with a chain or carry across all occupied configured racks. Rack mounting subtracts already-mounted vehicle `Weight` plus the incoming vehicle `Weight`; the remaining capacity is never allowed below zero. A value of `0` prevents chain-towing or rack-carrying other configured vehicles by default. Non-zero values are shown on the vehicle item tooltip as max payload. |
+| `Weight` | `50000` | Vehicle weight, in pounds, used when another vehicle attempts to chain-tow it or mount it on a rack. Non-zero values are shown on the vehicle item tooltip. |
 
 ## Hidden/advanced options initialized in source
 

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -72,6 +72,12 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
       MCH_EntityBaseVehicle ac = createAircraft(player.worldObj, -1.0D, -1.0D, -1.0D, stack);
       if (info != null) {
          lines.add(EnumChatFormatting.YELLOW + "Category: " + info.category);
+         if(info.weight != 0.0D) {
+            lines.add(EnumChatFormatting.YELLOW + "Weight: " + formatPounds(info.weight) + " lb");
+         }
+         if(info.maximumExternalPayloadCapacity != 0.0D) {
+            lines.add(EnumChatFormatting.YELLOW + "Max Payload: " + formatPounds(info.maximumExternalPayloadCapacity) + " lb");
+         }
          //lines.add(EnumChatFormatting.DARK_PURPLE + "Weapon: " + info.weaponSetList);
          //         tooltip.add(TextFormatting.DARK_PURPLE + "Weapons: " + Arrays.stream(ac.weapons).map(MCH_WeaponSet::getName).collect(Collectors.joining(", ")));
          //lines.add(EnumChatFormatting.DARK_PURPLE + "Weapons: " + Arrays.stream(ac.weapons).map(MCH_WeaponSet::getName).collect(Collectors.joining(", ")));
@@ -93,6 +99,14 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
       }
 //
       super.addInformation(stack, player, lines, par4);
+   }
+
+   private static String formatPounds(double pounds) {
+      if(Math.abs(pounds - (double)((long)pounds)) < 0.001D) {
+         return String.valueOf((long)pounds);
+      }
+
+      return String.format(java.util.Locale.ROOT, "%.1f", pounds);
    }
 
    public abstract MCH_BaseVehicleInfo getAircraftInfo();


### PR DESCRIPTION
### Motivation
- Make vehicle item tooltips show useful payload information so players can see a vehicle's configured `Weight` and `MaximumExternalPayloadCapacity` before spawning when those values are non-zero.
- Keep configuration reference and changelog in sync with the behavior so pack authors and users know these values are surfaced in the UI.

### Description
- Display `Weight: {lbs}` and `Max Payload: {lbs}` in `MCH_ItemBaseVehicle.addInformation` only when `info.weight` or `info.maximumExternalPayloadCapacity` is not `0.0`.
- Add a `formatPounds(double)` helper to format whole-pound values without decimals and fractional pounds with one decimal in `MCH_ItemBaseVehicle.java`.
- Update `docs/configuration.md` to note that non-zero `Weight` and `MaximumExternalPayloadCapacity` values are shown on vehicle item tooltips.
- Add a short changelog entry describing the new vehicle tooltip payload stats in `CHANGELOG.md`.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff-check issues, which succeeded.
- Ran `git status --short` to confirm working-tree changes are present, which reported the expected modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b5433c2c832388f827fd1b35374b)