### PR TITLE
Make tank wheels trample grass into dirt (use SetWheelPos contact points)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Tank wheel grass trampling
+- Added server-side tank wheel trampling so each simulated `SetWheelPos` contact point turns grass blocks beneath moving tank wheels into dirt.
+
 ## Config Reference Weight Audit
 - Corrected config reference vehicle weights to integer pounds using DisplayName/AddDisplayName identification and category-appropriate real-world weight definitions.
 - Added a config weight plausibility validator for cars, motorcycles, consumer drones, helicopters, tanks/armored vehicles, ships, aircraft, static weapons, trailers, and equipment.

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -76,7 +76,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `EntityPitch` | All | float | 0.0 | rendered entity pitch offset |
 | `EntityRoll` | All | float | 0.0 | rendered entity roll offset |
 | `BoundingBox` | All | list | none | extra damage/collision OBB; existing `x,y,z,width,height[,damageFactor]` syntax is preserved, and `x,y,z,width,height,depth,damageFactor` enables rectangular OBB footprints that rotate with vehicle yaw/pitch/roll. Debug rendering applies the vehicle model transform before each configured box offset, so rolled vehicles show boxes rotating with the airframe. |
-| `SetWheelPos` | All | vec3 | family default wheel list | wheel contact point; repeatable |
+| `SetWheelPos` | All | vec3 | family default wheel list | wheel contact point; repeatable; tanks use these points for wheel-based grass-to-dirt trampling while moving |
 | `StepHeight` | All | float | 0.0 (intended plane/tank/ship helper returns 0.6 but is private) | block step height |
 | `maxhp` | All | int | 50 | health |
 | `damagefactor` | All | float | 0.2 | incoming damage multiplier |

--- a/docs/vehicle-config/tanks.md
+++ b/docs/vehicle-config/tanks.md
@@ -22,7 +22,7 @@ Tanks inherit all shared keys from `base.md` and add track/weight keys. Tank `sp
 ## Practical tuning
 
 - Use shared `speed`, `MotionFactor`, `MobilityYawOnGround`, `CanMoveOnGround`, `CanRotOnGround`, and `PivotTurnThrottle` for driving feel.
-- Use `SetWheelPos` for wheel/contact layout and `AddTrackHitBox` for damageable tracks.
+- Use `SetWheelPos` for wheel/contact layout and `AddTrackHitBox` for damageable tracks. Moving tanks also use their `SetWheelPos` contact points to trample grass blocks under their wheels into dirt.
 - `TrackRollerRot`, `PartWheelRot`, `AddCrawlerTrack`, `AddTrackRoller`, and `AddPartWheel` are visual helpers inherited from the shared parser.
 
 ## Minimal tank config

--- a/src/main/java/mcheli/tank/MCH_WheelManager.java
+++ b/src/main/java/mcheli/tank/MCH_WheelManager.java
@@ -558,6 +558,7 @@ public class MCH_WheelManager {
 
    public void updateBlock() {
       MCH_Config var10000 = MCH_MOD.config;
+      this.trampleGrassUnderWheels();
       if(MCH_Config.Collision_DestroyBlock.prmBool) {
          MCH_EntityBaseVehicle ac = this.parent;
          MCH_EntityWheel[] arr$ = this.wheels;
@@ -579,6 +580,39 @@ public class MCH_WheelManager {
             }
          }
 
+      }
+   }
+
+   private void trampleGrassUnderWheels() {
+      MCH_EntityBaseVehicle ac = this.parent;
+      if(ac == null || ac.worldObj == null || ac.worldObj.isRemote || this.wheels == null || this.wheels.length <= 0) {
+         return;
+      }
+
+      double horizontalMotionSq = ac.motionX * ac.motionX + ac.motionZ * ac.motionZ;
+      if(horizontalMotionSq < 1.0E-4D && Math.abs(this.prevYaw - ac.getRotYaw()) < 0.05F) {
+         return;
+      }
+
+      for(int i = 0; i < this.wheels.length; ++i) {
+         MCH_EntityWheel w = this.wheels[i];
+         if(w == null || w.pos == null) {
+            continue;
+         }
+
+         Vec3 v = ac.getTransformedPosition(w.pos);
+         int x = MathHelper.floor_double(v.xCoord + 0.5D);
+         int y = MathHelper.floor_double(v.yCoord - 0.5D);
+         int z = MathHelper.floor_double(v.zCoord + 0.5D);
+         Block block = ac.worldObj.getBlock(x, y, z);
+         if(Block.isEqualTo(block, Blocks.air)) {
+            --y;
+            block = ac.worldObj.getBlock(x, y, z);
+         }
+
+         if(Block.isEqualTo(block, Blocks.grass)) {
+            ac.worldObj.setBlock(x, y, z, Blocks.dirt, 0, 3);
+         }
       }
    }
 


### PR DESCRIPTION
### Motivation
- Add immersive ground interaction so tanks visually trample grass when they drive, using the already-configured `SetWheelPos` contact points.  

### Description
- Added `trampleGrassUnderWheels()` to `MCH_WheelManager` and call it from `updateBlock()` so each simulated wheel contact point checks the block under the wheel and replaces `Blocks.grass` with `Blocks.dirt` on the server.  
- The trampling is server-only and gated by a small motion/rotation threshold to avoid static conversions when the vehicle is idle.  
- Updated documentation to mention the behavior in `docs/vehicle-config-reference.md` and `docs/vehicle-config/tanks.md`, and added an entry to `CHANGELOG.md`.  
- Key files changed: `src/main/java/mcheli/tank/MCH_WheelManager.java`, `docs/vehicle-config-reference.md`, `docs/vehicle-config/tanks.md`, and `CHANGELOG.md`.  

### Testing
- Ran repository checks: `git diff --check` (no whitespace errors) — succeeded.  
- Verified working tree status and created a commit for the change (`Make tank wheels trample grass`) — commit succeeded.  
- No runtime/compile tests were executed in this PR; change is limited to server-side logic and docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5310f27dcc83238b2bf59191b95e3d)