### PR TITLE
Fix live landing gear key sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix live landing gear key sync
+
+- Changed the landing-gear key handler to send a gear intent even when the live client-side clearance/rotation prediction is stale, letting the server-authoritative vehicle process retraction or extension for large planes such as the Tu-95.
+- Documented that live multiplayer gear input is server-authoritative, while local prompts may still be conservative.
+
 ## Fix live LOD landing gear snapshots
 
 - Added landing-gear animation state to live server LOD snapshot packets so clients without the real vehicle entity can render large-aircraft `AddPartLG` parts correctly.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,8 @@ The config stores key codes rather than names. Common defaults:
 | Scoreboard | `KeyScoreboard` | L |
 | Multiplayer manager | `KeyMultiplayManager` | M |
 
+In live multiplayer, the Gear key sends the pilot's gear intent to the server even if the local client has stale clearance or animation state. This keeps large aircraft, including Tu-95-style bombers, from getting stuck with gear down when the client prediction differs from the dedicated server.
+
 ## 7. Useful first configuration changes
 
 For survival-friendly servers:

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -195,14 +195,21 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
                        new Object[]{Integer.valueOf(ac.getEntityId())});
             }
          }
-         if (this.KeyGearUpDown.isKeyDown() && ac.getAcInfo().haveLandingGear())
+         if (this.KeyGearUpDown.isKeyDown() && ac.getAcInfo().haveLandingGear()) {
             if (ac.canFoldLandingGear()) {
                pc.switchGear = 1;
                send = true;
             } else if (ac.canUnfoldLandingGear()) {
                pc.switchGear = 2;
                send = true;
+            } else if (!ac.isLandingGearFolded()) {
+               pc.switchGear = 1;
+               send = true;
+            } else if (ac.isLandingGearFolded()) {
+               pc.switchGear = 2;
+               send = true;
             }
+         }
          if (ac.canSwitchFreeLook()) {
             if (MCH_Config.EnableHoldFreelook.prmBool) {
                boolean cameraOnlyPlaneFreelook = ac instanceof MCP_EntityPlane


### PR DESCRIPTION
### Motivation
- Large planes (example: Tu-95) could get their landing gear stuck in live multiplayer because the client-side clearance/animation prediction is stale and suppressed a gear intent that the server should authoritatively handle.

### Description
- Changed the Gear-key handler in `MCH_BaseVehicleClientTickHandler` to always send a gear intent when the player presses the Gear key and the vehicle has landing gear, even if the client-side `canFoldLandingGear()`/`canUnfoldLandingGear()` checks are inconclusive. (File: `src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java`.)
- Added a documentation note in `docs/getting-started.md` explaining that Gear input is server-authoritative in live multiplayer and can be sent despite conservative client-side prompts. (File: `docs/getting-started.md`.)
- Added a changelog entry describing the fix. (File: `CHANGELOG.md`.)

### Testing
- Ran `git diff --check` with no problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54888c27748323a49faed2b3d5d2aa)