### PR TITLE
Fix missile countermeasure target classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,3 +245,9 @@
 
 ## Engine Waterboarding
 - Added waterboarding behavior for tank, plane, and helicopter engines: submerged non-floating vehicles now have throttle forced to zero while waterlogged, and recurring water damage stops once the configured `EngineShutdownThreshold` health percentage is reached instead of always continuing to destruction.
+
+# Missile lock target classification
+
+- Keep client-side smoke and visual flare emitters out of missile lock candidate lists.
+- Restrict heat guidance to active flare countermeasures and radar guidance to active chaff,
+  including revalidation while a weapon or active-radar missile continues tracking.

--- a/src/main/java/mcheli/flare/MCH_EntityChaff.java
+++ b/src/main/java/mcheli/flare/MCH_EntityChaff.java
@@ -38,6 +38,11 @@ public class MCH_EntityChaff extends W_Entity implements MCH_IEntityLockChecker 
       super.motionZ = mZ;
    }
 
+   public boolean isActiveCountermeasure() {
+      return !this.isDead && this.ticksExisted <= MAX_TICK_EXISTED
+              && !this.onGround && !this.isInWater();
+   }
+
    @Override
    public void onUpdate() {
       if (worldObj.isRemote) {

--- a/src/main/java/mcheli/flare/MCH_EntityFlare.java
+++ b/src/main/java/mcheli/flare/MCH_EntityFlare.java
@@ -18,10 +18,13 @@ import net.minecraft.world.World;
 
 public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnData , MCH_IEntityLockChecker {
 
+   public static final int MAX_TICK_EXISTED = 300;
+
    public double gravity;
    public double airResistance;
    public float size;
    public int fuseCount;
+   private boolean countermeasure;
 
 
    public MCH_EntityFlare(World par1World) {
@@ -34,6 +37,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
       super.prevRotationPitch = super.rotationPitch;
       this.size = 6.0F;
       this.fuseCount = 0;
+      this.countermeasure = false;
    }
 
    public MCH_EntityFlare(World par1World, double pX, double pY, double pZ, double mX, double mY, double mZ, float size, int fuseCount) {
@@ -49,6 +53,16 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
 
    public boolean isEntityInvulnerable() {
       return true;
+   }
+
+   public void setCountermeasure(boolean countermeasure) {
+      this.countermeasure = countermeasure;
+   }
+
+   public boolean isActiveCountermeasure() {
+      int lifetime = this.fuseCount > 0 ? this.fuseCount : MAX_TICK_EXISTED;
+      return this.countermeasure && !this.isDead && this.ticksExisted < lifetime
+              && !this.onGround && !this.isInWater();
    }
 
    @SideOnly(Side.CLIENT)
@@ -87,6 +101,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
    public void writeSpawnData(ByteBuf buffer) {
       try {
          buffer.writeByte(this.fuseCount);
+         buffer.writeBoolean(this.countermeasure);
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -96,6 +111,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
    public void readSpawnData(ByteBuf additionalData) {
       try {
          this.fuseCount = additionalData.readByte();
+         this.countermeasure = additionalData.readBoolean();
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -107,7 +123,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
          this.setDead();
       } else if(!super.worldObj.isRemote && !super.worldObj.blockExists((int)super.posX, (int)super.posY, (int)super.posZ)) {
          this.setDead();
-      } else if(super.ticksExisted > 300 && !super.worldObj.isRemote) {
+      } else if(super.ticksExisted > MAX_TICK_EXISTED && !super.worldObj.isRemote) {
          this.setDead();
       } else {
          super.onUpdate();

--- a/src/main/java/mcheli/flare/MCH_Flare.java
+++ b/src/main/java/mcheli/flare/MCH_Flare.java
@@ -190,6 +190,7 @@ public class MCH_Flare {
          }
 
          MCH_EntityFlare e = new MCH_EntityFlare(this.worldObj, x, y, z, tx * 0.5D, ty * 0.5D, tz * 0.5D, 6.0F, fuseCount);
+         e.setCountermeasure(true);
          e.rotationPitch = this.rand.nextFloat() * 360.0F;
          e.rotationYaw = this.rand.nextFloat() * 360.0F;
          e.prevRotationPitch = this.rand.nextFloat() * 360.0F;

--- a/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
@@ -3,6 +3,7 @@ package mcheli.weapon;
 import mcheli.MCH_Config;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.flare.MCH_EntityChaff;
+import mcheli.flare.MCH_EntityFlare;
 import mcheli.vector.Vector3f;
 import mcheli.wrapper.W_Entity;
 import net.minecraft.entity.Entity;
@@ -39,7 +40,7 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
       }
 
       if(!super.worldObj.isRemote && this.getInfo() != null) {
-         if(super.shootingEntity != null && super.targetEntity != null && !super.targetEntity.isDead) {
+         if(super.shootingEntity != null && isValidExistingTarget(super.targetEntity)) {
             double x = super.posX - super.targetEntity.posX;
             double y = super.posY - super.targetEntity.posY;
             double z = super.posZ - super.targetEntity.posZ;
@@ -58,6 +59,9 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
                }
             }
          } else {
+            if(super.targetEntity instanceof MCH_EntityFlare || super.targetEntity instanceof MCH_EntityChaff) {
+               super.targetEntity = null;
+            }
             if(getInfo().activeRadar && ticksExisted % getInfo().scanInterval == 0) {
                scanForTargets();
             }
@@ -79,7 +83,8 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
          Entity closestTarget = null;
 
          for (Entity entity : list) {
-            if (entity instanceof MCH_EntityBaseVehicle || entity instanceof MCH_EntityChaff) {
+            if (entity instanceof MCH_EntityBaseVehicle
+                    || MCH_WeaponGuidanceSystem.isValidCountermeasureTarget(entity, false, true)) {
 
                if (W_Entity.isEqual(entity, shootingAircraft)) {
                   continue;
@@ -112,6 +117,16 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
             super.targetEntity = closestTarget;
          }
       }
+   }
+
+   private boolean isValidExistingTarget(Entity entity) {
+      if(entity == null || entity.isDead) {
+         return false;
+      }
+      if(entity instanceof MCH_EntityFlare || entity instanceof MCH_EntityChaff) {
+         return MCH_WeaponGuidanceSystem.isValidCountermeasureTarget(entity, false, true);
+      }
+      return true;
    }
 
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
@@ -180,7 +180,9 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                ++this.lockCount;  // If target is locked, increments lock count
             }
          } else if(this.targetEntity != null && !this.targetEntity.isDead) {  // If a target already exists and is not dead
-            boolean canLockTarget = true;  // Whether target can continue to be locked
+            // Apply the same classification used to acquire a target; visual flare emitters and
+            // expired countermeasures may outlive the effect that made them appear target-like.
+            boolean canLockTarget = this.canLockEntity(this.targetEntity);  // Whether target can continue to be locked
 
             if(targetEntity instanceof MCH_EntityBaseVehicle) {
                if(isRadarMissile && targetEntity.getEntityData().getBoolean("ChaffUsing")) {
@@ -363,13 +365,10 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
          if(className.indexOf("EntityCamera") >= 0) {
             return false;
          }
-         // IR missiles can lock flares
-         if(this.isHeatSeekerMissile && entity instanceof MCH_EntityFlare) {
-            return true;
-         }
-         // Radar missiles can lock chaff
-         if(this.isRadarMissile && entity instanceof MCH_EntityChaff) {
-            return true;
+         // Countermeasure entities are classified before normal living/vehicle targets. Smoke
+         // particles are client-only EntityFX objects and never participate in this entity list.
+         if(entity instanceof MCH_EntityFlare || entity instanceof MCH_EntityChaff) {
+            return isValidCountermeasureTarget(entity, this.isHeatSeekerMissile, this.isRadarMissile);
          }
          // Locks missiles
          if(this.canLockMissile &&
@@ -404,6 +403,16 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
             return (this.canLockOnGround || !ong) && (this.canLockInAir || ong);
          }
       }
+   }
+
+   public static boolean isValidCountermeasureTarget(Entity entity, boolean heatSeeking, boolean radarGuided) {
+      if(entity instanceof MCH_EntityFlare) {
+         return !radarGuided && heatSeeking && ((MCH_EntityFlare)entity).isActiveCountermeasure();
+      }
+      if(entity instanceof MCH_EntityChaff) {
+         return radarGuided && ((MCH_EntityChaff)entity).isActiveCountermeasure();
+      }
+      return false;
    }
 
 


### PR DESCRIPTION
### Motivation

- Players could appear to lock smoke because the flare entity class also emitted client-side smoke visuals and was being considered a lock candidate.  
- Visual-only particle emitters and expired/inactive countermeasures must never be valid missile targets while keeping real flares and chaff effective.  
- Keep existing targeting rules (`canLockOnGround`, `canLockInAir`, `canLockInWater`, `canLockMissile`, custom checkers) unchanged for ordinary entities.  

### Description

- Add explicit countermeasure state to flares: `MCH_EntityFlare` now has a `countermeasure` flag, `MAX_TICK_EXISTED`, synchronization in spawn data, and `isActiveCountermeasure()` based on real lifetime and grounding/water state; visual-only flare smoke remains client-side and not targetable. (changed `src/main/java/mcheli/flare/MCH_EntityFlare.java`).  
- Add `isActiveCountermeasure()` to chaff so radar guidance rejects dead/expired/grounded/submerged chaff. (changed `src/main/java/mcheli/flare/MCH_EntityChaff.java`).  
- Ensure only server-spawned flares are marked as countermeasures when the flare controller spawns them by calling `setCountermeasure(true)` in `MCH_Flare`. (changed `src/main/java/mcheli/flare/MCH_Flare.java`).  
- Centralize and type-check countermeasure acceptance in `MCH_WeaponGuidanceSystem.isValidCountermeasureTarget(...)`, then classify countermeasures before generic living/vehicle checks so particle emitters and visual helpers are rejected early; revalidate the same rules when continuing a lock and immediately clear locks that become invalid. (changed `src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java`).  
- Update active-radar missile scanning and continuation to use the same classifier and to drop countermeasure targets that are no longer valid while leaving ordinary target rules untouched. (changed `src/main/java/mcheli/weapon/MCH_EntityAAMissile.java`).  
- Document the fix in the changelog. (changed `CHANGELOG.md`).  

### Testing

- `./gradlew compileJava` — pass (build compiled successfully in this environment).  
- `./gradlew build` — blocked by external repository access (Maven repo returned HTTP 403 while resolving `junit:junit:4.13.2`), so full build/tests could not be run here.  
- `git diff --check` — pass (no whitespace/git-diff problems).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a60e821e0832398c80be701b20bea)