### PR TITLE
Fix `/mcheli reload` concurrency crash

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -281,3 +281,11 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Replaced the timed protection bubble and hidden Iron Curtain immunity with a five-state automatic hard-kill APS.
 - Added native projectile interception, closest-approach prediction, finite ammunition persistence/refill, state/effect packets, HUD values, and `APSInterceptable` weapon overrides.
 - Removed FMUR/Flan's Mod reflection integration and updated Merkava and APS configuration documentation.
+
+## Fix `/mcheli reload` concurrency crash
+
+- Reload manager data into ordered, private snapshots and publish it atomically only after successful parsing.
+- Preserve registered items, runtime item IDs, and reusable vehicle/throwable models across matching definitions.
+- Schedule client reload, model, HUD, sound, renderer, and OpenGL cache work on the Minecraft client thread.
+- Clear stale vehicle item display lists and pending model builds during the client reload.
+- Rebuild the shared vehicle registry from current manager snapshots without exposing partially loaded data.

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -34,6 +34,7 @@ import mcheli.helicopter.MCH_HeliInfoManager;
 import mcheli.helicopter.MCH_RenderHeli;
 import mcheli.hud.MCH_HudManager;
 import mcheli.lweapon.MCH_ItemLightWeaponRender;
+import mcheli.item.MCH_ItemInfoManager;
 import mcheli.lod.MCH_VehicleLODManager;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.multiplay.MCH_MultiplayClient;
@@ -156,6 +157,25 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       W_MinecraftForgeClient.registerItemRenderer(W_Item.getItemFromBlock(MCH_MOD.blockDraftingTable), new MCH_DraftingTableItemRender());
    }
 
