### PR TITLE
Add persistent server-authoritative vehicle access locks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -295,3 +295,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Schedule client reload, model, HUD, sound, renderer, and OpenGL cache work on the Minecraft client thread.
 - Clear stale vehicle item display lists and pending model builds during the client reload.
 - Rebuild the shared vehicle registry from current manager snapshots without exposing partially loaded data.
+# Persistent server-authoritative vehicle access locks
+
+- Added placing-player ownership and legacy pilot claiming for player-ridable vehicles.
+- Added an operator-aware, persistent entry lock toggled by the pilot with O.
+- Added synchronized lock HUD state and owner/lock entity and item NBT data.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,3 +332,8 @@ Plane camera tuning is exposed in the in-game MCHeli options opened from the air
 For awareness, prefer stable distance plus a wider FOV rather than large dynamic distance swings. `EnablePlaneChaseFOVOverride` is disabled by default for public testing; when manually enabled it uses `PlaneChaseFOV = 95`. Recommended chase FOV values are 85-105. `PlaneChaseFreelookFOV` defaults to the same value, and `PlaneChaseFOVSmoothing` blends the override when entering, freelooking, or leaving the camera.
 
 Hold-freelook is hold-to-orbit: mouse input changes raw orbit yaw/pitch targets, while `PlaneFreelookYawSmoothing` and `PlaneFreelookPitchSmoothing` smooth the rendered orbit. `PlaneFreelookReturnSmoothing` controls the blend back to rear chase after release. Recommended starting values are sensitivity 0.15, yaw/pitch smoothing around 0.18-0.28, return smoothing around 0.12-0.22, max pitch up around 75 degrees, and max pitch down around 65 degrees. Freelook should feel smooth and camera-like, not raw or jittery.
+# Vehicle access lock key
+
+`KeyVehicleLock` defaults to LWJGL key code `24` (**O**). While directly riding
+the pilot seat, press it to ask the server to lock or unlock vehicle entry.
+The server, not the client key binding, decides whether the request is allowed.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -223,3 +223,25 @@ Conventional guided-bomb and normal ballistic bomb references use real standard 
 **How it differs from original MCHeli:** The project treats shared vehicle infrastructure as a cross-category framework for planes, helicopters, ships, tanks, turrets, UAVs, seats, weapons, renderers, and controls rather than a helicopter-only or aircraft-only layer.
 
 **Configuration:** Most refactor-facing options are documented in `docs/configuration.md`; developer-facing boundaries are documented in `docs/frame-rate-physics.md` and `docs/vehicle-naming-conventions.md`.
+# Persistent vehicle access locks
+
+Player-ridable helicopters, planes, ships, tanks, turrets, and other vehicles
+have a server-authoritative entry lock. The placing player owns a newly placed
+vehicle, which always starts unlocked. An ownerless legacy vehicle is claimed by
+the first player who successfully enters its pilot position; passenger entry and
+inventory, repair, fuel, or ammunition actions never claim it.
+
+Only the current pilot may toggle the lock, and that pilot must be the owner or
+a server operator. Owners and operators may enter a locked vehicle; everyone
+else is denied both pilot and passenger entry. Existing occupants are not
+ejected, may leave normally, and may switch seats inside the same vehicle.
+
+Ownership is stored as a Java-compatible UUID string in
+`MCH_VehicleOwnerUUID`, and the state is stored in
+`MCH_VehicleAccessLocked`. Missing or invalid owner data clears ownership and
+starts the legacy vehicle unlocked. Whole-vehicle item data records both values,
+but placement transfers ownership to the placing player and starts unlocked.
+
+The access lock is a door-style permission control only. It does not require or
+animate a visual hatch or canopy and does not affect weapon/missile target locks,
+UAV control, racks, towing, or AI gunners.

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -53,6 +53,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm KeyAttack;
    public static MCH_ConfigPrm KeyUseWeapon;
    public static MCH_ConfigPrm KeyCurrentWeaponLock;
+   public static MCH_ConfigPrm KeyVehicleLock;
    public static MCH_ConfigPrm KeySwitchWeapon1;
    public static MCH_ConfigPrm KeySwitchWeapon2;
    public static MCH_ConfigPrm KeySwWeaponMode;
