### PR TITLE
Bomb sight: fallback for unloaded/far-away chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Bomb Sight Unloaded Chunk Fallback
+- Kept the plane CCIP/bomb-sight reticle rendering when the predicted bomb path reaches unloaded or far-away chunks by falling back to a non-mutating ballistic ground projection instead of treating the missing chunk ray trace as no impact.
+
 ## Debug-gated spam logging
 - Gated noisy startup, item registration, ore dictionary confirmation, language registration, reload, and auto-ore diagnostic logs behind `McHeliOutputDebugLog` while preserving normal startup milestones, model completion checks, warnings, and errors.
 

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -788,8 +788,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Boolean.valueOf(enabled), name, result != null ? result.releaseMode : "-", Boolean.valueOf(result != null && result.valid),
             result != null ? result.reasonInvalid : (enabled ? "not_predicted" : "not_bomb_or_disabled"),
             Integer.valueOf(result != null ? result.ticksSimulated : 0), Double.valueOf(result != null ? result.impactDistance : 0.0D));
-      String msg2 = String.format("releasePos=%s impactWorldPos=%s aircraftSpeedHorizontal=%.3f",
-            this.formatVec(result != null ? result.releasePos : null), this.formatVec(result != null ? result.impact : null), Double.valueOf(horizontalSpeed));
+      String msg2 = String.format("releasePos=%s impactWorldPos=%s aircraftSpeedHorizontal=%.3f unloadedFallback=%s",
+            this.formatVec(result != null ? result.releasePos : null), this.formatVec(result != null ? result.impact : null),
+            Double.valueOf(horizontalSpeed), Boolean.valueOf(result != null && result.unloadedChunkFallback));
       String msg3 = String.format("aircraftMotion=%s ejectionVelocity=%s initialBombVelocity=%s deltaFromAircraft=%s",
             this.formatVec(aircraftMotion), this.formatVec(result != null ? result.ejectionVelocity : null),
             this.formatVec(result != null ? result.initialVelocity : null), this.formatVec(result != null ? result.initialVelocityDeltaFromAircraft : null));

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -68,6 +68,8 @@ public final class MCP_PlaneCCIPHelper {
 
       Vec3 position = copy(releasePos);
       Vec3 velocity = copy(initialVelocity);
+      Vec3 firstUnloadedPosition = null;
+      Vec3 previousPosition = null;
       double entityAcceleration = getConstructorAcceleration(info);
       entityAcceleration = applySpeedDependsAircraftFirstTick(
             info, aircraftMotion, velocity, entityAcceleration, result);
@@ -109,6 +111,23 @@ public final class MCP_PlaneCCIPHelper {
             return result;
          }
 
+         if(firstUnloadedPosition == null && !isChunkLoadedForPrediction(world, next)) {
+            firstUnloadedPosition = copy(next);
+         }
+
+         if(firstUnloadedPosition != null && next.yCoord <= 0.0D) {
+            result.valid = true;
+            result.unloadedChunkFallback = true;
+            result.firstUnloadedPosition = copy(firstUnloadedPosition);
+            result.impact = interpolateAtY(previousPosition != null ? previousPosition : position, next, 0.0D);
+            result.finalVelocity = copy(velocity);
+            result.impactDistance = releasePos.distanceTo(result.impact);
+            result.releaseAltitude = releasePos.yCoord - result.impact.yCoord;
+            result.reasonInvalid = "unloaded_chunk_fallback";
+            return result;
+         }
+
+         previousPosition = position;
          position = next;
 
          // MCH_EntityBomb applies this once, after super.onUpdate().
@@ -135,6 +154,16 @@ public final class MCP_PlaneCCIPHelper {
       }
 
       result.finalVelocity = copy(velocity);
+      if(firstUnloadedPosition != null && position != null) {
+         result.valid = true;
+         result.unloadedChunkFallback = true;
+         result.firstUnloadedPosition = copy(firstUnloadedPosition);
+         result.impact = copy(position);
+         result.impactDistance = releasePos.distanceTo(result.impact);
+         result.releaseAltitude = releasePos.yCoord - result.impact.yCoord;
+         result.reasonInvalid = "unloaded_chunk_fallback";
+         return result;
+      }
       if("not_run".equals(result.reasonInvalid)) {
          result.reasonInvalid = "no_collision";
       }
@@ -205,6 +234,32 @@ public final class MCP_PlaneCCIPHelper {
          return hit;
       }
       return null;
+   }
+
+
+   private static boolean isChunkLoadedForPrediction(World world, Vec3 position) {
+      if(world == null || position == null) {
+         return false;
+      }
+      int x = MathHelper.floor_double(position.xCoord);
+      int z = MathHelper.floor_double(position.zCoord);
+      // Use a mid-world Y so this is a chunk availability check, not an altitude check.
+      return world.blockExists(x, 64, z);
+   }
+
+   private static Vec3 interpolateAtY(Vec3 start, Vec3 end, double targetY) {
+      if(start == null || end == null) {
+         return end != null ? copy(end) : null;
+      }
+      double dy = end.yCoord - start.yCoord;
+      if(Math.abs(dy) <= EPSILON) {
+         return copy(end);
+      }
+      double t = MathHelper.clamp_double((targetY - start.yCoord) / dy, 0.0D, 1.0D);
+      return Vec3.createVectorHelper(
+            start.xCoord + (end.xCoord - start.xCoord) * t,
+            targetY,
+            start.zCoord + (end.zCoord - start.zCoord) * t);
    }
 
    private static boolean isWaterAt(World world, Vec3 position) {
@@ -374,6 +429,8 @@ public final class MCP_PlaneCCIPHelper {
       public double speedAddedFromAircraft;
       public double predictedAccelerationBeforeAircraft;
       public double predictedAccelerationAfterAircraft;
+      public boolean unloadedChunkFallback;
+      public Vec3 firstUnloadedPosition;
       public Vec3 ejectionVelocity;
       public Vec3 initialVelocityDeltaFromAircraft;
       public double initialVelocityUpDot;


### PR DESCRIPTION
### Motivation
- Prevent the plane CCIP/bomb-sight reticle from disappearing when the ballistic prediction traverses far-away or unloaded chunks by providing a safe non-mutating fallback instead of treating a missing ray-trace hit as no impact.

### Description
- Added unloaded-chunk detection and tracking to `MCP_PlaneCCIPHelper.predict` using `firstUnloadedPosition` and `previousPosition` and set a fallback impact when the simulated path enters unloaded chunks; this sets `Result.unloadedChunkFallback` and `Result.firstUnloadedPosition` so callers can distinguish the case.
- Implemented `isChunkLoadedForPrediction(World, Vec3)` to check chunk availability and `interpolateAtY(Vec3, Vec3, double)` to compute a ground-level impact without loading or mutating terrain in `MCP_PlaneCCIPHelper.java`.
- When the predictor encounters unloaded terrain and the path reaches ground-level the code now returns a valid prediction with `reasonInvalid = "unloaded_chunk_fallback"` and a best-effort impact position (interpolated or last simulated position).
- Exposed the unloaded-chunk fallback state in the CCIP debug overlay by adding `unloadedFallback` to the debug message in `MCP_GuiPlane.java` and documented the change in `CHANGELOG.md`.

### Testing
- Ran `git diff --check` locally and the check completed without reported whitespace/patch errors.
- No build/compile was executed per repository instructions not to compile binaries, so runtime verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a533afb25f48323a53f8efef1c366e6)