### PR TITLE
Fix real-time dismount duration and HUD countdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Real-Time Dismount Countdown
+
+- Measure the three-second MCHeli dismount hold with Java's monotonic clock so low client TPS no longer extends the real-world wait.
+- Show the synchronized `3s`, `2s`, and `1s` remaining hold time beside the configured Sneak key in the vehicle HUD.
+
 ## Three-Second MCHeli Dismount
 
 - Require pilots and passengers to hold the configured Minecraft Sneak key for 60 continuous client ticks before requesting a server-authoritative dismount.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,7 +83,7 @@ The config stores key codes rather than names. Common defaults:
 | Switch weapon mode | `KeySwitchWeaponMode` | X |
 | Zoom | `KeyZoom` | Z |
 | Camera mode | `KeyCameraMode` | C |
-| Dismount vehicle | Minecraft Sneak control | Hold the configured Sneak key for 3 seconds (Left Shift by default) |
+| Dismount vehicle | Minecraft Sneak control | Hold the configured Sneak key for 3 real-time seconds (Left Shift by default); the HUD shows the remaining hold time |
 | Dismount mob/crew action | `KeyUnmountMob` | Y |
 | Flares/chaff/maintenance/APS | `KeyFlare`, `KeyChaff`, `KeyMaintenance`, `KeyAPS` | V |
 | Extra function | `KeyExtra` | F |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -60,8 +60,8 @@ import mcheli.ship.MCH_GuiShip;
 @SideOnly(Side.CLIENT)
 public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
-   /** Three seconds at Minecraft's normal 20 client ticks per second. */
-   public static final int DISMOUNT_HOLD_TICKS = 60;
+   /** Three seconds measured against a monotonic clock. */
+   public static final long DISMOUNT_HOLD_NANOS = 3000000000L;
 
    public static MCH_ClientCommonTickHandler instance;
    public MCH_GuiCommon gui_Common;
@@ -100,8 +100,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private static double mouseRollDeltaY = 0.0D;
    private static boolean isRideAircraft = false;
    private static float prevTick = 0.0F;
-   private int dismountHoldTicks;
+   private long dismountHoldStartNanos = -1L;
    private boolean dismountRequestPending;
+   private boolean dismountHoldTriggered;
    private boolean suppressedDismountKey;
    private Entity dismountMount;
    private EntityClientPlayerMP dismountPlayer;
@@ -909,13 +910,15 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
       boolean pressed = MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak);
       if(!mcheliMount || super.mc.currentScreen != null || !pressed) {
-         this.dismountHoldTicks = 0;
+         this.dismountHoldStartNanos = -1L;
          this.dismountRequestPending = false;
-      } else if(this.dismountHoldTicks < DISMOUNT_HOLD_TICKS) {
-         ++this.dismountHoldTicks;
-         if(this.dismountHoldTicks == DISMOUNT_HOLD_TICKS) {
-            this.dismountRequestPending = true;
-         }
+         this.dismountHoldTriggered = false;
+      } else if(this.dismountHoldStartNanos < 0L) {
+         this.dismountHoldStartNanos = System.nanoTime();
+      } else if(!this.dismountHoldTriggered
+            && System.nanoTime() - this.dismountHoldStartNanos >= DISMOUNT_HOLD_NANOS) {
+         this.dismountRequestPending = true;
+         this.dismountHoldTriggered = true;
       }
 
       if(this.isHoldingMCHeliDismount()) {
@@ -926,8 +929,8 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    private boolean isHoldingMCHeliDismount() {
-      return this.dismountMount != null && this.dismountHoldTicks > 0
-            && this.dismountHoldTicks < DISMOUNT_HOLD_TICKS;
+      return this.dismountMount != null && this.dismountHoldStartNanos >= 0L
+            && !this.dismountHoldTriggered;
    }
 
    private void resetDismountHoldState() {
@@ -935,8 +938,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(),
                MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak));
       }
-      this.dismountHoldTicks = 0;
+      this.dismountHoldStartNanos = -1L;
       this.dismountRequestPending = false;
