### PR TITLE
Fix three-second MCHeli dismount hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Three-Second MCHeli Dismount
+
+- Require pilots and passengers to hold the configured Minecraft Sneak key for 60 continuous client ticks before requesting a server-authoritative dismount.
+- Prevent vanilla's mounted-player Sneak handling from dismounting early while leaving non-MCHeli mounts and unmounted sneaking unchanged.
+
 ## PR #568 - Binary-density Smoke Reconstruction
 
 - Confirmed that PR #567 enlarged the bundled texture's binary-alpha density samples before a zero-skipping blur, producing block-shaped alpha in the generated atlas even though the renderer correctly bound it.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ The config stores key codes rather than names. Common defaults:
 | Switch weapon mode | `KeySwitchWeaponMode` | X |
 | Zoom | `KeyZoom` | Z |
 | Camera mode | `KeyCameraMode` | C |
-| Dismount vehicle | Fixed control | Hold Left Shift for 3 seconds |
+| Dismount vehicle | Minecraft Sneak control | Hold the configured Sneak key for 3 seconds (Left Shift by default) |
 | Dismount mob/crew action | `KeyUnmountMob` | Y |
 | Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
 | Extra function | `KeyExtra` | F |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -44,11 +44,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.renderer.entity.RenderManager;
+import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
+import net.minecraft.world.World;
 import org.lwjgl.opengl.Display;
 import mcheli.ship.MCH_ClientShipTickHandler;
 import mcheli.ship.MCH_EntityShip;
