### PR TITLE
Add configurable MCH_Lib logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+## Configurable MCH_Lib Logging
+
+- Added independent normal and verbose MCHLib logging controls backed by standard config properties.
+- Routed MCHLib messages through Forge's Log4j logger with safe printf formatting and side/world labels.
+- Preserved legacy `McHeliOutputDebugLog` configs while migrating rewritten files to the new debug property.
+- Loaded the configuration before configurable startup and content-loading messages.
+
 ## Player-Style Villager and Living Damage Factors
 
 - Added inheritance-aware weapon damage-factor matching, with explicit aircraft and vehicle types taking priority over player and living fallbacks.

--- a/docs/server-administration.md
+++ b/docs/server-administration.md
@@ -71,8 +71,9 @@ Be careful: matching is a case-insensitive substring search against full Java cl
 
 ## Logging and diagnostics
 
-- Leave the legacy `McHeliOutputDebugLog` marker disabled for normal servers. Startup milestones, system checks, warnings, and errors still log without it.
-- Enable `McHeliOutputDebugLog` only while diagnosing noisy internals such as per-item registration, ore dictionary confirmations, language-entry registration, reload traces, and similar spam-level debug output.
+- `EnableMCHLibLog = true` writes normal `MCH_Lib.Log` startup milestones, system checks, warnings, and errors to the Minecraft/Forge log. Set it to `false` to suppress only those MCHeli messages.
+- `EnableMCHLibDebugLog = false` controls verbose `MCH_Lib.DbgLog` output. Enable it only while diagnosing noisy internals such as per-item registration, ore dictionary confirmations, language-entry registration, reload traces, and similar spam-level debug output.
+- The old standalone `McHeliOutputDebugLog` marker remains accepted for compatibility and enables `EnableMCHLibDebugLog`. The next config rewrite removes the marker and writes `EnableMCHLibDebugLog = true` instead.
 
 ## Performance notes
 

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -186,7 +186,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             label85: {
                if(super.mc.isSingleplayer()) {
                   MCH_Config var10000 = MCH_MOD.config;
-                  if(!MCH_Config.DebugLog) {
+                  if(!MCH_Config.EnableMCHLibDebugLog.prmBool) {
                      break label85;
                   }
                }

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -28,7 +28,8 @@ public class MCH_Config {
 
    public static String mcPath;
    public static String configFilePath;
-   public static boolean DebugLog;
+   public static MCH_ConfigPrm EnableMCHLibLog;
+   public static MCH_ConfigPrm EnableMCHLibDebugLog;
    public static String configVer;
    public static int hitMarkColorRGB;
    public static float hitMarkColorAlpha;
@@ -332,7 +333,6 @@ public class MCH_Config {
    public MCH_Config(String minecraftPath, String cfgFile) {
       mcPath = minecraftPath;
       configFilePath = mcPath + cfgFile;
-      DebugLog = false;
       configVer = "0.0.0";
       bulletBreakableBlocks = new ArrayList();
       carBreakableBlocks = new ArrayList();
@@ -418,6 +418,10 @@ public class MCH_Config {
       CommandPermissionList = new ArrayList();
       IgnoreBulletHitList = new ArrayList();
       IgnoreBulletHitItem = new MCH_ConfigPrm("IgnoreBulletHit", "");
+      EnableMCHLibLog = new MCH_ConfigPrm("EnableMCHLibLog", true);
+      EnableMCHLibLog.desc = ";Write normal MCH_Lib.Log messages to the Minecraft log.";
+      EnableMCHLibDebugLog = new MCH_ConfigPrm("EnableMCHLibDebugLog", false);
+      EnableMCHLibDebugLog.desc = ";Write verbose MCH_Lib.DbgLog messages to the Minecraft log.";
       TestMode = new MCH_ConfigPrm("TestMode", false);
       EnableCommand = new MCH_ConfigPrm("EnableCommand", true);
       PlaceableOnSpongeOnly = new MCH_ConfigPrm("PlaceableOnSpongeOnly", false);
@@ -706,6 +710,8 @@ public class MCH_Config {
       BlockID_DraftingTableOFF = new MCH_ConfigPrm("BlockID_DraftingTable", 3450);
       BlockID_DraftingTableON = new MCH_ConfigPrm("BlockID_DraftingTableON", 3451);
       General = new MCH_ConfigPrm[]{
+              EnableMCHLibLog,
+              EnableMCHLibDebugLog,
               TestMode,
               EnableCommand,
               null,
@@ -1199,7 +1205,7 @@ public class MCH_Config {
       if(file.open(configFilePath)) {
          for(String str = file.readLine(); str != null; str = file.readLine()) {
             if(str.trim().equalsIgnoreCase("McHeliOutputDebugLog")) {
-               DebugLog = true;
+               EnableMCHLibDebugLog.prmBool = true;
             } else {
                this.readConfigData(str);
             }
@@ -1289,11 +1295,6 @@ public class MCH_Config {
       pw.println("MOD_Version = " + MCH_MOD.VER);
       pw.println("MOD_MC_Version = 1.7.10");
       pw.println();
-      if(DebugLog) {
-         pw.println("McHeliOutputDebugLog");
-         pw.println();
-      }
-
       MCH_ConfigPrm[] arr$ = General;
       int len$ = arr$.length;
 

--- a/src/main/java/mcheli/MCH_Lib.java
+++ b/src/main/java/mcheli/MCH_Lib.java
@@ -8,6 +8,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import mcheli.plane.MCP_PlaneChaseCamera;
 import mcheli.wrapper.W_Block;
 import mcheli.wrapper.W_McClient;
@@ -18,7 +21,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
@@ -35,6 +37,7 @@ import net.minecraft.world.World;
 //Very broken logger, and misc functions such as all vehicle speed mult, and some other stuff I still have no idea what it does.
 public class MCH_Lib {
 
+   private static final Logger LOGGER = LogManager.getLogger("mcheli");
    private static HashMap mapMaterial = new HashMap();
    public static final String[] AZIMUTH_8 = new String[]{"S", "SW", "W", "NW", "N", "NE", "E", "SE"};
    public static final int AZIMUTH_8_ANG = 360 / AZIMUTH_8.length;
@@ -232,15 +235,19 @@ public class MCH_Lib {
    }
 
    public static void Log(String format, Object ... data) {
-      String side = MCH_MOD.proxy.isRemote()?"[Client]":"[Server]";
-      System.out.printf("[" + getTime() + "][" + "mcheli" + "]" + side + " " + format + "\n", data);
+      if(MCH_Config.EnableMCHLibLog == null || !MCH_Config.EnableMCHLibLog.prmBool) {
+         return;
+      }
+
+      String side = MCH_MOD.proxy == null?"[Unknown]":(MCH_MOD.proxy.isRemote()?"[Client]":"[Server]");
+      LOGGER.info(side + " " + formatMessage(format, data));
    }
 
    public static void Log(World world, String format, Object ... data) {
       if(world != null) {
          Log((world.isRemote?"[ClientWorld]":"[ServerWorld]") + " " + format, data);
       } else {
-         Log("[UnknownWorld]" + format, data);
+         Log("[UnknownWorld] " + format, data);
       }
 
    }
@@ -255,25 +262,36 @@ public class MCH_Lib {
    }
 
    public static void DbgLog(boolean isRemote, String format, Object ... data) {
-      MCH_Config var10000 = MCH_MOD.config;
-      if(MCH_Config.DebugLog) {
-         String t = getTime();
-         if(isRemote) {
-            String playerName = "null";
-            if(getClientPlayer() instanceof EntityPlayer) {
-               playerName = ((EntityPlayer)getClientPlayer()).getDisplayName();
-            }
-
-            System.out.println(String.format(format, data));
-         } else {
-            System.out.println(String.format(format, data));
-         }
+      if(MCH_Config.EnableMCHLibDebugLog == null || !MCH_Config.EnableMCHLibDebugLog.prmBool) {
+         return;
       }
 
+      LOGGER.info("[MCH DEBUG] " + (isRemote?"[Client]":"[Server]") + " " + formatMessage(format, data));
    }
 
-   public static void DbgLog(World w, String format, Object ... data) {
-      DbgLog(w.isRemote, format, data);
+   public static void DbgLog(World world, String format, Object ... data) {
+      if(MCH_Config.EnableMCHLibDebugLog == null || !MCH_Config.EnableMCHLibDebugLog.prmBool) {
+         return;
+      }
+
+      String side = world == null?"[UnknownWorld]":(world.isRemote?"[ClientWorld]":"[ServerWorld]");
+      LOGGER.info("[MCH DEBUG] " + side + " " + formatMessage(format, data));
+   }
+
+   private static String formatMessage(String format, Object ... data) {
+      if(format == null) {
+         return "null";
+      }
+
+      if(data == null || data.length == 0) {
+         return format;
+      }
+
+      try {
+         return String.format(format, data);
+      } catch(RuntimeException e) {
+         return format + " [format error: " + e.getClass().getSimpleName() + "]";
+      }
    }
 
    public static String getTime() {

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -167,6 +167,7 @@ public class MCH_MOD {
    public void PreInit(FMLPreInitializationEvent evt) {
 
       VER = Loader.instance().activeModContainer().getVersion();
+      config = proxy.loadConfig("config/mcheli.cfg");
       MCH_Lib.init();
       MCH_Lib.Log("MC Ver:1.7.10 MOD Ver:" + VER + "", new Object[0]);
       MCH_Lib.Log("Start load...", new Object[0]);
@@ -260,7 +261,6 @@ public class MCH_MOD {
       creativeTabsTank = new MCH_CreativeTabs("MCHeliO Tanks");
       creativeTabsVehicle = new MCH_CreativeTabs("MCHeliO Vehicles");
       W_ItemList.init();
-      config = proxy.loadConfig("config/mcheli.cfg");
        proxy.loadHUD("assets/" + "mcheli" + "/");
       MCH_WeaponInfoManager.load("assets/" + "mcheli" + "/");
       MCH_HeliInfoManager.getInstance().load("assets/" + "mcheli" + "/", "helicopters");

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -49,7 +49,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
 
    public void drawDebugtInfo(MCH_EntityBaseVehicle ac) {
       MCH_Config var10000 = MCH_MOD.config;
-      if(MCH_Config.DebugLog) {
+      if(MCH_Config.EnableMCHLibDebugLog.prmBool) {
          int LX = super.centerX - 100;
       }
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -7134,7 +7134,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void debugVehicleState(String context, EntityPlayer player) {
-      if(!MCH_Config.DebugLog) {
+      if(!MCH_Config.EnableMCHLibDebugLog.prmBool) {
          return;
       }
       MCH_Lib.DbgLog(super.worldObj,
@@ -7152,7 +7152,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void debugRackState(String context) {
-      if(!MCH_Config.DebugLog) {
+      if(!MCH_Config.EnableMCHLibDebugLog.prmBool) {
          return;
       }
       int rackCount = 0;

--- a/src/main/java/mcheli/gui/MCH_GuiCommonHandler.java
+++ b/src/main/java/mcheli/gui/MCH_GuiCommonHandler.java
@@ -60,7 +60,7 @@ public class MCH_GuiCommonHandler implements IGuiHandler {
       case 5:
          if(MinecraftServer.getServer().isSinglePlayer()) {
             MCH_Config var10000 = MCH_MOD.config;
-            if(!MCH_Config.DebugLog) {
+            if(!MCH_Config.EnableMCHLibDebugLog.prmBool) {
                return null;
             }
          }

--- a/src/main/java/mcheli/multiplay/MCH_MultiplayClient.java
+++ b/src/main/java/mcheli/multiplay/MCH_MultiplayClient.java
@@ -283,7 +283,7 @@ public class MCH_MultiplayClient {
 
    public static void sendModsInfo(String playerName, int id) {
       MCH_Config var10000 = MCH_MOD.config;
-      if(MCH_Config.DebugLog) {
+      if(MCH_Config.EnableMCHLibDebugLog.prmBool) {
          modList.clear();
          readModList(playerName);
       }

--- a/src/main/java/mcheli/tank/MCH_GuiTank.java
+++ b/src/main/java/mcheli/tank/MCH_GuiTank.java
@@ -81,7 +81,7 @@ public class MCH_GuiTank extends MCH_BaseVehicleCommonGui {
 
    public void drawDebugtInfo(MCH_EntityTank ac) {
       MCH_Config var10000 = MCH_MOD.config;
-      if(MCH_Config.DebugLog) {
+      if(MCH_Config.EnableMCHLibDebugLog.prmBool) {
          int LX = super.centerX - 100;
          super.drawDebugtInfo(ac);
       }


### PR DESCRIPTION
### Motivation

- Make `MCH_Lib.Log` and `MCH_Lib.DbgLog` obey normal config options instead of always printing to `System.out` and using a brittle legacy marker. 
- Route MCHeli messages through the Forge/Log4j logger so messages integrate with the game log and respect runtime configuration. 
- Preserve legacy `McHeliOutputDebugLog` compatibility and ensure startup-order behavior loads the config before the first configurable log call.

### Description

- Added two `MCH_ConfigPrm` boolean parameters `EnableMCHLibLog` (default `true`) and `EnableMCHLibDebugLog` (default `false`) with descriptions and inserted them into the existing `General` array. (edited `src/main/java/mcheli/MCH_Config.java`)
- Replaced the old static `DebugLog` usage by referencing `EnableMCHLibDebugLog.prmBool` across the codebase and removed active references to the removed field. (multiple files under `src/main/java/mcheli/`)
- Implemented a private Log4j `Logger` in `MCH_Lib` and routed `Log`/`DbgLog` through it, keeping original public method signatures and world/entity overloads, preserving side/world labels and adding safe `proxy`/null checks. (`src/main/java/mcheli/MCH_Lib.java`)
- Added `formatMessage(String, Object...)` to format printf-style messages with `String.format`, protecting against null formats and format exceptions by returning the original string plus a clear format-error suffix on failure. (`src/main/java/mcheli/MCH_Lib.java`)
- Kept debug messages logged via `LOGGER.info` with a `[MCH DEBUG]` prefix (do not use `LOGGER.debug`) and ensured `DbgLog(World,...)` is safe when the `World` is null. (`src/main/java/mcheli/MCH_Lib.java`)
- Supported the legacy standalone `McHeliOutputDebugLog` loader token by mapping it to `EnableMCHLibDebugLog.prmBool = true` during `load()`, and stopped writing the legacy marker back to `mcheli.cfg` (the writer now emits the new boolean entries via the `General` listing). (`src/main/java/mcheli/MCH_Config.java`)
- Fixed startup ordering in `MCH_MOD.PreInit` to load `mcheli.cfg` once and assign `MCH_MOD.config` before emitting configurable startup logs and before content loading; removed the duplicate later `proxy.loadConfig("config/mcheli.cfg")` call. (`src/main/java/mcheli/MCH_MOD.java`)
- Updated `docs/server-administration.md` to document the two new properties and the legacy-marker behavior and added an entry to `changelog.md`. (`docs/server-administration.md`, `changelog.md`)

### Testing

- Ran `git diff --check` to verify there are no whitespace/merge errors and it passed. 
- Executed a repository static-assertion script (via a `python3` check) that validated defaults, `General` membership order, presence of new `MCH_ConfigPrm` defaults, logger routing, format-protection code, legacy-marker migration, and startup ordering; all assertions passed. 
- Searched the tree with ripgrep to confirm there are no remaining `public static boolean DebugLog` or `MCH_Config.DebugLog` references and that `proxy.loadConfig("config/mcheli.cfg")` appears exactly once in pre-init; search results matched expectations. 
- Committed changes as `Add configurable MCH_Lib logging`; `./gradlew compileJava` was not run because the task instructions explicitly prohibit producing or adding compiled binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8b98c96c83238a7f8e4c4b3de46d)