### PR TITLE
Fix ground vehicle fall damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Direct right-click placement for UAV vehicle items now stops before hold-to-deploy starts and immediately tells players to use the correct UAV controller instead of failing at deployment time.
 
 ## Tank and Turret Fall Damage
+- Fixed tank and turret fall damage tracking when the shared vehicle update loop clears vanilla `fallDistance`; landings now calculate server-side impact damage from drop height, gravity, downward acceleration, landing speed, and current health.
 - Added server-side fall damage for tanks and turrets after drops greater than three blocks, using fall damage sources so armor and existing vehicle damage handling apply consistently.
 
 ## Vehicle tooltip payload stats

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,6 +19,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 - `HitMarkColor` uses `Alpha, Red, Green, Blue`, each clamped to 0-255.
 - `CommandPermission` uses `commandName:Player1, Player2`.
 - Damage factors use either a plain multiplier such as `1.0` or a multiplier with an entity-class filter, depending on the existing config format.
+- Tank and turret fall damage is server-side vehicle behavior, not a separate config key: impacts above three effective blocks use the vehicle fall damage source and scale from current health, configured gravity/gravity-in-water, downward acceleration, and landing speed.
 
 ## General options
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -118,6 +118,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    protected static final int PART_ID_WING = 3;
    protected static final int PART_ID_HATCH = 4;
    public static final byte LIMIT_GROUND_PITCH = 40;
+   private double groundVehicleFallStartY = Double.MAX_VALUE;
+   private double groundVehicleMaxFallSpeed = 0.0D;
+   private double groundVehicleMaxDownwardAcceleration = 0.0D;
    public static final byte LIMIT_GROUND_ROLL = 40;
    public boolean isRequestedSyncStatus = false;
    private MCH_BaseVehicleInfo acInfo;
@@ -3058,6 +3061,53 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.rotLightHatch = 0.0F;
       }
 
