### PR TITLE
Creative Instant Vehicle Placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For development asset testing, the build/run setup expects assets in `build/run/
 
 1. Open the MCHeli creative tabs (`MCHeliO Item`, `MCHeliO Helicopters`, `MCHeliO Planes`, `MCHeliO Ships`, `MCHeliO Tanks`, `MCHeliO Vehicles`, and `MCHeliO Recipe Items`).
 2. Place or craft a **Drafting Table** to access recipes when recipes are enabled.
-3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. Turret items place instantly after the normal placement checks, while other vehicles use the hold-to-deploy flow. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
+3. Use vehicle item icons to place vehicles; those icons render the loaded 3D vehicle model in inventories, held views, and dropped item form. Creative-mode players place all non-UAV vehicles instantly after the normal placement checks. In Survival, turret items remain instant while other vehicles use the configured hold-to-deploy delay. If `PlaceableOnSpongeOnly` is enabled, vehicles must be placed on sponge blocks.
 4. Enter vehicles, use the configured movement/weapon keys, and refuel/repair according to the content pack's vehicle definitions.
 5. Server operators can use `/mcheli list` to discover available administrative subcommands.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Creative Instant Vehicle Placement
+
+- Made all normal non-UAV vehicle items place instantly for Creative-mode players after the existing target, world-age, sponge-only, entity, and collision checks.
+- Preserved the configured hold-to-deploy timer for Survival-mode players and the existing instant-placement behavior of vehicle types such as turrets.
+- Updated the player and configuration documentation to distinguish Creative and Survival placement behavior.
+
 ## Fix local vehicle appearing on RWR
 
 - Excluded the locally controlled aircraft from RWR contacts by synchronized entity ID before applying contact type or display-distance filters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `delayrangeloader` | `5` | Advanced loader timing option. Exact gameplay effect needs code-level tracing. |
 | `bombletloader` | `10` | Advanced bomblet loader option. Exact gameplay effect needs code-level tracing. |
 | `wrenchdropitem` | `false` | Wrench drop-item behavior toggle. |
-| `placetimer` | `60` | Placement timer value. |
+| `placetimer` | `60` | Survival-mode vehicle hold-to-deploy timer; Creative placement is instant. |
 | `RangeFinderSpotDist` | `400` | Rangefinder spot distance. |
 | `RangeFinderSpotTime` | `15` | Rangefinder spot duration. |
 | `RangeFinderConsume` | `true` | Rangefinder consumes required item/ammo when spotting. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ Set `ItemRecipe_DraftingTable` in `mcheli.cfg` to change or disable the recipe a
 
 ## 5. Place and use vehicles
 
-- Vehicle placement is controlled by item definitions and global settings.
+- Creative-mode players place non-UAV vehicles instantly after the normal placement checks. Survival-mode players retain the configured placement delay, except for vehicle types such as turrets whose item definitions already opt into instant placement.
 - UAV vehicle items are not placed with the normal hold-to-deploy flow. Large UAVs must be placed and controlled from a UAV Station; small UAVs use a UAV Station or Portable UAV Controller when supported.
 - If `PlaceableOnSpongeOnly = true`, vehicle placement is restricted to sponge blocks.
 - Global speed scalars are controlled by `AllHeliSpeed`, `AllPlaneSpeed`, `AllShipSpeed`, and `AllTankSpeed`.

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -253,7 +253,7 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
             return par1ItemStack;
          }
 
-         if(this.shouldPlaceInstantly()) {
+         if(player.capabilities.isCreativeMode || this.shouldPlaceInstantly()) {
             if(par1ItemStack.stackTagCompound != null) {
                clearDeployTags(par1ItemStack.stackTagCompound);
             }


### PR DESCRIPTION
### Motivation
- Improve UX by making vehicle item placement instant for Creative-mode players while keeping existing hold-to-deploy safety checks and Survival behavior intact.
- Keep UAV placement rules and existing instant-placement overrides (e.g. turrets) unchanged.
- Record the change in the changelog and update user-facing documentation to avoid confusion about placement behavior.

### Description
- Deploys immediately when the player is in Creative by changing the placement branch to `if (player.capabilities.isCreativeMode || this.shouldPlaceInstantly())` in `MCH_ItemBaseVehicle` so creative players bypass the hold-to-deploy timer but still run all placement checks and collision/sponge/world-age tests.
- Preserved the existing hold-to-deploy flow driven by `MCH_Config.placetimer` for Survival-mode players and preserved UAV special-case behavior and turret instant-placement overrides.
- Updated `README.md` and `docs/getting-started.md` to explain the Creative vs Survival placement distinction, and clarified `placetimer` in `docs/configuration.md` as a Survival-mode hold-to-deploy timer.
- Added an entry to `changelog.md` documenting the Creative instant-placement change.

### Testing
- Ran `git diff --check` to ensure no diff warnings and it passed.
- Executed Python assertions that verified the new Creative instant-placement branch exists, that the UAV guard remains earlier than the instant branch, and that the Survival `placetimer` branch remains present, which all succeeded.
- Verified the working tree and file changes via automated checks to ensure the source and documentation files were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ac75e02288323aa21ac3074aaaf7a)