### PR TITLE
Player-style villager and living damage factors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Player-Style Villager and Living Damage Factors
+
+- Added inheritance-aware weapon damage-factor matching, with explicit aircraft and vehicle types taking priority over player and living fallbacks.
+- Added `other` and `others` weapon factor aliases for non-player, non-villager living entities; without one, living targets inherit the player factor.
+- Routed villagers through global player damage configuration and removed duplicate direct-hit player-factor multiplication.
+
 ## Global Artillery Range Modifier
 
 - Added the reloadable, minimum-clamped `ArtilleryRangeModifier` global setting and the opt-in `UseGlobalArtilleryRangeModifier` weapon text key.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,17 @@ UseGlobalArtilleryRangeModifier = true
 
 The weapon-key default is `false`, so existing weapon files and explicitly disabled weapons retain their original speed and range. `ArtilleryRangeModifier = 1.0` also preserves the original range. `DisplayMortarDistance` controls only whether the HUD displays an impact distance; it neither classifies a weapon as artillery nor controls modifier eligibility. This is a per-weapon opt-in, not a per-vehicle setting, so one vehicle can combine a modified artillery weapon with an unchanged secondary weapon.
 
+## Weapon damage factors
+
+Weapon text files use comma-separated `DamageFactor = type, multiplier` entries. The existing `tank`, `plane`, `vehicle`, `heli`/`helicopter`, `ship`, and `player` types are supported. `other` and `others` select non-player, non-villager living entities:
+
+```text
+DamageFactor = player, 20.0
+DamageFactor = other, 3.0
+```
+
+Players and villagers use `player`. Other living entities use `other` when it is present and fall back to `player` when it is absent. Explicit aircraft and vehicle factors take priority and apply to subclasses. Nonliving entities have a factor of `1.0` unless an explicit class factor applies.
+
 Vehicle `.txt` definitions can opt individual items into or out of 3D item rendering and tune their own size after the global type scale is applied:
 
 | Key | Default | Notes |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -19,6 +19,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.passive.EntityVillager;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.DamageSource;
 
