### PR TITLE
Fix multiplayer vehicle yaw and running-gear synchronization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## Multiplayer Vehicle Yaw and Running-Gear Synchronization
+
+- Removed the tank's extra per-packet interpolation delay and made remote hull yaw corrections follow the shortest wrapped angle over the server-provided interpolation window.
+- Derived wheel, track-roller, and crawler-track motion from synchronized vehicle displacement and wrapped hull rotation instead of delayed client control flags and throttle.
+- Corrected crawler-track render interpolation to use the frame partial tick and the shortest path across phase wrap boundaries.
+
 ## Configurable MCH_Lib Logging
 
 - Added independent normal and verbose MCHLib logging controls backed by standard config properties.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -237,6 +237,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public float prevRotWheel = 0.0F;
    public float rotYawWheel = 0.0F;
    public float prevRotYawWheel = 0.0F;
+   private boolean partAnimationPositionInitialized;
+   private double lastPartAnimationPosX;
+   private double lastPartAnimationPosZ;
+   private float lastPartAnimationYaw;
+   private double partAnimationForwardTravel;
+   private double partAnimationYawTravel;
    private boolean isParachuting;
    public float ropesLength = 0.0F;
    private MCH_Queue prevPosition;
@@ -3193,23 +3199,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public void updatePartWheel() {
       if(super.worldObj.isRemote) {
          if(this.getAcInfo() != null) {
+            this.updatePartAnimationTravel();
             this.prevRotWheel = this.rotWheel;
             this.prevRotYawWheel = this.rotYawWheel;
-            float LEN = 1.0F;
-            float MIN = 0.0F;
-            double throttle = this.getCurrentThrottle();
-            double pivotTurnThrottle = (double)this.getAcInfo().pivotTurnThrottle;
-            if(pivotTurnThrottle <= 0.0D) {
-               pivotTurnThrottle = 1.0D;
-            } else {
-               pivotTurnThrottle *= 0.10000000149011612D;
-            }
-
             boolean localMoveLeft = this.moveLeft;
             boolean localMoveRight = this.moveRight;
-            if(this.getAcInfo().enableBack && (double)this.throttleBack > 0.01D && throttle <= 0.0D) {
-               throttle = (double)(-this.throttleBack * 15.0F);
-            }
 
             if(localMoveLeft && !localMoveRight) {
                this.rotYawWheel += 0.1F;
@@ -3225,14 +3219,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
                this.rotYawWheel *= 0.9F;
             }
 
-            this.rotWheel = (float)((double)this.rotWheel + throttle * (double)this.getAcInfo().partWheelRot);
-            if(this.rotWheel >= 360.0F) {
-               this.rotWheel -= 360.0F;
-               this.prevRotWheel -= 360.0F;
-            } else if(this.rotWheel < 0.0F) {
-               this.rotWheel += 360.0F;
-               this.prevRotWheel += 360.0F;
-            }
+            this.rotWheel += (float)(this.partAnimationForwardTravel * (double)this.getAcInfo().partWheelRot);
+            this.wrapWheelAngle();
 
          }
       }
@@ -3245,62 +3233,16 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             this.prevRotTrackRoller[1] = this.rotTrackRoller[1];
             this.prevRotCrawlerTrack[0] = this.rotCrawlerTrack[0];
             this.prevRotCrawlerTrack[1] = this.rotCrawlerTrack[1];
-            float LEN = 1.0F;
-            float MIN = 0.0F;
-            double throttle = this.getCurrentThrottle();
-            double pivotTurnThrottle = (double)this.getAcInfo().pivotTurnThrottle;
-            if(pivotTurnThrottle <= 0.0D) {
-               pivotTurnThrottle = 1.0D;
-            } else {
-               pivotTurnThrottle *= 0.10000000149011612D;
-            }
-
-            boolean localMoveLeft = this.moveLeft;
-            boolean localMoveRight = this.moveRight;
-            byte dir = 1;
-            if(this.getAcInfo().enableBack && this.throttleBack > 0.0F && throttle <= 0.0D) {
-               throttle = (double)(-this.throttleBack * 5.0F);
-               if(localMoveLeft != localMoveRight) {
-                  boolean i = localMoveLeft;
-                  localMoveLeft = localMoveRight;
-                  localMoveRight = i;
-                  dir = -1;
-               }
-            }
-
-            if(localMoveLeft && !localMoveRight) {
-               throttle = 0.2D * (double)dir;
-               this.throttleCrawlerTrack[0] = (float)((double)this.throttleCrawlerTrack[0] + throttle);
-               this.throttleCrawlerTrack[1] = (float)((double)this.throttleCrawlerTrack[1] - pivotTurnThrottle * throttle);
-            } else if(!localMoveLeft && localMoveRight) {
-               throttle = 0.2D * (double)dir;
-               this.throttleCrawlerTrack[0] = (float)((double)this.throttleCrawlerTrack[0] - pivotTurnThrottle * throttle);
-               this.throttleCrawlerTrack[1] = (float)((double)this.throttleCrawlerTrack[1] + throttle);
-            } else {
-               if(throttle > 0.2D) {
-                  throttle = 0.2D;
-               }
-
-               if(throttle < -0.2D) {
-                  throttle = -0.2D;
-               }
-
-               this.throttleCrawlerTrack[0] = (float)((double)this.throttleCrawlerTrack[0] + throttle);
-               this.throttleCrawlerTrack[1] = (float)((double)this.throttleCrawlerTrack[1] + throttle);
-            }
+            this.throttleCrawlerTrack[0] = (float)(this.partAnimationForwardTravel + this.partAnimationYawTravel);
+            this.throttleCrawlerTrack[1] = (float)(this.partAnimationForwardTravel - this.partAnimationYawTravel);
 
             for(int var11 = 0; var11 < 2; ++var11) {
-               if(this.throttleCrawlerTrack[var11] < -0.72F) {
-                  this.throttleCrawlerTrack[var11] = -0.72F;
-               } else if(this.throttleCrawlerTrack[var11] > 0.72F) {
-                  this.throttleCrawlerTrack[var11] = 0.72F;
-               }
-
                this.rotTrackRoller[var11] += this.throttleCrawlerTrack[var11] * this.getAcInfo().trackRollerRot;
-               if(this.rotTrackRoller[var11] >= 360.0F) {
+               while(this.rotTrackRoller[var11] >= 360.0F) {
                   this.rotTrackRoller[var11] -= 360.0F;
                   this.prevRotTrackRoller[var11] -= 360.0F;
-               } else if(this.rotTrackRoller[var11] < 0.0F) {
+               }
+               while(this.rotTrackRoller[var11] < 0.0F) {
                   this.rotTrackRoller[var11] += 360.0F;
                   this.prevRotTrackRoller[var11] += 360.0F;
                }
@@ -3317,10 +3259,58 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
                   ++this.prevRotCrawlerTrack[var11];
                }
 
-               this.throttleCrawlerTrack[var11] = (float)((double)this.throttleCrawlerTrack[var11] * 0.75D);
             }
 
          }
