### PR TITLE
Fix reconstructed smoke particle square backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Fix Reconstructed Smoke Particle Backgrounds
+
+- Removed reconstruction haze by scaling per-frame alpha coverage instead of bicubic ARGB, applying a silhouette-limited blur, discarding alpha at or below 4/255, and renormalizing the retained soft coverage.
+- Increased each reconstructed frame's transparent gutter to two pixels, forced content edges and zero-alpha RGB transparent, and sampled the complete cell with half-texel UV insets.
+- Preserved source-alpha blending while adding a 1/255 alpha-test guard and restoring all fixed-function state changed by standalone smoke rendering.
+- Added image-only regressions for the bundled 64 by 8 smoke texture, transparent borders/corners, soft coverage, frame isolation, edge-touching coverage, and transparent RGB.
+
 ## PR #566 - Soft Particle Texture Runtime Reconstruction
 
 - Kept the crunched eight-frame smoke asset and added one-time, client-side runtime reconstruction of soft alpha edges for undersized or binary-alpha resource-pack textures.

--- a/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
@@ -118,11 +118,16 @@ public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
          return;
       }
 
+      GL11.glPushAttrib(GL11.GL_CURRENT_BIT | GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT |
+         GL11.GL_LIGHTING_BIT | GL11.GL_POLYGON_BIT | GL11.GL_TEXTURE_BIT);
       MCH_ParticleTexture.bind();
+      boolean alphaTest = GL11.glIsEnabled(GL11.GL_ALPHA_TEST);
+      int alphaFunction = GL11.glGetInteger(GL11.GL_ALPHA_TEST_FUNC);
+      float alphaReference = GL11.glGetFloat(GL11.GL_ALPHA_TEST_REF);
       GL11.glEnable(3042);
-      int srcBlend = GL11.glGetInteger(3041);
-      int dstBlend = GL11.glGetInteger(3040);
       GL11.glBlendFunc(770, 771);
+      GL11.glEnable(GL11.GL_ALPHA_TEST);
+      GL11.glAlphaFunc(GL11.GL_GREATER, 1.0F / 255.0F);
       GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
       GL11.glDisable(2896);
       GL11.glDisable(2884);
@@ -143,9 +148,8 @@ public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
       par1Tessellator.addVertexWithUV((double)(f11 + par3 * f10 + par6 * f10), (double)(f12 + par4 * f10), (double)(f13 + par5 * f10 + par7 * f10), (double)f6, (double)f8);
       par1Tessellator.addVertexWithUV((double)(f11 + par3 * f10 - par6 * f10), (double)(f12 - par4 * f10), (double)(f13 + par5 * f10 - par7 * f10), (double)f6, (double)f9);
       par1Tessellator.draw();
-      GL11.glEnable(2884);
-      GL11.glEnable(2896);
-      GL11.glBlendFunc(srcBlend, dstBlend);
-      GL11.glDisable(3042);
+      GL11.glAlphaFunc(alphaFunction, alphaReference);
+      if(!alphaTest) GL11.glDisable(GL11.GL_ALPHA_TEST);
+      GL11.glPopAttrib();
    }
 }

--- a/src/main/java/mcheli/particles/MCH_ParticleTexture.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleTexture.java
@@ -44,7 +44,7 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
       if(!INSTANCE.result.processed) {
          return (frame + 0.5F / INSTANCE.result.cellWidth) / 8.0F;
       }
