### PR TITLE
Global Artillery Range Modifier

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Global Artillery Range Modifier
+
+- Added the reloadable, minimum-clamped `ArtilleryRangeModifier` global setting and the opt-in `UseGlobalArtilleryRangeModifier` weapon text key.
+- Kept existing weapons unchanged by default while using one effective launch acceleration for projectile spawning, high-speed projectile stepping, mortar distance output, and client ballistic prediction.
+- Documented that mortar-distance display is independent of modifier eligibility and that vehicles do not receive a separate artillery modifier.
+
 ## Creative Instant Vehicle Placement
 
 - Made all normal non-UAV vehicle items place instantly for Creative-mode players after the existing target, world-age, sponge-only, entity, and collision checks.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `AutoThrottleDownTank` | `false` | Auto-throttle-down behavior for tanks. |
 | `SwitchWeaponWithMouseWheel` | `true` | Allows mouse-wheel weapon switching. |
 | `LWeaponAutoFire` | `false` | Auto-fire behavior for light weapons. |
+| `ArtilleryRangeModifier` | `1.0` | Multiplies launch speed only for weapon text files with `UseGlobalArtilleryRangeModifier = true`. Values below `0.01` are clamped to `0.01`; `1.0` keeps original range. |
 | `EnableHandheld` | `true` | Enables crafting recipes for hand-held weapons and their ammunition (`Stinger`, `Javelin`, and `RPG`). Set to `false` to prevent those recipes from registering. |
 | `DisableItemRender` | `1` | Valid range noted in source: `0 ~ 3`; `1` recommended. |
 | `Override3DItemIcon` | `false` | Global 3D vehicle item icon override. `true` forces 3D item icons off; `false` allows per-vehicle `Enable3DItemIcon` settings. |
@@ -119,6 +120,16 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
 
 ## Vehicle content-pack keys
+
+## Weapon artillery range opt-in
+
+Place the following key in an individual weapon text file to opt that weapon into the global launch-speed multiplier:
+
+```text
+UseGlobalArtilleryRangeModifier = true
+```
+
+The weapon-key default is `false`, so existing weapon files and explicitly disabled weapons retain their original speed and range. `ArtilleryRangeModifier = 1.0` also preserves the original range. `DisplayMortarDistance` controls only whether the HUD displays an impact distance; it neither classifies a weapon as artillery nor controls modifier eligibility. This is a per-weapon opt-in, not a per-vehicle setting, so one vehicle can combine a modified artillery weapon with an unchanged secondary weapon.
 
 Vehicle `.txt` definitions can opt individual items into or out of 3D item rendering and tune their own size after the global type scale is applied:
 

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -113,6 +113,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm Collision_EntityDamage;
    public static MCH_ConfigPrm Collision_EntityTankDamage;
    public static MCH_ConfigPrm LWeaponAutoFire;
+   public static MCH_ConfigPrm ArtilleryRangeModifier;
    public static MCH_ConfigPrm EnableHandheld;
    public static MCH_ConfigPrm DismountAll;
    public static MCH_ConfigPrm MountMinecartHeli;
