### PR TITLE
Fix local vehicle appearing on its own RWR

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Fix local vehicle appearing on RWR
+
+- Excluded the locally controlled aircraft from RWR contacts by synchronized entity ID before applying contact type or display-distance filters.
+- Reused the shared direct-ride, seat-parent, and UAV-control aircraft resolution without changing shared entity synchronization or BVR tracking.
+
 ## Changed
 
 - Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classification for missile guidance.

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -3,10 +3,8 @@ package mcheli;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import mcheli.aircraft.EnumRWRType;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
-import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.plane.MCP_EntityPlane;
-import mcheli.uav.MCH_EntityUavStation;
 import mcheli.wrapper.W_MOD;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
@@ -46,14 +44,8 @@ public class MCH_RenderRWR {
         if (player == null || world == null) return;
 
         //Gets the player aircraft weapon
-        MCH_EntityBaseVehicle ac = null;
-        if(player.ridingEntity instanceof MCH_EntityBaseVehicle) {
-            ac = (MCH_EntityBaseVehicle)player.ridingEntity;
-        } else if(player.ridingEntity instanceof MCH_EntitySeat) {
-            ac = ((MCH_EntitySeat)player.ridingEntity).getParent();
-        } else if(player.ridingEntity instanceof MCH_EntityUavStation) {
-            ac = ((MCH_EntityUavStation)player.ridingEntity).getControlAircract();
-        }
+        MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
+        if(ac == null) return;
         if(!(ac instanceof MCP_EntityPlane || ac instanceof MCH_EntityHeli)) return;
         if(ac.getAcInfo().rwrType == null || ac.getAcInfo().rwrType == EnumRWRType.NONE) return;
 
@@ -67,7 +59,7 @@ public class MCH_RenderRWR {
             // New entity rendering logic
             double circleRadius = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
             for(MCH_EntityInfo entity : getServerLoadedEntity()) {
-                if(!isValidEntity(entity, player)) continue;
+                if(!isValidEntity(entity, player, ac)) continue;
 
                 // Calculates interpolated position
                 double xPos = interpolate(entity.posX, entity.lastTickPosX, event.partialTicks);
@@ -141,7 +133,13 @@ public class MCH_RenderRWR {
 
 
     // New entity validation method
-    private boolean isValidEntity(MCH_EntityInfo entity, EntityPlayer player) {
+    private boolean isValidEntity(MCH_EntityInfo entity, EntityPlayer player, MCH_EntityBaseVehicle ac) {
+        if(entity == null || entity.entityId <= 0) {
+            return false;
+        }
+        if(entity.entityId == ac.getEntityId()) {
+            return false;
+        }
         if (entity.entityClassName.contains("MCH_EntityChaff") || entity.entityClassName.contains("MCH_EntityFlare")
                 || entity.entityClassName.contains("EntityPlayer")) {
             return false;


### PR DESCRIPTION
### Motivation
- Prevent the locally controlled aircraft from appearing as a contact on its own RWR when synchronized entity positions are stale or delayed.
- Apply the exclusion at render-time so shared entity tracking and BVR features remain unchanged while keeping distance filtering and all RWR types intact.

### Description
- Resolve the controlled vehicle using the existing helper `MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player)` and return immediately when no controlled aircraft is present.
- Pass the resolved `MCH_EntityBaseVehicle ac` into RWR validation and reject entries whose synchronized entity ID matches the controlled vehicle by checking `entity.entityId == ac.getEntityId()` before any class, emitter, or distance filters.
- Add defensive rejection for null `MCH_EntityInfo` and invalid entity IDs while preserving `MIN_DISTANCE` as a display-distance filter, missile contacts, flare/chaff/player filtering, and all RWR modes.
- Files changed: `src/main/java/mcheli/MCH_RenderRWR.java` and `changelog.md`; the exact entity ID comparison is performed in `MCH_RenderRWR.isValidEntity` as `entity.entityId == ac.getEntityId()` and the exclusion is applied only inside the RWR renderer.

### Testing
- Ran `./gradlew compileJava` and the build completed successfully (BUILD SUCCESSFUL).
- Ran `git diff --check` with no reported issues.
- No automated runtime/integration tests were executed here; in-game verification (singleplayer and dedicated-server scenarios listed in the task) should be performed manually and is unchanged by shared entity synchronization or BVR code because `MCH_EntityInfoManager` and `MCH_EntityInfoClientTracker` were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7b0140588323bbab7c01485d4674)