-      return (frame * INSTANCE.result.cellWidth + INSTANCE.result.padding + 0.5F) / INSTANCE.result.image.getWidth();
+      return (frame * INSTANCE.result.cellWidth + 0.5F) / INSTANCE.result.image.getWidth();
    }
 
    public static float maxU(int frame) {
@@ -53,21 +53,21 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
       if(!INSTANCE.result.processed) {
          return (frame + 1.0F - 0.5F / INSTANCE.result.cellWidth) / 8.0F;
       }
-      return ((frame + 1) * INSTANCE.result.cellWidth - INSTANCE.result.padding - 0.5F) / INSTANCE.result.image.getWidth();
+      return ((frame + 1) * INSTANCE.result.cellWidth - 0.5F) / INSTANCE.result.image.getWidth();
    }
 
    public static float minV() {
       INSTANCE.ensureLoaded();
       if(INSTANCE.result == null) return 0.0F;
       return INSTANCE.result.processed
-         ? (INSTANCE.result.padding + 0.5F) / INSTANCE.result.image.getHeight() : 0.5F / INSTANCE.result.cellHeight;
+         ? 0.5F / INSTANCE.result.image.getHeight() : 0.5F / INSTANCE.result.cellHeight;
    }
 
    public static float maxV() {
       INSTANCE.ensureLoaded();
       if(INSTANCE.result == null) return 1.0F;
       return INSTANCE.result.processed
-         ? (INSTANCE.result.image.getHeight() - INSTANCE.result.padding - 0.5F) / INSTANCE.result.image.getHeight()
+         ? (INSTANCE.result.image.getHeight() - 0.5F) / INSTANCE.result.image.getHeight()
          : 1.0F - 0.5F / INSTANCE.result.cellHeight;
    }
 

--- a/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
@@ -1,36 +1,31 @@
 package mcheli.particles;
 
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import javax.imageio.ImageIO;
 