@@ -435,6 +436,8 @@ public class MCH_Config {
       Collision_EntityDamage = new MCH_ConfigPrm("Collision_EntityDamage", true);
       Collision_EntityTankDamage = new MCH_ConfigPrm("Collision_EntityTankDamage", false);
       LWeaponAutoFire = new MCH_ConfigPrm("LWeaponAutoFire", false);
+      ArtilleryRangeModifier = new MCH_ConfigPrm("ArtilleryRangeModifier", 1.0D);
+      ArtilleryRangeModifier.desc = ";Multiplies launch speed for weapon text files that enable UseGlobalArtilleryRangeModifier. 1.0 keeps the original speed.";
       EnableHandheld = new MCH_ConfigPrm("EnableHandheld", true);
       DismountAll = new MCH_ConfigPrm("DismountAll", false);
       MountMinecartHeli = new MCH_ConfigPrm("MountMinecartHeli", true);
@@ -792,6 +795,7 @@ public class MCH_Config {
               AutoThrottleDownShip,
               AutoThrottleDownTank,
               SwitchWeaponWithMouseWheel,
+              ArtilleryRangeModifier,
               LWeaponAutoFire,
               EnableHandheld,
               DisableItemRender,
@@ -1252,6 +1256,9 @@ public class MCH_Config {
                var8 = var7[i$];
                if(var8 != null && var8.compare(s[0]) && var8.isValidVer(configVer)) {
                   var8.setPrm(s[1]);
+                  if(var8 == ArtilleryRangeModifier && ArtilleryRangeModifier.prmDouble < 0.01D) {
+                     ArtilleryRangeModifier.prmDouble = 0.01D;
+                  }
                   return;
                }
             }

--- a/src/main/java/mcheli/plane/MCP_GuiPlane.java
+++ b/src/main/java/mcheli/plane/MCP_GuiPlane.java
@@ -883,7 +883,7 @@ public class MCP_GuiPlane extends MCH_BaseVehicleCommonGui {
          Vec3 direction = mcheli.MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -roll);
          double length = direction.lengthVector();
          if(length > 1.0E-7D) {
-            double constructorSpeed = Math.min(3.9D, (double)weapon.getInfo().acceleration);
+            double constructorSpeed = Math.min(3.9D, weapon.getEffectiveLaunchAcceleration());
             double ejectionScale = constructorSpeed * 0.5D / length;
             k.ejectionVelocity = Vec3.createVectorHelper(
                   direction.xCoord * ejectionScale,

--- a/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java
@@ -454,7 +454,8 @@ public final class MCP_PlaneCCIPHelper {
       if(info == null) {
          return 0.0D;
       }
-      return Math.min(3.9D, Math.max(0.0D, (double)info.acceleration));
+      double effectiveAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(info, (double)info.acceleration);
+      return Math.min(3.9D, Math.max(0.0D, effectiveAcceleration));
    }
 
    private static double getInitialHorizontalDrag(MCH_WeaponInfo info, double entityAcceleration) {
@@ -539,7 +540,7 @@ public final class MCP_PlaneCCIPHelper {
          Vec3 direction = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -yaw, -pitch, -roll);
          double length = direction.lengthVector();
          if(length > EPSILON) {
-            double constructorSpeed = Math.min(3.9D, (double)weapon.getInfo().acceleration);
+            double constructorSpeed = Math.min(3.9D, weapon.getEffectiveLaunchAcceleration());
             double ejectionScale = constructorSpeed * 0.5D / length;
             k.ejectionVelocity = Vec3.createVectorHelper(direction.xCoord * ejectionScale, direction.yCoord * ejectionScale, direction.zCoord * ejectionScale);
             k.initialVelocity.xCoord += k.ejectionVelocity.xCoord;

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -347,11 +347,15 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
 
         this.piercing = this.getInfo().piercing;
         if (this instanceof MCH_EntityBullet) {
-            if (this.getInfo().acceleration > 4.0F) {
-                this.accelerationFactor = (double) (this.getInfo().acceleration / 4.0F);
+            double effectiveAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(this.getInfo(), (double)this.getInfo().acceleration);
+            if (effectiveAcceleration > 4.0D) {
+                this.accelerationFactor = effectiveAcceleration / 4.0D;
             }
-        } else if (this instanceof MCH_EntityRocket && this.isBomblet == 0 && this.getInfo().acceleration > 4.0F) {
-            this.accelerationFactor = (double) (this.getInfo().acceleration / 4.0F);
+        } else if (this instanceof MCH_EntityRocket && this.isBomblet == 0) {
+            double effectiveAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(this.getInfo(), (double)this.getInfo().acceleration);
+            if(effectiveAcceleration > 4.0D) {
+                this.accelerationFactor = effectiveAcceleration / 4.0D;
+            }
         }
 
     }

--- a/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
@@ -48,7 +48,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
             double tX = -MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tZ = MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tY = -MathHelper.sin(pitch / 180.0F * 3.1415927F);
-            MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, (double) super.acceleration);
+            MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
             if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
                yaw -= 360.0F;
             } else if (yaw < -180.0F) {
@@ -73,7 +73,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
                double tX = (double) (-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tZ = (double) (MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tY = (double) (-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-               MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, (double) super.acceleration);
+               MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
                if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
                   yaw -= 360.0F;
                } else if (yaw < -180.0F) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponASMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponASMissile.java
@@ -92,7 +92,7 @@ public class MCH_WeaponASMissile extends MCH_WeaponBase {
       // If raycast hits a valid block and it is not underwater
       if (!this.worldObj.isRemote) {
          // Creates missile entity and sets parameters
-         MCH_EntityASMissile missile = new MCH_EntityASMissile(this.worldObj, params.posX, params.posY, params.posZ, targetX, targetY, targetZ, yaw, pitch, this.acceleration);
+         MCH_EntityASMissile missile = new MCH_EntityASMissile(this.worldObj, params.posX, params.posY, params.posZ, targetX, targetY, targetZ, yaw, pitch, this.getEffectiveLaunchAcceleration());
          missile.setName(this.name);
          missile.setParameterFromWeapon(this, params.entity, params.user);
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
@@ -62,7 +62,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
             double tX = -MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tZ = MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tY = -MathHelper.sin(pitch / 180.0F * 3.1415927F);
-            MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, (double) super.acceleration);
+            MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
             if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
                yaw -= 360.0F;
             } else if (yaw < -180.0F) {
@@ -88,7 +88,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
                double tX = (double) (-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tZ = (double) (MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tY = (double) (-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-               MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, (double) super.acceleration);
+               MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
                if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
                   yaw -= 360.0F;
                } else if (yaw < -180.0F) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponBase.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponBase.java
@@ -1,5 +1,6 @@
 package mcheli.weapon;
 
+import mcheli.MCH_Config;
 import mcheli.MCH_Lib;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.wrapper.W_McClient;
@@ -79,6 +80,18 @@ public abstract class MCH_WeaponBase {
 
    public MCH_WeaponInfo getInfo() {
       return this.weaponInfo;
+   }
+
+   public static double getEffectiveLaunchAcceleration(MCH_WeaponInfo weaponInfo, double originalAcceleration) {
+      double effectiveAcceleration = originalAcceleration;
+      if(weaponInfo != null && weaponInfo.useGlobalArtilleryRangeModifier) {
+         effectiveAcceleration *= Math.max(0.01D, MCH_Config.ArtilleryRangeModifier.prmDouble);
+      }
+      return effectiveAcceleration;
+   }
+
+   public double getEffectiveLaunchAcceleration() {
+      return getEffectiveLaunchAcceleration(this.weaponInfo, (double)this.acceleration);
    }
 
    public String getName() {
@@ -241,14 +254,15 @@ public abstract class MCH_WeaponBase {
       } else {
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
          double s = Math.sqrt(v.xCoord * v.xCoord + v.yCoord * v.yCoord + v.zCoord * v.zCoord);
-         double acc = this.acceleration < 4.0F?(double)this.acceleration:4.0D;
-         double accFac = (double)this.acceleration / acc;
-         double my = v.yCoord * (double)this.acceleration / s;
+         double effectiveAcceleration = this.getEffectiveLaunchAcceleration();
+         double acc = effectiveAcceleration < 4.0D?effectiveAcceleration:4.0D;
+         double accFac = effectiveAcceleration / acc;
+         double my = v.yCoord * effectiveAcceleration / s;
          if(my <= 0.0D) {
             return -1.0D;
          } else {
-            double mx = v.xCoord * (double)this.acceleration / s;
-            double mz = v.zCoord * (double)this.acceleration / s;
+            double mx = v.xCoord * effectiveAcceleration / s;
+            double mz = v.zCoord * effectiveAcceleration / s;
             double ls = my / (double)this.weaponInfo.gravity;
             double gravity = (double)this.weaponInfo.gravity * accFac;
             double spx;

--- a/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponBomb.java
@@ -45,7 +45,7 @@ public class MCH_WeaponBomb extends MCH_WeaponBase {
                prm.posX, prm.posY, prm.posZ,
                prm.entity.motionX, prm.entity.motionY, prm.entity.motionZ,
                prm.entity.rotationYaw, 0.0F,
-               (double)super.acceleration);
+               super.getEffectiveLaunchAcceleration());
 
          bomb.setName(super.name);
          bomb.setParameterFromWeapon(this, prm.entity, prm.user);

--- a/src/main/java/mcheli/weapon/MCH_WeaponCAS.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponCAS.java
@@ -119,7 +119,7 @@ public class MCH_WeaponCAS extends MCH_WeaponBase {
       a10.shootingAircraft = this.shooter;
       a10.explosionPower = super.explosionPower;
       a10.power = super.power;
-      a10.acceleration = super.acceleration;
+      a10.acceleration = (float)super.getEffectiveLaunchAcceleration();
       super.worldObj.spawnEntityInWorld(a10);
       W_WorldFunc.MOD_playSoundEffect(super.worldObj, x, y, z, "a-10_snd", 150.0F, 1.0F);
    }

--- a/src/main/java/mcheli/weapon/MCH_WeaponDispenser.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponDispenser.java
@@ -26,7 +26,7 @@ public class MCH_WeaponDispenser extends MCH_WeaponBase {
       if(!super.worldObj.isRemote) {
          this.playSound(prm.entity);
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
-         MCH_EntityDispensedItem e = new MCH_EntityDispensedItem(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, (double)super.acceleration);
+         MCH_EntityDispensedItem e = new MCH_EntityDispensedItem(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, super.getEffectiveLaunchAcceleration());
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          e.motionX = prm.entity.motionX + e.motionX * 0.5D;

--- a/src/main/java/mcheli/weapon/MCH_WeaponInfo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponInfo.java
@@ -93,6 +93,7 @@ public class MCH_WeaponInfo extends MCH_BaseInfo {
     public float radius;
     public float angle;
     public boolean displayMortarDistance;
+    public boolean useGlobalArtilleryRangeModifier = false;
     public boolean fixCameraPitch;
     public float cameraRotationSpeedPitch;
     public int target;
@@ -439,6 +440,8 @@ public class MCH_WeaponInfo extends MCH_BaseInfo {
             this.flaming = this.toBool(data);
         } else if (item.equalsIgnoreCase("DisplayMortarDistance")) {
             this.displayMortarDistance = this.toBool(data);
+        } else if (item.equalsIgnoreCase("UseGlobalArtilleryRangeModifier")) {
+            this.useGlobalArtilleryRangeModifier = this.toBool(data);
         } else if (item.equalsIgnoreCase("FixCameraPitch")) {
             this.fixCameraPitch = this.toBool(data);
         } else if (item.equalsIgnoreCase("CameraRotationSpeedPitch")) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponMachineGun1.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponMachineGun1.java
@@ -18,7 +18,7 @@ public class MCH_WeaponMachineGun1 extends MCH_WeaponBase {
    public boolean shot(MCH_WeaponParam prm) {
       if(!super.worldObj.isRemote) {
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
-         MCH_EntityBullet e = new MCH_EntityBullet(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, (double)super.acceleration);
+         MCH_EntityBullet e = new MCH_EntityBullet(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, super.getEffectiveLaunchAcceleration());
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          e.posX += e.motionX * 0.5D;

--- a/src/main/java/mcheli/weapon/MCH_WeaponMachineGun2.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponMachineGun2.java
@@ -30,7 +30,7 @@ public class MCH_WeaponMachineGun2 extends MCH_WeaponBase {
    public boolean shot(MCH_WeaponParam prm) {
       if(!super.worldObj.isRemote) {
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
-         MCH_EntityBullet e = new MCH_EntityBullet(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, (double)super.acceleration);
+         MCH_EntityBullet e = new MCH_EntityBullet(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, super.getEffectiveLaunchAcceleration());
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          if(this.getInfo().modeNum < 2) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponMarkerRocket.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponMarkerRocket.java
@@ -26,7 +26,7 @@ public class MCH_WeaponMarkerRocket extends MCH_WeaponBase {
       if(!super.worldObj.isRemote) {
          this.playSound(prm.entity);
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
-         MCH_EntityMarkerRocket e = new MCH_EntityMarkerRocket(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, (double)super.acceleration);
+         MCH_EntityMarkerRocket e = new MCH_EntityMarkerRocket(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, super.getEffectiveLaunchAcceleration());
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          e.setMarkerStatus(1);

--- a/src/main/java/mcheli/weapon/MCH_WeaponRocket.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponRocket.java
@@ -30,7 +30,7 @@ public class MCH_WeaponRocket extends MCH_WeaponBase {
       if(!super.worldObj.isRemote) {
          this.playSound(prm.entity);
          Vec3 v = MCH_Lib.RotVec3(0.0D, 0.0D, 1.0D, -prm.rotYaw, -prm.rotPitch, -prm.rotRoll);
-         MCH_EntityRocket e = new MCH_EntityRocket(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, (double)super.acceleration);
+         MCH_EntityRocket e = new MCH_EntityRocket(super.worldObj, prm.posX, prm.posY, prm.posZ, v.xCoord, v.yCoord, v.zCoord, prm.rotYaw, prm.rotPitch, super.getEffectiveLaunchAcceleration());
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          if(prm.option1 == 0 && super.numMode > 1) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponTorpedo.java
@@ -59,11 +59,12 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
          double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
          double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
          double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-         mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
-         my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
-         mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
-         super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
-         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, 0.0F, (double)super.acceleration);
+         double launchAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(this.getInfo(), (double)this.getInfo().acceleration);
+         mx = mx * launchAcceleration + prm.entity.motionX;
+         my = my * launchAcceleration + prm.entity.motionY;
+         mz = mz * launchAcceleration + prm.entity.motionZ;
+         double acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
+         MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, 0.0F, acceleration);
          e.setName(super.name);
          e.setParameterFromWeapon(this, prm.entity, prm.user);
          e.motionX = mx;
@@ -86,12 +87,13 @@ public class MCH_WeaponTorpedo extends MCH_WeaponBase {
       double mx = (double)(-MathHelper.sin(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
       double mz = (double)(MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
       double my = (double)(-MathHelper.sin(pitch / 180.0F * 3.1415927F));
-      mx = mx * (double)this.getInfo().acceleration + prm.entity.motionX;
-      my = my * (double)this.getInfo().acceleration + prm.entity.motionY;
-      mz = mz * (double)this.getInfo().acceleration + prm.entity.motionZ;
-      super.acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
+      double launchAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(this.getInfo(), (double)this.getInfo().acceleration);
+      mx = mx * launchAcceleration + prm.entity.motionX;
+      my = my * launchAcceleration + prm.entity.motionY;
+      mz = mz * launchAcceleration + prm.entity.motionZ;
+      double acceleration = MathHelper.sqrt_double(mx * mx + my * my + mz * mz);
 
-      MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, pitch, (double)super.acceleration);
+      MCH_EntityTorpedo e = new MCH_EntityTorpedo(super.worldObj, prm.posX, prm.posY, prm.posZ, mx, my, mz, yaw, pitch, acceleration);
       e.setName(super.name);
       e.setParameterFromWeapon(this, prm.entity, prm.user);
       e.motionX = mx;

--- a/src/main/java/mcheli/weapon/MCH_WeaponTvMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponTvMissile.java
@@ -123,7 +123,8 @@ public class MCH_WeaponTvMissile extends MCH_WeaponBase {
          acr = (float)((double)acr * 1.5D);
       }
 
-      MCH_EntityTvMissile e = new MCH_EntityTvMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, (double)acr);
+      double effectiveAcceleration = MCH_WeaponBase.getEffectiveLaunchAcceleration(this.getInfo(), (double)acr);
+      MCH_EntityTvMissile e = new MCH_EntityTvMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, effectiveAcceleration);
       e.setName(super.name);
       e.setParameterFromWeapon(this, prm.entity, prm.user);
       this.lastShotEntity = prm.entity;

--- a/src/main/resources/assets/mcheli/readme_weaponEN.txt
+++ b/src/main/resources/assets/mcheli/readme_weaponEN.txt
@@ -287,7 +287,14 @@ SmokeMaxAge = 500
 ; Maximum duration the smoke is displayed.
 
 DisplayMortarDistance = true
-; Displays the distance to impact for mortars.
+; Controls only the HUD distance-to-impact display. It does not make a weapon
+; eligible for the global artillery range modifier.
+
+UseGlobalArtilleryRangeModifier = true
+; This key belongs in a weapon text file and defaults to false. When true, the
+; configured Acceleration launch speed is multiplied by the global
+; ArtilleryRangeModifier. A global value of 1.0 keeps the original range.
+; DisplayMortarDistance does not control modifier eligibility.
 
 FixCameraPitch = true
 ; Fixes the vertical camera angle to 0.


### PR DESCRIPTION
### Motivation
- Provide a single, reloadable global multiplier to adjust artillery launch speed while keeping existing weapon behavior unchanged unless explicitly opted in.
- Ensure client ballistic prediction, HUD mortar-distance displays, and server projectile creation all use the same effective launch acceleration so prediction and server motion remain consistent.

### Description
- Added a new global config parameter `ArtilleryRangeModifier` (type `MCH_ConfigPrm`, default `1.0`, clamped to `0.01`) and registered it in the `General` config group with a descriptive comment; it is read at runtime from `MCH_Config` and saved/loaded with the existing config system (`src/main/java/mcheli/MCH_Config.java`).
- Added a weapon text key `UseGlobalArtilleryRangeModifier` parsed into `MCH_WeaponInfo` as `public boolean useGlobalArtilleryRangeModifier = false;` so existing weapon files keep their original acceleration unless they set the key (`src/main/java/mcheli/weapon/MCH_WeaponInfo.java`).
- Implemented a single shared helper `getEffectiveLaunchAcceleration(MCH_WeaponInfo, double)` in `MCH_WeaponBase` and an instance accessor `getEffectiveLaunchAcceleration()` that returns the effective launch acceleration by applying the global modifier only when the weapon has opted in; this method never mutates `MCH_WeaponInfo` or stored weapon fields (`src/main/java/mcheli/weapon/MCH_WeaponBase.java`).
- Rewired projectile creation and relevant ballistic code to use the local effective acceleration (applied exactly once): projectile constructors, high-speed motion setup, accelerationFactor calculations, and client ballistic prediction now use the helper so server and client remain consistent (`src/main/java/mcheli/weapon/*`, `src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java`, `src/main/java/mcheli/plane/MCP_PlaneCCIPHelper.java`, `src/main/java/mcheli/plane/MCP_GuiPlane.java`).
- Added documentation and examples describing the new global key and the per-weapon opt-in flag in `src/main/resources/assets/mcheli/readme_weaponEN.txt` and added the new option to `docs/configuration.md` and `changelog.md`.
- Kept changes narrowly scoped: did not add per-vehicle settings, did not mutate `MCH_WeaponInfo.acceleration`, and ensured the multiplier is applied only during launch calculations (local effective acceleration values are used when creating projectiles).

### Testing
- Ran `git diff --check` (no whitespace or trivial issues reported) and verified repository status; commit created (`Add opt-in global artillery range modifier`).
- Ran source-level assertions and small Python checks to confirm `ArtilleryRangeModifier` registration, the `UseGlobalArtilleryRangeModifier` parsing, the presence of `getEffectiveLaunchAcceleration`, and that the clamping logic to `0.01` exists; those checks passed.
- Verified changed code paths where effective acceleration is consumed (projectile constructors, `MCH_EntityBaseBullet` accelerationFactor, `MCP_PlaneCCIPHelper` constructor acceleration), ensuring the helper is used instead of direct reads; static grep/inspection confirmed updates.
- Did not run `./gradlew compileJava`, repository build, or Java tests because compiling/binary outputs was explicitly avoided per instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad162ef188323a23eae4dde05760e)