### PR TITLE
Fix LOD landing gear animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix large aircraft landing gear in LOD rendering
+
+- Restored common animated part rendering during far-distance vehicle LOD passes so large aircraft landing gear (`AddPartLG`/related parts) continues to animate beyond the LOD start distance.
+- Documented that the LOD path keeps animated parts while only skipping close-range light effects.
+
 ## Bomb Sight No-Terrain Stability
 
 - Fixed first-person bomb-sight camera forcing so no-terrain predictions use a stable ballistic target angle instead of bobbing with nearby fallback terrain heights.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -112,7 +112,7 @@ Conventional guided-bomb and normal ballistic bomb references use real standard 
 
 **Why it exists:** Large combined-arms servers often need aircraft, ships, tanks, and turrets to remain visually identifiable at distances where full entity tracking/rendering is too expensive or unreliable.
 
-**How it differs from original MCHeli:** Overdrive adds a dedicated snapshot packet and client LOD manager. Snapshots include entity identity, category, type, texture, position, rotation, scale, and sampled world lighting, and the render path switches to cheaper displays beyond `AircraftLODStartDistance`.
+**How it differs from original MCHeli:** Overdrive adds a dedicated snapshot packet and client LOD manager. Snapshots include entity identity, category, type, texture, position, rotation, scale, and sampled world lighting, and the render path switches to cheaper displays beyond `AircraftLODStartDistance`. Far LOD rendering still draws configured animated vehicle parts, including landing gear (`AddPartLG`, `AddPartLGRev`, `AddPartLGHatch`, and `AddPartSlideRotLG`), while skipping close-range-only light effects.
 
 **Configuration:** Users/server owners configure `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance`. `AircraftLODFarDistance` also guides the extended tracking range helper so the render-only system has useful data without replacing real entity simulation.
 

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -144,7 +144,13 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       GL11.glEnable(GL11.GL_BLEND);
       GL11.glDisable(GL11.GL_ALPHA_TEST);
       GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      this.renderBaseVehicle(ac, posX, posY, posZ, yaw, pitch, roll, tickTime);
+      beginSkinOverlayRender(info, ac);
+      try {
+         this.renderBaseVehicle(ac, posX, posY, posZ, yaw, pitch, roll, tickTime);
+         this.renderCommonPart(ac, info, posX, posY, posZ, tickTime);
+      } finally {
+         endSkinOverlayRender();
+      }
       GL11.glPopAttrib();
       GL11.glPopMatrix();
    }


### PR DESCRIPTION
### Motivation

- Large aircraft landing gear configured via `AddPartLG` and related part directives stopped animating when the vehicle switched to the far-distance LOD render path, breaking e.g. Tu-95 gear behavior. 
- The LOD path should still render configured animated/common parts (landing gear, slide/rot hatches) while skipping close-range-only effects, and it must preserve skin overlay state during that pass.

### Description

- Restored animated common-part rendering in the far-distance LOD pass by calling `beginSkinOverlayRender(info, ac)`, then running `renderBaseVehicle(...)` and `renderCommonPart(...)` in a `try`/`finally` that calls `endSkinOverlayRender()` in `MCH_RenderBaseVehicle.renderAircraftLOD`.  
- Updated documentation in `docs/overdrive-features.md` to note that far LOD rendering still draws configured animated vehicle parts (including `AddPartLG`, `AddPartLGRev`, `AddPartLGHatch`, and `AddPartSlideRotLG`) while skipping only close-range light effects. 
- Recorded the change in `CHANGELOG.md` so releases track the fix.

### Testing

- Ran `git diff --check` to validate whitespace/patch issues and ensured no diff warnings were reported.  
- Verified code and documentation changes with targeted searches using `rg` for `beginSkinOverlayRender(info, ac)`, `renderCommonPart(ac, info`, and the new LOD-doc text to confirm the edit locations.  
- Did not run a compile/build step per repository/user instruction, so no binary artifacts were produced or included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5478d9a2708323b95f236d6edb726c)