### PR TITLE
Fix three-second vehicle dismount handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Fix Three-Second Vehicle Dismount
+
+- Blocked Minecraft's built-in instant Sneak dismount while riding MCHeli vehicles and seats, then restored normal dismount handling only after Sneak has been held continuously for three seconds.
+- Applied the delay to the configured Minecraft Sneak key instead of a hard-coded Left Shift key and clarified the control documentation.
+
 ## PR #568 - Binary-density Smoke Reconstruction
 
 - Confirmed that PR #567 enlarged the bundled texture's binary-alpha density samples before a zero-skipping blur, producing block-shaped alpha in the generated atlas even though the renderer correctly bound it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ The config stores key codes rather than names. Common defaults:
 | Switch weapon mode | `KeySwitchWeaponMode` | X |
 | Zoom | `KeyZoom` | Z |
 | Camera mode | `KeyCameraMode` | C |
-| Dismount vehicle | Fixed control | Hold Left Shift for 3 seconds |
+| Dismount vehicle | Minecraft Sneak control | Hold the configured Sneak key for 3 seconds (Left Shift by default) |
 | Dismount mob/crew action | `KeyUnmountMob` | Y |
 | Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
 | Extra function | `KeyExtra` | F |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -42,6 +42,7 @@ import mcheli.wrapper.W_TickHandler;
 import mcheli.wrapper.W_Vec3;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.Entity;
@@ -57,6 +58,9 @@ import mcheli.ship.MCH_GuiShip;
 //Eventhooks, clientproxy, tickhandler, guis and config just to name a few inheritors
 @SideOnly(Side.CLIENT)
 public class MCH_ClientCommonTickHandler extends W_TickHandler {
+
+   /** Three seconds at Minecraft's normal 20 player ticks per second. */
+   private static final int DISMOUNT_HOLD_TICKS = 60;
 
    public static MCH_ClientCommonTickHandler instance;
    public MCH_GuiCommon gui_Common;
@@ -95,6 +99,8 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private static double mouseRollDeltaY = 0.0D;
    private static boolean isRideAircraft = false;
    private static float prevTick = 0.0F;
+   private int dismountHoldTicks;
+   private boolean suppressedDismountKey;
 
 
 
@@ -240,6 +246,47 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          MCH_GuiTargetMarker.onClientTick();
       }
       MCH_PlayerViewHandler.onUpdate();
+   }
+
+   /**
+    * Prevent vanilla's mounted-player update from seeing Sneak until it has been held long
+    * enough. Sending a delayed MCHeli unmount packet alone is insufficient because vanilla
+    * dismounts the local player immediately when the Sneak key reaches its movement input.
+    */
+   @Override
+   public void onPlayerTickPre(EntityPlayer player) {
+      if(player != super.mc.thePlayer) {
+         return;
+      }
+
+      boolean ridingVehicle = player.ridingEntity instanceof MCH_EntityBaseVehicle
+            || player.ridingEntity instanceof MCH_EntitySeat;
+      boolean dismountKeyPressed = MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak);
+
+      if(!ridingVehicle || !dismountKeyPressed) {
+         this.dismountHoldTicks = 0;
+         this.suppressedDismountKey = false;
+         return;
+      }
+
+      if(this.dismountHoldTicks < DISMOUNT_HOLD_TICKS) {
+         ++this.dismountHoldTicks;
+      }
+
+      if(this.dismountHoldTicks < DISMOUNT_HOLD_TICKS) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(), false);
+         player.movementInput.sneak = false;
+         this.suppressedDismountKey = true;
+      }
+   }
+
+   @Override
+   public void onPlayerTickPost(EntityPlayer player) {
+      if(player == super.mc.thePlayer && this.suppressedDismountKey) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(),
+               MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak));
+         this.suppressedDismountKey = false;
+      }
    }
 
    public static double getCurrentStickX() {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -16,9 +16,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import org.lwjgl.input.Keyboard;
 
 public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHandlerBase {
-   /** Three seconds at Minecraft's 20 client ticks per second. */
-   private static final int DISMOUNT_HOLD_TICKS = 60;
-
    protected boolean isRiding = false;
 
    protected boolean isBeforeRiding = false;
@@ -61,8 +58,6 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
 
    public MCH_Key KeyBrake;
    public MCH_Key KeyCurrentWeaponLock;
-
-   private int unmountForceHoldTicks;
 
    /**
     * Chaff key
@@ -138,21 +133,6 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
          }
       }
       boolean send = false;
-
-      if(this.KeyUnmountForce.isKeyPress()) {
-         if(this.unmountForceHoldTicks < DISMOUNT_HOLD_TICKS) {
-            ++this.unmountForceHoldTicks;
-         }
-      } else {
-         this.unmountForceHoldTicks = 0;
-      }
-
-      if(this.unmountForceHoldTicks == DISMOUNT_HOLD_TICKS) {
-         pc.isUnmount = 1;
-         send = true;
-         // Do not send another dismount request until Shift is released and held again.
-         ++this.unmountForceHoldTicks;
-      }
 
       if (this.KeyCameraMode.isKeyDown())
          if (ac.haveSearchLight()) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -226,7 +226,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
             msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
             color = -256;
          } else {
-            msg = "Dismount : Hold Left Shift (3s)";
+            msg = "Dismount : Hold Sneak (3s)";
          }
 
          this.drawString(msg, LX, super.centerY - 30, color);


### PR DESCRIPTION
### Motivation

- The previous attempt to require holding a dismount key still allowed Minecraft's vanilla Sneak to instantaneously dismount players because vanilla processes the Sneak movement input earlier in the player-tick path. 
- The intent is to require the configured Sneak key to be held for three seconds (60 ticks) before the local player is actually dismounted, avoiding accidental dismounts.

### Description

- Removed the ineffective local `KeyUnmountForce` hold/unmount path and instead intercept the vanilla Sneak input at player-tick level by adding a 60-tick gate (`DISMOUNT_HOLD_TICKS`) and hold-state fields to `MCH_ClientCommonTickHandler`. 
- Implemented `onPlayerTickPre` / `onPlayerTickPost` overrides that suppress the configured Sneak key state and `player.movementInput.sneak` until the hold timer reaches `DISMOUNT_HOLD_TICKS`, then restore normal Sneak behavior. 
- Updated the HUD hint to `"Dismount : Hold Sneak (3s)"` and changed the getting-started docs to reference the configured Minecraft Sneak control instead of a hard-coded Left Shift. 
- Recorded the fix in `CHANGELOG.md` and removed the old per-handler unmount-hold counter from `MCH_BaseVehicleClientTickHandler` (the previous, ineffective approach). 

### Testing

- `python` source assertions were executed to verify the 60-tick gate, configured Sneak lookup, suppression of the vanilla key state and `movementInput.sneak`, and removal of the old immediate packet path, and all assertions passed. 
- `git diff --check` was run and reported no whitespace or patch errors. 
- A repository scan confirmed no binary assets were modified. 
- The changes were committed and a pull request titled `Fix three-second vehicle dismount handling` was created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a292dcbd88323a733c2bd1ebe4857)