### PR TITLE
Improve CCIP unloaded chunk fallback stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## CCIP Unloaded Chunk Fallback Stability
+
+- Added CCIP prediction diagnostics for unloaded chunk coordinates, fallback reason, fallback target height, and whether an impact came from real terrain or synthetic fallback.
+- Improved unloaded chunk fallback to use nearby loaded terrain height when available while keeping a deterministic Y=0 fallback for truly unloaded areas.
+- Added short GUI hysteresis so transient invalid/unloaded fallback predictions reuse the last stable impact briefly, while preserving fallback diagnostics in the debug overlay.
+
 # Changelog
 
 ## CCIP Far-Plane Projection Fallback

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -45,6 +45,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    private static final double CCIP_SCREEN_SMOOTHING = 0.35D;
    private static final double CCIP_IMPACT_RESET_DISTANCE = 64.0D;
    private static final double CCIP_PIPPER_SCALE = 1.35D;
+   private static final int CCIP_HYSTERESIS_GRACE_TICKS = 5;
    private static final FloatBuffer CCIP_PROJECTED_COORDS = BufferUtils.createFloatBuffer(3);
    private static Field activeRenderModelViewField;
    private static Field activeRenderProjectionField;
@@ -61,6 +62,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
    private int cachedCCIPDimension = Integer.MIN_VALUE;
    private String cachedCCIPWeaponName = "";
    private MCP_PlaneCCIPHelper.Result cachedCCIPResult;
+   private MCP_PlaneCCIPHelper.Result lastStableCCIPResult;
+   private int lastStableCCIPTick = Integer.MIN_VALUE;
+   private int lastStableCCIPEntityId = Integer.MIN_VALUE;
+   private int lastStableCCIPDimension = Integer.MIN_VALUE;
+   private String lastStableCCIPWeaponName = "";
    private String lastCCIPProjectionStatus = "invalid";
    private String lastCCIPProjectMode = "invalid";
    private double lastCCIPProjectWinZ = Double.NaN;
@@ -700,12 +706,85 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       result.initialVelocitySideDot = k.initialVelocitySideDot;
       result.warningImpossibleLaunch = k.warningImpossibleLaunch;
 
+      if(result.valid && result.impact != null && !result.unloadedChunkFallback) {
+         this.lastStableCCIPResult = result;
+         this.lastStableCCIPTick = plane.ticksExisted;
+         this.lastStableCCIPEntityId = entityId;
+         this.lastStableCCIPDimension = dimension;
+         this.lastStableCCIPWeaponName = weaponName;
+      } else if(this.canReuseStableCCIP(plane.ticksExisted, entityId, dimension, weaponName)) {
+         MCP_PlaneCCIPHelper.Result transientResult = result;
+         result = this.copyCCIPResult(this.lastStableCCIPResult);
+         result.hysteresisReused = true;
+         result.hysteresisAgeTicks = plane.ticksExisted - this.lastStableCCIPTick;
+         result.unloadedChunkFallback = transientResult.unloadedChunkFallback;
+         result.firstUnloadedPosition = this.copyVec(transientResult.firstUnloadedPosition);
+         result.firstUnloadedChunkX = transientResult.firstUnloadedChunkX;
+         result.firstUnloadedChunkZ = transientResult.firstUnloadedChunkZ;
+         result.fallbackReason = transientResult.fallbackReason;
+         result.fallbackTargetY = transientResult.fallbackTargetY;
+         result.syntheticFallback = transientResult.syntheticFallback;
+         result.reasonInvalid = transientResult.reasonInvalid;
+      }
+
       this.cachedCCIPTick = plane.ticksExisted;
       this.cachedCCIPEntityId = entityId;
       this.cachedCCIPDimension = dimension;
       this.cachedCCIPWeaponName = weaponName;
       this.cachedCCIPResult = result;
       return result;
