### PR TITLE
Require three-second Shift hold to dismount vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Hold Shift Vehicle Dismount
+
+- Changed vehicle dismounting to require holding Left Shift continuously for three seconds, preventing accidental exits from pilot seats.
+- Updated the in-game vehicle control hint and getting-started control reference to document the hold-to-dismount behavior.
+
 ## Angelica Dynamic Vehicle Part Render Compatibility
 
 - Added an Angelica-only Tessellator compatibility path for dynamically transformed MCHeli model parts so per-part `glPushMatrix`/translate/rotate transforms are consumed by Angelica's fixed-function state emulation.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,8 @@ The config stores key codes rather than names. Common defaults:
 | Switch weapon mode | `KeySwitchWeaponMode` | X |
 | Zoom | `KeyZoom` | Z |
 | Camera mode | `KeyCameraMode` | C |
-| Dismount mob/seat action | `KeyUnmountMob` | Y |
+| Dismount vehicle | Fixed control | Hold Left Shift for 3 seconds |
+| Dismount mob/crew action | `KeyUnmountMob` | Y |
 | Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
 | Extra function | `KeyExtra` | F |
 | Hold free look | `KeyFreeLook` | Left Control |

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -16,6 +16,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import org.lwjgl.input.Keyboard;
 
 public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHandlerBase {
+   /** Three seconds at Minecraft's 20 client ticks per second. */
+   private static final int DISMOUNT_HOLD_TICKS = 60;
+
    protected boolean isRiding = false;
 
    protected boolean isBeforeRiding = false;
@@ -58,6 +61,8 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
 
    public MCH_Key KeyBrake;
    public MCH_Key KeyCurrentWeaponLock;
+
+   private int unmountForceHoldTicks;
 
    /**
     * Chaff key
@@ -133,6 +138,22 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
          }
       }
       boolean send = false;
+
+      if(this.KeyUnmountForce.isKeyPress()) {
+         if(this.unmountForceHoldTicks < DISMOUNT_HOLD_TICKS) {
+            ++this.unmountForceHoldTicks;
+         }
+      } else {
+         this.unmountForceHoldTicks = 0;
+      }
+
+      if(this.unmountForceHoldTicks == DISMOUNT_HOLD_TICKS) {
+         pc.isUnmount = 1;
+         send = true;
+         // Do not send another dismount request until Shift is released and held again.
+         ++this.unmountForceHoldTicks;
+      }
+
       if (this.KeyCameraMode.isKeyDown())
          if (ac.haveSearchLight()) {
             if (ac.canSwitchSearchLight((Entity)player)) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -226,9 +226,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
             msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
             color = -256;
          } else {
-            var10000 = (new StringBuilder()).append("Dismount : ");
-            var10001 = MCH_MOD.config;
-            msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
+            msg = "Dismount : Hold Left Shift (3s)";
          }
 
          this.drawString(msg, LX, super.centerY - 30, color);


### PR DESCRIPTION
### Motivation

- Prevent accidental vehicle exits by requiring an intentional hold before forcing a dismount, as requested to require holding Shift for 3 seconds to dismount.

### Description

- Added a 3-second hold guard by introducing `DISMOUNT_HOLD_TICKS = 60` and an `unmountForceHoldTicks` counter and wiring the logic into `MCH_BaseVehicleClientTickHandler.commonPlayerControl` to send `pc.isUnmount = 1` only after the left-Shift hold reaches 60 client ticks and to require release before another attempt.
- Updated the in-vehicle HUD text in `MCH_BaseVehicleCommonGui` to show the new instruction `Dismount : Hold Left Shift (3s)`.
- Updated documentation in `docs/getting-started.md` to document the new fixed control for vehicle dismounts and added a short entry to `CHANGELOG.md` describing the change.
- Modified files: `src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java`, `src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java`, `docs/getting-started.md`, and `CHANGELOG.md`.

### Testing

- Ran `git diff --check` to validate the patch format and found no issues (passed).
- Verified changes with `git status --short` and confirmed the commit was created (`Require hold to dismount vehicles`) (passed).
- No build or binary compilation was run in accordance with project instructions (no compilation performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a5d123af88323ad6bad973df59700)