+      this.dismountHoldTriggered = false;
       this.suppressedDismountKey = false;
       this.dismountMount = null;
       this.dismountPlayer = null;
@@ -951,6 +955,19 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          return true;
       }
       return false;
+   }
+
+   public int getDismountHoldRemainingSeconds(EntityPlayer player) {
+      if(player == null || player != this.dismountPlayer || player != super.mc.thePlayer
+            || player.ridingEntity != this.dismountMount || this.dismountHoldStartNanos < 0L
+            || this.dismountHoldTriggered || super.mc.currentScreen != null
+            || !MCH_Key.isKeyDown(super.mc.gameSettings.keyBindSneak)) {
+         return 3;
+      }
+
+      long remainingNanos = DISMOUNT_HOLD_NANOS - (System.nanoTime() - this.dismountHoldStartNanos);
+      int seconds = (int)Math.ceil((double)remainingNanos / 1000000000.0D);
+      return Math.max(1, Math.min(3, seconds));
    }
 
    public void onRenderTickPost(float partialTicks) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -2,6 +2,7 @@ package mcheli.aircraft;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_Config;
 import mcheli.MCH_KeyName;
 import mcheli.MCH_Lib;
@@ -226,7 +227,12 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
             msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
             color = -256;
          } else {
-            msg = "Dismount : Hold " + MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode()) + " (3s)";
+            int remainingSeconds = 3;
+            if(MCH_ClientCommonTickHandler.instance != null) {
+               remainingSeconds = MCH_ClientCommonTickHandler.instance.getDismountHoldRemainingSeconds(player);
+            }
+            msg = "Dismount : Hold " + MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode())
+                  + " (" + remainingSeconds + "s)";
          }
 
          this.drawString(msg, LX, super.centerY - 30, color);


### PR DESCRIPTION
### Motivation
- The previous dismount logic used a 60-client-tick counter which could take ~5 real seconds under client lag because the counter advanced only when tick-processing occurred.  
- Replace the tick-counting approach with a monotonic real-time duration so dismount triggers after three real seconds regardless of client TPS.  
- Provide a synchronized HUD countdown driven by the same timer so the player sees `3s`, `2s`, `1s` while holding the configured Sneak key.  

### Description
- Replace the 60-tick counter with a monotonic-duration constant `DISMOUNT_HOLD_NANOS = 3000000000L` and a start timestamp field `dismountHoldStartNanos` initialized to `-1L`.  
- Use `System.nanoTime()` to start the timestamp on the first valid Sneak press and compare elapsed nanoseconds to trigger `dismountRequestPending` after the three-second interval, and add a boolean `dismountHoldTriggered` to avoid duplicate requests during a continuous hold.  
- Add a read-only API `getDismountHoldRemainingSeconds(EntityPlayer)` in `MCH_ClientCommonTickHandler` that computes the HUD countdown with a ceiling calculation and clamps values to `1..3`, returning `3` when inactive.  
- Read the shared countdown during GUI rendering in `MCH_BaseVehicleCommonGui` using a null-safe `MCH_ClientCommonTickHandler.instance`, and update documentation and changelog to mention the real-time behavior.  
- Changed files: `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`, `src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java`, `CHANGELOG.md`, and `docs/getting-started.md`.  

### Testing
- Ran `git diff --check` and it returned no whitespace errors. (passed)  
- Executed scripted source assertions that verified the presence of a single `DISMOUNT_HOLD_NANOS` constant, removal of the old tick counter, use of `System.nanoTime()`, the ceiling countdown expression, and null-safe HUD access, and they passed. (passed)  
- Verified there are no new separate timers introduced in the pilot/passenger handlers with `git diff --quiet` for the relevant handler files, confirming packet handlers still consume the shared request. (passed)  
- Compilation was not executed in this environment as requested; the exact command to run locally is `./gradlew compileJava` and it was intentionally not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a3f1b327483239a379647ec1f3b0d)