### PR TITLE
Add aircraft coordinates to the new plane simple HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## New Plane Simple HUD Coordinates
+
+- Added signed, one-decimal X, Y, and Z aircraft coordinates directly below altitude in the new plane simple HUD.
+- Made the simple HUD vertical clamp use the rendered main and warning panel heights so the expanded stack remains on screen at small GUI resolutions.
+
 ## Real-Time Dismount Countdown
 
 - Measure the three-second MCHeli dismount hold with Java's monotonic clock so low client TPS no longer extends the real-world wait.

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -165,6 +165,9 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
       lines.add(MCH_HudShared.formatThrottleOrCollective("THR  ", plane));
       lines.add(MCH_HudShared.formatSpeedKmh(plane));
       lines.add(MCH_HudShared.formatAltitude(plane));
+      lines.add(String.format("X: %+.1f", new Object[]{Double.valueOf(plane.posX)}));
+      lines.add(String.format("Y: %+.1f", new Object[]{Double.valueOf(plane.posY)}));
+      lines.add(String.format("Z: %+.1f", new Object[]{Double.valueOf(plane.posZ)}));
       lines.add(MCH_HudShared.formatVerticalSpeed(plane));
       lines.add(String.format("PITCH %+.0f\u00B0", new Object[]{Float.valueOf(this.getDisplayPitchDegrees(plane))}));
       lines.add(MCH_HudShared.formatFuelMinutes(plane));
@@ -174,8 +177,11 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
 
       List warnings = this.collectSimpleHudWarnings(plane);
       int x = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudX.prmInt, 4, Math.max(4, super.width - 118));
-      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - 102));
-      this.drawHudPanel(x - 4, y - 4, 116, lines.size() * 10 + 8);
+      int mainPanelHeight = lines.size() * 10 + 8;
+      int warningPanelHeight = warnings.isEmpty()?0:warnings.size() * 10 + 4;
+      int panelStackHeight = mainPanelHeight + (warnings.isEmpty()?0:warningPanelHeight + 3);
+      int y = MathHelper.clamp_int(MCH_Config.NewPlaneSimpleHudY.prmInt, 4, Math.max(4, super.height - panelStackHeight));
+      this.drawHudPanel(x - 4, y - 4, 116, mainPanelHeight);
       this.drawHudLines(lines, x, y, 0xFFE8E8E8, 0x66303030);
 
       this.drawStickInputGauge(x + 126, y + 12);


### PR DESCRIPTION
### Motivation

- Provide pilots with the aircraft world coordinates inside the compact new plane simple HUD so position data is available without using player or camera locations.
- Ensure the compact HUD can expand vertically to accommodate the extra lines while keeping the panel and warning block visible at small GUI resolutions.

### Description

- Added three separate HUD lines showing the aircraft `X`, `Y`, and `Z` coordinates immediately after the altitude line using `plane.posX`, `plane.posY`, and `plane.posZ` with the format `"%+.1f"`.
- Kept existing rendering, panel, and line-spacing logic by appending the coordinate strings to the existing `lines` list and relying on `lines.size()` for panel height.
- Replaced the previous hard-coded vertical clamp with a clamp computed from the calculated main panel height and warning panel height so the HUD stack cannot leave the screen when taller.
- Updated `CHANGELOG.md` with a short note describing the new HUD coordinates and the vertical-clamp behavior change.

### Testing

- Ran repository checks including `diff --check` and a small static Python assertion script that verified the coordinate lines use `plane.posX/Y/Z`, appear between altitude and vertical speed, and format values as `-12.3`, `+12.3`, and `+0.0` (all passed).
- Verified the working tree and file changes are present and that `CHANGELOG.md` was updated (status clean after changes).
- Java compilation was not executed because the project build instructions for this task prohibit producing binary artifacts; no compile-time errors were produced by the automated checks performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a4e6e4b5c83239e22e2bbcfe6b275)