@@ -1150,10 +1151,10 @@ public class MCH_Config {
                list = DamageVsMCHeliTank.list;
             } else if(target instanceof MCH_EntityTurret) {
                list = DamageVsMCHeliVehicle.list;
+            } else if(target instanceof EntityPlayer || target instanceof EntityVillager) {
+               list = DamageVsPlayer.list;
             } else if(targetName.indexOf("mcheli.") > 0) {
                list = DamageVsMCHeliOther.list;
-            } else if(target instanceof EntityPlayer) {
-               list = DamageVsPlayer.list;
             } else if(target instanceof EntityLivingBase) {
                list = DamageVsLiving.list;
             } else {

--- a/src/main/java/mcheli/MCH_DamageFactor.java
+++ b/src/main/java/mcheli/MCH_DamageFactor.java
@@ -1,7 +1,12 @@
 package mcheli;
 
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.player.EntityPlayer;
 
 public class MCH_DamageFactor {
 
@@ -17,7 +22,49 @@ public class MCH_DamageFactor {
    }
 
    public float getDamageFactor(Class c) {
-      return this.map.containsKey(c)?((Float)this.map.get(c)).floatValue():1.0F;
+      if(c == null) {
+         return 1.0F;
+      }
+
+      Float exact = (Float)this.map.get(c);
+      if(exact != null) {
+         return exact.floatValue();
+      }
+
+      Class best = null;
+      Float bestValue = null;
+      Iterator i$ = this.map.entrySet().iterator();
+
+      while(i$.hasNext()) {
+         Map.Entry entry = (Map.Entry)i$.next();
+         Class configured = (Class)entry.getKey();
+         if(configured != EntityPlayer.class && configured != EntityLivingBase.class && configured.isAssignableFrom(c)
+               && (best == null || best.isAssignableFrom(configured))) {
+            best = configured;
+            bestValue = (Float)entry.getValue();
+         }
+      }
+
+      if(bestValue != null) {
+         return bestValue.floatValue();
+      }
+
+      if(EntityPlayer.class.isAssignableFrom(c) || EntityVillager.class.isAssignableFrom(c)) {
+         Float player = (Float)this.map.get(EntityPlayer.class);
+         return player != null?player.floatValue():1.0F;
+      }
+
+      if(EntityLivingBase.class.isAssignableFrom(c)) {
+         Float other = (Float)this.map.get(EntityLivingBase.class);
+         if(other != null) {
+            return other.floatValue();
+         }
+
+         Float player = (Float)this.map.get(EntityPlayer.class);
+         return player != null?player.floatValue():1.0F;
+      }
+
+      return 1.0F;
    }
 
    public float getDamageFactor(Entity e) {

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -1423,8 +1423,6 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
                 DamageSource ds = DamageSource.causeThrownDamage(this, this.shootingEntity);
                 if (this.power == 1) {
                     ds = new MCH_DamageSource("bullet", this);
-
-                    this.power *= this.weaponInfo.damageFactor.getDamageFactor(EntityPlayer.class);
                 }
                 MCH_Config var10000 = MCH_MOD.config;
                 float damage = MCH_Config.applyDamageVsEntity(entity, ds, (float) this.getPower() * damageFactor);
@@ -1440,8 +1438,6 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
                 DamageSource ds = DamageSource.causeThrownDamage(this, this.shootingEntity);
                 if (this.power == 1) {
                     ds = new MCH_DamageSource("bullet", this);
-
-                    this.power *= this.weaponInfo.damageFactor.getDamageFactor(EntityPlayer.class);
                 }
                 //todone: add piercing compat here
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponInfo.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponInfo.java
@@ -10,6 +10,7 @@ import mcheli.tank.MCH_EntityTank;
 import mcheli.vehicle.MCH_EntityTurret;
 import mcheli.wrapper.W_Item;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -714,6 +715,8 @@ public class MCH_WeaponInfo extends MCH_BaseInfo {
                                 String var14 = s[0].toLowerCase();
                                 if (var14.equals("player")) {
                                     var13 = EntityPlayer.class;
+                                } else if (var14.equals("other") || var14.equals("others")) {
+                                    var13 = EntityLivingBase.class;
                                 } else if (!var14.equals("heli") && !var14.equals("helicopter")) {
                                     if (var14.equals("plane")) {
                                         var13 = MCP_EntityPlane.class;

--- a/src/test/java/mcheli/MCH_DamageFactorTest.java
+++ b/src/test/java/mcheli/MCH_DamageFactorTest.java
@@ -1,0 +1,96 @@
+package mcheli;
+
+import static org.junit.Assert.assertEquals;
+
+import mcheli.helicopter.MCH_EntityHeli;
+import mcheli.plane.MCP_EntityPlane;
+import mcheli.ship.MCH_EntityShip;
+import mcheli.tank.MCH_EntityTank;
+import mcheli.vehicle.MCH_EntityTurret;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityZombie;
+import net.minecraft.entity.passive.EntityCow;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.world.World;
+import org.junit.Test;
+
+public class MCH_DamageFactorTest {
+   @Test
+   public void usesPlayerFactorForPlayersVillagersAndLivingFallback() {
+      MCH_DamageFactor factors = new MCH_DamageFactor();
+      factors.add(EntityPlayer.class, 20.0F);
+
+      assertFactor(20.0F, factors, EntityPlayer.class);
+      assertFactor(20.0F, factors, EntityPlayerMP.class);
+      assertFactor(20.0F, factors, EntityVillager.class);
+      assertFactor(20.0F, factors, EntityCow.class);
+      assertFactor(20.0F, factors, EntityZombie.class);
+      assertFactor(20.0F, factors, ModdedLiving.class);
+      assertFactor(1.0F, factors, Entity.class);
+   }
+
+   @Test
+   public void usesOtherForNonPlayerLivingEntitiesOnly() {
+      MCH_DamageFactor factors = new MCH_DamageFactor();
+      factors.add(EntityPlayer.class, 20.0F);
+      factors.add(EntityLivingBase.class, 3.0F);
+
+      assertFactor(20.0F, factors, EntityPlayerMP.class);
+      assertFactor(20.0F, factors, EntityVillager.class);
+      assertFactor(3.0F, factors, EntityCow.class);
+      assertFactor(3.0F, factors, EntityZombie.class);
+      assertFactor(3.0F, factors, ModdedLiving.class);
+      assertFactor(1.0F, factors, Entity.class);
+   }
+
+   @Test
+   public void explicitVehicleFactorsApplyToSubclassesBeforeLivingFallbacks() {
+      MCH_DamageFactor factors = new MCH_DamageFactor();
+      factors.add(EntityPlayer.class, 20.0F);
+      factors.add(EntityLivingBase.class, 3.0F);
+      factors.add(MCP_EntityPlane.class, 4.0F);
+      factors.add(MCH_EntityHeli.class, 5.0F);
+      factors.add(MCH_EntityTank.class, 2.0F);
+      factors.add(MCH_EntityTurret.class, 6.0F);
+      factors.add(MCH_EntityShip.class, 7.0F);
+
+      assertFactor(4.0F, factors, TestPlane.class);
+      assertFactor(5.0F, factors, TestHeli.class);
+      assertFactor(2.0F, factors, TestTank.class);
+      assertFactor(6.0F, factors, TestTurret.class);
+      assertFactor(7.0F, factors, TestShip.class);
+   }
+
+   private static void assertFactor(float expected, MCH_DamageFactor factors, Class target) {
+      assertEquals(expected, factors.getDamageFactor(target), 0.0F);
+   }
+
+   private abstract static class ModdedLiving extends EntityLivingBase {
+      protected ModdedLiving(World world) {
+         super(world);
+      }
+   }
+
+   private static class TestPlane extends MCP_EntityPlane {
+      public TestPlane(World world) { super(world); }
+   }
+
+   private static class TestHeli extends MCH_EntityHeli {
+      public TestHeli(World world) { super(world); }
+   }
+
+   private static class TestTank extends MCH_EntityTank {
+      public TestTank(World world) { super(world); }
+   }
+
+   private static class TestTurret extends MCH_EntityTurret {
+      public TestTurret(World world) { super(world); }
+   }
+
+   private static class TestShip extends MCH_EntityShip {
+      public TestShip(World world) { super(world); }
+   }
+}


### PR DESCRIPTION
### Motivation

- Ensure weapon damage-factor lookup treats villagers as players and lets weapons target other living mobs via an `other`/`others` alias while preserving explicit vehicle/aircraft factors. 
- Prevent double-application of player factors on direct bullet hits so each target factor is applied exactly once. 

### Description

- Implemented inheritance-aware damage-factor lookup in `MCH_DamageFactor` that prefers exact class matches, then the most-specific explicit configured class (aircraft/vehicle/etc.), then `player` for players and villagers, then `other` for remaining `EntityLivingBase` when present, and `1.0F` for nonliving targets. (src/main/java/mcheli/MCH_DamageFactor.java)
- Updated the weapon TXT parser to accept `DamageFactor = other, X` and `DamageFactor = others, X` as the living-entity category (`EntityLivingBase`), while keeping existing names (`player`, `tank`, `plane`, `heli`/`helicopter`, `vehicle`, `ship`) and ignoring unknown types. (src/main/java/mcheli/weapon/MCH_WeaponInfo.java)
- Routed `EntityVillager` and villager subclasses through the player damage list so villagers use the `player` category; other living entities continue to use the `DamageVsLiving` list unless `other` is configured. (src/main/java/mcheli/MCH_Config.java)
- Removed the duplicate direct-impact multiplication that previously modified the bullet `power` by a player factor in `MCH_EntityBaseBullet.onImpactEntity`, so the damage factor is applied once to final damage instead of being baked into stored bullet power. (src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java)
- Preserved the explosion path’s single target-based factor application (no behavior change to explosion factoring). (src/main/java/mcheli/MCH_Explosion.java)
- Added focused unit tests for the damage-factor lookup and subclass/alias behavior. (src/test/java/mcheli/MCH_DamageFactorTest.java)
- Updated configuration documentation to describe `other`/`others` and the expected lookup behavior and added an entry in `changelog.md`. (docs/configuration.md, changelog.md)

Files changed or added:
- src/main/java/mcheli/MCH_DamageFactor.java
- src/main/java/mcheli/weapon/MCH_WeaponInfo.java
- src/main/java/mcheli/MCH_Config.java
- src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
- src/test/java/mcheli/MCH_DamageFactorTest.java (new)
- docs/configuration.md (updated)
- changelog.md (updated)

Lookup priority implemented (summary):
1. Exact configured class key.
2. Most-specific configured class that is assignable from the runtime class (aircraft/vehicle/etc.).
3. `player` for `EntityPlayer` and `EntityVillager` (and their subclasses).
4. `other` (`EntityLivingBase`) for other living entities when configured.
5. `player` fallback when `other` is not configured for living entities.
6. `1.0F` for nonliving or null targets.

### Testing

- Ran `./gradlew compileJava` and the build completed successfully (no compilation errors). 
- Ran `git diff --check` and there were no whitespace or diff-check failures. 
- Added unit tests at `src/test/java/mcheli/MCH_DamageFactorTest.java`, but `./gradlew test --tests mcheli.MCH_DamageFactorTest` could not complete because Gradle failed to resolve the configured JUnit dependency from the project's repositories (HTTP 403 responses), so tests were not executed to completion in this environment. 
- No behavioral changes were made to explosion factoring; direct-hit bullet paths now apply the selected target factor exactly once.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8710acfc8323968672ad763cd8fb)