@@ -57,6 +59,9 @@ import mcheli.ship.MCH_GuiShip;
 //Eventhooks, clientproxy, tickhandler, guis and config just to name a few inheritors
 @SideOnly(Side.CLIENT)
 public class MCH_ClientCommonTickHandler extends W_TickHandler {
+
+   /** Three seconds at Minecraft's normal 20 client ticks per second. */
+   public static final int DISMOUNT_HOLD_TICKS = 60;
 
    public static MCH_ClientCommonTickHandler instance;
    public MCH_GuiCommon gui_Common;
@@ -95,6 +100,13 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private static double mouseRollDeltaY = 0.0D;
    private static boolean isRideAircraft = false;
    private static float prevTick = 0.0F;
+   private int dismountHoldTicks;
+   private boolean dismountRequestPending;
+   private boolean suppressedDismountKey;
+   private Entity dismountMount;
+   private EntityClientPlayerMP dismountPlayer;
+   private World dismountWorld;
+   private Object dismountConnection;
 
 
 
@@ -230,7 +242,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
    public void onTickPre() {
       if(super.mc.thePlayer != null && super.mc.theWorld != null) {
+         this.updateDismountHoldState();
          this.onTick();
+      } else {
+         this.resetDismountHoldState();
       }
 
    }
@@ -850,6 +865,12 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onPlayerTickPre(EntityPlayer player) {
+      if(player == super.mc.thePlayer && this.isHoldingMCHeliDismount()) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(), false);
+         ((EntityClientPlayerMP)player).movementInput.sneak = false;
+         this.suppressedDismountKey = true;
+      }
+
       if(player.worldObj.isRemote) {
          ItemStack currentItemstack = player.getCurrentEquippedItem();
          if(currentItemstack != null && currentItemstack.getItem() instanceof MCH_ItemWrench && player.getItemInUseCount() > 0 && player.getItemInUse() != currentItemstack) {
@@ -863,7 +884,74 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
    }
 
-   public void onPlayerTickPost(EntityPlayer player) {}
+   public void onPlayerTickPost(EntityPlayer player) {
+      if(player == super.mc.thePlayer && this.suppressedDismountKey) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(),
+               MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak));
+         this.suppressedDismountKey = false;
+      }
+   }
+
+   private void updateDismountHoldState() {
+      EntityClientPlayerMP player = super.mc.thePlayer;
+      Entity mount = player.ridingEntity;
+      boolean mcheliMount = mount instanceof MCH_EntityBaseVehicle || mount instanceof MCH_EntitySeat;
+      boolean contextChanged = player != this.dismountPlayer || player.worldObj != this.dismountWorld
+            || player.sendQueue != this.dismountConnection || mount != this.dismountMount;
+
+      if(contextChanged) {
+         this.resetDismountHoldState();
+         this.dismountPlayer = player;
+         this.dismountWorld = player.worldObj;
+         this.dismountConnection = player.sendQueue;
+         this.dismountMount = mount;
+      }
+
+      boolean pressed = MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak);
+      if(!mcheliMount || super.mc.currentScreen != null || !pressed) {
+         this.dismountHoldTicks = 0;
+         this.dismountRequestPending = false;
+      } else if(this.dismountHoldTicks < DISMOUNT_HOLD_TICKS) {
+         ++this.dismountHoldTicks;
+         if(this.dismountHoldTicks == DISMOUNT_HOLD_TICKS) {
+            this.dismountRequestPending = true;
+         }
+      }
+
+      if(this.isHoldingMCHeliDismount()) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(), false);
+         player.movementInput.sneak = false;
+         this.suppressedDismountKey = true;
+      }
+   }
+
+   private boolean isHoldingMCHeliDismount() {
+      return this.dismountMount != null && this.dismountHoldTicks > 0
+            && this.dismountHoldTicks < DISMOUNT_HOLD_TICKS;
+   }
+
+   private void resetDismountHoldState() {
+      if(this.suppressedDismountKey) {
+         KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(),
+               MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak));
+      }
+      this.dismountHoldTicks = 0;
+      this.dismountRequestPending = false;
+      this.suppressedDismountKey = false;
+      this.dismountMount = null;
+      this.dismountPlayer = null;
+      this.dismountWorld = null;
+      this.dismountConnection = null;
+   }
+
+   public boolean consumeDismountRequest(EntityPlayer player) {
+      if(player == this.dismountPlayer && player.ridingEntity == this.dismountMount
+            && this.dismountRequestPending) {
+         this.dismountRequestPending = false;
+         return true;
+      }
+      return false;
+   }
 
    public void onRenderTickPost(float partialTicks) {
       if (this.mc.thePlayer != null) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -4,6 +4,7 @@ import mcheli.MCH_ClientTickHandlerBase;
 import mcheli.MCH_Config;
 import mcheli.MCH_Key;
 import mcheli.MCH_Lib;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_PacketIndOpenScreen;
 import mcheli.network.packets.PacketLockTarget;
 import mcheli.plane.MCP_EntityPlane;
@@ -16,9 +17,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import org.lwjgl.input.Keyboard;
 
 public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHandlerBase {
-   /** Three seconds at Minecraft's 20 client ticks per second. */
-   private static final int DISMOUNT_HOLD_TICKS = 60;
-
    protected boolean isRiding = false;
 
    protected boolean isBeforeRiding = false;
@@ -62,8 +60,6 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
    public MCH_Key KeyBrake;
    public MCH_Key KeyCurrentWeaponLock;
 
-   private int unmountForceHoldTicks;
-
    /**
     * Chaff key
     */
@@ -92,7 +88,7 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       this.KeySwitchWeapon2 = new MCH_Key(MCH_Config.KeySwitchWeapon2.prmInt);
       this.KeySwWeaponMode = new MCH_Key(MCH_Config.KeySwWeaponMode.prmInt);
       this.KeyUnmount = new MCH_Key(MCH_Config.KeyUnmount.prmInt);
-      this.KeyUnmountForce = new MCH_Key(42);
+      this.KeyUnmountForce = new MCH_Key(super.mc.gameSettings.keyBindSneak.getKeyCode());
       this.KeyExtra = new MCH_Key(MCH_Config.KeyExtra.prmInt);
       this.KeyFlare = new MCH_Key(MCH_Config.KeyFlare.prmInt);
       this.KeyCameraMode = new MCH_Key(MCH_Config.KeyCameraMode.prmInt);
@@ -139,19 +135,10 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       }
       boolean send = false;
 
-      if(this.KeyUnmountForce.isKeyPress()) {
-         if(this.unmountForceHoldTicks < DISMOUNT_HOLD_TICKS) {
-            ++this.unmountForceHoldTicks;
-         }
-      } else {
-         this.unmountForceHoldTicks = 0;
-      }
-
-      if(this.unmountForceHoldTicks == DISMOUNT_HOLD_TICKS) {
+      if(player.ridingEntity instanceof MCH_EntityBaseVehicle
+            && MCH_ClientCommonTickHandler.instance.consumeDismountRequest(player)) {
          pc.isUnmount = 1;
          send = true;
-         // Do not send another dismount request until Shift is released and held again.
-         ++this.unmountForceHoldTicks;
       }
 
       if (this.KeyCameraMode.isKeyDown())

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -226,7 +226,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
             msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
             color = -256;
          } else {
-            msg = "Dismount : Hold Left Shift (3s)";
+            msg = "Dismount : Hold " + MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode()) + " (3s)";
          }
 
          this.drawString(msg, LX, super.centerY - 30, color);

--- a/src/main/java/mcheli/aircraft/MCH_ClientSeatTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_ClientSeatTickHandler.java
@@ -4,6 +4,7 @@ import mcheli.MCH_ClientTickHandlerBase;
 import mcheli.MCH_Config;
 import mcheli.MCH_Key;
 import mcheli.MCH_Lib;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.aircraft.MCH_PacketSeatPlayerControl;