-/** Pure image conversion for the smoke atlas.  This class deliberately has no Minecraft or GL dependencies. */
+/** Pure image conversion for the smoke atlas. This class deliberately has no Minecraft or GL dependencies. */
 public final class MCH_ParticleTextureProcessor {
    public static final int FRAME_COUNT = 8;
    private static final int MIN_FRAME_SIZE = 32;
    private static final int MAX_FRAME_SIZE = 128;
-   private static final int PADDING = 1;
+   /** Two texels keep a filtered frame sample isolated from the next frame. */
+   private static final int PADDING = 2;
+   /** Values at or below 4/255 are reconstruction haze, rather than visible smoke coverage. */
+   private static final int ALPHA_CUTOFF = 4;
 
    private MCH_ParticleTextureProcessor() {}
 
    public static Result readAndProcess(InputStream stream) throws IOException {
-      if(stream == null) {
-         throw new IOException("resource stream is missing");
-      }
+      if(stream == null) throw new IOException("resource stream is missing");
       BufferedImage source = ImageIO.read(stream);
-      if(source == null) {
-         throw new IOException("resource is not a supported image");
-      }
+      if(source == null) throw new IOException("resource is not a supported image");
       return process(source);
    }
 
    public static Result process(BufferedImage source) {
-      if(source == null) {
-         throw new IllegalArgumentException("source image is missing");
-      }
+      if(source == null) throw new IllegalArgumentException("source image is missing");
       if(source.getWidth() % FRAME_COUNT != 0) {
          throw new IllegalArgumentException("source width " + source.getWidth() + " is not divisible by eight");
       }
@@ -40,16 +35,7 @@ public final class MCH_ParticleTextureProcessor {
          throw new IllegalArgumentException("source has an empty animation frame");
       }
 
-      boolean usefulAlpha = false;
-      for(int y = 0; y < source.getHeight() && !usefulAlpha; ++y) {
-         for(int x = 0; x < source.getWidth(); ++x) {
-            int alpha = source.getRGB(x, y) >>> 24;
-            if(alpha > 0 && alpha < 255) {
-               usefulAlpha = true;
-               break;
-            }
-         }
-      }
+      boolean usefulAlpha = hasIntermediateAlpha(source);
       if(frameWidth >= MIN_FRAME_SIZE && frameHeight >= MIN_FRAME_SIZE && usefulAlpha) {
          return new Result(source, false, frameWidth, frameHeight, 0, source.getWidth(), source.getHeight());
       }
@@ -57,73 +43,104 @@ public final class MCH_ParticleTextureProcessor {
       int contentWidth = Math.min(MAX_FRAME_SIZE, Math.max(MIN_FRAME_SIZE, frameWidth));
       int contentHeight = Math.min(MAX_FRAME_SIZE, Math.max(MIN_FRAME_SIZE, frameHeight));
       int cellWidth = contentWidth + PADDING * 2;
-      BufferedImage atlas = new BufferedImage(cellWidth * FRAME_COUNT, contentHeight + PADDING * 2,
-         BufferedImage.TYPE_INT_ARGB);
+      int cellHeight = contentHeight + PADDING * 2;
+      BufferedImage atlas = new BufferedImage(cellWidth * FRAME_COUNT, cellHeight, BufferedImage.TYPE_INT_ARGB);
+
       for(int frame = 0; frame < FRAME_COUNT; ++frame) {
-         BufferedImage scaled = new BufferedImage(contentWidth, contentHeight, BufferedImage.TYPE_INT_ARGB);
-         Graphics2D graphics = scaled.createGraphics();
-         graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-         graphics.drawImage(source, 0, 0, contentWidth, contentHeight,
-            frame * frameWidth, 0, (frame + 1) * frameWidth, frameHeight, null);
-         graphics.dispose();
-         int[] alpha = rebuildAlpha(scaled);
-         blurAlpha(alpha, contentWidth, contentHeight);
+         int[] sourceCoverage = extractCoverage(source, frame * frameWidth, frameWidth, frameHeight);
+         int[] coverage = scaleBilinear(sourceCoverage, frameWidth, frameHeight, contentWidth, contentHeight);
+         blurInsideSilhouette(coverage, contentWidth, contentHeight);
+         finishCoverage(coverage, contentWidth, contentHeight);
          for(int y = 0; y < contentHeight; ++y) {
             for(int x = 0; x < contentWidth; ++x) {
-               atlas.setRGB(frame * cellWidth + PADDING + x, PADDING + y,
-                  alpha[y * contentWidth + x] << 24 | 0x00FFFFFF);
+               int alpha = coverage[y * contentWidth + x];
+               int argb = alpha == 0 ? 0x00000000 : alpha << 24 | 0x00FFFFFF;
+               atlas.setRGB(frame * cellWidth + PADDING + x, PADDING + y, argb);
             }
          }
       }
-      return new Result(atlas, true, cellWidth, contentHeight + PADDING * 2, PADDING,
-         source.getWidth(), source.getHeight());
+      return new Result(atlas, true, cellWidth, cellHeight, PADDING, source.getWidth(), source.getHeight());
    }
 
-   private static int[] rebuildAlpha(BufferedImage image) {
-      int width = image.getWidth();
-      int height = image.getHeight();
-      int[] result = new int[width * height];
+   private static boolean hasIntermediateAlpha(BufferedImage image) {
+      for(int y = 0; y < image.getHeight(); ++y) {
+         for(int x = 0; x < image.getWidth(); ++x) {
+            int alpha = image.getRGB(x, y) >>> 24;
+            if(alpha > 0 && alpha < 255) return true;
+         }
+      }
+      return false;
+   }
+
+   private static int[] extractCoverage(BufferedImage source, int startX, int width, int height) {
+      int[] coverage = new int[width * height];
       for(int y = 0; y < height; ++y) {
          for(int x = 0; x < width; ++x) {
-            int argb = image.getRGB(x, y);
-            int originalAlpha = argb >>> 24;
-            if(originalAlpha != 0) {
-               int red = argb >> 16 & 255;
-               int green = argb >> 8 & 255;
-               int blue = argb & 255;
-               int luminance = (red * 54 + green * 183 + blue * 19) >> 8;
-               // Crunching commonly leaves binary alpha but useful coverage in the grey smoke shape.
-               result[y * width + x] = originalAlpha * Math.max(24, luminance) / 255;
+            int argb = source.getRGB(startX + x, y);
+            int alpha = argb >>> 24;
+            if(alpha == 0) continue;
+            // Alpha is coverage. In particular, binary-alpha crunches must not turn incidental RGB into haze.
+            coverage[y * width + x] = alpha;
+         }
+      }
+      return coverage;
+   }
+
+   private static int[] scaleBilinear(int[] source, int sourceWidth, int sourceHeight,
+      int width, int height) {
+      int[] scaled = new int[width * height];
+      for(int y = 0; y < height; ++y) {
+         float sourceY = ((y + 0.5F) * sourceHeight / height) - 0.5F;
+         int y0 = Math.max(0, (int)Math.floor(sourceY));
+         int y1 = Math.min(sourceHeight - 1, y0 + 1);
+         float fy = Math.max(0.0F, sourceY - y0);
+         for(int x = 0; x < width; ++x) {
+            float sourceX = ((x + 0.5F) * sourceWidth / width) - 0.5F;
+            int x0 = Math.max(0, (int)Math.floor(sourceX));
+            int x1 = Math.min(sourceWidth - 1, x0 + 1);
+            float fx = Math.max(0.0F, sourceX - x0);
+            float top = source[y0 * sourceWidth + x0] * (1.0F - fx) + source[y0 * sourceWidth + x1] * fx;
+            float bottom = source[y1 * sourceWidth + x0] * (1.0F - fx) + source[y1 * sourceWidth + x1] * fx;
+            scaled[y * width + x] = clamp(Math.round(top * (1.0F - fy) + bottom * fy));
+         }
+      }
+      return scaled;
+   }
+
+   private static void blurInsideSilhouette(int[] alpha, int width, int height) {
+      int[] original = alpha.clone();
+      for(int y = 1; y < height - 1; ++y) {
+         for(int x = 1; x < width - 1; ++x) {
+            int index = y * width + x;
+            if(original[index] == 0) continue;
+            int sum = 0;
+            for(int offsetY = -1; offsetY <= 1; ++offsetY) {
+               for(int offsetX = -1; offsetX <= 1; ++offsetX) {
+                  int weight = offsetX == 0 && offsetY == 0 ? 4 :
+                     (offsetX == 0 || offsetY == 0 ? 2 : 1);
+                  sum += original[index + offsetY * width + offsetX] * weight;
+               }
             }
+            alpha[index] = clamp((sum + 8) / 16);
          }
       }
-      return result;
    }
 
-   private static void blurAlpha(int[] alpha, int width, int height) {
-      int[] horizontal = new int[alpha.length];
+   private static void finishCoverage(int[] alpha, int width, int height) {
       for(int y = 0; y < height; ++y) {
          for(int x = 0; x < width; ++x) {
-            int left = alpha[y * width + Math.max(0, x - 1)];
-            int center = alpha[y * width + x];
-            int right = alpha[y * width + Math.min(width - 1, x + 1)];
-            horizontal[y * width + x] = (left + center * 2 + right) / 4;
-         }
-      }
-      for(int y = 0; y < height; ++y) {
-         for(int x = 0; x < width; ++x) {
-            int original = alpha[y * width + x];
-            if(original == 0) {
-               // Never expand the silhouette into pixels which were fully transparent after scaling.
-               alpha[y * width + x] = 0;
+            int index = y * width + x;
+            if(x == 0 || y == 0 || x == width - 1 || y == height - 1 || alpha[index] <= ALPHA_CUTOFF) {
+               alpha[index] = 0;
             } else {
-               int top = horizontal[Math.max(0, y - 1) * width + x];
-               int center = horizontal[y * width + x];
-               int bottom = horizontal[Math.min(height - 1, y + 1) * width + x];
-               alpha[y * width + x] = (top + center * 2 + bottom) / 4;
+               alpha[index] = clamp((alpha[index] - ALPHA_CUTOFF) * 255 / (255 - ALPHA_CUTOFF));
             }
          }
       }
+   }
+
+   private static int clamp(int value) {
+      return Math.max(0, Math.min(255, value));
    }
 
    public static final class Result {

--- a/src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java
+++ b/src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java
@@ -4,33 +4,66 @@ import static org.junit.Assert.*;
 
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.InputStream;
 import org.junit.Test;
 
 public class MCH_ParticleTextureProcessorTest {
    @Test
-   public void processesEightSmallFramesWithoutCrossingBoundaries() {
-      BufferedImage source = new BufferedImage(64, 8, BufferedImage.TYPE_INT_ARGB);
-      for(int frame = 0; frame < 8; ++frame) {
-         for(int y = 1; y < 7; ++y) {
-            for(int x = 1; x < 7; ++x) {
-               source.setRGB(frame * 8 + x, y, 0xFF000000 | (frame + 1) * 0x10101);
-            }
-         }
+   public void processesBundledSmokeWithTransparentFrameBorders() throws IOException {
+      InputStream stream = getClass().getResourceAsStream("/assets/mcheli/textures/particles/smoke.png");
+      assertNotNull(stream);
+      MCH_ParticleTextureProcessor.Result result;
+      try {
+         result = MCH_ParticleTextureProcessor.readAndProcess(stream);
+      } finally {
+         stream.close();
       }
 
-      MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
       assertTrue(result.processed);
-      assertEquals(result.cellWidth * 8, result.image.getWidth());
-      assertEquals(8, result.image.getWidth() / result.cellWidth);
-      assertTrue(hasIntermediateAlpha(result.image));
-      assertEquals(0, result.image.getRGB(0, 0) >>> 24);
+      assertEquals(2, result.padding);
+      assertEquals(288, result.image.getWidth());
+      assertEquals(36, result.image.getHeight());
       for(int frame = 0; frame < 8; ++frame) {
-         int center = result.image.getRGB(frame * result.cellWidth + result.cellWidth / 2,
-            result.cellHeight / 2) >>> 24;
-         assertTrue("frame " + frame + " should retain its distinct coverage", center > 0);
-         assertEquals(0, result.image.getRGB((frame + 1) * result.cellWidth - 1,
-            result.cellHeight / 2) >>> 24);
+         assertTransparentGutterAndContentEdge(result, frame);
+         assertTrue("frame " + frame + " should remain visible", hasAlpha(result, frame, false));
+         assertTrue("frame " + frame + " should retain soft alpha", hasIntermediateAlpha(result, frame));
       }
+      assertZeroAlphaHasZeroRgb(result.image);
+   }
+
+   @Test
+   public void keepsFramesIndependent() {
+      BufferedImage source = new BufferedImage(64, 8, BufferedImage.TYPE_INT_ARGB);
+      source.setRGB(4, 4, 0xFFFFFFFF);
+      MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
+      assertTrue(hasAlpha(result, 0, false));
+      for(int frame = 1; frame < 8; ++frame) {
+         assertFalse("frame " + frame + " copied neighboring alpha", hasAlpha(result, frame, false));
+      }
+   }
+
+   @Test
+   public void centeredPixelCoverageDoesNotReachFrameBorder() {
+      BufferedImage source = new BufferedImage(64, 8, BufferedImage.TYPE_INT_ARGB);
+      for(int frame = 0; frame < 8; ++frame) source.setRGB(frame * 8 + 4, 4, 0xFFFFFFFF);
+      MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
+      for(int frame = 0; frame < 8; ++frame) {
+         assertTransparentGutterAndContentEdge(result, frame);
+         assertTrue(hasAlpha(result, frame, false));
+      }
+   }
+
+   @Test
+   public void sourceEdgeCoverageStillGetsTransparentOutputBorder() {
+      BufferedImage source = new BufferedImage(64, 8, BufferedImage.TYPE_INT_ARGB);
+      for(int frame = 0; frame < 8; ++frame) {
+         for(int y = 0; y < 8; ++y) {
+            source.setRGB(frame * 8, y, 0xFFFFFFFF);
+            source.setRGB(frame * 8 + 7, y, 0xFFFFFFFF);
+         }
+      }
+      MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
+      for(int frame = 0; frame < 8; ++frame) assertTransparentGutterAndContentEdge(result, frame);
    }
 
    @Test
@@ -52,13 +85,49 @@ public class MCH_ParticleTextureProcessorTest {
       MCH_ParticleTextureProcessor.readAndProcess(null);
    }
 
-   private static boolean hasIntermediateAlpha(BufferedImage image) {
-      for(int y = 0; y < image.getHeight(); ++y) {
-         for(int x = 0; x < image.getWidth(); ++x) {
-            int alpha = image.getRGB(x, y) >>> 24;
-            if(alpha > 0 && alpha < 255) return true;
+   private static void assertTransparentGutterAndContentEdge(MCH_ParticleTextureProcessor.Result result, int frame) {
+      int cellStart = frame * result.cellWidth;
+      int contentStartX = cellStart + result.padding;
+      int contentEndX = cellStart + result.cellWidth - result.padding - 1;
+      int contentStartY = result.padding;
+      int contentEndY = result.cellHeight - result.padding - 1;
+      for(int y = 0; y < result.cellHeight; ++y) {
+         for(int x = cellStart; x < cellStart + result.cellWidth; ++x) {
+            boolean gutter = x < contentStartX || x > contentEndX || y < contentStartY || y > contentEndY;
+            boolean contentEdge = x == contentStartX || x == contentEndX || y == contentStartY || y == contentEndY;
+            if(gutter || contentEdge) {
+               assertEquals("nontransparent frame border at " + x + "," + y, 0,
+                  result.image.getRGB(x, y));
+            }
+         }
+      }
+      assertEquals(0, result.image.getRGB(cellStart, 0));
+      assertEquals(0, result.image.getRGB(cellStart + result.cellWidth - 1, 0));
+      assertEquals(0, result.image.getRGB(cellStart, result.cellHeight - 1));
+      assertEquals(0, result.image.getRGB(cellStart + result.cellWidth - 1, result.cellHeight - 1));
+   }
+
+   private static boolean hasAlpha(MCH_ParticleTextureProcessor.Result result, int frame, boolean intermediateOnly) {
+      int start = frame * result.cellWidth;
+      for(int y = 0; y < result.cellHeight; ++y) {
+         for(int x = start; x < start + result.cellWidth; ++x) {
+            int alpha = result.image.getRGB(x, y) >>> 24;
+            if(intermediateOnly ? alpha > 0 && alpha < 255 : alpha > 0) return true;
          }
       }
       return false;
+   }
+
+   private static boolean hasIntermediateAlpha(MCH_ParticleTextureProcessor.Result result, int frame) {
+      return hasAlpha(result, frame, true);
+   }
+
+   private static void assertZeroAlphaHasZeroRgb(BufferedImage image) {
+      for(int y = 0; y < image.getHeight(); ++y) {
+         for(int x = 0; x < image.getWidth(); ++x) {
+            int argb = image.getRGB(x, y);
+            if((argb >>> 24) == 0) assertEquals(0, argb);
+         }
+      }
    }
 }


### PR DESCRIPTION
### Motivation
- The runtime reconstruction produced low nonzero alpha around each crunched `64x8` smoke frame because ARGB bicubic scaling and an earlier luminance floor created haze that was sampled by UVs excluding transparent padding, revealing a translucent square behind soft smoke.
- The intent is to keep the compact `64x8` resource and the runtime reconstruction while removing visible rectangular artifacts without changing particle behavior or server-side logic.

### Description
- Replaced ARGB bicubic frame scaling with per-frame alpha coverage extraction and bilinear scaling, applied a silhouette-limited blur, removed very small haze values, renormalized retained coverage, and forced zero-alpha pixels to `0x00000000` in `src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java`.
- Increased the transparent gutter to two pixels, forced every outer content-edge pixel to alpha zero, stored white RGB only when alpha > 0, and adjusted UV math to sample complete frame cells with half-texel insets in `src/main/java/mcheli/particles/MCH_ParticleTexture.java`.
- Preserved normal blending (`GL_SRC_ALPHA`, `GL_ONE_MINUS_SRC_ALPHA`), added a minimal alpha-test guard of `1/255` while saving and restoring prior alpha-test, blend, lighting, culling, color, and texture state for the smoke renderer in `src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java`.
- Added image-only regression tests validating the bundled `64x8` texture, transparent gutters/corners/content edges, intermediate alpha preservation, frame isolation, and zero-alpha RGB in `src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java`, and documented the change in `CHANGELOG.md`.

Key documented parameters: cutoff `alpha <= 4/255`; gutter `2` pixels per side; generated atlas `288x36` (eight 36x36 cells containing 32x32 content).

Files changed: `src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java`, `src/main/java/mcheli/particles/MCH_ParticleTexture.java`, `src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java`, `src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java`, `CHANGELOG.md`.

### Testing
- Ran `git diff --check` which passed on the modified files.
- Executed a source-only Python PNG coverage audit that decoded the bundled `smoke.png` and reproduced the reconstruction logic; the audit confirmed every processed frame has a fully transparent gutter and content edges, frames remain visible and contain intermediate alpha, and zero-alpha pixels use zero RGB.
- Added JUnit image-only tests to exercise the real `64x8` asset, isolation, and edge cases; these tests are present under `src/test/java/...` but were not executed here because building/running Gradle/JUnit and launching a Forge client were not performed in this environment per constraints.
- No runtime Forge/GL client rendering, resource-reload leak checks, dedicated-server startup, or performance comparisons were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a695a28350c83238e5a4445ef850aa0)