+
+   public void scheduleClientInfoReload() {
+      Minecraft.getMinecraft().func_152344_a(new Runnable() {
+         public void run() {
+            MCH_HeliInfoManager.getInstance().reload();
+            MCP_PlaneInfoManager.getInstance().reload();
+            MCH_ShipInfoManager.getInstance().reload();
+            MCH_TankInfoManager.getInstance().reload();
+            MCH_TurretInfoManager.getInstance().reload();
+            MCH_WeaponInfoManager.reload();
+            MCH_ItemInfoManager.reload();
+            MCH_ThrowableInfoManager.reload();
+            MCH_VehicleItemModelRender.resetForReload();
+            registerModels();
+            reloadHUD();
+            MCH_SoundsJson.update("assets/mcheli/");
+         }
+      });
+   }
 
    public void registerModels() {
       MCH_ModelManager.setForceReloadMode(true);

--- a/src/main/java/mcheli/MCH_CommonProxy.java
+++ b/src/main/java/mcheli/MCH_CommonProxy.java
@@ -77,6 +77,8 @@ public class MCH_CommonProxy {
 
    public void reloadHUD() {}
 
+   public void scheduleClientInfoReload() {}
+
    public Entity getClientPlayer() {
       return null;
    }

--- a/src/main/java/mcheli/MCH_InfoManagerBase.java
+++ b/src/main/java/mcheli/MCH_InfoManagerBase.java
@@ -1,71 +1,76 @@
 package mcheli;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import mcheli.MCH_BaseInfo;
-import mcheli.MCH_InputFile;
-import mcheli.MCH_Lib;
 
-//Inherited by all vehicle classes.
+/** Base for information managers whose data is published as immutable snapshots. */
 public abstract class MCH_InfoManagerBase {
 
    private String lastPath;
    private String lastType;
 
-   public abstract MCH_BaseInfo newInfo(String var1);
-
+   public abstract MCH_BaseInfo newInfo(String name);
    public abstract Map getMap();
+   protected abstract void setMap(Map map);
+
+   /** Copies runtime-only state from an already published entry. */
+   protected void preserveRuntimeState(MCH_BaseInfo oldInfo, MCH_BaseInfo newInfo) {}
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) {}
 
    public boolean load(String path, String type) {
       lastPath = path;
       lastType = type;
+      return loadAndPublish(path, type, false);
+   }
+
+   private boolean loadAndPublish(String path, String type, boolean reload) {
+      Map oldMap = getMap();
+      LinkedHashMap newMap = new LinkedHashMap();
       path = path.replace('\\', '/');
-      String dirPrefix = path + type;
-      List<String> entries = MCH_ResourceHelper.listResources(dirPrefix, ".txt");
-      if(entries != null && entries.size() > 0) {
-         for(int i = 0; i < entries.size(); ++i) {
-            String resourcePath = entries.get(i);
-            MCH_InputFile inFile = new MCH_InputFile();
-            int line = 0;
+      List<String> entries = MCH_ResourceHelper.listResources(path + type, ".txt");
+      if(entries == null || entries.isEmpty()) return false;
 
-            try {
-               String e = MCH_ResourceHelper.getEntryName(resourcePath);
-               if(!this.getMap().containsKey(e) && inFile.openClasspath("/" + resourcePath)) {
-                  MCH_BaseInfo info = this.newInfo(e);
-                  info.filePath = resourcePath;
-
-                  String str;
-                  while((str = inFile.readLine()) != null) {
-                     ++line;
-                     str = str.trim();
-                     int eqIdx = str.indexOf(61);
-                     if(eqIdx >= 0 && str.length() > eqIdx + 1) {
-                        info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
-                     }
-                  }
-
-                  if(info.isValidData()) {
-                     this.getMap().put(e, info);
+      for(int i = 0; i < entries.size(); ++i) {
+         String resourcePath = entries.get(i);
+         MCH_InputFile inFile = new MCH_InputFile();
+         int line = 0;
+         try {
+            String name = MCH_ResourceHelper.getEntryName(resourcePath);
+            if(!newMap.containsKey(name) && inFile.openClasspath("/" + resourcePath)) {
+               MCH_BaseInfo info = newInfo(name);
+               info.filePath = resourcePath;
+               String str;
+               while((str = inFile.readLine()) != null) {
+                  ++line;
+                  str = str.trim();
+                  int eqIdx = str.indexOf(61);
+                  if(eqIdx >= 0 && str.length() > eqIdx + 1) {
+                     info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
                   }
                }
-            } catch (Exception var19) {
-               if(line > 0) {
-                  MCH_Lib.Log("### Load failed %s : line=%d", new Object[]{resourcePath, Integer.valueOf(line)});
-               } else {
-                  MCH_Lib.Log("### Load failed %s", new Object[]{resourcePath});
-               }
-
-               var19.printStackTrace();
-            } finally {
-               inFile.close();
+               if(info.isValidData()) newMap.put(name, info);
             }
+         } catch(Exception e) {
+            MCH_Lib.Log("### Reload failed %s%s; keeping previous %s data", new Object[]{resourcePath, line > 0 ? " : line=" + line : "", type});
+            e.printStackTrace();
+            return false;
+         } finally {
+            inFile.close();
          }
-
-         MCH_Lib.Log("Read %d %s", new Object[]{Integer.valueOf(this.getMap().size()), type});
-         return this.getMap().size() > 0;
-      } else {
-         return false;
       }
+
+      if(newMap.isEmpty()) return false;
+      if(reload) {
+         for(Object key : newMap.keySet()) {
+            MCH_BaseInfo oldInfo = (MCH_BaseInfo)oldMap.get(key);
+            if(oldInfo != null) preserveRuntimeState(oldInfo, (MCH_BaseInfo)newMap.get(key));
+            else onNewReloadEntry((String)key, (MCH_BaseInfo)newMap.get(key));
+         }
+      }
+      setMap(newMap); // Single volatile publication; published maps are never mutated.
+      MCH_Lib.Log("Read %d %s", new Object[]{Integer.valueOf(newMap.size()), type});
+      return true;
    }
 
    public boolean reload() {
@@ -73,12 +78,6 @@ public abstract class MCH_InfoManagerBase {
          MCH_Lib.Log("### Cannot reload: never loaded");
          return false;
       }
-      try {
-         this.getMap().clear();
-         return this.load(lastPath, lastType);
-      } catch (Exception e) {
-         e.printStackTrace();
-         return false;
-      }
+      return loadAndPublish(lastPath, lastType, true);
    }
 }

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -23,7 +23,18 @@ import java.util.*;
 
 public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
 
-   public static Map<String, MCH_BaseVehicleInfo> allBaseVehicleInfo = new HashMap<>();
+   public static volatile Map<String, MCH_BaseVehicleInfo> allBaseVehicleInfo = new LinkedHashMap<String, MCH_BaseVehicleInfo>();
+
+   /** Atomically rebuilds the cross-family registry from published manager snapshots. */
+   public static void rebuildGlobalRegistry() {
+      LinkedHashMap<String, MCH_BaseVehicleInfo> registry = new LinkedHashMap<String, MCH_BaseVehicleInfo>();
+      registry.putAll(mcheli.helicopter.MCH_HeliInfoManager.map);
+      registry.putAll(mcheli.plane.MCP_PlaneInfoManager.map);
+      registry.putAll(mcheli.ship.MCH_ShipInfoManager.map);
+      registry.putAll(mcheli.tank.MCH_TankInfoManager.map);
+      registry.putAll(mcheli.vehicle.MCH_TurretInfoManager.map);
+      allBaseVehicleInfo = registry;
+   }
 
    public final String name;
    public String displayName;

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -402,16 +402,7 @@ public class MCH_BaseVehiclePacketHandler {
 
       // Client-side: full info reload (sent by server after /mcheli reload)
       if(player.worldObj.isRemote && pc.type == 2) {
-         mcheli.helicopter.MCH_HeliInfoManager.getInstance().reload();
-         mcheli.plane.MCP_PlaneInfoManager.getInstance().reload();
-         mcheli.ship.MCH_ShipInfoManager.getInstance().reload();
-         mcheli.tank.MCH_TankInfoManager.getInstance().reload();
-         mcheli.vehicle.MCH_TurretInfoManager.getInstance().reload();
-         mcheli.weapon.MCH_WeaponInfoManager.reload();
-         mcheli.item.MCH_ItemInfoManager.reload();
-         mcheli.throwable.MCH_ThrowableInfoManager.reload();
-         mcheli.MCH_MOD.proxy.reloadHUD();
-         mcheli.MCH_SoundsJson.update("assets/mcheli/");
+         MCH_MOD.proxy.scheduleClientInfoReload();
          return;
       }
 

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -46,6 +46,18 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
 
    private static long nextModelBuildTime;
 
+   /** Releases reload-stale GL state. Must only be called on the client thread. */
+   public static void resetForReload() {
+      for(Object value : MODEL_DISPLAY_LISTS.values()) {
+         ((CachedDisplayList)value).delete();
+      }
+      MODEL_DISPLAY_LISTS.clear();
+      MODEL_BUILD_QUEUE.clear();
+      QUEUED_MODELS.clear();
+      activeModelBuild = null;
+      nextModelBuildTime = 0L;
+   }
+
    public boolean handleRenderType(ItemStack item, ItemRenderType type) {
       MCH_BaseVehicleInfo info = getInfo(item);
 

--- a/src/main/java/mcheli/command/MCH_Command.java
+++ b/src/main/java/mcheli/command/MCH_Command.java
@@ -227,9 +227,6 @@ public class MCH_Command extends CommandBase {
                    }
                 }
 
-                MCH_MOD.proxy.reloadHUD();
-                MCH_SoundsJson.update("assets/mcheli/");
-
                 // Notify clients to also reload (matters on dedicated servers)
                 mcheli.aircraft.MCH_PacketNotifyInfoReloaded.sendToAllClients(2);
 

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfo.java
@@ -213,8 +213,6 @@ public class MCH_HeliInfo extends MCH_BaseVehicleInfo {
             this.rotorList.add(e);
          }
       }
-
-      MCH_BaseVehicleInfo.allBaseVehicleInfo.put(name, this);
    }
 
    public String getDirectoryName() {

--- a/src/main/java/mcheli/helicopter/MCH_HeliInfoManager.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliInfoManager.java
@@ -1,57 +1,41 @@
 package mcheli.helicopter;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import mcheli.MCH_BaseInfo;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_BaseVehicleInfoManager;
-import mcheli.helicopter.MCH_HeliInfo;
 import net.minecraft.item.Item;
 
 public class MCH_HeliInfoManager extends MCH_BaseVehicleInfoManager {
-
    private static final MCH_HeliInfoManager instance = new MCH_HeliInfoManager();
-   public static final HashMap map = new LinkedHashMap();
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) { MCH_Lib.Log("### New vehicle definition %s requires item registration; restart the game", new Object[]{name}); }
 
+   public static volatile Map map = new LinkedHashMap();
 
-   public static MCH_HeliInfoManager getInstance() {
-      return instance;
+   public static MCH_HeliInfoManager getInstance() { return instance; }
+   public static MCH_HeliInfo get(String name) { return (MCH_HeliInfo)map.get(name); }
+   public MCH_BaseInfo newInfo(String name) { return new MCH_HeliInfo(name); }
+   public Map getMap() { return map; }
+   protected void setMap(Map newMap) { map = newMap; MCH_BaseVehicleInfo.rebuildGlobalRegistry(); }
+
+   protected void preserveRuntimeState(MCH_BaseInfo oldValue, MCH_BaseInfo newValue) {
+      MCH_HeliInfo oldInfo = (MCH_HeliInfo)oldValue;
+      MCH_HeliInfo newInfo = (MCH_HeliInfo)newValue;
+      newInfo.item = oldInfo.item;
+      newInfo.itemID = oldInfo.itemID;
+      newInfo.model = oldInfo.model;
    }
 
-   public static MCH_HeliInfo get(String name) {
-      return (MCH_HeliInfo)map.get(name);
-   }
-
-   public MCH_BaseInfo newInfo(String name) {
-      return new MCH_HeliInfo(name);
-   }
-
-   public Map getMap() {
-      return map;
-   }
-
-   public static MCH_HeliInfo getFromItem(Item item) {
-      return getInstance().getAcInfoFromItem(item);
-   }
-
+   public static MCH_HeliInfo getFromItem(Item item) { return getInstance().getAcInfoFromItem(item); }
    public MCH_HeliInfo getAcInfoFromItem(Item item) {
-      if(item == null) {
-         return null;
-      } else {
-         Iterator i$ = map.values().iterator();
-
-         MCH_HeliInfo info;
-         do {
-            if(!i$.hasNext()) {
-               return null;
-            }
-
-            info = (MCH_HeliInfo)i$.next();
-         } while(info.item != item);
-
-         return info;
+      if(item == null) return null;
+      Map snapshot = map;
+      for(Object value : snapshot.values()) {
+         MCH_HeliInfo info = (MCH_HeliInfo)value;
+         if(info.item == item) return info;
       }
+      return null;
    }
-
 }

--- a/src/main/java/mcheli/item/MCH_ItemInfoManager.java
+++ b/src/main/java/mcheli/item/MCH_ItemInfoManager.java
@@ -1,11 +1,9 @@
 package mcheli.item;
 
-import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import mcheli.MCH_InputFile;
 import mcheli.MCH_Lib;
@@ -13,98 +11,53 @@ import mcheli.MCH_ResourceHelper;
 import net.minecraft.item.Item;
 
 public class MCH_ItemInfoManager {
+   private static volatile Map map = new LinkedHashMap();
+   private static String lastPath;
 
-    private static HashMap map = new LinkedHashMap();
-    private static String lastPath;
+   public static boolean load(String path) { lastPath = path; return loadAndPublish(path, false); }
+   public static boolean reload() { return lastPath != null && loadAndPublish(lastPath, true); }
 
-    public static boolean load(String path) {
-        lastPath = path;
-        path = path.replace('\\', '/');
-        String dirPrefix = path + "item";
-        List<String> entries = MCH_ResourceHelper.listResources(dirPrefix, ".txt");
-        if(entries != null && entries.size() > 0) {
-            for(int i = 0; i < entries.size(); ++i) {
-                String resourcePath = entries.get(i);
-                MCH_InputFile inFile = new MCH_InputFile();
-                int line = 0;
+   private static boolean loadAndPublish(String path, boolean reload) {
+      Map oldMap = map;
+      LinkedHashMap newMap = new LinkedHashMap();
+      List<String> entries = MCH_ResourceHelper.listResources(path.replace('\\', '/') + "item", ".txt");
+      if(entries == null || entries.isEmpty()) return false;
+      for(int i = 0; i < entries.size(); ++i) {
+         String resourcePath = entries.get(i);
+         MCH_InputFile inFile = new MCH_InputFile();
+         int line = 0;
+         try {
+            String name = MCH_ResourceHelper.getEntryName(resourcePath);
+            if(!newMap.containsKey(name) && inFile.openClasspath("/" + resourcePath)) {
+               MCH_ItemInfo info = new MCH_ItemInfo(name);
+               String str;
+               while((str = inFile.readLine()) != null) {
+                  ++line; str = str.trim(); int eqIdx = str.indexOf(61);
+                  if(eqIdx >= 0 && str.length() > eqIdx + 1) info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
+               }
 
-                try {
-                    String e = MCH_ResourceHelper.getEntryName(resourcePath);
-                    if(!map.containsKey(e) && inFile.openClasspath("/" + resourcePath)) {
-                        MCH_ItemInfo info = new MCH_ItemInfo(e);
-
-                        String str;
-                        while((str = inFile.readLine()) != null) {
-                            ++line;
-                            str = str.trim();
-                            int eqIdx = str.indexOf(61);
-                            if(eqIdx >= 0 && str.length() > eqIdx + 1) {
-                                info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
-                            }
-                        }
-
-                        map.put(e, info);
-                    }
-                } catch (Exception var16) {
-                    if(line > 0) {
-                        MCH_Lib.Log("### Load failed %s : line=%d", new Object[]{resourcePath, Integer.valueOf(line)});
-                    } else {
-                        MCH_Lib.Log("### Load failed %s", new Object[]{resourcePath});
-                    }
-
-                    var16.printStackTrace();
-                } finally {
-                    inFile.close();
-                }
+               newMap.put(name, info);
             }
+         } catch(Exception e) {
+            MCH_Lib.Log("### Reload failed %s : line=%d; keeping previous item data", new Object[]{resourcePath, Integer.valueOf(line)});
+            e.printStackTrace(); return false;
+         } finally { inFile.close(); }
+      }
+      if(newMap.isEmpty()) return false;
+      if(reload) for(Object key : newMap.keySet()) {
+         MCH_ItemInfo oldInfo = (MCH_ItemInfo)oldMap.get(key);
+         MCH_ItemInfo newInfo = (MCH_ItemInfo)newMap.get(key);
+         if(oldInfo != null) { newInfo.item = oldInfo.item; newInfo.itemID = oldInfo.itemID;  }
+         else MCH_Lib.Log("### New item definition %s requires item registration; restart the game", new Object[]{key});
+      }
+      map = newMap;
+      MCH_Lib.Log("Read %d item", new Object[]{Integer.valueOf(newMap.size())});
+      return true;
+   }
 
-            MCH_Lib.Log("Read %d item", new Object[]{Integer.valueOf(map.size())});
-            return map.size() > 0;
-        } else {
-            return false;
-        }
-    }
-
-    public static boolean reload() {
-        if(lastPath == null) return false;
-        try {
-            map.clear();
-            return load(lastPath);
-        } catch (Exception e) {
-            e.printStackTrace();
-            return false;
-        }
-    }
-
-    public static MCH_ItemInfo get(String name) {
-        return (MCH_ItemInfo)map.get(name);
-    }
-
-    public static MCH_ItemInfo get(Item item) {
-        Iterator i$ = map.values().iterator();
-
-        MCH_ItemInfo info;
-        do {
-            if(!i$.hasNext()) {
-                return null;
-            }
-
-            info = (MCH_ItemInfo)i$.next();
-        } while(info.item != item);
-
-        return info;
-    }
-
-    public static boolean contains(String name) {
-        return map.containsKey(name);
-    }
-
-    public static Set getKeySet() {
-        return map.keySet();
-    }
-
-    public static Collection getValues() {
-        return map.values();
-    }
-
+   public static MCH_ItemInfo get(String name) { return (MCH_ItemInfo)map.get(name); }
+   public static MCH_ItemInfo get(Item item) { Map snapshot = map; for(Object value : snapshot.values()) { MCH_ItemInfo info = (MCH_ItemInfo)value; if(info.item == item) return info; } return null; }
+   public static boolean contains(String name) { return map.containsKey(name); }
+   public static Set getKeySet() { return map.keySet(); }
+   public static Collection getValues() { return map.values(); }
 }

--- a/src/main/java/mcheli/plane/MCP_PlaneInfo.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfo.java
@@ -425,7 +425,6 @@ public class MCP_PlaneInfo extends MCH_BaseVehicleInfo {
             this.overspeedDamageRate = this.parseNewFlightFloat("OverspeedDamageRate", data, 0.0F, 1.0F);
          }
       }
-      MCH_BaseVehicleInfo.allBaseVehicleInfo.put(name, this);
    }
 
    public String getDirectoryName() {

--- a/src/main/java/mcheli/plane/MCP_PlaneInfoManager.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneInfoManager.java
@@ -1,57 +1,41 @@
 package mcheli.plane;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import mcheli.MCH_BaseInfo;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_BaseVehicleInfoManager;
-import mcheli.plane.MCP_PlaneInfo;
 import net.minecraft.item.Item;
 
 public class MCP_PlaneInfoManager extends MCH_BaseVehicleInfoManager {
+   private static final MCP_PlaneInfoManager instance = new MCP_PlaneInfoManager();
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) { MCH_Lib.Log("### New vehicle definition %s requires item registration; restart the game", new Object[]{name}); }
 
-   private static MCP_PlaneInfoManager instance = new MCP_PlaneInfoManager();
-   public static HashMap map = new LinkedHashMap();
+   public static volatile Map map = new LinkedHashMap();
 
+   public static MCP_PlaneInfoManager getInstance() { return instance; }
+   public static MCP_PlaneInfo get(String name) { return (MCP_PlaneInfo)map.get(name); }
+   public MCH_BaseInfo newInfo(String name) { return new MCP_PlaneInfo(name); }
+   public Map getMap() { return map; }
+   protected void setMap(Map newMap) { map = newMap; MCH_BaseVehicleInfo.rebuildGlobalRegistry(); }
 
-   public static MCP_PlaneInfo get(String name) {
-      return (MCP_PlaneInfo)map.get(name);
+   protected void preserveRuntimeState(MCH_BaseInfo oldValue, MCH_BaseInfo newValue) {
+      MCP_PlaneInfo oldInfo = (MCP_PlaneInfo)oldValue;
+      MCP_PlaneInfo newInfo = (MCP_PlaneInfo)newValue;
+      newInfo.item = oldInfo.item;
+      newInfo.itemID = oldInfo.itemID;
+      newInfo.model = oldInfo.model;
    }
 
-   public static MCP_PlaneInfoManager getInstance() {
-      return instance;
-   }
-
-   public MCH_BaseInfo newInfo(String name) {
-      return new MCP_PlaneInfo(name);
-   }
-
-   public Map getMap() {
-      return map;
-   }
-
-   public static MCP_PlaneInfo getFromItem(Item item) {
-      return getInstance().getAcInfoFromItem(item);
-   }
-
+   public static MCP_PlaneInfo getFromItem(Item item) { return getInstance().getAcInfoFromItem(item); }
    public MCP_PlaneInfo getAcInfoFromItem(Item item) {
-      if(item == null) {
-         return null;
-      } else {
-         Iterator i$ = map.values().iterator();
-
-         MCP_PlaneInfo info;
-         do {
-            if(!i$.hasNext()) {
-               return null;
-            }
-
-            info = (MCP_PlaneInfo)i$.next();
-         } while(info.item != item);
-
-         return info;
+      if(item == null) return null;
+      Map snapshot = map;
+      for(Object value : snapshot.values()) {
+         MCP_PlaneInfo info = (MCP_PlaneInfo)value;
+         if(info.item == item) return info;
       }
+      return null;
    }
-
 }

--- a/src/main/java/mcheli/ship/MCH_ShipInfoManager.java
+++ b/src/main/java/mcheli/ship/MCH_ShipInfoManager.java
@@ -1,56 +1,41 @@
 package mcheli.ship;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import mcheli.MCH_BaseInfo;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_BaseVehicleInfoManager;
 import net.minecraft.item.Item;
 
 public class MCH_ShipInfoManager extends MCH_BaseVehicleInfoManager {
+   private static final MCH_ShipInfoManager instance = new MCH_ShipInfoManager();
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) { MCH_Lib.Log("### New vehicle definition %s requires item registration; restart the game", new Object[]{name}); }
 
-    private static MCH_ShipInfoManager instance = new MCH_ShipInfoManager();
-    public static HashMap map = new LinkedHashMap();
+   public static volatile Map map = new LinkedHashMap();
 
+   public static MCH_ShipInfoManager getInstance() { return instance; }
+   public static MCH_ShipInfo get(String name) { return (MCH_ShipInfo)map.get(name); }
+   public MCH_BaseInfo newInfo(String name) { return new MCH_ShipInfo(name); }
+   public Map getMap() { return map; }
+   protected void setMap(Map newMap) { map = newMap; MCH_BaseVehicleInfo.rebuildGlobalRegistry(); }
 
-    public static MCH_ShipInfo get(String name) {
-        return (MCH_ShipInfo)map.get(name);
-    }
+   protected void preserveRuntimeState(MCH_BaseInfo oldValue, MCH_BaseInfo newValue) {
+      MCH_ShipInfo oldInfo = (MCH_ShipInfo)oldValue;
+      MCH_ShipInfo newInfo = (MCH_ShipInfo)newValue;
+      newInfo.item = oldInfo.item;
+      newInfo.itemID = oldInfo.itemID;
+      newInfo.model = oldInfo.model;
+   }
 
-    public static MCH_ShipInfoManager getInstance() {
-        return instance;
-    }
-
-    public MCH_BaseInfo newInfo(String name) {
-        return new MCH_ShipInfo(name);
-    }
-
-    public Map getMap() {
-        return map;
-    }
-
-    public static MCH_ShipInfo getFromItem(Item item) {
-        return getInstance().getAcInfoFromItem(item);
-    }
-
-    public MCH_ShipInfo getAcInfoFromItem(Item item) {
-        if(item == null) {
-            return null;
-        } else {
-            Iterator i$ = map.values().iterator();
-
-            MCH_ShipInfo info;
-            do {
-                if(!i$.hasNext()) {
-                    return null;
-                }
-
-                info = (MCH_ShipInfo)i$.next();
-            } while(info.item != item);
-
-            return info;
-        }
-    }
-
+   public static MCH_ShipInfo getFromItem(Item item) { return getInstance().getAcInfoFromItem(item); }
+   public MCH_ShipInfo getAcInfoFromItem(Item item) {
+      if(item == null) return null;
+      Map snapshot = map;
+      for(Object value : snapshot.values()) {
+         MCH_ShipInfo info = (MCH_ShipInfo)value;
+         if(info.item == item) return info;
+      }
+      return null;
+   }
 }

--- a/src/main/java/mcheli/tank/MCH_TankInfo.java
+++ b/src/main/java/mcheli/tank/MCH_TankInfo.java
@@ -87,7 +87,6 @@ public class MCH_TankInfo extends MCH_BaseVehicleInfo {
             this.extraBoundingBox.add(bb);
          }
       }
-      MCH_BaseVehicleInfo.allBaseVehicleInfo.put(name, this);
    }
 
    public String getDirectoryName() {

--- a/src/main/java/mcheli/tank/MCH_TankInfoManager.java
+++ b/src/main/java/mcheli/tank/MCH_TankInfoManager.java
@@ -1,57 +1,41 @@
 package mcheli.tank;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import mcheli.MCH_BaseInfo;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_BaseVehicleInfoManager;
-import mcheli.tank.MCH_TankInfo;
 import net.minecraft.item.Item;
 
 public class MCH_TankInfoManager extends MCH_BaseVehicleInfoManager {
+   private static final MCH_TankInfoManager instance = new MCH_TankInfoManager();
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) { MCH_Lib.Log("### New vehicle definition %s requires item registration; restart the game", new Object[]{name}); }
 
-   private static MCH_TankInfoManager instance = new MCH_TankInfoManager();
-   public static HashMap map = new LinkedHashMap();
+   public static volatile Map map = new LinkedHashMap();
 
+   public static MCH_TankInfoManager getInstance() { return instance; }
+   public static MCH_TankInfo get(String name) { return (MCH_TankInfo)map.get(name); }
+   public MCH_BaseInfo newInfo(String name) { return new MCH_TankInfo(name); }
+   public Map getMap() { return map; }
+   protected void setMap(Map newMap) { map = newMap; MCH_BaseVehicleInfo.rebuildGlobalRegistry(); }
 
-   public static MCH_TankInfo get(String name) {
-      return (MCH_TankInfo)map.get(name);
+   protected void preserveRuntimeState(MCH_BaseInfo oldValue, MCH_BaseInfo newValue) {
+      MCH_TankInfo oldInfo = (MCH_TankInfo)oldValue;
+      MCH_TankInfo newInfo = (MCH_TankInfo)newValue;
+      newInfo.item = oldInfo.item;
+      newInfo.itemID = oldInfo.itemID;
+      newInfo.model = oldInfo.model;
    }
 
-   public static MCH_TankInfoManager getInstance() {
-      return instance;
-   }
-
-   public MCH_BaseInfo newInfo(String name) {
-      return new MCH_TankInfo(name);
-   }
-
-   public Map getMap() {
-      return map;
-   }
-
-   public static MCH_TankInfo getFromItem(Item item) {
-      return getInstance().getAcInfoFromItem(item);
-   }
-
+   public static MCH_TankInfo getFromItem(Item item) { return getInstance().getAcInfoFromItem(item); }
    public MCH_TankInfo getAcInfoFromItem(Item item) {
-      if(item == null) {
-         return null;
-      } else {
-         Iterator i$ = map.values().iterator();
-
-         MCH_TankInfo info;
-         do {
-            if(!i$.hasNext()) {
-               return null;
-            }
-
-            info = (MCH_TankInfo)i$.next();
-         } while(info.item != item);
-
-         return info;
+      if(item == null) return null;
+      Map snapshot = map;
+      for(Object value : snapshot.values()) {
+         MCH_TankInfo info = (MCH_TankInfo)value;
+         if(info.item == item) return info;
       }
+      return null;
    }
-
 }

--- a/src/main/java/mcheli/throwable/MCH_ThrowableInfoManager.java
+++ b/src/main/java/mcheli/throwable/MCH_ThrowableInfoManager.java
@@ -1,114 +1,63 @@
 package mcheli.throwable;
 
-import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import mcheli.MCH_InputFile;
 import mcheli.MCH_Lib;
 import mcheli.MCH_ResourceHelper;
-import mcheli.throwable.MCH_ThrowableInfo;
 import net.minecraft.item.Item;
 
 public class MCH_ThrowableInfoManager {
-
-   private static MCH_ThrowableInfoManager instance = new MCH_ThrowableInfoManager();
-   private static HashMap map = new LinkedHashMap();
+   private static volatile Map map = new LinkedHashMap();
    private static String lastPath;
 
+   public static boolean load(String path) { lastPath = path; return loadAndPublish(path, false); }
+   public static boolean reload() { return lastPath != null && loadAndPublish(lastPath, true); }
 
-   public static boolean load(String path) {
-      lastPath = path;
-      path = path.replace('\\', '/');
-      String dirPrefix = path + "throwable";
-      List<String> entries = MCH_ResourceHelper.listResources(dirPrefix, ".txt");
-      if(entries != null && entries.size() > 0) {
-         for(int i = 0; i < entries.size(); ++i) {
-            String resourcePath = entries.get(i);
-            MCH_InputFile inFile = new MCH_InputFile();
-            int line = 0;
-
-            try {
-               String e = MCH_ResourceHelper.getEntryName(resourcePath);
-               if(!map.containsKey(e) && inFile.openClasspath("/" + resourcePath)) {
-                  MCH_ThrowableInfo info = new MCH_ThrowableInfo(e);
-
-                  String str;
-                  while((str = inFile.readLine()) != null) {
-                     ++line;
-                     str = str.trim();
-                     int eqIdx = str.indexOf(61);
-                     if(eqIdx >= 0 && str.length() > eqIdx + 1) {
-                        info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
-                     }
-                  }
-
-                  info.checkData();
-                  map.put(e, info);
+   private static boolean loadAndPublish(String path, boolean reload) {
+      Map oldMap = map;
+      LinkedHashMap newMap = new LinkedHashMap();
+      List<String> entries = MCH_ResourceHelper.listResources(path.replace('\\', '/') + "throwable", ".txt");
+      if(entries == null || entries.isEmpty()) return false;
+      for(int i = 0; i < entries.size(); ++i) {
+         String resourcePath = entries.get(i);
+         MCH_InputFile inFile = new MCH_InputFile();
+         int line = 0;
+         try {
+            String name = MCH_ResourceHelper.getEntryName(resourcePath);
+            if(!newMap.containsKey(name) && inFile.openClasspath("/" + resourcePath)) {
+               MCH_ThrowableInfo info = new MCH_ThrowableInfo(name);
+               String str;
+               while((str = inFile.readLine()) != null) {
+                  ++line; str = str.trim(); int eqIdx = str.indexOf(61);
+                  if(eqIdx >= 0 && str.length() > eqIdx + 1) info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
                }
-            } catch (Exception var16) {
-               if(line > 0) {
-                  MCH_Lib.Log("### Load failed %s : line=%d", new Object[]{resourcePath, Integer.valueOf(line)});
-               } else {
-                  MCH_Lib.Log("### Load failed %s", new Object[]{resourcePath});
-               }
-
-               var16.printStackTrace();
-            } finally {
-               inFile.close();
+               info.checkData();
+               newMap.put(name, info);
             }
-         }
-
-         MCH_Lib.Log("Read %d throwable", new Object[]{Integer.valueOf(map.size())});
-         return map.size() > 0;
-      } else {
-         return false;
+         } catch(Exception e) {
+            MCH_Lib.Log("### Reload failed %s : line=%d; keeping previous throwable data", new Object[]{resourcePath, Integer.valueOf(line)});
+            e.printStackTrace(); return false;
+         } finally { inFile.close(); }
       }
-   }
-
-   public static boolean reload() {
-      if(lastPath == null) return false;
-      try {
-         map.clear();
-         return load(lastPath);
-      } catch (Exception e) {
-         e.printStackTrace();
-         return false;
+      if(newMap.isEmpty()) return false;
+      if(reload) for(Object key : newMap.keySet()) {
+         MCH_ThrowableInfo oldInfo = (MCH_ThrowableInfo)oldMap.get(key);
+         MCH_ThrowableInfo newInfo = (MCH_ThrowableInfo)newMap.get(key);
+         if(oldInfo != null) { newInfo.item = oldInfo.item; newInfo.itemID = oldInfo.itemID; newInfo.model = oldInfo.model; }
+         else MCH_Lib.Log("### New throwable definition %s requires item registration; restart the game", new Object[]{key});
       }
+      map = newMap;
+      MCH_Lib.Log("Read %d throwable", new Object[]{Integer.valueOf(newMap.size())});
+      return true;
    }
 
-   public static MCH_ThrowableInfo get(String name) {
-      return (MCH_ThrowableInfo)map.get(name);
-   }
-
-   public static MCH_ThrowableInfo get(Item item) {
-      Iterator i$ = map.values().iterator();
-
-      MCH_ThrowableInfo info;
-      do {
-         if(!i$.hasNext()) {
-            return null;
-         }
-
-         info = (MCH_ThrowableInfo)i$.next();
-      } while(info.item != item);
-
-      return info;
-   }
-
-   public static boolean contains(String name) {
-      return map.containsKey(name);
-   }
-
-   public static Set getKeySet() {
-      return map.keySet();
-   }
-
-   public static Collection getValues() {
-      return map.values();
-   }
-
+   public static MCH_ThrowableInfo get(String name) { return (MCH_ThrowableInfo)map.get(name); }
+   public static MCH_ThrowableInfo get(Item item) { Map snapshot = map; for(Object value : snapshot.values()) { MCH_ThrowableInfo info = (MCH_ThrowableInfo)value; if(info.item == item) return info; } return null; }
+   public static boolean contains(String name) { return map.containsKey(name); }
+   public static Set getKeySet() { return map.keySet(); }
+   public static Collection getValues() { return map.values(); }
 }

--- a/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
@@ -76,7 +76,6 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
             }
          }
       }
-      MCH_BaseVehicleInfo.allBaseVehicleInfo.put(name, this);
    }
 
    public String getDirectoryName() {

--- a/src/main/java/mcheli/vehicle/MCH_TurretInfoManager.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretInfoManager.java
@@ -1,57 +1,41 @@
 package mcheli.vehicle;
 
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import mcheli.MCH_BaseInfo;
+import mcheli.MCH_Lib;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_BaseVehicleInfoManager;
-import mcheli.vehicle.MCH_TurretInfo;
 import net.minecraft.item.Item;
 
 public class MCH_TurretInfoManager extends MCH_BaseVehicleInfoManager {
+   private static final MCH_TurretInfoManager instance = new MCH_TurretInfoManager();
+   protected void onNewReloadEntry(String name, MCH_BaseInfo info) { MCH_Lib.Log("### New vehicle definition %s requires item registration; restart the game", new Object[]{name}); }
 
-   private static MCH_TurretInfoManager instance = new MCH_TurretInfoManager();
-   public static HashMap map = new LinkedHashMap();
+   public static volatile Map map = new LinkedHashMap();
 
+   public static MCH_TurretInfoManager getInstance() { return instance; }
+   public static MCH_TurretInfo get(String name) { return (MCH_TurretInfo)map.get(name); }
+   public MCH_BaseInfo newInfo(String name) { return new MCH_TurretInfo(name); }
+   public Map getMap() { return map; }
+   protected void setMap(Map newMap) { map = newMap; MCH_BaseVehicleInfo.rebuildGlobalRegistry(); }
 
-   public static MCH_TurretInfo get(String name) {
-      return (MCH_TurretInfo)map.get(name);
+   protected void preserveRuntimeState(MCH_BaseInfo oldValue, MCH_BaseInfo newValue) {
+      MCH_TurretInfo oldInfo = (MCH_TurretInfo)oldValue;
+      MCH_TurretInfo newInfo = (MCH_TurretInfo)newValue;
+      newInfo.item = oldInfo.item;
+      newInfo.itemID = oldInfo.itemID;
+      newInfo.model = oldInfo.model;
    }
 
-   public static MCH_TurretInfoManager getInstance() {
-      return instance;
-   }
-
-   public MCH_BaseInfo newInfo(String name) {
-      return new MCH_TurretInfo(name);
-   }
-
-   public Map getMap() {
-      return map;
-   }
-
-   public static MCH_TurretInfo getFromItem(Item item) {
-      return getInstance().getAcInfoFromItem(item);
-   }
-
+   public static MCH_TurretInfo getFromItem(Item item) { return getInstance().getAcInfoFromItem(item); }
    public MCH_TurretInfo getAcInfoFromItem(Item item) {
-      if(item == null) {
-         return null;
-      } else {
-         Iterator i$ = map.values().iterator();
-
-         MCH_TurretInfo info;
-         do {
-            if(!i$.hasNext()) {
-               return null;
-            }
-
-            info = (MCH_TurretInfo)i$.next();
-         } while(info.item != item);
-
-         return info;
+      if(item == null) return null;
+      Map snapshot = map;
+      for(Object value : snapshot.values()) {
+         MCH_TurretInfo info = (MCH_TurretInfo)value;
+         if(info.item == item) return info;
       }
+      return null;
    }
-
 }

--- a/src/main/java/mcheli/weapon/MCH_WeaponInfoManager.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponInfoManager.java
@@ -4,6 +4,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -19,89 +21,64 @@ import net.minecraft.item.ItemStack;
 public class MCH_WeaponInfoManager {
 
    private static MCH_WeaponInfoManager instance = new MCH_WeaponInfoManager();
-   private static HashMap map;
+   private static volatile Map map;
    private static String lastPath;
 
 
    private MCH_WeaponInfoManager() {
-      map = new HashMap();
+      map = new LinkedHashMap();
    }
 
    public static boolean reload() {
-      boolean ret = false;
-
-      try {
-         map.clear();
-         ret = load(lastPath);
-         setRoundItems();
-         MCH_MOD.proxy.registerModels();
-      } catch (Exception var2) {
-         var2.printStackTrace();
-      }
-
-      return ret;
+      return lastPath != null && loadAndPublish(lastPath, true);
    }
 
    public static boolean load(String path) {
       lastPath = path;
+      return loadAndPublish(path, false);
+   }
+
+   private static boolean loadAndPublish(String path, boolean reload) {
+      LinkedHashMap newMap = new LinkedHashMap();
       path = path.replace('\\', '/');
-      String dirPrefix = path + "weapons";
-      List<String> entries = MCH_ResourceHelper.listResources(dirPrefix, ".txt");
-      if(entries != null && entries.size() > 0) {
-         for(int i = 0; i < entries.size(); ++i) {
-            String resourcePath = entries.get(i);
-            BufferedReader br = null;
-            int line = 0;
-
-            try {
-               String e = MCH_ResourceHelper.getEntryName(resourcePath);
-               if(!map.containsKey(e)) {
-                  br = MCH_ResourceHelper.openResource("/" + resourcePath);
-                  if (br == null) continue;
-                  MCH_WeaponInfo info = new MCH_WeaponInfo(e);
-
-                  String str;
-                  while((str = br.readLine()) != null) {
-                     ++line;
-                     str = str.trim();
-                     int eqIdx = str.indexOf(61);
-                     if(eqIdx >= 0 && str.length() > eqIdx + 1) {
-                        info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
-                     }
-                  }
-
-                  info.checkData();
-                  map.put(e, info);
+      List<String> entries = MCH_ResourceHelper.listResources(path + "weapons", ".txt");
+      if(entries == null || entries.isEmpty()) return false;
+      for(int i = 0; i < entries.size(); ++i) {
+         String resourcePath = entries.get(i);
+         BufferedReader br = null;
+         int line = 0;
+         try {
+            String name = MCH_ResourceHelper.getEntryName(resourcePath);
+            if(!newMap.containsKey(name)) {
+               br = MCH_ResourceHelper.openResource("/" + resourcePath);
+               if(br == null) continue;
+               MCH_WeaponInfo info = new MCH_WeaponInfo(name);
+               String str;
+               while((str = br.readLine()) != null) {
+                  ++line; str = str.trim(); int eqIdx = str.indexOf(61);
+                  if(eqIdx >= 0 && str.length() > eqIdx + 1) info.loadItemData(str.substring(0, eqIdx).trim().toLowerCase(), str.substring(eqIdx + 1).trim());
                }
-            } catch (IOException var22) {
-               if(line > 0) {
-                  MCH_Lib.Log("### Load failed %s : line=%d", new Object[]{resourcePath, Integer.valueOf(line)});
-               } else {
-                  MCH_Lib.Log("### Load failed %s", new Object[]{resourcePath});
-               }
-
-               var22.printStackTrace();
-            } finally {
-               try {
-                  if(br != null) {
-                     br.close();
-                  }
-               } catch (Exception var21) {
-                  ;
-               }
-
+               info.checkData();
+               newMap.put(name, info);
             }
-         }
-
-         MCH_Lib.Log("[mcheli] Read %d weapons", new Object[]{Integer.valueOf(map.size())});
-         return map.size() > 0;
-      } else {
-         return false;
+         } catch(Exception e) {
+            MCH_Lib.Log("### Reload failed %s : line=%d; keeping previous weapon data", new Object[]{resourcePath, Integer.valueOf(line)});
+            e.printStackTrace(); return false;
+         } finally { try { if(br != null) br.close(); } catch(IOException ignored) {} }
       }
+      if(newMap.isEmpty()) return false;
+      setRoundItems(newMap);
+      map = newMap;
+      MCH_Lib.Log("[mcheli] Read %d weapons", new Object[]{Integer.valueOf(newMap.size())});
+      return true;
    }
 
    public static void setRoundItems() {
-      Iterator i$ = map.values().iterator();
+      setRoundItems(map);
+   }
+
+   private static void setRoundItems(Map snapshot) {
+      Iterator i$ = snapshot.values().iterator();
 
       while(i$.hasNext()) {
          MCH_WeaponInfo w = (MCH_WeaponInfo)i$.next();


### PR DESCRIPTION
### Motivation

- The reload path mutated published `LinkedHashMap` instances in-place, allowing the render/netty thread to iterate a map while it was being cleared and repopulated, causing `ConcurrentModificationException` during item rendering.  
- The intent is to make `/mcheli reload` transactional and thread-safe so rendering and network threads always see a stable, ordered snapshot while reload parsing runs concurrently.

### Description

- Replaced in-place map mutation with transactional reload snapshots in `MCH_InfoManagerBase` by parsing into a fresh `LinkedHashMap` and atomically publishing it with `setMap(...)`; added `preserveRuntimeState(...)` and `onNewReloadEntry(...)` hooks to preserve runtime-only fields when appropriate. (`src/main/java/mcheli/MCH_InfoManagerBase.java`).
- Converted per-family managers to publish `volatile` ordered snapshots and to preserve runtime state for matching entries; applied changes to helicopters, planes, ships, tanks, and turrets and rebuilt the global registry atomically via `MCH_BaseVehicleInfo.rebuildGlobalRegistry()`. (`src/main/java/mcheli/*/*InfoManager.java`, `src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java`).
- Implemented transactional reloads for weapons, items, and throwables so they build new ordered maps and atomically replace the published snapshot while preserving runtime item registrations and model references where applicable. (`src/main/java/mcheli/weapon/MCH_WeaponInfoManager.java`, `src/main/java/mcheli/item/MCH_ItemInfoManager.java`, `src/main/java/mcheli/throwable/MCH_ThrowableInfoManager.java`).
- Moved client-only reload work off the Netty/thread pool and into the main Minecraft client thread using the Forge 1.7.10 scheduler `Minecraft.func_152344_a(Runnable)` via a sided-proxy method `scheduleClientInfoReload()` so that model registration, HUD reload, sound updates, and OpenGL work run on the safe client thread; server-side command now notifies clients and schedules only server-safe tasks. (`src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java`, `src/main/java/mcheli/MCH_ClientProxy.java`, `src/main/java/mcheli/MCH_CommonProxy.java`, `src/main/java/mcheli/command/MCH_Command.java`).
- Added client-only renderer cache cleanup that deletes stale GL display lists and clears the model build queue and scheduler state during reload to avoid retaining stale GL resources and queued model builds. (`src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java`).
- Updated behavior: new definitions detected during reload no longer attempt item registration (they log a clear warning), matching names preserve `item`, `itemID`, and `model` runtime fields, and published maps preserve insertion order via `LinkedHashMap` snapshots. (`multiple files`).
- Documented the change in `changelog.md` and committed the changes as the PR. (`changelog.md`).

### Testing

- Ran `git diff --check` to verify no whitespace/merge issues and the diff sanity checks passed. (success).  
- Ran `./gradlew tasks --offline` to verify Gradle configuration/task discovery works in this environment. (success).  
- Did not run `./gradlew compileJava` or `./gradlew build` because compiling/artifact generation was intentionally skipped per repository instructions; no binary artifacts were produced. (not run).  
- In-game, multi-cycle reload and rendering verification (the 20x reload while rendering, dedicated-server/client packet behavior, and display-list leak checks) require a Forge 1.7.10 runtime and were not executed in this environment; those manual runtime verifications remain required before merging.  

Files with key changes: `MCH_InfoManagerBase.java`, `MCH_BaseVehicleInfo.java`, family managers under `helicopter/`, `plane/`, `ship/`, `tank/`, `vehicle/`, `weapon/MCH_WeaponInfoManager.java`, `item/MCH_ItemInfoManager.java`, `throwable/MCH_ThrowableInfoManager.java`, `MCH_VehicleItemModelRender.java`, `MCH_BaseVehiclePacketHandler.java`, `MCH_ClientProxy.java`, `MCH_CommonProxy.java`, `MCH_Command.java`, and `changelog.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a94c0ce208323a9ead2474dcdb1c8)