### PR TITLE
Fix tank/turret fall damage physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Tank and Turret Fall Damage Physics Fix
+- Fixed tank and turret fall damage being absorbed by armor minimums by scaling impact damage with vehicle health, configured gravity, downward acceleration, and impact speed before applying the normal fall damage source.
+
 ## Instant Turret Placement
 - Turret items now deploy immediately on right-click after the normal placement validation, bypassing vehicle hold-to-deploy timer setup, ready messages, and release-delay checks.
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1345,6 +1345,31 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       nbt.setBoolean("MCH_HasUavStationPosition", this.hasLinkedUavStationPosition);
    }
 
+
+   protected float calculateVehicleFallDamage(float distance, double impactSpeed, double downwardAcceleration, double gravity) {
+      if(distance <= 3.0F || this.isDestroyed()) {
+         return 0.0F;
+      }
+
+      float maxHp = (float)Math.max(1, this.getMaxHP());
+      float healthRatio = Math.max(0.0F, Math.min(1.0F, (float)this.getHP() / maxHp));
+      float missingHealthFactor = 1.0F + (1.0F - healthRatio) * 0.75F;
+      float hpScale = Math.max(1.0F, maxHp / 100.0F);
+      float distanceDamage = (distance - 3.0F) * 2.0F;
+      float speedDamage = (float)(impactSpeed * impactSpeed * 20.0D);
+      float accelerationDamage = (float)(Math.max(0.0D, downwardAcceleration) * 12.0D);
+      float gravityDamage = (float)(Math.abs(gravity) * 10.0D);
+      float damage = (distanceDamage + speedDamage + accelerationDamage + gravityDamage) * hpScale * missingHealthFactor;
+
+      MCH_BaseVehicleInfo info = this.getAcInfo();
+      if(info != null) {
+         float armorFactor = info.armorDamageFactor <= 0.0F?1.0F:info.armorDamageFactor;
+         damage = damage / armorFactor + info.armorMinDamage + 1.0F;
+      }
+
+      return Math.max(1.0F, damage);
+   }
+
    public boolean attackEntityFrom(DamageSource damageSource, float org_damage) {
 
       this.clearPlacementMotionLock();

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -57,6 +57,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    public final MCH_WheelManager WheelMng;
    public float partialTicks;
    private int trackDamageTaken;
+   private double fallImpactSpeed;
+   private double fallDownwardAcceleration;
+   private double fallGravity;
 
    //TODO
    private int currentGear = 1;  // Starting gear
@@ -81,6 +84,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.prevRotationRotor = 0.0F;
       this.WheelMng = new MCH_WheelManager(this);
       this.trackDamageTaken = 0;
+      this.fallImpactSpeed = 0.0D;
+      this.fallDownwardAcceleration = 0.0D;
+      this.fallGravity = 0.0D;
    }
 
    //tracks are very broken
