### PR TITLE
Add engine waterboarding for submerged tanks, planes, and helicopters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,3 +109,6 @@
 ## CCIP Static Bomb Reticle Fix
 - Fixed the plane CCIP pipper so it draws directly at the predicted bomb impact projection instead of smoothing toward a look-following cursor.
 - Documented that CCIP is projected in the aircraft body frame and is not driven by player freelook or mouse aim.
+
+## Engine Waterboarding
+- Added waterboarding behavior for tank, plane, and helicopter engines: submerged non-floating vehicles now have throttle forced to zero while waterlogged, and recurring water damage stops once the configured `EngineShutdownThreshold` health percentage is reached instead of always continuing to destruction.

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -85,7 +85,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `ArmorMaxDamage` | All | float | 100000.0 | armor clamp ceiling |
 | `ArmorDamageFactor` | All | float | 1.0 | armor damage scale |
 | `ExplosionSizeByCrash` | All | int[0..100] | 5 | death/crash explosion radius |
-| `EngineShutdownThreshold` | All | int | 20 | engine disabled below this HP percent |
+| `EngineShutdownThreshold` | All | int | 20 | engine disabled below this HP percent; also caps waterboarding damage for submerged non-floating tanks, planes, and helicopters |
 | `float` | All | boolean | false | enables water floating behavior |
 | `floatoffset` | All | float | 0.0 | waterline offset |
 | `gravity` | All | float | -0.04 | air gravity per tick |

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -85,7 +85,7 @@ For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is
 | `ArmorDamageFactor` | float[0..10000] | 1 | Armor multiplier. |
 | `ArmorMinDamage` / `ArmorMaxDamage` | float[0..1000000] | 0 / 100000 | Armor damage clamp. Constructor field for max is 100000, parser allows up to 1000000. |
 | `ExplosionSizeByCrash` | int[0..100] | 5 | Explosion size when destroyed/crashed. |
-| `EngineShutdownThreshold` | int[0..100] | 20 | Engine shutdown below this health percentage. |
+| `EngineShutdownThreshold` | int[0..100] | 20 | Engine shutdown below this health percentage. For non-floating tanks, planes, and helicopters submerged by `SubmergedDamageHeight`, waterboarding damage now stops at this threshold and throttle is forced to 0 while the engine is waterlogged. |
 | `MaxFuel` | int[0..100000000] | 0 | Capacity; zero effectively disables fuel limit. |
 | `FuelConsumption` | float[0..10000] | 1 | Consumption multiplier. |
 | `FuelSupplyRange` / `AmmoSupplyRange` | float[0..1000] | 0 | Support radius. |

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -3655,24 +3655,29 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             }
          }
 