@@ -350,6 +351,7 @@ public class MCH_Config {
       KeyAttack = new MCH_ConfigPrm("KeyAttack", -100);
       KeyUseWeapon = new MCH_ConfigPrm("KeyUseWeapon", -99);
       KeyCurrentWeaponLock = new MCH_ConfigPrm("KeyCurrentWeaponLock", -100);
+      KeyVehicleLock = new MCH_ConfigPrm("KeyVehicleLock", 24);
       KeySwitchWeapon1 = new MCH_ConfigPrm("KeySwitchWeapon1", -98);
       KeySwitchWeapon2 = new MCH_ConfigPrm("KeySwitchWeapon2", 34);
       KeySwWeaponMode = new MCH_ConfigPrm("KeySwitchWeaponMode", 45);
@@ -407,7 +409,8 @@ public class MCH_Config {
               KeyAPS,
               KeyUseWeapon,
               KeyAttack,
-              KeyCurrentWeaponLock};
+              KeyCurrentWeaponLock,
+              KeyVehicleLock};
       DamageVs = new ArrayList();
       CommandPermission = new ArrayList();
       CommandPermissionList = new ArrayList();

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -59,6 +59,7 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
 
    public MCH_Key KeyBrake;
    public MCH_Key KeyCurrentWeaponLock;
+   public MCH_Key KeyVehicleLock;
 
    /**
     * Chaff key
@@ -99,6 +100,7 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       this.KeyDownFromRack = new MCH_Key(MCH_Config.KeyDownFromRack.prmInt);
       this.KeyBrake = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyCurrentWeaponLock = new MCH_Key(MCH_Config.KeyCurrentWeaponLock.prmInt);
+      this.KeyVehicleLock = new MCH_Key(MCH_Config.KeyVehicleLock.prmInt);
       //todo here
       this.KeyChaff = new MCH_Key(MCH_Config.KeyChaff.prmInt);
       this.KeyMaintenance = new MCH_Key(MCH_Config.KeyMaintenance.prmInt);
@@ -163,6 +165,10 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       if (this.KeyUnmount.isKeyDown() && !ac.isDestroyed() && ac.getSizeInventory() > 0 && !isPilot)
          MCH_PacketIndOpenScreen.send(3);
       if (isPilot) {
+         if(this.KeyVehicleLock.isKeyDown()) {
+            pc.toggleVehicleAccessLock = true;
+            send = true;
+         }
          if (this.KeyUnmount.isKeyDown()) {
             pc.isUnmount = 2;
             send = true;

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -108,6 +108,9 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
       boolean c = false;
       StringBuilder var10000;
       MCH_Config var10001;
+      if(seatID == 0) {
+         this.drawString(ac.isVehicleAccessLocked() ? "Lock: LOCKED" : "Lock: UNLOCKED", LX, super.centerY + 20, colorActive);
+      }
       if(seatID == 0 && ac.canPutToRack()) {
          var10000 = (new StringBuilder()).append("PutRack : ");
          var10001 = MCH_MOD.config;

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -34,6 +34,13 @@ import net.minecraft.world.WorldServer;
 
 public class MCH_BaseVehiclePacketHandler {
 
+   public static void handleVehicleAccessLockToggle(EntityPlayer player, MCH_EntityBaseVehicle vehicle,
+                                                     MCH_PacketPlayerControlBase control) {
+      if(control.toggleVehicleAccessLock) {
+         vehicle.requestVehicleAccessLockToggle(player);
+      }
+   }
+
    public static void onPacketIndRotation(EntityPlayer player, ByteArrayDataInput data) {
       if(player != null && !player.worldObj.isRemote) {
          MCH_PacketIndRotation req = new MCH_PacketIndRotation();

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -105,6 +105,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private static final int CMN_ID_CNTRL_UP = 9;
    private static final int CMN_ID_CNTRL_DOWN = 10;
    private static final int CMN_ID_CNTRL_BRAKE = 11;
+   /** Bit 12 is the first unused bit in the shared status watcher. */
+   private static final int CMN_ID_VEHICLE_ACCESS_LOCK = 12;
    private static final int DATAWT_ID_USE_WEAPON = 24;
    private static final int DATAWT_ID_FUEL = 25;
    private static final int DATAWT_ID_ROT_ROLL = 26;
