### PR TITLE
Instant turret placement (bypass placement delay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Instant Turret Placement
+- Turret items now deploy immediately on right-click after the normal placement validation, bypassing vehicle hold-to-deploy timer setup, ready messages, and release-delay checks.
+
 ## Clear UAV placement guidance
 - Vehicle item tooltips now identify small versus large UAVs and state whether to use a UAV Station or Portable UAV Controller.
 - Direct right-click placement for UAV vehicle items now stops before hold-to-deploy starts and immediately tells players to use the correct UAV controller instead of failing at deployment time.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For development asset testing, the build/run setup expects assets in `build/run/
 
 1. Open the MCHeli creative tabs (`MCHeliO Item`, `MCHeliO Helicopters`, `MCHeliO Planes`, `MCHeliO Ships`, `MCHeliO Tanks`, `MCHeliO Vehicles`, and `MCHeliO Recipe Items`).
 2. Place or craft a **Drafting Table** to access recipes when recipes are enabled.
-3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
+3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. Turret items place instantly after the normal placement checks, while other vehicles use the hold-to-deploy flow. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
 4. Enter vehicles, use the configured movement/weapon keys, and refuel/repair according to the content pack's vehicle definitions.
 5. Server operators can use `/mcheli list` to discover available administrative subcommands.
 

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -117,6 +117,10 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
 
    public abstract MCH_EntityBaseVehicle createAircraft(World var1, double var2, double var4, double var6, ItemStack var8);
 
+   protected boolean shouldPlaceInstantly() {
+      return false;
+   }
+
    private static boolean isUavInfo(MCH_BaseVehicleInfo info) {
       return info != null && (info.isUAV || info.isNewUAV);
    }
@@ -237,6 +241,14 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
 
          if (world.getWorldTime() < 100) {
             logPlacementDebug(world, "rightClick ignored: world too new time=%d item=%s", Long.valueOf(world.getWorldTime()), getItemDebugName(par1ItemStack));
+            return par1ItemStack;
+         }
+
+         if(this.shouldPlaceInstantly()) {
+            if(par1ItemStack.stackTagCompound != null) {
+               clearDeployTags(par1ItemStack.stackTagCompound);
+            }
+            deployVehicle(par1ItemStack, world, player, mop.blockX, mop.blockY, mop.blockZ, 0);
             return par1ItemStack;
          }
 
@@ -433,41 +445,41 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
          int y = tag.getInteger("TargetY");
          int z = tag.getInteger("TargetZ");
 
-         logPlacementDebug(world, "stopUsing placement attempt: item=%s player=%s used=%d target=(%d,%d,%d)", getItemDebugName(stack), player.getCommandSenderName(), Integer.valueOf(used), Integer.valueOf(x), Integer.valueOf(y), Integer.valueOf(z));
-         MCH_EntityBaseVehicle placed = spawnAircraft(stack, world, player, x, y, z);
+         deployVehicle(stack, world, player, x, y, z, used);
          clearDeployTags(tag);
-         if(placed == null) {
-            if(!world.isRemote) {
-               player.addChatMessage(new ChatComponentText("Vehicle deployment failed. Check server log for [VehiclePlacement] details."));
-            }
-            return;
+      }
+      // Minecraft handles usage reset automatically
+   }
+
+   private boolean deployVehicle(ItemStack stack, World world, EntityPlayer player, int x, int y, int z, int used) {
+      logPlacementDebug(world, "placement attempt: item=%s player=%s used=%d target=(%d,%d,%d) instant=%s", getItemDebugName(stack), player.getCommandSenderName(), Integer.valueOf(used), Integer.valueOf(x), Integer.valueOf(y), Integer.valueOf(z), Boolean.valueOf(this.shouldPlaceInstantly()));
+      MCH_EntityBaseVehicle placed = spawnAircraft(stack, world, player, x, y, z);
+      if(placed == null) {
+         if(!world.isRemote) {
+            player.addChatMessage(new ChatComponentText("Vehicle deployment failed. Check server log for [VehiclePlacement] details."));
          }
+         return false;
+      }
 
-         W_WorldFunc.MOD_playSoundAtEntity(player, "deploy", 1.0F, 1.0F);
+      W_WorldFunc.MOD_playSoundAtEntity(player, "deploy", 1.0F, 1.0F);
 
-         // SERVER SIDE ONLY
-         if (!world.isRemote) {
-            // Message to the deploying player
-            player.addChatMessage(new ChatComponentText("Vehicle deployed."));
+      if(!world.isRemote) {
+         player.addChatMessage(new ChatComponentText("Vehicle deployed."));
 
-            // Message to everyone else
-            MinecraftServer server = MinecraftServer.getServer();
-            if (server != null) {
-               for (Object o : server.getConfigurationManager().playerEntityList) {
-                  EntityPlayerMP other = (EntityPlayerMP) o;
-                  if (other != player) {
-                     other.addChatMessage(
-                             new ChatComponentText( EnumChatFormatting.DARK_BLUE +
-                                     player.getCommandSenderName() + " has deployed a vehicle!"
-                             )
-                     );
-                  }
+         MinecraftServer server = MinecraftServer.getServer();
+         if(server != null) {
+            for(Object o : server.getConfigurationManager().playerEntityList) {
+               EntityPlayerMP other = (EntityPlayerMP)o;
+               if(other != player) {
+                  other.addChatMessage(new ChatComponentText(EnumChatFormatting.DARK_BLUE + player.getCommandSenderName() + " has deployed a vehicle!"));
                }
             }
          }
       }
-      // Minecraft handles usage reset automatically
+
+      return true;
    }
+
 
 
    //@Override
@@ -475,7 +487,6 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
    //   return true;
    //}
    //idk if we will still need this but it is here
-
    //@Override
    //public boolean canContinueUsing(ItemStack oldStack, ItemStack newStack) {
    //   // Return true only if StartCount tag is still present (meaning still holding)

--- a/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_ItemTurret.java
@@ -20,6 +20,11 @@ public class MCH_ItemTurret extends MCH_ItemBaseVehicle {
       return MCH_TurretInfoManager.getFromItem(this);
    }
 
+   @Override
+   protected boolean shouldPlaceInstantly() {
+      return true;
+   }
+
    public MCH_EntityTurret createAircraft(World world, double x, double y, double z, ItemStack item) {
       MCH_TurretInfo info = MCH_TurretInfoManager.getFromItem(this);
       if(info == null) {


### PR DESCRIPTION
### Motivation
- Turret items should place immediately after the usual placement validation to improve UX and avoid the hold-to-deploy timer, ready messages, and release-delay checks that are unnecessary for turrets.

### Description
- Add a protected hook `shouldPlaceInstantly()` to `MCH_ItemBaseVehicle` (default `false`) and short-circuit the right-click placement flow to call a new shared `deployVehicle(...)` path when instant placement is enabled.
- Extract shared spawn/result handling into `deployVehicle(ItemStack, World, EntityPlayer, int x, int y, int z, int used)` in `MCH_ItemBaseVehicle` so both immediate and delayed placements reuse the same success/failure logging, sound, and chat notifications.
- Override `shouldPlaceInstantly()` in `MCH_ItemTurret` to return `true`, making turret items deploy instantly after placement validation.
- Update `CHANGELOG.md` and `README.md` to document instant turret placement behavior.

### Testing
- Ran `git diff --check` and there were no whitespace/patch errors reported.
- No automated build or binary compilation was performed (per repository policy); runtime testing was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52bef2f37c832383b2c11ce21a1db3)