+   }
+
+   private boolean canReuseStableCCIP(int tick, int entityId, int dimension, String weaponName) {
+      return this.lastStableCCIPResult != null
+            && this.lastStableCCIPResult.valid
+            && this.lastStableCCIPResult.impact != null
+            && tick - this.lastStableCCIPTick <= CCIP_HYSTERESIS_GRACE_TICKS
+            && this.lastStableCCIPEntityId == entityId
+            && this.lastStableCCIPDimension == dimension
+            && weaponName.equals(this.lastStableCCIPWeaponName);
+   }
+
+   private MCP_PlaneCCIPHelper.Result copyCCIPResult(MCP_PlaneCCIPHelper.Result source) {
+      MCP_PlaneCCIPHelper.Result copy = new MCP_PlaneCCIPHelper.Result();
+      copy.valid = source.valid;
+      copy.impact = this.copyVec(source.impact);
+      copy.releasePos = this.copyVec(source.releasePos);
+      copy.ticksSimulated = source.ticksSimulated;
+      copy.impactDistance = source.impactDistance;
+      copy.releaseAltitude = source.releaseAltitude;
+      copy.initialVelocity = this.copyVec(source.initialVelocity);
+      copy.finalVelocity = this.copyVec(source.finalVelocity);
+      copy.aircraftMotion = this.copyVec(source.aircraftMotion);
+      copy.gravity = source.gravity;
+      copy.horizontalDrag = source.horizontalDrag;
+      copy.accelerationFactor = source.accelerationFactor;
+      copy.simulationTimeStep = source.simulationTimeStep;
+      copy.speedDependsAircraft = source.speedDependsAircraft;
+      copy.speedDependsAircraftApplied = source.speedDependsAircraftApplied;
+      copy.speedAddedFromAircraft = source.speedAddedFromAircraft;
+      copy.predictedAccelerationBeforeAircraft = source.predictedAccelerationBeforeAircraft;
+      copy.predictedAccelerationAfterAircraft = source.predictedAccelerationAfterAircraft;
+      copy.unloadedChunkFallback = source.unloadedChunkFallback;
+      copy.firstUnloadedPosition = this.copyVec(source.firstUnloadedPosition);
+      copy.firstUnloadedChunkX = source.firstUnloadedChunkX;
+      copy.firstUnloadedChunkZ = source.firstUnloadedChunkZ;
+      copy.fallbackReason = source.fallbackReason;
+      copy.fallbackTargetY = source.fallbackTargetY;
+      copy.hitRealTerrain = source.hitRealTerrain;
+      copy.syntheticFallback = source.syntheticFallback;
+      copy.ejectionVelocity = this.copyVec(source.ejectionVelocity);
+      copy.initialVelocityDeltaFromAircraft = this.copyVec(source.initialVelocityDeltaFromAircraft);
+      copy.initialVelocityUpDot = source.initialVelocityUpDot;
+      copy.initialVelocitySideDot = source.initialVelocitySideDot;
+      copy.warningImpossibleLaunch = source.warningImpossibleLaunch;
+      copy.releaseMode = source.releaseMode;
+      copy.reasonInvalid = source.reasonInvalid;
+      return copy;
+   }
+
+   private Vec3 copyVec(Vec3 source) {
+      return source != null ? Vec3.createVectorHelper(source.xCoord, source.yCoord, source.zCoord) : null;
    }
 
    private ReleaseKinematics getInitialBombVelocity(MCP_EntityPlane plane, MCH_WeaponSet ws,
@@ -792,6 +871,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       this.cachedCCIPDimension = Integer.MIN_VALUE;
       this.cachedCCIPWeaponName = "";
       this.cachedCCIPResult = null;
+      this.lastStableCCIPResult = null;
+      this.lastStableCCIPTick = Integer.MIN_VALUE;
+      this.lastStableCCIPEntityId = Integer.MIN_VALUE;
+      this.lastStableCCIPDimension = Integer.MIN_VALUE;
+      this.lastStableCCIPWeaponName = "";
       this.lastCCIPProjectionStatus = "invalid";
       this.lastCCIPProjectMode = "invalid";
       this.lastCCIPProjectWinZ = Double.NaN;
@@ -806,9 +890,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Boolean.valueOf(enabled), name, result != null ? result.releaseMode : "-", Boolean.valueOf(result != null && result.valid),
             result != null ? result.reasonInvalid : (enabled ? "not_predicted" : "not_bomb_or_disabled"),
             Integer.valueOf(result != null ? result.ticksSimulated : 0), Double.valueOf(result != null ? result.impactDistance : 0.0D));
