### PR TITLE
Fix binary smoke density reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## PR #568 - Binary-density Smoke Reconstruction
+
+- Confirmed that PR #567 enlarged the bundled texture's binary-alpha density samples before a zero-skipping blur, producing block-shaped alpha in the generated atlas even though the renderer correctly bound it.
+- Reconstruct each 8 by 8 frame independently by padding and Gaussian-blurring its low-resolution density field (radius 2, sigma 1.0), globally normalizing all eight frames, applying gamma 0.8, and only then bilinearly scaling into the 288 by 36 atlas.
+- Added opt-in generated-atlas dumping with `-Dmcheli.debugParticleAtlas=true`, reconstruction diagnostics, clamped half-texel frame UVs, and image-only regressions for source alpha, soft gaps, global fade, transparent gutters, frame isolation, and clean transparent RGB.
+
 ## Fix Reconstructed Smoke Particle Backgrounds
 
 - Removed reconstruction haze by scaling per-frame alpha coverage instead of bicubic ARGB, applying a silhouette-limited blur, discarding alpha at or below 4/255, and renormalizing the retained soft coverage.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,6 +5,8 @@ def localDevMods = fileTree("devmods") {
 }
 
 dependencies {
+    testImplementation "junit:junit:4.13.2"
+
     devOnlyNonPublishable "com.github.GTNewHorizons:CodeChickenCore:1.4.16:dev"
     devOnlyNonPublishable "com.github.GTNewHorizons:NotEnoughItems:2.8.114-GTNH:dev"
 

--- a/src/main/java/mcheli/particles/MCH_ParticleTexture.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleTexture.java
@@ -3,7 +3,9 @@ package mcheli.particles;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.InputStream;
+import javax.imageio.ImageIO;
 import mcheli.MCH_Lib;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.DynamicTexture;
@@ -40,6 +42,7 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
 
    public static float minU(int frame) {
       INSTANCE.ensureLoaded();
+      frame = clampFrame(frame);
       if(INSTANCE.result == null) return frame / 8.0F;
       if(!INSTANCE.result.processed) {
          return (frame + 0.5F / INSTANCE.result.cellWidth) / 8.0F;
@@ -49,6 +52,7 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
 
    public static float maxU(int frame) {
       INSTANCE.ensureLoaded();
+      frame = clampFrame(frame);
       if(INSTANCE.result == null) return (frame + 1) / 8.0F;
       if(!INSTANCE.result.processed) {
          return (frame + 1.0F - 0.5F / INSTANCE.result.cellWidth) / 8.0F;
@@ -71,6 +75,10 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
          : 1.0F - 0.5F / INSTANCE.result.cellHeight;
    }
 
+   private static int clampFrame(int frame) {
+      return Math.max(0, Math.min(MCH_ParticleTextureProcessor.FRAME_COUNT - 1, frame));
+   }
+
    private void ensureLoaded() {
       if(loaded) return;
       loaded = true;
@@ -86,11 +94,14 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
          if(result.processed) {
             TextureManager manager = Minecraft.getMinecraft().getTextureManager();
             texture = manager.getDynamicTextureLocation("mcheli_soft_smoke", new LinearDynamicTexture(result.image));
+            if(Boolean.getBoolean("mcheli.debugParticleAtlas")) dumpAtlas(result.image);
          } else {
             texture = SOURCE;
          }
-         MCH_Lib.Log("Particle smoke texture %s: source/result %dx%d, atlas %dx%d.",
-            result.processed ? "processed" : "used directly", width, height, result.image.getWidth(), result.image.getHeight());
+         MCH_Lib.Log("Particle smoke texture: source %dx%d, atlas %dx%d, path=%s, blur radius=%d, sigma=%.2f, gamma=%.2f, normalization=%.6f.",
+            width, height, result.image.getWidth(), result.image.getHeight(), result.reconstructionPath,
+            MCH_ParticleTextureProcessor.BLUR_RADIUS, MCH_ParticleTextureProcessor.BLUR_SIGMA,
+            MCH_ParticleTextureProcessor.GAMMA, result.normalizationReference);
       } catch(Exception error) {
          texture = SOURCE;
          result = null;
@@ -100,6 +111,17 @@ public final class MCH_ParticleTexture implements IResourceManagerReloadListener
          }
       } finally {
          if(stream != null) try { stream.close(); } catch(Exception ignored) {}
+      }
+   }
+
+   private static void dumpAtlas(BufferedImage image) {
+      File output = new File(Minecraft.getMinecraft().mcDataDir, "mcheli-debug-particle-atlas.png");
+      try {
+         ImageIO.write(image, "png", output);
+         MCH_Lib.Log("Particle smoke generated atlas written to %s", output.getAbsolutePath());
+      } catch(Exception error) {
+         MCH_Lib.Log("Particle smoke generated atlas could not be written to %s: %s",
+            output.getAbsolutePath(), error.toString());
       }
    }
 

--- a/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
@@ -8,12 +8,15 @@ import javax.imageio.ImageIO;
 /** Pure image conversion for the smoke atlas. This class deliberately has no Minecraft or GL dependencies. */
 public final class MCH_ParticleTextureProcessor {
    public static final int FRAME_COUNT = 8;
+   public static final int BLUR_RADIUS = 2;
+   public static final double BLUR_SIGMA = 1.0D;
+   public static final double GAMMA = 0.8D;
+   public static final String BINARY_DENSITY = "binary-density reconstruction";
+   public static final String DIRECT_USE = "direct use";
    private static final int MIN_FRAME_SIZE = 32;
    private static final int MAX_FRAME_SIZE = 128;
-   /** Two texels keep a filtered frame sample isolated from the next frame. */
-   private static final int PADDING = 2;
-   /** Values at or below 4/255 are reconstruction haze, rather than visible smoke coverage. */
-   private static final int ALPHA_CUTOFF = 4;
+   private static final int SOURCE_PADDING = 2;
+   private static final int OUTPUT_PADDING = 2;
 
    private MCH_ParticleTextureProcessor() {}
 
@@ -31,136 +34,150 @@ public final class MCH_ParticleTextureProcessor {
       }
       int frameWidth = source.getWidth() / FRAME_COUNT;
       int frameHeight = source.getHeight();
-      if(frameWidth <= 0 || frameHeight <= 0) {
-         throw new IllegalArgumentException("source has an empty animation frame");
-      }
+      if(frameWidth <= 0 || frameHeight <= 0) throw new IllegalArgumentException("source has an empty animation frame");
 
-      boolean usefulAlpha = hasIntermediateAlpha(source);
-      if(frameWidth >= MIN_FRAME_SIZE && frameHeight >= MIN_FRAME_SIZE && usefulAlpha) {
-         return new Result(source, false, frameWidth, frameHeight, 0, source.getWidth(), source.getHeight());
+      if(hasIntermediateAlpha(source)) {
+         return new Result(source, false, DIRECT_USE, frameWidth, frameHeight, 0,
+            source.getWidth(), source.getHeight(), 0.0D);
       }
 
       int contentWidth = Math.min(MAX_FRAME_SIZE, Math.max(MIN_FRAME_SIZE, frameWidth));
       int contentHeight = Math.min(MAX_FRAME_SIZE, Math.max(MIN_FRAME_SIZE, frameHeight));
-      int cellWidth = contentWidth + PADDING * 2;
-      int cellHeight = contentHeight + PADDING * 2;
-      BufferedImage atlas = new BufferedImage(cellWidth * FRAME_COUNT, cellHeight, BufferedImage.TYPE_INT_ARGB);
+      int cellWidth = contentWidth + OUTPUT_PADDING * 2;
+      int cellHeight = contentHeight + OUTPUT_PADDING * 2;
+      int fieldWidth = frameWidth + SOURCE_PADDING * 2;
+      int fieldHeight = frameHeight + SOURCE_PADDING * 2;
+      double[][] fields = new double[FRAME_COUNT][];
+      double normalizationReference = 0.0D;
 
+      // Binary alpha is a low-resolution density sampling pattern, not a finished silhouette.
+      // Blur radius 2 and sigma 1.0 merge nearby samples without rounding away the irregular outline.
+      double[] kernel = gaussianKernel(BLUR_RADIUS, BLUR_SIGMA);
       for(int frame = 0; frame < FRAME_COUNT; ++frame) {
-         int[] sourceCoverage = extractCoverage(source, frame * frameWidth, frameWidth, frameHeight);
-         int[] coverage = scaleBilinear(sourceCoverage, frameWidth, frameHeight, contentWidth, contentHeight);
-         blurInsideSilhouette(coverage, contentWidth, contentHeight);
-         finishCoverage(coverage, contentWidth, contentHeight);
-         for(int y = 0; y < contentHeight; ++y) {
-            for(int x = 0; x < contentWidth; ++x) {
-               int alpha = coverage[y * contentWidth + x];
-               int argb = alpha == 0 ? 0x00000000 : alpha << 24 | 0x00FFFFFF;
-               atlas.setRGB(frame * cellWidth + PADDING + x, PADDING + y, argb);
+         double[] density = new double[fieldWidth * fieldHeight];
+         for(int y = 0; y < frameHeight; ++y) {
+            for(int x = 0; x < frameWidth; ++x) {
+               if((source.getRGB(frame * frameWidth + x, y) >>> 24) != 0) {
+                  density[(y + SOURCE_PADDING) * fieldWidth + x + SOURCE_PADDING] = 1.0D;
+               }
+            }
+         }
+         fields[frame] = gaussianBlur(density, fieldWidth, fieldHeight, kernel, BLUR_RADIUS);
+         for(double value : fields[frame]) normalizationReference = Math.max(normalizationReference, value);
+      }
+
+      BufferedImage atlas = new BufferedImage(cellWidth * FRAME_COUNT, cellHeight, BufferedImage.TYPE_INT_ARGB);
+      for(int frame = 0; frame < FRAME_COUNT; ++frame) {
+         double[] opacity = new double[fields[frame].length];
+         if(normalizationReference > 0.0D) {
+            for(int i = 0; i < opacity.length; ++i) {
+               opacity[i] = Math.pow(fields[frame][i] / normalizationReference, GAMMA);
+            }
+         }
+         double[] scaled = scaleBilinear(opacity, fieldWidth, fieldHeight, cellWidth, cellHeight);
+         for(int y = 0; y < cellHeight; ++y) {
+            for(int x = 0; x < cellWidth; ++x) {
+               int alpha = clamp((int)Math.round(scaled[y * cellWidth + x] * 255.0D));
+               if(x < OUTPUT_PADDING || x >= cellWidth - OUTPUT_PADDING ||
+                  y < OUTPUT_PADDING || y >= cellHeight - OUTPUT_PADDING || alpha <= 1) alpha = 0;
+               atlas.setRGB(frame * cellWidth + x, y, alpha == 0 ? 0x00000000 : alpha << 24 | 0x00FFFFFF);
             }
          }
       }
-      return new Result(atlas, true, cellWidth, cellHeight, PADDING, source.getWidth(), source.getHeight());
+      return new Result(atlas, true, BINARY_DENSITY, cellWidth, cellHeight, OUTPUT_PADDING,
+         source.getWidth(), source.getHeight(), normalizationReference);
    }
 
    private static boolean hasIntermediateAlpha(BufferedImage image) {
-      for(int y = 0; y < image.getHeight(); ++y) {
-         for(int x = 0; x < image.getWidth(); ++x) {
-            int alpha = image.getRGB(x, y) >>> 24;
-            if(alpha > 0 && alpha < 255) return true;
-         }
+      for(int y = 0; y < image.getHeight(); ++y) for(int x = 0; x < image.getWidth(); ++x) {
+         int alpha = image.getRGB(x, y) >>> 24;
+         if(alpha > 0 && alpha < 255) return true;
       }
       return false;
    }
 
-   private static int[] extractCoverage(BufferedImage source, int startX, int width, int height) {
-      int[] coverage = new int[width * height];
-      for(int y = 0; y < height; ++y) {
-         for(int x = 0; x < width; ++x) {
-            int argb = source.getRGB(startX + x, y);
-            int alpha = argb >>> 24;
-            if(alpha == 0) continue;
-            // Alpha is coverage. In particular, binary-alpha crunches must not turn incidental RGB into haze.
-            coverage[y * width + x] = alpha;
-         }
+   private static double[] gaussianKernel(int radius, double sigma) {
+      double[] kernel = new double[radius * 2 + 1];
+      double sum = 0.0D;
+      for(int offset = -radius; offset <= radius; ++offset) {
+         double value = Math.exp(-(offset * offset) / (2.0D * sigma * sigma));
+         kernel[offset + radius] = value;
+         sum += value;
       }
-      return coverage;
+      for(int i = 0; i < kernel.length; ++i) kernel[i] /= sum;
+      return kernel;
    }
 
-   private static int[] scaleBilinear(int[] source, int sourceWidth, int sourceHeight,
-      int width, int height) {
-      int[] scaled = new int[width * height];
+   private static double[] gaussianBlur(double[] source, int width, int height, double[] kernel, int radius) {
+      double[] horizontal = new double[source.length];
+      double[] result = new double[source.length];
+      for(int y = 0; y < height; ++y) for(int x = 0; x < width; ++x) {
+         double sum = 0.0D;
+         for(int offset = -radius; offset <= radius; ++offset) {
+            int sampleX = x + offset;
+            if(sampleX >= 0 && sampleX < width) sum += source[y * width + sampleX] * kernel[offset + radius];
+         }
+         horizontal[y * width + x] = sum;
+      }
+      for(int y = 0; y < height; ++y) for(int x = 0; x < width; ++x) {
+         double sum = 0.0D;
+         for(int offset = -radius; offset <= radius; ++offset) {
+            int sampleY = y + offset;
+            if(sampleY >= 0 && sampleY < height) sum += horizontal[sampleY * width + x] * kernel[offset + radius];
+         }
+         result[y * width + x] = sum;
+      }
+      return result;
+   }
+
+   private static double[] scaleBilinear(double[] source, int sourceWidth, int sourceHeight, int width, int height) {
+      double[] scaled = new double[width * height];
       for(int y = 0; y < height; ++y) {
-         float sourceY = ((y + 0.5F) * sourceHeight / height) - 0.5F;
-         int y0 = Math.max(0, (int)Math.floor(sourceY));
-         int y1 = Math.min(sourceHeight - 1, y0 + 1);
-         float fy = Math.max(0.0F, sourceY - y0);
+         double sourceY = (y + 0.5D) * sourceHeight / height - 0.5D;
+         int y0 = (int)Math.floor(sourceY);
+         double fy = sourceY - y0;
          for(int x = 0; x < width; ++x) {
-            float sourceX = ((x + 0.5F) * sourceWidth / width) - 0.5F;
-            int x0 = Math.max(0, (int)Math.floor(sourceX));
-            int x1 = Math.min(sourceWidth - 1, x0 + 1);
-            float fx = Math.max(0.0F, sourceX - x0);
-            float top = source[y0 * sourceWidth + x0] * (1.0F - fx) + source[y0 * sourceWidth + x1] * fx;
-            float bottom = source[y1 * sourceWidth + x0] * (1.0F - fx) + source[y1 * sourceWidth + x1] * fx;
-            scaled[y * width + x] = clamp(Math.round(top * (1.0F - fy) + bottom * fy));
+            double sourceX = (x + 0.5D) * sourceWidth / width - 0.5D;
+            int x0 = (int)Math.floor(sourceX);
+            double fx = sourceX - x0;
+            double top = sample(source, sourceWidth, sourceHeight, x0, y0) * (1.0D - fx) +
+               sample(source, sourceWidth, sourceHeight, x0 + 1, y0) * fx;
+            double bottom = sample(source, sourceWidth, sourceHeight, x0, y0 + 1) * (1.0D - fx) +
+               sample(source, sourceWidth, sourceHeight, x0 + 1, y0 + 1) * fx;
+            scaled[y * width + x] = top * (1.0D - fy) + bottom * fy;
          }
       }
       return scaled;
    }
 
-   private static void blurInsideSilhouette(int[] alpha, int width, int height) {
-      int[] original = alpha.clone();
-      for(int y = 1; y < height - 1; ++y) {
-         for(int x = 1; x < width - 1; ++x) {
-            int index = y * width + x;
-            if(original[index] == 0) continue;
-            int sum = 0;
-            for(int offsetY = -1; offsetY <= 1; ++offsetY) {
-               for(int offsetX = -1; offsetX <= 1; ++offsetX) {
-                  int weight = offsetX == 0 && offsetY == 0 ? 4 :
-                     (offsetX == 0 || offsetY == 0 ? 2 : 1);
-                  sum += original[index + offsetY * width + offsetX] * weight;
-               }
-            }
-            alpha[index] = clamp((sum + 8) / 16);
-         }
-      }
+   private static double sample(double[] source, int width, int height, int x, int y) {
+      return x < 0 || x >= width || y < 0 || y >= height ? 0.0D : source[y * width + x];
    }
 
-   private static void finishCoverage(int[] alpha, int width, int height) {
-      for(int y = 0; y < height; ++y) {
-         for(int x = 0; x < width; ++x) {
-            int index = y * width + x;
-            if(x == 0 || y == 0 || x == width - 1 || y == height - 1 || alpha[index] <= ALPHA_CUTOFF) {
-               alpha[index] = 0;
-            } else {
-               alpha[index] = clamp((alpha[index] - ALPHA_CUTOFF) * 255 / (255 - ALPHA_CUTOFF));
-            }
-         }
-      }
-   }
-
-   private static int clamp(int value) {
-      return Math.max(0, Math.min(255, value));
-   }
+   private static int clamp(int value) { return Math.max(0, Math.min(255, value)); }
 
    public static final class Result {
       public final BufferedImage image;
       public final boolean processed;
+      public final String reconstructionPath;
       public final int cellWidth;
       public final int cellHeight;
       public final int padding;
       public final int sourceWidth;
       public final int sourceHeight;
+      public final double normalizationReference;
 
-      private Result(BufferedImage image, boolean processed, int cellWidth, int cellHeight, int padding,
-         int sourceWidth, int sourceHeight) {
+      private Result(BufferedImage image, boolean processed, String reconstructionPath, int cellWidth, int cellHeight,
+         int padding, int sourceWidth, int sourceHeight, double normalizationReference) {
          this.image = image;
          this.processed = processed;
+         this.reconstructionPath = reconstructionPath;
          this.cellWidth = cellWidth;
          this.cellHeight = cellHeight;
          this.padding = padding;
          this.sourceWidth = sourceWidth;
          this.sourceHeight = sourceHeight;
+         this.normalizationReference = normalizationReference;
       }
    }
 }

--- a/src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java
+++ b/src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java
@@ -12,6 +12,15 @@ public class MCH_ParticleTextureProcessorTest {
    public void processesBundledSmokeWithTransparentFrameBorders() throws IOException {
       InputStream stream = getClass().getResourceAsStream("/assets/mcheli/textures/particles/smoke.png");
       assertNotNull(stream);
+      BufferedImage source = javax.imageio.ImageIO.read(stream);
+      assertEquals(64, source.getWidth());
+      assertEquals(8, source.getHeight());
+      for(int x = 0; x < source.getWidth(); ++x) for(int y = 0; y < source.getHeight(); ++y) {
+         int alpha = source.getRGB(x, y) >>> 24;
+         assertTrue("source alpha must be binary", alpha == 0 || alpha == 255);
+      }
+      stream.close();
+      stream = getClass().getResourceAsStream("/assets/mcheli/textures/particles/smoke.png");
       MCH_ParticleTextureProcessor.Result result;
       try {
          result = MCH_ParticleTextureProcessor.readAndProcess(stream);
@@ -20,6 +29,7 @@ public class MCH_ParticleTextureProcessorTest {
       }
 
       assertTrue(result.processed);
+      assertEquals(MCH_ParticleTextureProcessor.BINARY_DENSITY, result.reconstructionPath);
       assertEquals(2, result.padding);
       assertEquals(288, result.image.getWidth());
       assertEquals(36, result.image.getHeight());
@@ -28,7 +38,24 @@ public class MCH_ParticleTextureProcessorTest {
          assertTrue("frame " + frame + " should remain visible", hasAlpha(result, frame, false));
          assertTrue("frame " + frame + " should retain soft alpha", hasIntermediateAlpha(result, frame));
       }
+      assertTrue("first frame should be denser than final frame", alphaSum(result, 0) > alphaSum(result, 7));
+      assertTrue("final frame must not be independently normalized", maxAlpha(result, 7) < maxAlpha(result, 0));
       assertZeroAlphaHasZeroRgb(result.image);
+   }
+
+   @Test
+   public void blursBinarySamplesBeforeScaling() {
+      BufferedImage source = new BufferedImage(64, 8, BufferedImage.TYPE_INT_ARGB);
+      source.setRGB(2, 4, 0xFFFFFFFF);
+      source.setRGB(4, 4, 0xFFFFFFFF);
+      MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
+      int centerY = result.cellHeight / 2;
+      int left = alpha(result.image, 11, centerY);
+      int gap = alpha(result.image, 15, centerY);
+      int right = alpha(result.image, 20, centerY);
+      assertTrue("transparent source gap should receive blurred coverage", gap > 1);
+      assertTrue("nearby samples should merge into a continuous gradient", left > 0 && right > 0);
+      assertNotEquals("a source sample must not become a flat enlarged square", left, alpha(result.image, 12, centerY));
    }
 
    @Test
@@ -72,6 +99,7 @@ public class MCH_ParticleTextureProcessorTest {
       source.setRGB(0, 0, 0x80FFFFFF);
       MCH_ParticleTextureProcessor.Result result = MCH_ParticleTextureProcessor.process(source);
       assertFalse(result.processed);
+      assertEquals(MCH_ParticleTextureProcessor.DIRECT_USE, result.reconstructionPath);
       assertSame(source, result.image);
    }
 
@@ -129,5 +157,27 @@ public class MCH_ParticleTextureProcessorTest {
             if((argb >>> 24) == 0) assertEquals(0, argb);
          }
       }
+   }
+
+   private static int alpha(BufferedImage image, int x, int y) {
+      return image.getRGB(x, y) >>> 24;
+   }
+
+   private static long alphaSum(MCH_ParticleTextureProcessor.Result result, int frame) {
+      long sum = 0L;
+      int start = frame * result.cellWidth;
+      for(int y = 0; y < result.cellHeight; ++y) for(int x = start; x < start + result.cellWidth; ++x) {
+         sum += result.image.getRGB(x, y) >>> 24;
+      }
+      return sum;
+   }
+
+   private static int maxAlpha(MCH_ParticleTextureProcessor.Result result, int frame) {
+      int maximum = 0;
+      int start = frame * result.cellWidth;
+      for(int y = 0; y < result.cellHeight; ++y) for(int x = start; x < start + result.cellWidth; ++x) {
+         maximum = Math.max(maximum, result.image.getRGB(x, y) >>> 24);
+      }
+      return maximum;
    }
 }


### PR DESCRIPTION
### Motivation

- The bundled `64×8` smoke source uses eight `8×8` binary-alpha frames that represent dithered density samples, and the previous reconstruction upscaled those binary pixels before smoothing, producing enlarged blocky alpha in the generated atlas rather than a continuous soft cloud.
- The change implements a correct reconstruction path for binary-alpha particle textures while preserving the direct-use path for textures that already contain useful intermediate alpha.

### Description

- Added a dedicated binary-density reconstruction path in `MCH_ParticleTextureProcessor.java` that: pads each `8×8` frame in source-space, treats opaque source pixels as single density samples, applies a separable Gaussian blur (radius `2`, sigma `1.0`) in source-space, computes a single global normalization reference across all eight frames, applies a gamma curve (`0.8`), then bilinearly scales into the final per-frame cell and writes an isolated atlas with two-pixel transparent gutters and forced transparent corners and RGB-zero for zero-alpha pixels.
- Kept the direct-use bypass when the source contains intermediate alpha and otherwise generate an ARGB atlas below the 1MB target (resulting atlas: `288×36`). The reconstruction path string (`"binary-density reconstruction"`) or `"direct use"` is exposed via `Result.reconstructionPath`.
- Updated runtime texture handling in `MCH_ParticleTexture.java` to clamp requested frame indices to `0..7`, to log reconstruction diagnostics (source/atlas sizes, path, blur radius/sigma, gamma, normalization reference) and to optionally dump the generated atlas when the JVM property `-Dmcheli.debugParticleAtlas=true` is present (dump is written under the game directory and is logged). The dynamic texture upload still uses the existing ARGB upload path.
- Expanded image-only unit tests in `src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java` to validate the real bundled `64×8` texture is binary-alpha, that the binary-density path is selected, that gutters/corners remain transparent, that adjacent source samples merge into smooth coverage, that per-frame isolation is preserved, and that later frames are not normalized independently to full opacity.
- Declared the JUnit 4 test dependency in `dependencies.gradle` and recorded the change and reasoning in `CHANGELOG.md`.

Files changed:
- `src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java`
- `src/main/java/mcheli/particles/MCH_ParticleTexture.java`
- `src/test/java/mcheli/particles/MCH_ParticleTextureProcessorTest.java`
- `dependencies.gradle`
- `CHANGELOG.md`

### Testing

- `./gradlew compileJava --no-configuration-cache` completed successfully (main compilation passed).
- Static checks: `git diff --check` passed in the working tree.
- JShell image inspection executed in-process verified the bundled `smoke.png` frames are 8×8 binary-alpha, that the processor selected the binary-density path, produced a `288×36` atlas, computed a global normalization reference (~`0.744670` in this run), and showed per-frame declining alpha sums and a final-frame maximum alpha well below 255 (i.e. not independently normalized). These observations confirm the reconstruction behaves as specified in-source.
- `./gradlew test --tests mcheli.particles.MCH_ParticleTextureProcessorTest --no-configuration-cache` could not run in this environment because Gradle failed to resolve `junit:junit:4.13.2` from the configured repositories (HTTP 403 responses); this is an environment/repository access issue rather than a test code failure in the module.
- `./gradlew build --no-configuration-cache` progressed through assemble/reobf/jar tasks but stopped at `compileTestJava` for the same JUnit resolution issue described above.

Notes and runtime options

- To dump the generated atlas for manual inspection, run the client (or otherwise trigger `MCH_ParticleTexture.ensureLoaded()`) with the JVM property: `-Dmcheli.debugParticleAtlas=true` and check the logged path under the game directory.
- Manual visual verification in a Forge client (resource reload, spawn smoke, inspect against sky/terrain/overlap) should be performed in a live environment; that step was not possible in this non-interactive execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6964208180832393268a47e2fd0dde)