@@ -271,6 +273,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private int delayedUavInventoryTicks;
    private UUID uavPersistentUUID;
    private UUID uavOwnerUUID;
+   private UUID vehicleOwnerUUID;
    private UUID linkedUavStationUUID;
    private int linkedUavStationDimension;
    private double linkedUavStationX;
@@ -762,6 +765,55 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public boolean getCommonStatus(int bit) {
       return (this.commonStatus >> bit & 1) != 0;
+   }
+
+   public UUID getVehicleOwnerUUID() {
+      return this.vehicleOwnerUUID;
+   }
+
+   public void setVehicleOwnerUUID(UUID ownerUUID) {
+      this.vehicleOwnerUUID = ownerUUID;
+   }
+
+   public boolean isVehicleAccessLocked() {
+      return this.getCommonStatus(CMN_ID_VEHICLE_ACCESS_LOCK);
+   }
+
+   public void setVehicleAccessLocked(boolean locked) {
+      this.setCommonStatus(CMN_ID_VEHICLE_ACCESS_LOCK, locked);
+   }
+
+   private boolean isVehicleAccessOperator(EntityPlayer player) {
+      return player != null && (new net.minecraft.command.CommandGameMode()).canCommandSenderUseCommand(player);
+   }
+
+   public boolean canPlayerEnterVehicle(EntityPlayer player) {
+      return player != null && (!this.isVehicleAccessLocked()
+              || player.getUniqueID().equals(this.vehicleOwnerUUID)
+              || this.isVehicleAccessOperator(player));
+   }
+
+   private void notifyVehicleAccessDenied(EntityPlayer player) {
+      if(!super.worldObj.isRemote) {
+         player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "This vehicle is locked."));
+      }
+   }
+
+   public void requestVehicleAccessLockToggle(EntityPlayer player) {
+      if(super.worldObj.isRemote || player == null || this.isDead || this.isDestroyed()
+              || this.getRiddenByEntity() != player || player.ridingEntity != this) {
+         return;
+      }
+      if(this.vehicleOwnerUUID == null) {
+         this.vehicleOwnerUUID = player.getUniqueID();
+      }
+      if(!player.getUniqueID().equals(this.vehicleOwnerUUID) && !this.isVehicleAccessOperator(player)) {
+         player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "You do not own this vehicle."));
+         return;
+      }
+      this.setVehicleAccessLocked(!this.isVehicleAccessLocked());
+      player.addChatMessage(new ChatComponentText(this.isVehicleAccessLocked() ? "Vehicle locked." : "Vehicle unlocked."));
+      W_WorldFunc.DEF_playSoundEffect(super.worldObj, super.posX, super.posY, super.posZ, "random.click", 1.0F, 1.0F);
    }
 
    public void setCommonStatus(int bit, boolean b) {
@@ -1277,6 +1329,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          this.uavPersistentUUID = this.getUniqueID();
       }
       this.uavOwnerUUID = parseUUID(nbt.getString("MCH_UavOwnerUUID"));
+      this.vehicleOwnerUUID = parseUUID(nbt.getString("MCH_VehicleOwnerUUID"));
+      this.setVehicleAccessLocked(this.vehicleOwnerUUID != null && nbt.getBoolean("MCH_VehicleAccessLocked"));
       this.linkedUavStationUUID = parseUUID(nbt.getString("MCH_UavStationUUID"));
       this.linkedUavStationDimension = nbt.getInteger("MCH_UavStationDim");
       this.linkedUavStationX = nbt.getDouble("MCH_UavStationX");
@@ -1350,6 +1404,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
       nbt.setString("MCH_UavPersistentUUID", persistentId == null ? "" : persistentId.toString());
       nbt.setString("MCH_UavOwnerUUID", this.uavOwnerUUID == null ? "" : this.uavOwnerUUID.toString());
+      nbt.setString("MCH_VehicleOwnerUUID", this.vehicleOwnerUUID == null ? "" : this.vehicleOwnerUUID.toString());
+      nbt.setBoolean("MCH_VehicleAccessLocked", this.isVehicleAccessLocked());
       nbt.setString("MCH_UavStationUUID", this.linkedUavStationUUID == null ? "" : this.linkedUavStationUUID.toString());
       nbt.setInteger("MCH_UavStationDim", this.linkedUavStationDimension);
       nbt.setDouble("MCH_UavStationX", this.linkedUavStationX);