+   }
+
+
+   protected void updateGroundVehicleFallDamage(boolean wasOnGroundBeforeMove, double motionYBeforeGravity, double motionYBeforeMove) {
+      if(super.worldObj.isRemote || this.isDestroyed()) {
+         return;
+      }
+
+      double downwardAcceleration = Math.max(0.0D, motionYBeforeGravity - motionYBeforeMove);
+      double gravity = this.getAcInfo() != null?Math.abs((double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater)):0.04D;
+      if(gravity < 1.0E-4D) {
+         gravity = 0.04D;
+      }
+
+      if(!super.onGround) {
+         if(!wasOnGroundBeforeMove && this.groundVehicleFallStartY == Double.MAX_VALUE) {
+            this.groundVehicleFallStartY = super.prevPosY;
+         }
+
+         if(this.groundVehicleFallStartY == Double.MAX_VALUE) {
+            this.groundVehicleFallStartY = super.posY;
+         }
+
+         this.groundVehicleMaxFallSpeed = Math.max(this.groundVehicleMaxFallSpeed, Math.max(0.0D, -motionYBeforeMove));
+         this.groundVehicleMaxDownwardAcceleration = Math.max(this.groundVehicleMaxDownwardAcceleration, downwardAcceleration);
+         return;
+      }
+
+      if(!wasOnGroundBeforeMove && this.groundVehicleFallStartY != Double.MAX_VALUE) {
+         double dropDistance = Math.max(0.0D, this.groundVehicleFallStartY - super.posY);
+         double speedDistance = this.groundVehicleMaxFallSpeed * this.groundVehicleMaxFallSpeed / (2.0D * gravity);
+         double effectiveDistance = Math.max(dropDistance, speedDistance);
+         if(effectiveDistance > 3.0D) {
+            double healthRatio = this.getMaxHP() > 0?(double)this.getHP() / (double)this.getMaxHP():1.0D;
+            double healthFactor = 1.0D + (1.0D - MathHelper.clamp_double(healthRatio, 0.0D, 1.0D)) * 0.5D;
+            double gravityFactor = MathHelper.clamp_double(gravity / 0.04D, 0.5D, 2.0D);
+            double accelerationFactor = MathHelper.clamp_double(this.groundVehicleMaxDownwardAcceleration / gravity, 0.75D, 2.0D);
+            float damage = (float)((effectiveDistance - 3.0D) * 2.0D * healthFactor * gravityFactor * accelerationFactor);
+            if(damage > 0.0F) {
+               this.attackEntityFrom(DamageSource.fall, damage);
+            }
+         }
+      }
+
+      this.groundVehicleFallStartY = Double.MAX_VALUE;
+      this.groundVehicleMaxFallSpeed = 0.0D;
+      this.groundVehicleMaxDownwardAcceleration = 0.0D;
    }
 
    public void updateExtraBoundingBox() {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -960,6 +960,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       double dp = this.canFloatWater() ? this.getWaterDepth() : 0.0D;
       boolean levelOff = super.isGunnerMode;
 
+      boolean wasOnGroundBeforeMove = super.onGround;
+      double motionYBeforeGravity = super.motionY;
+
       if (dp == 0.0D) {
          if (!levelOff) {
             super.motionY += 0.04D + (!this.isInWater()
@@ -1044,7 +1047,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       // MOVE
       // --------------------------------------------------
       this.updateWheels();
+      double motionYBeforeMove = super.motionY;
       this.moveEntity(super.motionX, super.motionY, super.motionZ);
+      this.updateGroundVehicleFallDamage(wasOnGroundBeforeMove, motionYBeforeGravity, motionYBeforeMove);
 
       // --------------------------------------------------
       // C: after move

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -406,6 +406,9 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
          dp = this.getWaterDepth();
       }
 
+      boolean wasOnGroundBeforeMove = super.onGround;
+      double motionYBeforeGravity = super.motionY;
+
       if(dp == 0.0D) {
          super.motionY += (double)(!this.isInWater()?this.getAcInfo().gravity:this.getAcInfo().gravityInWater);
       } else if(dp < 1.0D) {
@@ -444,7 +447,9 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
          super.motionZ *= 0.5D;
       }
 
+      double motionYBeforeMove = super.motionY;
       this.moveEntity(super.motionX, super.motionY, super.motionZ);
+      this.updateGroundVehicleFallDamage(wasOnGroundBeforeMove, motionYBeforeGravity, motionYBeforeMove);
       super.motionY *= 0.95D;
       super.motionX *= 0.99D;
       super.motionZ *= 0.99D;


### PR DESCRIPTION
### Motivation
- Ground vehicles (tanks and turrets) lost reliable fall-impact damage because the shared vehicle update loop clears vanilla `fallDistance`, so landings were not measured correctly.
- The intent is to compute server-side impact damage that accounts for configured gravity, downward acceleration, landing speed, and current vehicle health so armor/damage-factors still apply consistently.

### Description
- Added per-vehicle fall-tracking state and a helper `updateGroundVehicleFallDamage` in `MCH_EntityBaseVehicle` that computes damage from drop height, sampled landing speed, configured gravity/gravity-in-water, and downward acceleration, and applies damage via `DamageSource.fall`.
- Integrated the helper in `MCH_EntityTank` and `MCH_EntityTurret` by sampling `motionY` before gravity, sampling `motionY` before and after movement, and invoking `updateGroundVehicleFallDamage` after the move step so collisions and the shared update loop don’t hide the landing.
- Damage calculation scales with current health and clamps gravity/acceleration factors to avoid extreme multipliers, preserving existing vehicle armor and external damage factor logic.
- Updated documentation: `CHANGELOG.md` and `docs/configuration.md` now describe the new server-side tank/turret fall damage behavior.

### Testing
- Ran `git diff --check` to verify no whitespace/patch problems and reviewed diffs; the check passed.
- Per repository/build policy no compilation or binary builds were run as requested, so no runtime/compile-time tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52de355b0c832382a867f275e0db2f)