@@ -516,7 +522,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
    protected void fall(float distance) {
       if(!super.worldObj.isRemote && distance > 3.0F && !this.isDestroyed()) {
-         float damage = (distance - 3.0F) * 2.0F;
+         float damage = this.calculateVehicleFallDamage(distance, this.fallImpactSpeed, this.fallDownwardAcceleration, this.fallGravity);
          this.attackEntityFrom(DamageSource.fall, damage);
       }
 
@@ -959,6 +965,8 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       // --------------------------------------------------
       double dp = this.canFloatWater() ? this.getWaterDepth() : 0.0D;
       boolean levelOff = super.isGunnerMode;
+      double previousMotionY = super.motionY;
+      this.fallGravity = !this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater;
 
       if (dp == 0.0D) {
          if (!levelOff) {
@@ -978,6 +986,8 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
             super.motionY += 0.007D;
          }
       }
+
+      this.fallDownwardAcceleration = Math.max(0.0D, previousMotionY - super.motionY);
 
       // --------------------------------------------------
       // THRUST (ACCEL ONLY, NOT SPEED)
@@ -1044,6 +1054,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       // MOVE
       // --------------------------------------------------
       this.updateWheels();
+      this.fallImpactSpeed = Math.max(0.0D, -super.motionY);
       this.moveEntity(super.motionX, super.motionY, super.motionZ);
 
       // --------------------------------------------------

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -19,6 +19,7 @@ import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.Item;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
@@ -30,6 +31,9 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
    public float lastRiderYaw;
    public float lastRiderPitch;
    private int trackDamageTaken;
+   private double fallImpactSpeed;
+   private double fallDownwardAcceleration;
+   private double fallGravity;
 
 
    public MCH_EntityTurret(World world) {
@@ -45,6 +49,9 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
       this.lastRiderYaw = 0.0F;
       this.lastRiderPitch = 0.0F;
       this.trackDamageTaken = 0;
+      this.fallImpactSpeed = 0.0D;
+      this.fallDownwardAcceleration = 0.0D;
+      this.fallGravity = 0.0D;
       super.weapons = this.createWeapon(0);
    }
 
@@ -313,7 +320,7 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
 
    protected void fall(float distance) {
       if(!super.worldObj.isRemote && distance > 3.0F && !this.isDestroyed()) {
-         float damage = (distance - 3.0F) * 2.0F;
+         float damage = this.calculateVehicleFallDamage(distance, this.fallImpactSpeed, this.fallDownwardAcceleration, this.fallGravity);
          this.attackEntityFrom(DamageSource.fall, damage);
       }
 
@@ -405,8 +412,11 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
          dp = this.getWaterDepth();
       }
 
+      double previousMotionY = super.motionY;
+      this.fallGravity = !this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater;
+
       if(dp == 0.0D) {
-         super.motionY += (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
+         super.motionY += (double)this.fallGravity;
       } else if(dp < 1.0D) {
          super.motionY -= 1.0E-4D;
          super.motionY += 0.007D * this.getCurrentThrottle();
@@ -417,6 +427,8 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
 
          super.motionY += 0.007D;
       }
+
+      this.fallDownwardAcceleration = Math.max(0.0D, previousMotionY - super.motionY);
 
       double motion = Math.sqrt(super.motionX * super.motionX + super.motionZ * super.motionZ);
       float speedLimit = this.getAcInfo().speed;
@@ -443,6 +455,7 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
          super.motionZ *= 0.5D;
       }
 
+      this.fallImpactSpeed = Math.max(0.0D, -super.motionY);
       this.moveEntity(super.motionX, super.motionY, super.motionZ);
       super.motionY *= 0.95D;
       super.motionX *= 0.99D;


### PR DESCRIPTION
### Motivation
- Tanks and turrets were taking no or negligible fall damage because armor minimums and existing damage routing could reduce fall hits to zero; the intent is to compute a more realistic impact amount before passing it into the normal damage pipeline. 
- The calculation must account for vehicle health, configured gravity, downward acceleration and impact speed so heavy/fast/low-health vehicles receive appropriate fall damage.

### Description
- Added a shared helper `calculateVehicleFallDamage(distance, impactSpeed, downwardAcceleration, gravity)` to `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java` that scales damage by distance, impact speed, downward acceleration, configured gravity and current/max HP and applies armor min/factor adjustments. 
- Tracked per-tick fall physics inputs (`fallImpactSpeed`, `fallDownwardAcceleration`, `fallGravity`) in `src/main/java/mcheli/tank/MCH_EntityTank.java` and `src/main/java/mcheli/vehicle/MCH_EntityTurret.java`, populated them during server movement, and used them when computing fall damage inside each class's `fall(float distance)` override. 
- Added the missing `DamageSource` import for turret class and initialized the new tracking fields in constructors. 
- Updated `CHANGELOG.md` with the `Tank and Turret Fall Damage Physics Fix` entry describing the change.

### Testing
- Ran `git diff --check` to validate there are no trivial whitespace/patch errors and it completed successfully. 
- Ran targeted searches with `rg -n` for the new symbols (`calculateVehicleFallDamage`, `fallImpactSpeed`, `fallDownwardAcceleration`, `fallGravity`) and the changelog entry to verify the edits were applied and found the expected locations. 
- Created a commit for the changes; no full project build or binary compilation was run per repository instructions and request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52daccd0548323aaaeb40a6d49adf6)