### PR TITLE
Restore drafting table description textures from PR #564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## PR #564 - Drafting Table Description Textures
+
+- Fixed drafting table description bindings so classpath and addon existence checks resolve the same texture path used by Minecraft's resource manager.
+- Preserved numbered description pages, addon overrides, and the intended description crop while supporting textures with dimensions other than 512 by 512 pixels.
+- Added one-time warnings for unresolved description pages instead of adding textures that render as the missing-texture checkerboard.
+
 ## Hold Shift Vehicle Dismount
 
 - Changed vehicle dismounting to require holding Left Shift continuously for three seconds, preventing accidental exits from pilot seats.

--- a/src/main/java/mcheli/MCH_AddonResourcePack.java
+++ b/src/main/java/mcheli/MCH_AddonResourcePack.java
@@ -66,7 +66,9 @@ public class MCH_AddonResourcePack implements IResourcePack {
     }
 
     private File findFile(ResourceLocation location) {
-        String path = location.getResourcePath();
+        String path = location.getResourcePath().replace('\\', '/');
+        while (path.startsWith("/")) path = path.substring(1);
+        while (path.contains("//")) path = path.replace("//", "/");
         for (File root : addonRoots) {
             File candidate = new File(root, "assets/" + DOMAIN + "/" + path);
             if (candidate.isFile()) {

--- a/src/main/java/mcheli/MCH_ResourceHelper.java
+++ b/src/main/java/mcheli/MCH_ResourceHelper.java
@@ -225,7 +225,7 @@ public class MCH_ResourceHelper {
     }
 
     public static boolean resourceExists(String resourcePath) {
-        if (!resourcePath.startsWith("/")) resourcePath = "/" + resourcePath;
+        resourcePath = normalizeAssetPath(resourcePath);
 
         // Check addon asset roots first (additive overlay)
         if (addonAssetRoots != null && !addonAssetRoots.isEmpty()) {
@@ -235,19 +235,19 @@ public class MCH_ResourceHelper {
 
         if (sourceJar != null && sourceJar.exists() && sourceJar.isFile()) {
             try (JarFile jar = new JarFile(sourceJar)) {
-                return jar.getEntry(resourcePath.substring(1)) != null;
+                return jar.getEntry(resourcePath) != null;
             } catch (Exception e) {
                 return false;
             }
         }
 
-        String relPath = resourcePath.substring(1);
+        String relPath = resourcePath;
         if (devClasspathDirs != null) {
             for (File cpDir : devClasspathDirs) {
                 if (new File(cpDir, relPath).isFile()) return true;
             }
         }
-        return MCH_ResourceHelper.class.getResourceAsStream(resourcePath) != null;
+        return MCH_ResourceHelper.class.getResourceAsStream("/" + resourcePath) != null;
     }
 
     public static BufferedReader openResource(String resourcePath) {
@@ -299,7 +299,7 @@ public class MCH_ResourceHelper {
      * Returns the first match found.
      */
     private static File findAddonResourceFile(String resourcePath) {
-        String path = resourcePath.startsWith("/") ? resourcePath.substring(1) : resourcePath;
+        String path = normalizeAssetPath(resourcePath);
         if (!path.startsWith(ASSET_PREFIX)) return null;
         String relPath = path.substring(ASSET_PREFIX.length());
 
@@ -312,10 +312,18 @@ public class MCH_ResourceHelper {
         }
         // Check flat layout last
         if (addonDir != null && addonAssetRoots.contains(addonDir)) {
-            File candidate = new File(addonDir, relPath);
+            File candidate = new File(addonDir, ASSET_PREFIX + relPath);
             if (candidate.isFile()) return candidate;
         }
         return null;
+    }
+
+    /** Classpath and filesystem probes always use an assets/mcheli path. */
+    public static String normalizeAssetPath(String resourcePath) {
+        String path = resourcePath == null ? "" : resourcePath.replace('\\', '/');
+        while (path.startsWith("/")) path = path.substring(1);
+        while (path.contains("//")) path = path.replace("//", "/");
+        return path;
     }
 
     public static String getFileName(String resourcePath) {

--- a/src/main/java/mcheli/block/MCH_CurrentRecipe.java
+++ b/src/main/java/mcheli/block/MCH_CurrentRecipe.java
@@ -2,6 +2,9 @@ package mcheli.block;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
+import mcheli.MCH_Lib;
 import mcheli.MCH_IRecipeList;
 import mcheli.MCH_MOD;
 import mcheli.MCH_ModelManager;
@@ -23,7 +26,8 @@ public class MCH_CurrentRecipe {
    public final IRecipe recipe;
    public final int index;
    public final String displayName;
-   public final List descTexture;
+   public final List<ResourceLocation> descTexture;
+   private static final Set<String> WARNED_DESC_TEXTURES = new HashSet<String>();
    private final MCH_BaseVehicleInfo acInfo;
    public List infoItem;
    public List infoData;
@@ -190,8 +194,8 @@ public class MCH_CurrentRecipe {
       return this.getAcInfo() != null && this.descPage == this.descMaxPage - 1;
    }
 
-   private List getDescTexture(IRecipe r) {
-      ArrayList list = new ArrayList();
+   private List<ResourceLocation> getDescTexture(IRecipe r) {
+      ArrayList<ResourceLocation> list = new ArrayList<ResourceLocation>();
       if(r != null) {
          for(int i = 0; i < 20; ++i) {
             String itemName = r.getRecipeOutput().getUnlocalizedName();
@@ -203,13 +207,31 @@ public class MCH_CurrentRecipe {
                itemName = itemName.substring(itemName.indexOf(":") + 1);
             }
 
-            itemName = "/textures/drafting_table_desc/" + itemName + "#" + i + ".png";
-            if(MCH_ResourceHelper.resourceExists("assets/mcheli" + itemName)) {
-               list.add(new ResourceLocation("mcheli", itemName));
+            // ResourceLocation paths omit assets/mcheli and never begin with a slash.
+            String texturePath = normalizeTexturePath("textures/drafting_table_desc/" + itemName + "#" + i + ".png");
+            String assetPath = MCH_ResourceHelper.normalizeAssetPath("assets/mcheli/" + texturePath);
+            if(MCH_ResourceHelper.resourceExists(assetPath)) {
+               list.add(new ResourceLocation("mcheli", texturePath));
+            } else {
+               warnMissingDescTexture(r.getRecipeOutput().getDisplayName(), assetPath);
             }
          }
       }
 
       return list;
+   }
+
+   private static String normalizeTexturePath(String path) {
+      path = path.replace('\\', '/');
+      while(path.startsWith("/")) path = path.substring(1);
+      while(path.contains("//")) path = path.replace("//", "/");
+      return path;
+   }
+
+   private static void warnMissingDescTexture(String outputName, String resourcePath) {
+      String warningKey = outputName + "|" + resourcePath;
+      if(WARNED_DESC_TEXTURES.add(warningKey)) {
+         MCH_Lib.Log("WARNING: Drafting table description texture unresolved for '%s': %s", outputName, resourcePath);
+      }
    }
 }

--- a/src/main/java/mcheli/block/MCH_DraftingTableGui.java
+++ b/src/main/java/mcheli/block/MCH_DraftingTableGui.java
@@ -585,7 +585,7 @@ public class MCH_DraftingTableGui extends W_GuiContainer {
             if(this.current.isCurrentPageTexture()) {
                GL11.glColor4d(1.0D, 1.0D, 1.0D, 1.0D);
                super.mc.getTextureManager().bindTexture(this.current.getCurrentPageTexture());
-               this.drawTexturedModalRect(210, 20, 170, 190, 0, 0, 340, 380);
+               this.drawDescriptionTexture(210, 20, 170, 190);
             } else if(this.current.isCurrentPageAcInfo()) {
                i = -9491968;
 
@@ -1028,6 +1028,25 @@ public class MCH_DraftingTableGui extends W_GuiContainer {
       tessellator.addVertexWithUV((double)(dx + dw), (double)(dy + dh), (double)super.zLevel, (double)((float)(u + tw) * w), (double)((float)(v + th) * h));
       tessellator.addVertexWithUV((double)(dx + dw), (double)(dy + 0), (double)super.zLevel, (double)((float)(u + tw) * w), (double)((float)(v + 0) * h));
       tessellator.addVertexWithUV((double)(dx + 0), (double)(dy + 0), (double)super.zLevel, (double)((float)(u + 0) * w), (double)((float)(v + 0) * h));
+      tessellator.draw();
+   }
+
+   private void drawDescriptionTexture(int x, int y, int width, int height) {
+      int textureWidth = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_WIDTH);
+      int textureHeight = GL11.glGetTexLevelParameteri(GL11.GL_TEXTURE_2D, 0, GL11.GL_TEXTURE_HEIGHT);
+      if(textureWidth <= 0 || textureHeight <= 0) return;
+
+      // Scale the original 340x380 region proportionally for non-512 textures.
+      float sourceWidth = textureWidth * (340.0F / 512.0F);
+      float sourceHeight = textureHeight * (380.0F / 512.0F);
+      float maxU = sourceWidth / textureWidth;
+      float maxV = sourceHeight / textureHeight;
+      Tessellator tessellator = Tessellator.instance;
+      tessellator.startDrawingQuads();
+      tessellator.addVertexWithUV(x, y + height, super.zLevel, 0.0D, maxV);
+      tessellator.addVertexWithUV(x + width, y + height, super.zLevel, maxU, maxV);
+      tessellator.addVertexWithUV(x + width, y, super.zLevel, maxU, 0.0D);
+      tessellator.addVertexWithUV(x, y, super.zLevel, 0.0D, 0.0D);
       tessellator.draw();
    }
 


### PR DESCRIPTION
### Motivation

- Fix missing drafting-table description textures caused by mismatched existence checks (`assets/mcheli/...`) and the `ResourceLocation` binding path (`textures/...`) including an erroneous leading slash that made Forge bind the wrong resource and show the missing-texture checkerboard. 
- Preserve the classpath-based loading introduced in PR #564 and keep filesystem addon support via `mcheli_addons` while ensuring addon overrides remain higher priority. 
- Keep numbered pages `#0`–`#19` and the intended GUI crop (340×380 from a 512×512 source) while supporting textures with other dimensions.

### Description

- Normalized asset path handling and removed leading/slash inconsistencies by adding `MCH_ResourceHelper.normalizeAssetPath(...)` and using that value for JAR, dev-classpath, classpath, and addon checks (changed `MCH_ResourceHelper.java`).
- Changed drafting-table texture discovery to build a `textures/...` `ResourceLocation` (no leading slash) while checking existence using `assets/mcheli/...` normalized paths so the existence probe and bound `ResourceLocation` resolve the same underlying file (changed `MCH_CurrentRecipe.java`).
- Added one-time per-(outputName + assetPath) warnings via `MCH_Lib.Log(...)` when a description texture is unresolved so missing pages are not silently added and logging is not spammed (changed `MCH_CurrentRecipe.java`).
- Fixed flat-addon asset-root resolution and normalized addon-file probes so nested addon packs still override flat addon roots and filesystem lookups use the same `assets/mcheli/...` layout used by classpath/JAR entries (changed `MCH_ResourceHelper.java`).
- Normalized `ResourceLocation` path handling in the addon resource-pack filesystem resolver (`MCH_AddonResourcePack.java`) so addon textures with duplicate/leading slashes resolve correctly.
- Preserved the GUI display area and implemented `drawDescriptionTexture(...)` which computes normalized UVs from the actual bound texture size so the 340×380 source region is preserved for 512×512 textures and scaled appropriately for other sizes (changed `MCH_DraftingTableGui.java`).
- Added a short `CHANGELOG.md` entry documenting the fix and listed the files changed.

Files changed: `src/main/java/mcheli/MCH_ResourceHelper.java`, `src/main/java/mcheli/block/MCH_CurrentRecipe.java`, `src/main/java/mcheli/MCH_AddonResourcePack.java`, `src/main/java/mcheli/block/MCH_DraftingTableGui.java`, `CHANGELOG.md`.

### Testing

- Ran `git diff --check` and verified no whitespace or quick-diff issues were reported (success).
- Compared source `src/main/resources/assets/mcheli/textures/drafting_table_desc/` entries against the built JAR entries and confirmed all 34 texture paths are present and matched (scripted comparison; success).
- Inspected PNG headers for the bundled description textures and verified all current source/JAR textures are valid PNGs at 512×512 (scripted header checks; success).
- Verified via source grep and code inspection that `ResourceLocation` usage for drafting-table descriptions no longer contains a leading slash and that existence probes use `assets/mcheli/...` paths (static checks; success).
- Did not run `./gradlew build` or any Forge client/manual GUI tests because the task instructions and repository policies forbid producing or modifying binary build artifacts in this environment; in-client runtime verification (opening the drafting table, single/multi/no-page navigation, addon override runtime tests) remain to be performed in a Forge 1.7.10 client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a694aaaa4888323b7740e7c9a5d445b)