@@ -37,7 +38,7 @@ public class MCH_ClientSeatTickHandler extends MCH_ClientTickHandlerBase {
       this.KeySwitchPrevSeat = new MCH_Key(MCH_Config.KeyGUI.prmInt);
       this.KeyParachuting = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyHeliEject = new MCH_Key(MCH_Config.KeyEjectHeli.prmInt);
-      this.KeyUnmountForce = new MCH_Key(42);
+      this.KeyUnmountForce = new MCH_Key(super.mc.gameSettings.keyBindSneak.getKeyCode());
       this.KeyFreeLook = new MCH_Key(MCH_Config.KeyFreeLook.prmInt);
       this.Keys = new MCH_Key[]{this.KeySwitchNextSeat, this.KeySwitchPrevSeat, this.KeyParachuting, this.KeyUnmountForce, this.KeyFreeLook};
    }
@@ -80,6 +81,10 @@ public class MCH_ClientSeatTickHandler extends MCH_ClientTickHandlerBase {
    private void playerControl(EntityPlayer player, MCH_EntitySeat seat, MCH_EntityBaseVehicle ac) {
       MCH_PacketSeatPlayerControl pc = new MCH_PacketSeatPlayerControl();
       boolean send = false;
+      if(MCH_ClientCommonTickHandler.instance.consumeDismountRequest(player)) {
+         pc.isUnmount = true;
+         send = true;
+      }
       if(this.KeyFreeLook.isKeyDown() && ac.canSwitchGunnerFreeLook(player)) {
          ac.switchGunnerFreeLookMode();
       }


### PR DESCRIPTION
### Motivation

- Prevent immediate vanilla Sneak dismount when riding MCHeli vehicles or seats by requiring a continuous 60-client-tick hold of the configured Minecraft Sneak key before requesting an authoritative server dismount. 
- Apply the delay to both pilots and passengers while preserving normal sneaking and vanilla dismount behavior for non-MCHeli mounts and unmounted players. 
- Use a single source-of-truth hold state updated before vehicle control packets are built so timers cannot drift between vanilla and mod code.

### Description

- Centralized the 60-tick hold state in `MCH_ClientCommonTickHandler` by adding `DISMOUNT_HOLD_TICKS`, `updateDismountHoldState()`, `consumeDismountRequest(EntityPlayer)`, and supporting fields to track the player/world/connection/mount and one-shot request semantics, and by suppressing/restoring the Sneak binding and `movementInput.sneak` during the hold window.  (`src/main/java/mcheli/MCH_ClientCommonTickHandler.java`)
- Suppressed the configured Minecraft Sneak binding and `movementInput.sneak` for ticks 1–59 so vanilla’s mounted-player dismount gate does not run early, and restored the physical binding in the existing post-player-tick callback. (`onPlayerTickPre`/`onPlayerTickPost` usage in `MCH_ClientCommonTickHandler`)
- Removed the per-handler hard-coded hold timer and hard-coded key `42`; vehicle handlers now consume the centralized hold completion: direct riders call `MCH_ClientCommonTickHandler.instance.consumeDismountRequest(player)` and set `pc.isUnmount = 1`, and seat passengers set `MCH_PacketSeatPlayerControl.isUnmount` when the centralized hold completes. (`src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java`, `src/main/java/mcheli/aircraft/MCH_ClientSeatTickHandler.java`)
- Replaced uses of the hard-coded Left Shift text with the configured Sneak key name in the HUD by composing the label with `MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode())`. (`src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java`)
- Updated documentation and changelog entries to reflect the new Sneak-based 60-tick hold behavior. (`docs/getting-started.md`, `CHANGELOG.md`)
- Preserved existing hooks and packet paths; the server remains authoritative for the final mount state and no new network messages or mixins were added.

Files changed (key):
- `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`
- `src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java`
- `src/main/java/mcheli/aircraft/MCH_ClientSeatTickHandler.java`
- `src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java`
- `docs/getting-started.md`
- `CHANGELOG.md`

### Testing

- Ran `git diff --check` to ensure no whitespace or simple diff problems (no issues reported). 
- Searched the codebase to confirm a single `DISMOUNT_HOLD_TICKS` definition and removal of hard-coded `42` key uses and per-handler hold timers (search/validation succeeded). 
- Compiled main sources with the repository wrapper via `./gradlew compileJava`, which completed successfully (`BUILD SUCCESSFUL`). 
- Verified that `public void onPlayerTickPre(EntityPlayer)` and `public void onPlayerTickPost(EntityPlayer)` appear exactly once in the central tick handler and that vehicle handlers now call the centralized `consumeDismountRequest` (static checks passed).

Note: Interactive behavior checks (pilot and passenger timing, GUI interruption, rebinding, vanilla non-MCHeli mounts, multiplayer synchronization, and end-to-end in-client verification) require a running Minecraft 1.7.10 client/server and were not performed in this non-interactive environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a3a2c57108323ad7237497d2a3127)