-         if(this.getCountOnUpdate() % 30 == 0 && (this.getAcInfo() == null || !this.getAcInfo().isFloat) && MCH_Lib.isBlockInWater(super.worldObj, (int)(super.posX + 0.5D), (int)(super.posY + 1.5D + (double)this.getAcInfo().submergedDamageHeight), (int)(super.posZ + 0.5D))) {
+         if(this.getCountOnUpdate() % 30 == 0 && this.isSubmergedForDamage()) {
             int hp1 = this.getMaxHP() / 30;
             //int hp1 = this.ArmorMinDamage / 10;
             if(hp1 <= 0) {
                hp1 = 1;
             }
-            this.attackEntityFrom(DamageSource.inWall, hp1);
-            //Entity entity = damageSource.getEntity();
-            if (this instanceof MCH_EntityTank) {
 
+            if(this.isEngineWaterboarded()) {
+               this.attackEntityFromWaterboarding(hp1);
+            } else {
+               this.attackEntityFrom(DamageSource.inWall, hp1);
+            }
+
+            if(this instanceof MCH_EntityTank) {
                MCH_BaseVehicleInfo cmd1 = this.getAcInfo();
-
                if(cmd1 != null) {
-
-                  System.out.println("should be a tank");
-                  //MCH_BaseVehicleInfo.armorMinDamage
-                  //todo test for armor min damage
-                  this.attackEntityFrom(DamageSource.inWall, hp1 + cmd1.armorMinDamage);
+                  // Tanks keep their armor-minimum water pressure damage, but waterboarding
+                  // still stops applying damage once the engine shutdown threshold is reached.
+                  if(this.isEngineWaterboarded()) {
+                     this.attackEntityFromWaterboarding(hp1 + cmd1.armorMinDamage);
+                  } else {
+                     this.attackEntityFrom(DamageSource.inWall, hp1 + cmd1.armorMinDamage);
+                  }
                }
             }
 
@@ -4741,6 +4746,45 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       return collidingBoundingBoxes;
+   }
+
+
+   private boolean isSubmergedForDamage() {
+      MCH_BaseVehicleInfo info = this.getAcInfo();
+      return info != null
+         && !info.isFloat
+         && MCH_Lib.isBlockInWater(super.worldObj, (int)(super.posX + 0.5D), (int)(super.posY + 1.5D + (double)info.submergedDamageHeight), (int)(super.posZ + 0.5D));
+   }
+
+   protected boolean isEngineWaterboarded() {
+      return this.isSubmergedForDamage()
+         && (this instanceof MCH_EntityTank || this instanceof MCP_EntityPlane || this instanceof MCH_EntityHeli);
+   }
+
+   protected boolean applyEngineWaterboardingThrottleCut() {
+      if(this.isEngineWaterboarded()) {
+         this.setCurrentThrottle(0.0D);
+         this.setThrottle(0.0D);
+         super.throttleUp = false;
+         super.throttleDown = false;
+         super.throttleBack = 0.0F;
+         return true;
+      }
+
+      return false;
+   }
+
+   private void attackEntityFromWaterboarding(int damage) {
+      MCH_BaseVehicleInfo info = this.getAcInfo();
+      int shutdownHp = 0;
+      if(info != null && info.engineShutdownThreshold > 0) {
+         shutdownHp = (int)Math.ceil((double)this.getMaxHP() * (double)info.engineShutdownThreshold / 100.0D);
+      }
+
+      int cappedDamage = Math.min(Math.max(damage, 0), this.getHP() - shutdownHp);
+      if(cappedDamage > 0) {
+         this.attackEntityFrom(DamageSource.inWall, cappedDamage);
+      }
    }
 
    protected void onUpdate_updateBlock() {

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -1061,6 +1061,13 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       //}
       //hovering and death animation had issues with this. Not good!
 
+      if(this.applyEngineWaterboardingThrottleCut()) {
+         this.normalizedRotorRPM = 0.0F;
+         this.targetRotorRPM = 0.0F;
+         this.enginePowerOutput = 0.0F;
+         return;
+      }
+
       if(this.isHoveringMode() && !this.canUseFuel(true)) {
          this.switchHoveringMode(false);
       }

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -2740,6 +2740,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
    }
 
    protected void onUpdate_Control() {
+      if(this.applyEngineWaterboardingThrottleCut()) {
+         this.engineThrottle = 0.0D;
+         return;
+      }
+
       if(super.isGunnerMode && !this.canUseFuel()) {
          this.switchGunnerMode(false);
       }

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -457,6 +457,10 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          return;
       }
 
+      if(this.applyEngineWaterboardingThrottleCut()) {
+         return;
+      }
+
       if(getHP() * 100 / getMaxHP() < getAcInfo().engineShutdownThreshold) {
          setCurrentThrottle(0);
          throttleUp = false;


### PR DESCRIPTION
### Motivation
- Prevent non-floating vehicles from endlessly taking water damage while submerged by treating engine waterlogging as a distinct state. 
- Make engine behavior predictable when flooded by forcing engine/throttle output to zero instead of only applying raw HP loss. 
- Preserve existing submerged-damage behavior for vehicles that should still take structural water pressure damage while capping engine-related damage at an engine shutdown threshold.

### Description
- Added shared helpers in `MCH_EntityBaseVehicle` for submerged checks and engine-waterboard handling: `isSubmergedForDamage()`, `isEngineWaterboarded()`, `applyEngineWaterboardingThrottleCut()`, and `attackEntityFromWaterboarding(int)`. 
- Replaced the previous unconditional per-30-tick submerged damage path with logic that uses `isSubmergedForDamage()` and routes water damage through `attackEntityFromWaterboarding(...)` when the engine is waterboarded, capping recurring damage at the configured `EngineShutdownThreshold`. 
- Forced throttle/engine output to zero while waterboarded and wired the throttle cut into affected vehicle control loops: planes set `engineThrottle = 0.0D`, helicopters clear rotor spool/engine outputs, and tanks stop control updates while waterlogged. 
- Updated documentation and changelog: modified `docs/vehicle-config/base.md` and `docs/vehicle-config-reference.md` to note that `EngineShutdownThreshold` also caps waterboarding damage for submerged non-floating tanks, planes, and helicopters, and appended an `Engine Waterboarding` entry to `CHANGELOG.md`.

### Testing
- Ran a project-level text check (`python3` script) verifying presence of the new helpers and references in the modified files and confirmed the searched markers were present. (passed)
- Ran `git diff --check` to validate whitespace/patch issues before committing. (passed)
- No binary compilation or runtime execution was performed per repository/instructional constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52b84f71088323af70452e91f129a4)