-      String msg2 = String.format("releasePos=%s impactWorldPos=%s aircraftSpeedHorizontal=%.3f unloadedFallback=%s",
+      String msg2 = String.format("releasePos=%s impactWorldPos=%s aircraftSpeedHorizontal=%.3f unloadedFallback=%s synthetic=%s realTerrain=%s",
             this.formatVec(result != null ? result.releasePos : null), this.formatVec(result != null ? result.impact : null),
-            Double.valueOf(horizontalSpeed), Boolean.valueOf(result != null && result.unloadedChunkFallback));
+            Double.valueOf(horizontalSpeed), Boolean.valueOf(result != null && result.unloadedChunkFallback),
+            Boolean.valueOf(result != null && result.syntheticFallback), Boolean.valueOf(result != null && result.hitRealTerrain));
       String msg3 = String.format("aircraftMotion=%s ejectionVelocity=%s initialBombVelocity=%s deltaFromAircraft=%s",
             this.formatVec(aircraftMotion), this.formatVec(result != null ? result.ejectionVelocity : null),
             this.formatVec(result != null ? result.initialVelocity : null), this.formatVec(result != null ? result.initialVelocityDeltaFromAircraft : null));
@@ -819,9 +904,10 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
             Double.valueOf(result != null ? result.predictedAccelerationBeforeAircraft : 0.0D), Double.valueOf(result != null ? result.predictedAccelerationAfterAircraft : 0.0D),
             Boolean.valueOf(result != null && result.speedDependsAircraftApplied), Double.valueOf(result != null ? result.initialVelocityUpDot : 0.0D),
             Double.valueOf(result != null ? result.initialVelocitySideDot : 0.0D));