+      }
+   }
+
+   private void updatePartAnimationTravel() {
+      if(!this.partAnimationPositionInitialized) {
+         this.partAnimationPositionInitialized = true;
+         this.lastPartAnimationPosX = super.posX;
+         this.lastPartAnimationPosZ = super.posZ;
+         this.lastPartAnimationYaw = this.getRotYaw();
+         this.partAnimationForwardTravel = 0.0D;
+         this.partAnimationYawTravel = 0.0D;
+         return;
+      }
+
+      double dx = super.posX - this.lastPartAnimationPosX;
+      double dz = super.posZ - this.lastPartAnimationPosZ;
+      float yawChange = MathHelper.wrapAngleTo180_float(this.getRotYaw() - this.lastPartAnimationYaw);
+      float middleYaw = this.lastPartAnimationYaw + yawChange * 0.5F;
+      double yawRadians = (double)middleYaw * Math.PI / 180.0D;
+      double travel = dx * -Math.sin(yawRadians) + dz * Math.cos(yawRadians);
+      if(dx * dx + dz * dz < 1.0E-6D) {
+         travel = 0.0D;
+      }
+
+      this.partAnimationForwardTravel = travel;
+      this.partAnimationYawTravel = (double)yawChange * Math.PI / 180.0D * this.getTrackHalfWidth();
+      this.lastPartAnimationPosX = super.posX;
+      this.lastPartAnimationPosZ = super.posZ;
+      this.lastPartAnimationYaw = this.getRotYaw();
+   }
+
+   private double getTrackHalfWidth() {
+      double halfWidth = 0.0D;
+      Iterator i$ = this.getAcInfo().wheels.iterator();
+      while(i$.hasNext()) {
+         MCH_BaseVehicleInfo.Wheel wheel = (MCH_BaseVehicleInfo.Wheel)i$.next();
+         halfWidth = Math.max(halfWidth, Math.abs(wheel.pos.xCoord));
+      }
+      return halfWidth > 0.01D?halfWidth:Math.max(0.5D, (double)this.getAcInfo().bodyWidth * 0.5D);
+   }
+
+   private void wrapWheelAngle() {
+      while(this.rotWheel >= 360.0F) {
+         this.rotWheel -= 360.0F;
+         this.prevRotWheel -= 360.0F;
+      }
+      while(this.rotWheel < 0.0F) {
+         this.rotWheel += 360.0F;
+         this.prevRotWheel += 360.0F;
       }
    }
 