@@ -1645,6 +1701,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(MCH_Config.ItemDamage.prmBool) {
          is.setItemDamage(this.getDamageTaken());
       }
+
+      nbt.setString("MCH_VehicleOwnerUUID", this.vehicleOwnerUUID == null ? "" : this.vehicleOwnerUUID.toString());
+      nbt.setBoolean("MCH_VehicleAccessLocked", this.isVehicleAccessLocked());
 
    }
 
@@ -5554,6 +5613,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public boolean interactFirstSeat(EntityPlayer player) {
+      if(!super.worldObj.isRemote && !this.switchSeat && !this.canPlayerEnterVehicle(player)) {
+         this.notifyVehicleAccessDenied(player);
+         return false;
+      }
       if(!super.worldObj.isRemote) {
          this.searchSeat();
       }
@@ -7285,6 +7348,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          if(!canRideSeatOrRack(0, player)) {
             return this.rejectInteraction(player, "pilot_seat_exclusion");
          }
+         if(!super.worldObj.isRemote && !this.switchSeat && !this.canPlayerEnterVehicle(player)) {
+            this.notifyVehicleAccessDenied(player);
+            return false;
+         }
          if(!this.switchSeat) {
             if(getAcInfo().haveCanopy() && isCanopyClose()) {
                openCanopy();
@@ -7300,6 +7367,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          if(!this.worldObj.isRemote) {
             this.clearPlacementMotionLock();
             player.mountEntity(this);
+            if(player.ridingEntity == this && this.vehicleOwnerUUID == null) {
+               this.vehicleOwnerUUID = player.getUniqueID();
+            }
             if(!this.keepOnRideRotation) {
                mountMobToSeats();
             }

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -14,6 +14,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.ChatComponentText;
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.world.World;
 
 public class MCH_EntitySeat extends W_Entity implements IEntityAdditionalSpawnData {
@@ -317,6 +319,10 @@ public class MCH_EntitySeat extends W_Entity implements IEntityAdditionalSpawnDa
       if(player.ridingEntity != null) {
          MCH_Lib.DbgLog(this.worldObj, "[MCH-INTERACT][SEAT-REJECT] reason=player_already_riding seatId=%d riding=%s",
                  new Object[]{Integer.valueOf(this.seatID), player.ridingEntity});
+         return false;
+      }
+      if(!this.worldObj.isRemote && !getParent().canPlayerEnterVehicle(player)) {
+         player.addChatMessage(new ChatComponentText(EnumChatFormatting.RED + "This vehicle is locked."));
          return false;
       }
       if(!canRideMob(player)) {

--- a/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_ItemBaseVehicle.java
@@ -532,6 +532,8 @@ public abstract class MCH_ItemBaseVehicle extends W_Item {
          } else {
             if(!world.isRemote) {
                ac.getAcDataFromItem(itemStack);
+               ac.setVehicleOwnerUUID(player.getUniqueID());
+               ac.setVehicleAccessLocked(false);
                ac.markFreshlyPlaced();
                boolean spawned = world.spawnEntityInWorld(ac);
                logPlacementDebug(world, "spawnAircraft world.spawnEntityInWorld result=%s item=%s type=%s entityId=%d dim=%d", Boolean.valueOf(spawned), getItemDebugName(itemStack), ac.getTypeName(), Integer.valueOf(ac.getEntityId()), Integer.valueOf(world.provider.dimensionId));

--- a/src/main/java/mcheli/aircraft/MCH_PacketPlayerControlBase.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketPlayerControlBase.java
@@ -33,6 +33,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
    public boolean useChaff = false;
    public boolean useMaintenance = false;
    public boolean useAPS = false;
+   public boolean toggleVehicleAccessLock = false;
 
    public void readData(ByteArrayDataInput data) {
       try {
@@ -49,6 +50,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
          this.useChaff = this.getBit(e, 9);
          this.useMaintenance = this.getBit(e, 10);
          this.useAPS = this.getBit(e, 11);
+         this.toggleVehicleAccessLock = this.getBit(e, 12);
          e = (short)data.readByte();
          this.putDownRack = (byte)(e >> 6 & 3);
          this.isUnmount = (byte)(e >> 4 & 3);
@@ -89,6 +91,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
          e1 = this.setBit(e1, 9, this.useChaff);
          e1 = this.setBit(e1, 10, this.useMaintenance);
          e1 = this.setBit(e1, 11, this.useAPS);
+         e1 = this.setBit(e1, 12, this.toggleVehicleAccessLock);
          dos.writeShort(e1);
          e1 = (short)((byte)((this.putDownRack & 3) << 6 | (this.isUnmount & 3) << 4 | this.useFlareType & 15));
          dos.writeByte(e1);

--- a/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
@@ -38,7 +38,7 @@ public class MCH_ClientHeliTickHandler extends MCH_BaseVehicleClientTickHandler 
       this.KeyEjectSeat = new MCH_Key(MCH_Config.KeyEjectHeli.prmInt);
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance, super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance, super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCH_EntityHeli heli, boolean isPilot) {

--- a/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
@@ -34,6 +34,7 @@ public class MCH_HeliPacketHandler {
          }
 
          if(heli != null) {
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, heli, pc);
             if(pc.isUnmount == 1) {
                heli.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -51,7 +51,7 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyMouseAim = new MCH_Key(MCH_Config.KeyPlaneMouseAim.prmInt);
       this.KeyBombReticleMode = new MCH_Key(MCH_Config.KeyBombReticleMode.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, this.KeyBombReticleMode, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, this.KeyBombReticleMode, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCP_EntityPlane plane) {

--- a/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
+++ b/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
@@ -30,6 +30,7 @@ public class MCP_PlanePacketHandler {
          }
 
          if(plane != null) {
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, plane, pc);
             if(pc.isUnmount == 1) {
                plane.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/ship/MCH_ClientShipTickHandler.java
+++ b/src/main/java/mcheli/ship/MCH_ClientShipTickHandler.java
@@ -37,7 +37,7 @@ public class MCH_ClientShipTickHandler extends MCH_BaseVehicleClientTickHandler 
         this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
         this.KeySubmarineAscend = new MCH_Key(MCH_Config.KeySubmarineAscend.prmInt);
         this.KeySubmarineDescend = new MCH_Key(MCH_Config.KeySubmarineDescend.prmInt);
-        this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySubmarineAscend, this.KeySubmarineDescend, super.KeyUseWeapon, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+        this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySubmarineAscend, this.KeySubmarineDescend, super.KeyUseWeapon, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
     }
 
     protected void update(EntityPlayer player, MCH_EntityShip plane) {

--- a/src/main/java/mcheli/ship/MCH_ShipPacketHandler.java
+++ b/src/main/java/mcheli/ship/MCH_ShipPacketHandler.java
@@ -28,6 +28,7 @@ public class MCH_ShipPacketHandler {
             }
 
             if(plane != null) {
+                mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, plane, pc);
                 if(pc.isUnmount == 1) {
                     plane.unmountEntity();
                 } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/tank/MCH_ClientTankTickHandler.java
+++ b/src/main/java/mcheli/tank/MCH_ClientTankTickHandler.java
@@ -32,7 +32,7 @@ public class MCH_ClientTankTickHandler extends MCH_BaseVehicleClientTickHandler 
       super.updateKeybind(config);
       this.KeySwitchMode = new MCH_Key(MCH_Config.KeySwitchMode.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyBrake, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyBrake, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTank tank) {

--- a/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
+++ b/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
@@ -30,6 +30,7 @@ public class MCH_TankPacketHandler {
          }
 
          if(tank != null) {
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, tank, pc);
             if(pc.isUnmount == 1) {
                tank.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
@@ -36,7 +36,7 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyExtra = new MCH_Key(MCH_Config.KeyExtra.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyGUI};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyGUI};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTurret vehicle, MCH_TurretInfo info) {

--- a/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
@@ -16,6 +16,7 @@ public class MCH_TurretPacketHandler {
             MCH_PacketTurretPlayerControl pc = new MCH_PacketTurretPlayerControl();
             pc.readData(data);
             MCH_EntityTurret vehicle = (MCH_EntityTurret)player.ridingEntity;
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, vehicle, pc);
             if(pc.isUnmount == 1) {
                vehicle.unmountEntity();
             } else if(pc.isUnmount == 2) {


### PR DESCRIPTION
### Motivation

- Add a door-style, server-authoritative vehicle entry lock and persistent owner metadata to the shared vehicle base so vehicle entry can be restricted and survive saves/chunk reloads. 
- Use the shared vehicle entity and existing common-status watcher to avoid new DataWatcher objects and keep the server authoritative for permission checks and state synchronization.

### Description

- Added a `vehicleOwnerUUID` field and owner/lock methods to `MCH_EntityBaseVehicle`: `getVehicleOwnerUUID`, `setVehicleOwnerUUID`, `isVehicleAccessLocked`, `setVehicleAccessLocked`, `canPlayerEnterVehicle`, and `requestVehicleAccessLockToggle`, and a named bit constant `CMN_ID_VEHICLE_ACCESS_LOCK` (bit 12) stored in the existing common-status integer for metadata sync.  
- Persisted owner and lock state in entity/item NBT using `MCH_VehicleOwnerUUID` and `MCH_VehicleAccessLocked`, handled missing/invalid UUIDs safely, and made placed vehicles start unlocked with the placing player set as owner; saved items still carry owner/lock but placement transfers ownership to the placer and resets lock.  
- Added a `toggleVehicleAccessLock` boolean to `MCH_PacketPlayerControlBase` encoded in packet bit 12 (read/write symmetric) and routed family server packet handlers to a single helper `MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle` to centralize permission checks and request processing.  
- Client key and HUD integration: added `KeyVehicleLock` (default LWJGL 24 = O) to `MCH_Config` and `MCH_BaseVehicleClientTickHandler`, registered the key into every family `Keys` array so `MCH_Key.update()` runs, and send the toggle only on key-down while local player is pilot; added HUD text `Lock: LOCKED` / `Lock: UNLOCKED`.  
- Entry enforcement: blocked unauthorized pilot and passenger entry paths by checking `canPlayerEnterVehicle` in pilot `interactFirst` and seat `interactFirst` (preserving internal seat-switch, dismounts, AI gunner, rack, towing, UAV, and other behaviors).  
- Placement path: when a saved vehicle item is placed, the placer becomes the new owner and vehicle starts unlocked; item pickup/placement preserves NBT but placement transfers ownership.  

Changed files (summary): `MCH_Config.java`, `MCH_PacketPlayerControlBase.java`, `MCH_BaseVehicleClientTickHandler.java`, `MCH_BaseVehiclePacketHandler.java`, `MCH_EntityBaseVehicle.java`, `MCH_EntitySeat.java`, `MCH_ItemBaseVehicle.java`, family client tick handlers and packet handlers for helicopters/planes/ships/tanks/turrets, HUD/guides, and docs/changelog.  See commit for full file list. 

### Testing

- Ran static repository checks and project audits: `git diff --check` (passed), packet bit read/write symmetry and static checks confirmed bit 12 is read and written exactly once in `MCH_PacketPlayerControlBase` (passed), and common-status/DataWatcher ID scan confirmed bit 12 was unused before assignment (passed).  
- Confirmed every family client `Keys` arrays include `KeyVehicleLock` and every family server packet handler routes toggle requests to the shared helper (passed).  
- Confirmed no new DataWatcher objects were added and no collisions with existing watcher IDs or status bits were introduced (passed), and `version.properties` was not changed (passed).  
- Verified working-tree and commit: changes were committed as `Add persistent vehicle access locks` (passed).  
- Not run: `./gradlew compileJava` and runtime/multiplayer tests were not executed because Java 8 / Forge 1.7.10 runtime is required and the environment provides a newer Java; the user instruction also prohibited adding/compiling binaries in this session. Automated runtime tests therefore remain unexecuted.  

Notes: manual multiplayer verification on a Java 8 / Forge 1.7.10 server and client is still required to exercise message delivery, mount/seat edge cases, chunk-load persistence, and in-game permission edge cases (operator bypass, legacy claim behavior, and spoofed packet rejection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ad22aa42883239952d402591b1150)