### PR TITLE
Fix Angelica dynamic vehicle part rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Angelica Dynamic Vehicle Part Render Compatibility
+
+- Added an Angelica-only Tessellator compatibility path for dynamically transformed MCHeli model parts so per-part `glPushMatrix`/translate/rotate transforms are consumed by Angelica's fixed-function state emulation.
+- Kept normal static whole-model/body rendering on the existing VBO path and preserved the existing non-Angelica dynamic part path.
+- Added opt-in one-shot diagnostics for Angelica dynamic part path selection via `-Dmcheli.debugAngelicaDynamicPartRender=true`.
+
 ## Bomb Sight No-Terrain Stability
 
 - Fixed first-person bomb-sight camera forcing so no-terrain predictions use a stable ballistic target angle instead of bobbing with nearby fallback terrain heights.

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -1,7 +1,11 @@
 package mcheli.aircraft;
 
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Random;
+import java.util.Set;
+
+import cpw.mods.fml.common.Loader;
 
 import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_ClientEventHook;
@@ -44,6 +48,9 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    public static IModelCustom debugModel = null;
    private static ResourceLocation activeSkinOverlayTexture = null;
    private static ResourceLocation activeBaseTexture = null;
+   private static final boolean ANGELICA_DYNAMIC_PART_COMPAT = Loader.isModLoaded("angelica");
+   private static final boolean DEBUG_ANGELICA_DYNAMIC_PART_RENDER = Boolean.getBoolean("mcheli.debugAngelicaDynamicPartRender");
+   private static final Set angelicaDynamicPartRenderDiagnostics = new HashSet();
 
    public static Random rand = new Random();
 
@@ -621,10 +628,10 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    }
 
    public static void renderPart(final IModelCustom model, final IModelCustom modelBody, final String partName) {
-      renderPartModel(model, modelBody, partName);
+      renderPartModelTransformed(model, modelBody, partName);
       renderSkinOverlayPass(new RenderRunnable() {
          public void render() {
-            renderPartModel(model, modelBody, partName);
+            renderPartModelTransformed(model, modelBody, partName);
          }
       });
 
@@ -635,6 +642,35 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          model.renderAll();
       } else if(modelBody instanceof W_ModelCustom && ((W_ModelCustom)modelBody).containsPart("$" + partName)) {
          modelBody.renderPart("$" + partName);
+      }
+   }
+
+   private static void renderPartModelTransformed(IModelCustom model, IModelCustom modelBody, String partName) {
+      if(ANGELICA_DYNAMIC_PART_COMPAT && model instanceof W_ModelCustom) {
+         logAngelicaDynamicPartRender((W_ModelCustom)model, partName, "external", "compat-tessellator");
+         ((W_ModelCustom)model).renderAllTransformed();
+      } else if(model != null) {
+         logAngelicaDynamicPartRender(model, partName, "external", "vbo");
+         model.renderAll();
+      } else if(modelBody instanceof W_ModelCustom && ((W_ModelCustom)modelBody).containsPart("$" + partName)) {
+         if(ANGELICA_DYNAMIC_PART_COMPAT) {
+            logAngelicaDynamicPartRender(modelBody, partName, "body-part", "compat-tessellator");
+            ((W_ModelCustom)modelBody).renderPartTransformed("$" + partName);
+         } else {
+            logAngelicaDynamicPartRender(modelBody, partName, "body-part", "vbo");
+            modelBody.renderPart("$" + partName);
+         }
+      }
+   }
+
+   private static void logAngelicaDynamicPartRender(IModelCustom model, String partName, String modelType, String path) {
+      if(!DEBUG_ANGELICA_DYNAMIC_PART_RENDER || !ANGELICA_DYNAMIC_PART_COMPAT) {
+         return;
+      }
+
+      String key = model.getClass().getName() + ":" + modelType + ":" + partName + ":" + path;
+      if(angelicaDynamicPartRenderDiagnostics.add(key)) {
+         MCH_Lib.Log("[AngelicaDynamicPartRender] angelica=true model=%s modelType=%s group=%s transformedDynamicPart=true path=%s", new Object[]{model.getClass().getName(), modelType, partName, path});
       }
    }
 

--- a/src/main/java/mcheli/wrapper/modelloader/W_GroupObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_GroupObject.java
@@ -49,6 +49,15 @@ public class W_GroupObject {
       }
    }
 