@@ -5333,22 +5323,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public int getClientPositionDelayCorrection() {
-      return 7;
+      return 0;
    }
 
    public void setPositionAndRotation2(double par1, double par3, double par5, float par7, float par8, int par9) {
-      // Validate inputs
-      if (par9 < 0) {
-         System.out.println("get fucked");
-         throw new IllegalArgumentException("par9 must be non-negative");
-      }
-
-      // Enhanced precision and accuracy
-      this.aircraftPosRotInc = par9 + this.getClientPositionDelayCorrection();
+      this.aircraftPosRotInc = Math.max(1, par9 + this.getClientPositionDelayCorrection());
       this.aircraftX = par1;
       this.aircraftY = par3;
       this.aircraftZ = par5;
-      this.aircraftYaw = (double) par7;
+      this.aircraftYaw = (double)this.getRotYaw() + MathHelper.wrapAngleTo180_double((double)par7 - (double)this.getRotYaw());
       this.aircraftPitch = (double) par8;
 
       // Apply current velocities

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -1054,6 +1054,14 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
             L = c.lp.size() - 1;
             double rc = ac != null?(double)ac.rotCrawlerTrack[c.side]:0.0D;
             double pc = ac != null?(double)ac.prevRotCrawlerTrack[c.side]:0.0D;
+            double phaseDiff = rc - pc;
+            if(phaseDiff > 0.5D) {
+               pc += 1.0D;
+            } else if(phaseDiff < -0.5D) {
+               pc -= 1.0D;
+            }
+            double phase = pc + (rc - pc) * (double)tickTime;
+            phase -= Math.floor(phase);
 
             for(int i = 0; i < L; ++i) {
                MCH_BaseVehicleInfo.CrawlerTrackPrm cp = (MCH_BaseVehicleInfo.CrawlerTrackPrm)c.lp.get(i);
@@ -1072,15 +1080,9 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
                   r2 -= 360.0D;
                }
 
-               double sx = x1 + (x2 - x1) * rc;
-               double sy = y1 + (y2 - y1) * rc;
-               double sr = r1 + (r2 - r1) * rc;
-               double ex = x1 + (x2 - x1) * pc;
-               double ey = y1 + (y2 - y1) * pc;
-               double er = r1 + (r2 - r1) * pc;
-               double x = sx + (ex - sx) * pc;
-               double y = sy + (ey - sy) * pc;
-               double r = sr + (er - sr) * pc;
+               double x = x1 + (x2 - x1) * phase;
+               double y = y1 + (y2 - y1) * phase;
+               double r = r1 + (r2 - r1) * phase;
                GL11.glPushMatrix();
                GL11.glTranslated(0.0D, x, y);
                GL11.glRotatef((float)r, -1.0F, 0.0F, 0.0F);

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -818,10 +818,6 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       }
    }
 
-   public int getClientPositionDelayCorrection() {
-      return this.getTankInfo() == null?7:(this.getTankInfo().weightType == 1?2:7);
-   }
-
    protected void onUpdate_Client() {
 //      if(this.getRiddenByEntity() != null && W_Lib.isClientPlayer(this.getRiddenByEntity())) {
 //         this.getRiddenByEntity().rotationPitch = this.getRiddenByEntity().prevRotationPitch;


### PR DESCRIPTION
### Motivation

- Remote observers and passengers saw a persistent or snapped hull yaw because incoming server yaw targets were being delayed and not interpolated on the shortest wrapped path. 
- Wheel and crawler/roller animations were computed from client-side throttle/control flags (and delayed control state), allowing driver/observer animation drift. 
- Crawler rendering mixed phases incorrectly by using the previous phase value as a blend factor instead of using the render `tickTime` partial tick and shortest wrap path.

### Description

- Normalize and interpolate remote yaw through the shortest wrapped angle and stop adding an arbitrary extra client-side delay by returning `0` from `getClientPositionDelayCorrection()` and ensuring `setPositionAndRotation2`/`applyServerPositionAndRotation` use wrapped differences. (changes in `MCH_EntityBaseVehicle` and removal of the tank-specific delay override). 
- Replace control-bit/throttle-driven per-client wheel/track integration with a single, deterministic animation source derived from the synchronized horizontal displacement and wrapped hull-yaw change via a new `updatePartAnimationTravel()` helper, and use that travel to drive `rotWheel`, `rotTrackRoller`, and `rotCrawlerTrack`. (new helpers and logic in `MCH_EntityBaseVehicle`). 
- Keep steering-wheel yaw animation separate from rolling wheel animation so input steering visuals remain while rolling is derived from motion. (preserve `rotYawWheel` behavior). 
- Make crawler-track rendering use the render partial tick and a shortest-path phase blend across wrap boundaries so phase interpolation is stable and does not jump at wraps. (changes in `MCH_RenderBaseVehicle`). 
- Added wrap-safe angle/phase helpers and ensured wheel/roller angles wrap using loops (no long-path interpolation). 
- Update `changelog.md` with a short description of the multiplayer yaw and running-gear synchronization fix. 
- Files changed: `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/tank/MCH_EntityTank.java`, `changelog.md`.

### Testing

- Ran `./gradlew tasks --offline` to validate the Gradle project configuration; the task list completed successfully. (PASS)
- Ran repository checks: `git diff --check` to validate no whitespace or obvious diff-check issues; no problems reported. (PASS)
- Executed Python assertions that validate yaw wrap behavior and differential-track sign/arc math across +/−180 transitions and simple forward/pivot cases; all assertions passed. (PASS)
- Did not run `./gradlew build` per the instruction not to compile or produce binary artifacts in this environment. (INTENTIONAL SKIP)
- Multiplayer gameplay verification (three-client in-game scenarios) and graphical observation were not possible in this non-interactive environment and should be validated in a live Forge session using the described driver/passenger/observer tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b96824b508323a1fa0abac6bef24e)