### PR TITLE
MQ-8B Fire Scout Speed Correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## MQ-8B Fire Scout Speed Correction
+- Slowed the MQ-8B Fire Scout config reference speed so it no longer outruns the MQ-9 Reaper, matching the real-world MQ-8B/MQ-9A speed relationship.
+
 ## Config Reference Fl 282 Speed Nerf
 - Reduced the Flettner Fl 282 config reference top-speed and forward rotor-thrust tuning so the ultralight helicopter no longer outruns its intended scout role.
 

--- a/configreference/helicopters/mq-8b.txt
+++ b/configreference/helicopters/mq-8b.txt
@@ -15,7 +15,7 @@ EnableNightVision = true
 EnableEntityRadar = true
 RadarType = MODERN_AS
 EnableFoldBlade = true
-Speed = 1.84
+Speed = 0.24
 ThrottleUpDown = 0.8
 FlareType = 3
 HasChaff = true
@@ -30,6 +30,7 @@ HideEntity = true
 ThirdPersonDist = 20
 
 ; New helicopter flight model: light scout/attack baseline tuning.
+; Speed normalized below MQ-9 because real MQ-8B airspeed is roughly half of MQ-9A.
 UseNewHelicopterFlightModel = true
 PhysicalMass = 0.72
 MainRotorMaxThrust = 0.218


### PR DESCRIPTION
### Motivation
- The MQ-8B config reference was faster than the MQ-9 in the repository despite the real-world MQ-8B being substantially slower, so the config needed correction to restore realistic role/handling balance. 
- This change normalizes UAV speed ordering to match expected platform relationships and in-game role tuning. 
- The project policy requires documenting all changes in the changelog, so the correction is recorded in `CHANGELOG.md`.

### Description
- Reduced `Speed` in `configreference/helicopters/mq-8b.txt` from `1.84` to `0.24` to ensure the MQ-8B is slower than the MQ-9. 
- Added an inline comment to `configreference/helicopters/mq-8b.txt` noting the MQ-8B speed normalization relative to the MQ-9. 
- Added a `## MQ-8B Fire Scout Speed Correction` heading and an entry to `CHANGELOG.md` describing the change.

### Testing
- Ran a small Python check that parsed both configs and asserted `MQ-8B Speed < MQ-9 Speed` and `MQ-8B Speed < MQ-9 MaxLevelSpeed`, which succeeded and printed the validated values. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53238beaa083238ccc5e52e03f1e1c)