+   public void renderTransformed() {
+      if(this.faces.size() > 0) {
+         Tessellator tessellator = Tessellator.instance;
+         tessellator.startDrawing(this.glDrawingMode);
+         this.render(tessellator);
+         tessellator.draw();
+      }
+   }
+
    private boolean renderVbo() {
       if(this.vboUnavailable || !GLContext.getCapabilities().OpenGL15) {
          return false;

--- a/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
@@ -278,6 +278,16 @@ public class W_MetasequoiaObject extends W_ModelCustom {
       }
    }
 
+   public void renderAllTransformed() {
+      Iterator i$ = this.groupObjects.iterator();
+      while(i$.hasNext()) {
+         W_GroupObject groupObject = (W_GroupObject)i$.next();
+         if(groupObject != null) {
+            groupObject.renderTransformed();
+         }
+      }
+   }
+
    public void tessellateAll(Tessellator tessellator) {
       Iterator i$ = this.groupObjects.iterator();
 
@@ -351,6 +361,39 @@ public class W_MetasequoiaObject extends W_ModelCustom {
             groupObject = (W_GroupObject)var4.next();
             if(partName.equalsIgnoreCase(groupObject.name)) {
                groupObject.render();
+            }
+         }
+      }
+
+   }
+
+   public void renderPartTransformed(String partName) {
+      W_GroupObject groupObject;
+      if(partName.charAt(0) == 36) {
+         for(int i$ = 0; i$ < this.groupObjects.size(); ++i$) {
+            groupObject = (W_GroupObject)this.groupObjects.get(i$);
+            if(partName.equalsIgnoreCase(groupObject.name)) {
+               groupObject.renderTransformed();
+               ++i$;
+
+               while(i$ < this.groupObjects.size()) {
+                  groupObject = (W_GroupObject)this.groupObjects.get(i$);
+                  if(groupObject.name.charAt(0) == 36) {
+                     break;
+                  }
+
+                  groupObject.renderTransformed();
+                  ++i$;
+               }
+            }
+         }
+      } else {
+         Iterator var4 = this.groupObjects.iterator();
+
+         while(var4.hasNext()) {
+            groupObject = (W_GroupObject)var4.next();
+            if(partName.equalsIgnoreCase(groupObject.name)) {
+               groupObject.renderTransformed();
             }
          }
       }

--- a/src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java
@@ -79,6 +79,10 @@ public abstract class W_ModelCustom implements IModelCustom {
 
    public abstract boolean containsPart(String var1);
 
+   public abstract void renderAllTransformed();
+
+   public abstract void renderPartTransformed(String var1);
+
    public abstract void renderAll(int var1, int var2);
 
    public abstract void renderAllLine(int var1, int var2);

--- a/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
@@ -180,6 +180,16 @@ public class W_WavefrontObject extends W_ModelCustom {
       }
    }
 
+   public void renderAllTransformed() {
+      Iterator i$ = this.groupObjects.iterator();
+      while(i$.hasNext()) {
+         W_GroupObject groupObject = (W_GroupObject)i$.next();
+         if(groupObject != null) {
+            groupObject.renderTransformed();
+         }
+      }
+   }
+
    private void compactFaces() {
       Iterator i$ = this.groupObjects.iterator();
 
@@ -271,6 +281,18 @@ public class W_WavefrontObject extends W_ModelCustom {
          W_GroupObject groupObject = (W_GroupObject)i$.next();
          if(partName.equalsIgnoreCase(groupObject.name)) {
             groupObject.render();
+         }
+      }
+
+   }
+
+   public void renderPartTransformed(String partName) {
+      Iterator i$ = this.groupObjects.iterator();
+
+      while(i$.hasNext()) {
+         W_GroupObject groupObject = (W_GroupObject)i$.next();
+         if(partName.equalsIgnoreCase(groupObject.name)) {
+            groupObject.renderTransformed();
          }
       }
 


### PR DESCRIPTION
### Motivation

- Fix an Angelica compatibility bug where per-part matrix transforms (landing gear, hatches, wheels, etc.) were ignored when Angelica was present.
- Create the smallest safe compatibility boundary so Angelica performance and VBO acceleration remain available for static model rendering.
- Provide a low-noise, one-shot diagnostic to prove which path is used during live testing without spamming every frame.

### Description

- Added a cached Angelica detection using `Loader.isModLoaded("angelica")` and an opt-in one-shot diagnostic gate via `-Dmcheli.debugAngelicaDynamicPartRender=true` in `MCH_RenderBaseVehicle`.\n
- Routed dynamically transformed named-part rendering through a compatibility path: `renderPart(...)` now calls `renderPartModelTransformed(...)`, which selects a Tessellator-backed path when Angelica is present and otherwise preserves the existing VBO (`glBindBuffer`/`glInterleavedArrays`/`glDrawArrays`) path.\n
- Introduced explicit transformed-render hooks: `W_ModelCustom.renderAllTransformed()` and `W_ModelCustom.renderPartTransformed(...)`, implemented for both Wavefront (OBJ) and Metasequoia (MQO) model loaders, and added `W_GroupObject.renderTransformed()` which forces the Tessellator draw for a group.\n
- Kept all existing VBO-capable code intact so static whole-model/body rendering still uses the VBO path; only per-part, matrix-wrapped dynamic named-part draws switch to the Tessellator compatibility path when Angelica is detected.\n
- Updated `CHANGELOG.md` with a short entry describing the Angelica compatibility fix.

Why this fixes the root cause: Angelica rewrites/emulates fixed-function matrix and client-array state; the direct VBO draw path could be observed with stale/unsynchronized model-view state when invoked immediately after per-part `glPushMatrix`/translate/rotate calls. Using the Tessellator/immediate-style draw for transformed parts leverages Angelica's existing compatibility handling so the per-part matrix transforms are consumed correctly while preserving VBO acceleration for unaffected paths.

### Testing

- Ran static checks: `git diff --check` (no whitespace/patch errors) — passed.\n
- Attempted Java compile: `./gradlew compileJava` could not be completed in this environment because the Gradle wrapper failed to determine a supported Java 8 runtime (host provided Java versions `25.0.2` and `11.0.2`) and automated install of Java 8 failed due to a network tunnel error; therefore compilation could not be verified here.\n
- No unit/integration tests were present or run; live-game validation remains required (manual checklist included in PR notes) to confirm that: static bodies retain VBO rendering; transformed named parts render correctly with Angelica installed; behavior is unchanged when Angelica is absent; and OBJ/MQO models both behave correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a549421411c8323b68529ba09defe77)