### PR TITLE
Add tank and turret fall damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Tank and Turret Fall Damage
+- Added server-side fall damage for tanks and turrets after drops greater than three blocks, using fall damage sources so armor and existing vehicle damage handling apply consistently.
+
 ## Vehicle tooltip payload stats
 - Added vehicle item tooltip lines for non-zero configured `Weight` and `MaximumExternalPayloadCapacity` values so players can see vehicle weight and max payload capacity before spawning.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ MCHeli Overdrive+ is a combined-arms vehicle, weapon, and warfare framework for 
 
 - **Large weapon-definition support:** Overdrive keeps MCHeli's data-driven weapon model for large content packs, including weapon libraries that can scale to hundreds or thousands of definitions, and expands combat roles for anti-air, anti-armor, anti-ship, close-air-support, torpedo, guided-weapon, bomb, rocket, cannon, dispenser, chemical/nuclear-compatible, and support-equipment loadouts.
 - **Missile and warning systems:** radar/RWR identity fields, lock-on warning logic, missile guidance behavior, multipath/lock tuning, lockable entity synchronization, and vehicle naming fields support richer air-combat and radar gameplay.
-- **Countermeasures and protection:** flares and chaff are distinct systems, while active protection system (APS), maintenance, collision damage, damage factors, and armor configuration expand vehicle survivability and defensive roles.
+- **Countermeasures and protection:** flares and chaff are distinct systems, while active protection system (APS), maintenance, collision damage, tank/turret fall damage, damage factors, and armor configuration expand vehicle survivability and defensive roles.
 
 ### Naval warfare
 

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -510,6 +510,17 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
    }
 
+   protected void fall(float distance) {
+      if(!super.worldObj.isRemote && distance > 3.0F && !this.isDestroyed()) {
+         float damage = (distance - 3.0F) * 2.0F;
+         this.attackEntityFrom(DamageSource.fall, damage);
+      }
+
+      if(this.getRiddenByEntity() != null) {
+         this.getRiddenByEntity().fallDistance = 0.0F;
+      }
+   }
+
    public boolean attackEntityFrom(DamageSource damageSource, float damage) {
       EnumBoundingBoxType hitType = this.lastHitBoundingBoxType;
       if(!super.worldObj.isRemote && hitType == EnumBoundingBoxType.TRACK && !this.isDestroyed()) {

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -311,6 +311,17 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
    }
 
 
+   protected void fall(float distance) {
+      if(!super.worldObj.isRemote && distance > 3.0F && !this.isDestroyed()) {
+         float damage = (distance - 3.0F) * 2.0F;
+         this.attackEntityFrom(DamageSource.fall, damage);
+      }
+
+      if(this.getRiddenByEntity() != null) {
+         this.getRiddenByEntity().fallDistance = 0.0F;
+      }
+   }
+
    //no usages
    protected void onUpdate_Particle() {
       double particlePosY = super.posY;


### PR DESCRIPTION
### Motivation
- Ensure tanks and static turrets take server-side fall damage when dropped from height so vehicle survivability matches other entities and existing armor/damage systems apply.
- Prevent riders from suffering duplicated fall damage by clearing the rider's `fallDistance` after vehicle landings.

### Description
- Added `protected void fall(float distance)` to `MCH_EntityTank` which applies fall damage when `distance > 3.0F` using `attackEntityFrom(DamageSource.fall, damage)` and clears the rider's `fallDistance`.
- Added the same `protected void fall(float distance)` implementation to `MCH_EntityTurret` to provide equivalent turret behavior.
- Documented the change in `CHANGELOG.md` with a `Tank and Turret Fall Damage` entry and updated the README survivability line to mention tank/turret fall damage.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff hygiene, which reported no issues.
- Verified the modified files (`MCH_EntityTank.java`, `MCH_EntityTurret.java`, `CHANGELOG.md`, `README.md`) were staged and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b758f1f48323ba8620f4790332bd)