### PR TITLE
Add floating indicator to vehicle tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Vehicle tooltip floating indicator
+- Added a vehicle item tooltip line for configs with `Float = true` so plane, helicopter, tank, and turret/static-vehicle descriptions show when the vehicle floats on water.
+
 ## Cargo Paradrop Weight Limit
 - Added a 34,800 lb cargo airdrop limit so rack-dropped vehicles over the historical maximum cargo airdrop weight are released without spawning a paradrop parachute.
 - Added the 34,800 lb cargo airdrop limit to the parachute item tooltip.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,6 +128,7 @@ Vehicle `.txt` definitions can opt individual items into or out of 3D item rende
 | `ItemIconScaleFactor` | `1.0` | Per-vehicle 3D item icon scale multiplier, clamped to `0.01` through `100.0`. Alias: `3DItemIconScaleFactor`. |
 | `MaximumExternalPayloadCapacity` | `0` | Maximum total vehicle weight, in pounds, that this vehicle can lift/tow with a chain or carry across all occupied configured racks. Rack mounting subtracts already-mounted vehicle `Weight` plus the incoming vehicle `Weight`; the remaining capacity is never allowed below zero. A value of `0` prevents chain-towing or rack-carrying other configured vehicles by default. Non-zero values are shown on the vehicle item tooltip as max payload. |
 | `Weight` | `50000` | Vehicle weight, in pounds, used when another vehicle attempts to chain-tow it or mount it on a rack. Non-zero values are shown on the vehicle item tooltip. |
+| `Float` | `false` | Allows a vehicle to float on water. Enabled floating is shown on the vehicle item tooltip for plane, helicopter, tank, and turret/static-vehicle items. |
 
 ## Hidden/advanced options initialized in source
 

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -79,6 +79,9 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
          if(info.maximumExternalPayloadCapacity != 0.0D) {
             lines.add(EnumChatFormatting.YELLOW + "Max Payload: " + formatPounds(info.maximumExternalPayloadCapacity) + " lb");
          }
+         if(info.isFloat) {
+            lines.add(EnumChatFormatting.YELLOW + "Floats on water");
+         }
          //lines.add(EnumChatFormatting.DARK_PURPLE + "Weapon: " + info.weaponSetList);
          //         tooltip.add(TextFormatting.DARK_PURPLE + "Weapons: " + Arrays.stream(ac.weapons).map(MCH_WeaponSet::getName).collect(Collectors.joining(", ")));
          //lines.add(EnumChatFormatting.DARK_PURPLE + "Weapons: " + Arrays.stream(ac.weapons).map(MCH_WeaponSet::getName).collect(Collectors.joining(", ")));


### PR DESCRIPTION
### Motivation
- Surface the configured floating capability for placeable vehicles so players can see when planes, helicopters, tanks, and turret/static-vehicle items will float on water from the shared item tooltip.

### Description
- Added an `isFloat` check in `MCH_ItemBaseVehicle.addInformation` that appends "Floats on water" to vehicle item tooltips when present (`src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java`).
- Documented the `Float` content-pack key and its tooltip behavior in `docs/configuration.md` and recorded the change in `CHANGELOG.md`.

### Testing
- Searched and verified the new strings with `rg -n 'Floats on water|Vehicle tooltip floating indicator|`Float`'` across the modified files and ran `git diff --check`, both commands returned clean results and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52eaf0af108323ba123ad746287985)