### PR TITLE
Gate noisy startup logs behind debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Debug-gated spam logging
+- Gated noisy startup, item registration, ore dictionary confirmation, language registration, reload, and auto-ore diagnostic logs behind `McHeliOutputDebugLog` while preserving normal startup milestones, model completion checks, warnings, and errors.
+
 ## MQ-8B Fire Scout Speed Correction
 - Slowed the MQ-8B Fire Scout config reference speed so it no longer outruns the MQ-9 Reaper, matching the real-world MQ-8B/MQ-9A speed relationship.
 

--- a/docs/server-administration.md
+++ b/docs/server-administration.md
@@ -69,6 +69,11 @@ Emergency cleanup examples:
 
 Be careful: matching is a case-insensitive substring search against full Java class names and excludes players only.
 
+## Logging and diagnostics
+
+- Leave the legacy `McHeliOutputDebugLog` marker disabled for normal servers. Startup milestones, system checks, warnings, and errors still log without it.
+- Enable `McHeliOutputDebugLog` only while diagnosing noisy internals such as per-item registration, ore dictionary confirmations, language-entry registration, reload traces, and similar spam-level debug output.
+
 ## Performance notes
 
 - `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance` are client-side rendering aids for far vehicle snapshots.

--- a/src/main/java/mcheli/MCH_BaseInfo.java
+++ b/src/main/java/mcheli/MCH_BaseInfo.java
@@ -82,7 +82,7 @@ public class MCH_BaseInfo {
    }
 
    private boolean reload(MCH_BaseInfo info) {
-      System.out.println("reloading items");
+      MCH_Lib.DbgLog(false, "reloading items");
       int line = 0;
       MCH_InputFile inFile = new MCH_InputFile();
       Object br = null;

--- a/src/main/java/mcheli/MCH_ItemRecipe.java
+++ b/src/main/java/mcheli/MCH_ItemRecipe.java
@@ -217,10 +217,7 @@ public class MCH_ItemRecipe implements MCH_IRecipeList {
          return OreDictionary.getOreName(oreIDs[0]);
       }
 
-      System.out.println(
-              "AUTOORE CHECK: " + stack +
-                      " ORES=" + Arrays.toString(OreDictionary.getOreIDs(stack))
-      );
+      MCH_Lib.DbgLog(false, "AUTOORE CHECK: %s ORES=%s", stack, Arrays.toString(OreDictionary.getOreIDs(stack)));
 
 
       return obj;

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -177,9 +177,7 @@ public class MCH_MOD {
 
 
 
-      System.out.println(
-              "[MCH] fml.deobf = " + Launch.blackboard.get("fml.deobfuscatedEnvironment")
-      );
+      MCH_Lib.DbgLog(false, "[MCH] fml.deobf = %s", Launch.blackboard.get("fml.deobfuscatedEnvironment"));
 
 
 
@@ -196,21 +194,18 @@ public class MCH_MOD {
          sourcePath = modsDir.getAbsolutePath() + "/mcheli" + "/";
 
 
-         MCH_Lib.Log("Mods Directory: " + sourcePath, new Object[0]);
-         System.out.println("Mods Directory: " + sourcePath);
+         MCH_Lib.DbgLog(false, "Mods Directory: %s", sourcePath);
       } else {
          //works in a live minecraft instance
          sourcePath = Loader.instance().activeModContainer().getSource().getPath();
-         System.out.println("Mods Directory: " + sourcePath);
+         MCH_Lib.DbgLog(false, "Mods Directory: %s", sourcePath);
       }
 
       ///sourcePath = "D:\\Software\\GitHub\\MCHeli-Reforged\\src\\main\\resources";
               //new File(evt.getModConfigurationDirectory().getParentFile(), "/mods").getPath();
-      MCH_Lib.Log("SourcePath: " + sourcePath, new Object[0]);
-      System.out.println("SourcePath: " + sourcePath);
+      MCH_Lib.DbgLog(false, "SourcePath: %s", sourcePath);
       //MCH_Lib I have NO FUCKING CLUE HOW TO USE. I LITERALLY DO NOT THINK IT WORKS ANYMORE.
-      MCH_Lib.Log("CurrentDirectory:" + (new File(".")).getAbsolutePath(), new Object[0]);
-      System.out.println("CurrentDirectory:" + (new File(".")).getAbsolutePath());
+      MCH_Lib.DbgLog(false, "CurrentDirectory: %s", (new File(".")).getAbsolutePath());
 
 
 
@@ -418,27 +413,27 @@ public class MCH_MOD {
 
    //do this first so oredict shit can work properly...?
    public static void registerItemCustom() {
-      System.out.println("[mcheli.MCH_MOD:registerItemCustom] Starting custom item registration...");
+      MCH_Lib.DbgLog(false, "[mcheli.MCH_MOD:registerItemCustom] Starting custom item registration...");
 
       Iterator<String> i$ = MCH_ItemInfoManager.getKeySet().iterator();
 
       while (i$.hasNext()) {
          String name = i$.next();
-         System.out.println("[mcheli.MCH_MOD:registerItemCustom] Processing item: " + name);
+         MCH_Lib.DbgLog(false, "[mcheli.MCH_MOD:registerItemCustom] Processing item: %s", name);
 
          // Get the item info for the current item
          MCH_ItemInfo info = MCH_ItemInfoManager.get(name);
 
          // Check if item info is null
          if (info == null) {
-            System.out.println("[mcheli.MCH_MOD:registerItemCustom] Error: Item info for " + name + " is null! Skipping...");
+            MCH_Lib.Log("[mcheli.MCH_MOD:registerItemCustom] Error: Item info for %s is null! Skipping...", name);
             continue;
          }
 
          // Separate logic for throwable items (grenades)
          if (isThrowableItem(name)) {
             // Skip registering the throwable item in the normal item registration logic
-            System.out.println("[mcheli.MCH_MOD:registerItemCustom] Skipping throwable item: " + name);
+            MCH_Lib.DbgLog(false, "[mcheli.MCH_MOD:registerItemCustom] Skipping throwable item: %s", name);
             continue;
          }
 
@@ -466,7 +461,7 @@ public class MCH_MOD {
                        new ItemStack(info.item, 1, 0)
                );
 
-               System.out.println("[mcheli.MCH_MOD] Registered OreDict: " + ore + " -> " + name);
+               MCH_Lib.DbgLog(false, "[mcheli.MCH_MOD] Registered OreDict: %s -> %s", ore, name);
             }
          }
 

--- a/src/main/java/mcheli/multithread/MultiThreadModelManager.java
+++ b/src/main/java/mcheli/multithread/MultiThreadModelManager.java
@@ -1,6 +1,7 @@
 package mcheli.multithread;
 
 import mcheli.MCH_ClientProxy;
+import mcheli.MCH_Lib;
 import mcheli.helicopter.MCH_HeliInfoManager;
 import mcheli.plane.MCP_PlaneInfoManager;
 import mcheli.ship.MCH_ShipInfoManager;
@@ -119,6 +120,6 @@ public class MultiThreadModelManager {
             retries++;
         }
 
-        System.out.println(name + " data ready with " + map.size() + " entries.");
+        MCH_Lib.DbgLog(false, "%s data ready with %d entries.", name, Integer.valueOf(map.size()));
     }
 }

--- a/src/main/java/mcheli/wrapper/W_LanguageRegistry.java
+++ b/src/main/java/mcheli/wrapper/W_LanguageRegistry.java
@@ -1,5 +1,6 @@
 package mcheli.wrapper;
 
+import mcheli.MCH_Lib;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
@@ -22,7 +23,7 @@ public class W_LanguageRegistry {
 
     public static void addNameForObject(Object o, String lang, String name, String key, String desc) {
         if (o == null || lang == null || name == null) {
-            System.out.println("[MCH] Lang skipped null: " + o + ", " + lang + ", " + name);
+            MCH_Lib.Log("[MCH] Lang skipped null: %s, %s, %s", o, lang, name);
             return;
         }
 
@@ -36,7 +37,7 @@ public class W_LanguageRegistry {
             locKey = "achievement." + key;
         }
 
-        System.out.println("[MCH] Lang add: " + lang + " | " + locKey + " = " + name);
+        MCH_Lib.DbgLog(false, "[MCH] Lang add: %s | %s = %s", lang, locKey, name);
 
         map.putIfAbsent(lang, new HashMap<String, String>());
         Map<String, String> entries = map.get(lang);


### PR DESCRIPTION
### Motivation
- Reduce startup and registration log noise by gating verbose messages (item/ore/lang/reload/autore) behind the existing `McHeliOutputDebugLog` debug flag. 
- Preserve always-on, useful output such as system checks, model-completion confirmations, warnings, and errors. 
- Make server admin guidance explicit about when to enable the verbose debug marker and record the change in the changelog.

### Description
- Replaced noisy `System.out.println` calls with gated logging calls: swapped to `MCH_Lib.DbgLog(...)` for debug-level messages and `MCH_Lib.Log(...)` for error/always-on messages in `src/main/java/mcheli/MCH_MOD.java`, `src/main/java/mcheli/MCH_BaseInfo.java`, and `src/main/java/mcheli/MCH_ItemRecipe.java` to honor `McHeliOutputDebugLog`. 
- Moved per-category model-data readiness messages to `MCH_Lib.DbgLog(...)` in `src/main/java/mcheli/multithread/MultiThreadModelManager.java` and added the `MCH_Lib` import. 
- Replaced language registry `System.out.println` calls with `MCH_Lib.Log(...)` (null-skip warnings) and `MCH_Lib.DbgLog(...)` (per-entry adds) in `src/main/java/mcheli/wrapper/W_LanguageRegistry.java` and added the `MCH_Lib` import. 
- Updated `docs/server-administration.md` with a short `Logging and diagnostics` section describing when to enable `McHeliOutputDebugLog`. 
- Added a `Debug-gated spam logging` entry to `CHANGELOG.md` describing the change.

### Testing
- Ran `git diff --check` to validate no whitespace/diff issues and it passed. 
- Verified the modified call-sites with a targeted search using `rg` for the expected patterns and found the replaced messages (`registerItemCustom`, `Registered OreDict`, `AUTOORE CHECK`, `reloading items`, `Lang add`, and `data ready`). 
- Did not run a build/compile step per the non-compilation instruction; compilation was intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53311d2c5083299e5120ee4cfa1000)