-      String msg6 = String.format("warningImpossibleLaunch=%s projection=%s projectMode=%s winZ=%s farPlaneRejected=%s cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
+      String msg6 = String.format("warningImpossibleLaunch=%s projection=%s projectMode=%s winZ=%s farPlaneRejected=%s hysteresis=%s/%d cameraYaw/Pitch=%.1f/%.1f planeYaw/Pitch/Roll=%.1f/%.1f/%.1f",
             Boolean.valueOf(result != null && result.warningImpossibleLaunch), this.lastCCIPProjectionStatus, this.lastCCIPProjectMode,
             this.formatProjectWinZ(this.lastCCIPProjectWinZ), Boolean.valueOf(this.lastCCIPFarPlaneRejected),
+            Boolean.valueOf(result != null && result.hysteresisReused), Integer.valueOf(result != null ? result.hysteresisAgeTicks : 0),
             Float.valueOf(camera != null ? camera.rotationYaw : 0.0F), Float.valueOf(camera != null ? camera.rotationPitch : 0.0F),
             Float.valueOf(plane.rotationYaw), Float.valueOf(plane.rotationPitch), Float.valueOf(plane.getRotRoll()));
       this.drawString(msg1, super.centerX - 170, super.centerY + 70, 0xFF55FF66);
@@ -830,6 +916,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       this.drawString(msg4, super.centerX - 170, super.centerY + 100, 0xFF55FF66);
       this.drawString(msg5, super.centerX - 170, super.centerY + 110, 0xFF55FF66);
       this.drawString(msg6, super.centerX - 170, super.centerY + 120, 0xFF55FF66);
+      String msg7 = String.format("fallbackChunk=%d,%d firstUnloaded=%s fallbackReason=%s fallbackTargetY=%.1f",
+            Integer.valueOf(result != null ? result.firstUnloadedChunkX : 0), Integer.valueOf(result != null ? result.firstUnloadedChunkZ : 0),
+            this.formatVec(result != null ? result.firstUnloadedPosition : null), result != null && result.fallbackReason != null ? result.fallbackReason : "-",
+            Double.valueOf(result != null ? result.fallbackTargetY : 0.0D));
+      this.drawString(msg7, super.centerX - 170, super.centerY + 130, 0xFF55FF66);
    }
 
    private String formatVec(Vec3 v) {

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -28,6 +28,7 @@ public final class MCP_PlaneCCIPHelper {
    public static final int MAX_STEPS = 600;
    private static final double BOMB_HORIZONTAL_DRAG = 0.999D;
    private static final double EPSILON = 1.0E-7D;
+   private static final int FALLBACK_TERRAIN_SEARCH_RADIUS = 1;
 
    private MCP_PlaneCCIPHelper() {}
 
@@ -106,11 +107,13 @@ public final class MCP_PlaneCCIPHelper {
             result.impactDistance = releasePos.distanceTo(result.impact);
             result.releaseAltitude = releasePos.yCoord - result.impact.yCoord;
             result.reasonInvalid = "";
+            result.hitRealTerrain = true;
+            result.syntheticFallback = false;
             return result;
          }
 
          if(!isChunkLoadedForPrediction(world, next)) {
-            return buildUnloadedChunkFallback(result, info, releasePos, position, next,
+            return buildUnloadedChunkFallback(world, result, info, releasePos, position, next,
                   velocity, entityAcceleration, entityTick, maxSteps);
          }
 
@@ -145,15 +148,17 @@ public final class MCP_PlaneCCIPHelper {
       }
       return result;
    }
-   private static Result buildUnloadedChunkFallback(Result result, MCH_WeaponInfo info, Vec3 releasePos,
+   private static Result buildUnloadedChunkFallback(World world, Result result, MCH_WeaponInfo info, Vec3 releasePos,
          Vec3 segmentStart, Vec3 firstUnloadedPosition, Vec3 velocity, double entityAcceleration,
          int entityTick, int maxSteps) {
       Vec3 fallbackStart = segmentStart;
       Vec3 fallbackEnd = firstUnloadedPosition;
       Vec3 fallbackVelocity = copy(velocity);
       int fallbackTick = entityTick;
+      double fallbackTargetY = findLoadedTerrainFallbackY(world, segmentStart, firstUnloadedPosition);
+      String fallbackReason = fallbackTargetY > 0.0D ? "nearby_loaded_terrain_height" : "unloaded_chunk_safe_y0";
 
-      if(fallbackEnd != null && fallbackEnd.yCoord > 0.0D) {
+      if(fallbackEnd != null && fallbackEnd.yCoord > fallbackTargetY) {
          Vec3 position = copy(fallbackEnd);
          Vec3 simulatedVelocity = copy(velocity);
          double simulatedAcceleration = entityAcceleration;
@@ -191,7 +196,7 @@ public final class MCP_PlaneCCIPHelper {
             fallbackEnd = simulatedNext;
             fallbackVelocity = copy(simulatedVelocity);
             fallbackTick = nextEntityTick;
-            if(simulatedNext.yCoord <= 0.0D || simulatedNext.yCoord < -64.0D) {
+            if(simulatedNext.yCoord <= fallbackTargetY || simulatedNext.yCoord < -64.0D) {
                break;
             }
             position = simulatedNext;
@@ -201,8 +206,16 @@ public final class MCP_PlaneCCIPHelper {
       result.valid = true;
       result.unloadedChunkFallback = true;
       result.firstUnloadedPosition = copy(firstUnloadedPosition);
-      result.impact = fallbackEnd != null && fallbackEnd.yCoord <= 0.0D
-            ? interpolateAtY(fallbackStart, fallbackEnd, 0.0D)
+      if(firstUnloadedPosition != null) {
+         result.firstUnloadedChunkX = MathHelper.floor_double(firstUnloadedPosition.xCoord) >> 4;
+         result.firstUnloadedChunkZ = MathHelper.floor_double(firstUnloadedPosition.zCoord) >> 4;
+      }
+      result.fallbackReason = fallbackReason;
+      result.fallbackTargetY = fallbackTargetY;
+      result.hitRealTerrain = false;
+      result.syntheticFallback = true;
+      result.impact = fallbackEnd != null && fallbackEnd.yCoord <= fallbackTargetY
+            ? interpolateAtY(fallbackStart, fallbackEnd, fallbackTargetY)
             : copy(fallbackEnd);
       result.finalVelocity = copy(fallbackVelocity);
       result.ticksSimulated = fallbackTick;
@@ -286,8 +299,35 @@ public final class MCP_PlaneCCIPHelper {
       }
       int x = MathHelper.floor_double(position.xCoord);
       int z = MathHelper.floor_double(position.zCoord);
-      // Use a mid-world Y so this is a chunk availability check, not an altitude check.
-      return world.blockExists(x, 64, z);
+      // Use a stable in-world Y so this is a chunk availability check, not an altitude check.
+      return world.blockExists(x, 64, z) || world.blockExists(x, 1, z);
+   }
+
+   private static double findLoadedTerrainFallbackY(World world, Vec3 segmentStart, Vec3 firstUnloadedPosition) {
+      if(world == null || firstUnloadedPosition == null) {
+         return 0.0D;
+      }
+      int firstChunkX = MathHelper.floor_double(firstUnloadedPosition.xCoord) >> 4;
+      int firstChunkZ = MathHelper.floor_double(firstUnloadedPosition.zCoord) >> 4;
+      int centerX = MathHelper.floor_double(segmentStart != null ? segmentStart.xCoord : firstUnloadedPosition.xCoord);
+      int centerZ = MathHelper.floor_double(segmentStart != null ? segmentStart.zCoord : firstUnloadedPosition.zCoord);
+      double totalHeight = 0.0D;
+      int samples = 0;
+
+      for(int dx = -FALLBACK_TERRAIN_SEARCH_RADIUS; dx <= FALLBACK_TERRAIN_SEARCH_RADIUS; ++dx) {
+         for(int dz = -FALLBACK_TERRAIN_SEARCH_RADIUS; dz <= FALLBACK_TERRAIN_SEARCH_RADIUS; ++dz) {
+            int sampleX = centerX + dx * 16;
+            int sampleZ = centerZ + dz * 16;
+            if((sampleX >> 4) == firstChunkX && (sampleZ >> 4) == firstChunkZ) {
+               continue;
+            }
+            if(isChunkLoadedForPrediction(world, Vec3.createVectorHelper((double)sampleX, 64.0D, (double)sampleZ))) {
+               totalHeight += (double)Math.max(0, world.getHeightValue(sampleX, sampleZ));
+               ++samples;
+            }
+         }
+      }
+      return samples > 0 ? totalHeight / (double)samples : 0.0D;
    }
 
    private static Vec3 interpolateAtY(Vec3 start, Vec3 end, double targetY) {
@@ -474,6 +514,14 @@ public final class MCP_PlaneCCIPHelper {
       public double predictedAccelerationAfterAircraft;
       public boolean unloadedChunkFallback;
       public Vec3 firstUnloadedPosition;
+      public int firstUnloadedChunkX;
+      public int firstUnloadedChunkZ;
+      public String fallbackReason;
+      public double fallbackTargetY;
+      public boolean hitRealTerrain;
+      public boolean syntheticFallback;
+      public boolean hysteresisReused;
+      public int hysteresisAgeTicks;
       public Vec3 ejectionVelocity;
       public Vec3 initialVelocityDeltaFromAircraft;
       public double initialVelocityUpDot;


### PR DESCRIPTION
### Motivation
- Unloaded-chunk predictions could produce unstable or disappearing CCIP reticles and provided limited diagnostic information for testers. The goal is to make the fallback deterministic and safer while surfacing diagnostics to correlate sight disappearance with chunk availability. 
- Keep client-safe behavior (no force-loading) and prefer using nearby loaded terrain data when available to produce a more plausible fallback impact height.

### Description
- Expanded `Result` with diagnostic fields: `firstUnloadedChunkX`, `firstUnloadedChunkZ`, `fallbackReason`, `fallbackTargetY`, `hitRealTerrain`, `syntheticFallback`, `hysteresisReused`, and `hysteresisAgeTicks`, and preserved existing fields such as `unloadedChunkFallback` and `firstUnloadedPosition`.
- Mark real ray-trace hits via `hitRealTerrain` in `predict`, and route unloaded-chunk cases into a deterministic fallback builder `buildUnloadedChunkFallback(World, ...)` that computes a `fallbackTargetY` using `findLoadedTerrainFallbackY(World, ...)` (samples nearby loaded chunk heights without loading chunks) and sets `fallbackReason` accordingly.
- Improve chunk-availability check in `isChunkLoadedForPrediction` to use a stable Y probe (`blockExists(x,64,z)` or `blockExists(x,1,z)`) to avoid altitude-sensitive false negatives while still avoiding chunk loads.
- Add brief GUI hysteresis in `MCP_GuiPlane`: cache the last stable (real-terrain) CCIP result and, for up to `CCIP_HYSTERESIS_GRACE_TICKS` (5) ticks, reuse that impact if the current prediction is transiently invalid or an unloaded fallback, while still exposing the transient fallback diagnostics in the debug overlay; implemented `canReuseStableCCIP`, `copyCCIPResult`, and `copyVec` helpers.
- Expose fallback metadata in the CCIP debug overlay (unloadedFallback, synthetic/real, hysteresis reuse, `firstUnloadedPosition`, `fallbackChunk`, `fallbackReason`, and `fallbackTargetY`) and document the change in `CHANGELOG.md`.

### Testing
- Ran an automated style/check scan with `git diff --check` which reported no whitespace/merge problems.
- Performed repository checks and created the change bundle; no compilation or runtime unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5434e427c88323b14d452c990a49a2)