### PR TITLE
Fix vehicle LOD and mount synchronization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -319,3 +319,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Added placing-player ownership and legacy pilot claiming for player-ridable vehicles.
 - Added an operator-aware, persistent entry lock toggled by the pilot with O.
 - Added synchronized lock HUD state and owner/lock entity and item NBT data.
+# Fix vehicle LOD and mount synchronization
+
+* Fixed aircraft LOD selection retaining render state across local-player death, respawn, world changes, and entity retracking.
+* Restored normal vehicle and passenger-seat mount relationships with an authoritative server notification and a bounded client retry when tracking packets arrive out of order.
+* Kept UAV and NewUAV mounting paths excluded from the new normal-vehicle correction flow.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -866,6 +866,13 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onPlayerTickPre(EntityPlayer player) {
+      if(player == super.mc.thePlayer) {
+         MCH_BaseVehiclePacketHandler.tickPendingMounts(player);
+         if(player.isDead) {
+            MCH_MOD.proxy.clearVehicleLODSnapshots();
+            MCH_BaseVehiclePacketHandler.clearPendingMounts();
+         }
+      }
       if(player == super.mc.thePlayer && this.isHoldingMCHeliDismount()) {
          KeyBinding.setKeyBindState(super.mc.gameSettings.keyBindSneak.getKeyCode(), false);
          ((EntityClientPlayerMP)player).movementInput.sneak = false;

--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -15,6 +15,7 @@ import mcheli.MCH_TextureManagerDummy;
 import mcheli.MCH_ViewEntityDummy;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntitySeat;
+import mcheli.aircraft.MCH_BaseVehiclePacketHandler;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.lweapon.MCH_ClientLightWeaponTickHandler;
 import mcheli.multiplay.MCH_GuiTargetMarker;
@@ -171,13 +172,20 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
 
    public void worldEventUnload(Unload event) {
       MCH_ViewEntityDummy.onUnloadWorld();
+      MCH_MOD.proxy.clearVehicleLODSnapshots();
+      MCH_BaseVehiclePacketHandler.clearPendingMounts();
    }
 
    public void entityJoinWorldEvent(EntityJoinWorldEvent event) {
+      if(event.entity instanceof MCH_EntityBaseVehicle) {
+         ((MCH_EntityBaseVehicle)event.entity).isRenderingLOD = false;
+      }
       if(event.entity.isEntityEqual(MCH_Lib.getClientPlayer())) {
          MCH_Lib.DbgLog(true, "MCH_ClientEventHook.entityJoinWorldEvent : " + event.entity, new Object[0]);
          MCH_ItemRangeFinder.mode = Minecraft.getMinecraft().isSingleplayer()?1:0;
          MCH_ParticlesUtil.clearMarkPoint();
+         MCH_MOD.proxy.clearVehicleLODSnapshots();
+         MCH_BaseVehiclePacketHandler.clearPendingMounts();
       }
 
    }

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -1,6 +1,7 @@
 package mcheli.aircraft;
 
 import com.google.common.io.ByteArrayDataInput;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import mcheli.MCH_Lib;
@@ -33,6 +34,64 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.WorldServer;
 
 public class MCH_BaseVehiclePacketHandler {
+   private static final int MAX_PENDING_MOUNTS = 64;
+   private static final int PENDING_MOUNT_TICKS = 100;
+   private static final List<PendingMount> pendingMounts = new ArrayList<PendingMount>();
+   private static Object pendingWorld;
+
+   private static final class PendingMount {
+      final int aircraftId;
+      final int riderId;
+      final int seatId;
+      int ticksLeft = PENDING_MOUNT_TICKS;
+
+      PendingMount(int aircraftId, int riderId, int seatId) {
+         this.aircraftId = aircraftId;
+         this.riderId = riderId;
+         this.seatId = seatId;
+      }
+   }
+
+   public static void clearPendingMounts() {
+      pendingMounts.clear();
+      pendingWorld = null;
+   }
+
+   public static void tickPendingMounts(EntityPlayer player) {
+      if(player == null || !player.worldObj.isRemote) return;
+      if(pendingWorld != player.worldObj) {
+         pendingMounts.clear();
+         pendingWorld = player.worldObj;
+      }
+      for(int i = pendingMounts.size() - 1; i >= 0; --i) {
+         PendingMount pending = pendingMounts.get(i);
+         if(applyMount(player, pending.aircraftId, pending.riderId, pending.seatId) || --pending.ticksLeft <= 0) {
+            pendingMounts.remove(i);
+         }
+      }
+   }
+
+   private static void queueMount(EntityPlayer player, int aircraftId, int riderId, int seatId) {
+      if(pendingWorld != player.worldObj) clearPendingMounts();
+      pendingWorld = player.worldObj;
+      for(PendingMount pending : pendingMounts) {
+         if(pending.aircraftId == aircraftId && pending.riderId == riderId && pending.seatId == seatId) return;
+      }
+      if(pendingMounts.size() >= MAX_PENDING_MOUNTS) pendingMounts.remove(0);
+      pendingMounts.add(new PendingMount(aircraftId, riderId, seatId));
+   }
+
+   private static boolean applyMount(EntityPlayer player, int aircraftId, int riderId, int seatId) {
+      Entity aircraftEntity = player.worldObj.getEntityByID(aircraftId);
+      Entity rider = player.worldObj.getEntityByID(riderId);
+      if(!(aircraftEntity instanceof MCH_EntityBaseVehicle) || rider == null || rider.isDead) return false;
+      MCH_EntityBaseVehicle aircraft = (MCH_EntityBaseVehicle)aircraftEntity;
+      if(aircraft.isUAV() || aircraft.isNewUAV()) return true;
+      Entity mount = seatId == 0 ? aircraft : aircraft.getSeat(seatId - 1);
+      if(mount == null || mount.isDead) return false;
+      if(rider.ridingEntity != mount) rider.mountEntity(mount);
+      return rider.ridingEntity == mount && mount.riddenByEntity == rider;
+   }
 
    public static void handleVehicleAccessLockToggle(EntityPlayer player, MCH_EntityBaseVehicle vehicle,
                                                      MCH_PacketPlayerControlBase control) {
@@ -83,18 +142,9 @@ public class MCH_BaseVehiclePacketHandler {
          MCH_PacketNotifyOnMountEntity req = new MCH_PacketNotifyOnMountEntity();
          req.readData(data);
          MCH_Lib.DbgLog(player.worldObj, "onPacketOnMountEntity.rcv:%d, %d, %d, %d", new Object[]{Integer.valueOf(W_Entity.getEntityId(player)), Integer.valueOf(req.entityID_Ac), Integer.valueOf(req.entityID_rider), Integer.valueOf(req.seatID)});
-         if(req.entityID_Ac > 0) {
-            if(req.entityID_rider > 0) {
-               if(req.seatID >= 0) {
-                  Entity e = player.worldObj.getEntityByID(req.entityID_Ac);
-                  if(e instanceof MCH_EntityBaseVehicle) {
-                     MCH_Lib.DbgLog(player.worldObj, "onPacketOnMountEntity:" + W_Entity.getEntityId(player), new Object[0]);
-                     player.worldObj.getEntityByID(req.entityID_rider);
-                     MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)e;
-                  }
-
-               }
-            }
+         if(req.entityID_Ac > 0 && req.entityID_rider > 0 && req.seatID >= 0
+               && !applyMount(player, req.entityID_Ac, req.entityID_rider, req.seatID)) {
+            queueMount(player, req.entityID_Ac, req.entityID_rider, req.seatID);
          }
       }
    }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -5881,6 +5881,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
             player.playerNetServerHandler.sendPacket(new S1BPacketEntityAttach(0, seat.riddenByEntity, seat));
          }
       }
+      // Vanilla attach packets are discarded when their target has not spawned on
+      // the client yet.  Give the affected normal-vehicle rider a bounded, ID-only
+      // correction which can wait for aircraft/seat spawn ordering to settle.
+      if(!this.isUAV() && !this.isNewUAV()) {
+         int riderSeat = this.getSeatIdByEntity(player);
+         if(riderSeat >= 0) {
+            MCH_PacketNotifyOnMountEntity.sendToRider(this, player, riderSeat);
+         }
+      }
    }
 
    private void recreateMissingSeatsInLoadedChunks() {
@@ -7367,6 +7376,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          if(!this.worldObj.isRemote) {
             this.clearPlacementMotionLock();
             player.mountEntity(this);
+            if(player.ridingEntity == this) {
+               MCH_PacketNotifyOnMountEntity.sendToRider(this, player, 0);
+            }
             if(player.ridingEntity == this && this.vehicleOwnerUUID == null) {
                this.vehicleOwnerUUID = player.getUniqueID();
             }

--- a/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntitySeat.java
@@ -333,6 +333,10 @@ public class MCH_EntitySeat extends W_Entity implements IEntityAdditionalSpawnDa
          getParent().clearPlacementMotionLock();
       }
       player.mountEntity(this);
+      if(!this.worldObj.isRemote && player.ridingEntity == this && getParent() != null
+              && !getParent().isUAV() && !getParent().isNewUAV()) {
+         MCH_PacketNotifyOnMountEntity.sendToRider(getParent(), player, this.seatID + 1);
+      }
       return true;
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
@@ -55,4 +55,13 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
          }
       }
    }
+
+   public static void sendToRider(MCH_EntityBaseVehicle ac, EntityPlayer rider, int seatId) {
+      if(ac == null || rider == null || ac.isUAV() || ac.isNewUAV()) return;
+      MCH_PacketNotifyOnMountEntity packet = new MCH_PacketNotifyOnMountEntity();
+      packet.entityID_Ac = W_Entity.getEntityId(ac);
+      packet.entityID_rider = W_Entity.getEntityId(rider);
+      packet.seatID = seatId;
+      W_Network.sendToPlayer(packet, rider);
+   }
 }

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -118,10 +118,23 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          return false;
       }
 
+      Minecraft mc = Minecraft.getMinecraft();
+      Entity camera = mc.renderViewEntity;
+      if(camera == null || camera.isDead || camera.worldObj != ac.worldObj || mc.theWorld != ac.worldObj) {
+         ac.isRenderingLOD = false;
+         return false;
+      }
+
+      // Do not use a player (or the renderer coordinates derived from one) cached
+      // before respawn.  The render-view entity is replaceable and is authoritative
+      // for the current frame's distance.
+      double dx = ac.posX - camera.posX;
+      double dy = ac.posY - camera.posY;
+      double dz = ac.posZ - camera.posZ;
       double hysteresis = 16.0D;
       double exitDistance = Math.max(0.0D, startDistance - hysteresis);
       double threshold = ac.isRenderingLOD?exitDistance:startDistance;
-      boolean shouldRenderLOD = posX * posX + posY * posY + posZ * posZ >= threshold * threshold;
+      boolean shouldRenderLOD = dx * dx + dy * dy + dz * dz >= threshold * threshold;
       ac.isRenderingLOD = shouldRenderLOD;
       return shouldRenderLOD;
    }


### PR DESCRIPTION
### Motivation

- Fix two related client-side desync bugs where vehicles remain on their LOD model after the local player dies/respawns and where mounting breaks after chunk/tracking reloads. 
- Ensure LOD decisions and mount state use the current client world and render-view entity and restore authoritative rider relationships when entity/spawn ordering causes missed attach packets.

### Description

- Recalculate LOD distance against the current `Minecraft.renderViewEntity` and its world, reset `isRenderingLOD` when the camera/player is invalid, and avoid using stale renderer-relative coordinates for decisions (`MCH_RenderBaseVehicle.java`).
- Clear client-side LOD snapshots and any pending mount corrections on world unload and when the local player joins/replaces to avoid stale caches (`MCH_ClientEventHook.java`).
- Run a per-client tick handler to advance and clear the bounded pending-mount queue and to purge caches when the local player dies (`MCH_ClientCommonTickHandler.java`).
- Add a bounded, ID-only pending-mount retry system with a 64-entry limit and a 100-tick retry window that stores only entity IDs and seat index, retries safely while the client world is stable, and clears on world/player replacement (`MCH_BaseVehiclePacketHandler.java`).
- Apply mount packets immediately when possible, or queue them for bounded retries when the target vehicle/seat is not yet present on the client, and avoid affecting UAV/NewUAV paths (`MCH_BaseVehiclePacketHandler.java`, `MCH_PacketNotifyOnMountEntity.java`).
- Send a small, targeted rider-correction packet from the server to the affected player when `syncCompleteAircraftState` is performed so that clients receive an authoritative attach (excluded for UAV/NewUAV), and send the same correction after successful local mount interactions on the server (`MCH_EntityBaseVehicle.java`, `MCH_EntitySeat.java`, `MCH_PacketNotifyOnMountEntity.java`).
- Add a changelog entry documenting the fix (`changelog.md`).

Files changed: `MCH_RenderBaseVehicle.java`, `MCH_ClientEventHook.java`, `MCH_ClientCommonTickHandler.java`, `MCH_BaseVehiclePacketHandler.java`, `MCH_EntityBaseVehicle.java`, `MCH_EntitySeat.java`, `MCH_PacketNotifyOnMountEntity.java`, and `changelog.md`.

### Testing

- Ran static/source checks including `git diff --check`, balanced-brace inspection, and repository status checks, and they succeeded. 
- Performed source-level inspection of affected client/server packet flows and mount/seat logic to validate the retry/correction flow and to confirm UAV/NewUAV paths are excluded; inspection passed. 
- Did not run `./gradlew build` or in-engine multiplayer/manual tests due to environment and the repository instruction not to compile binaries in this workspace. 
- Manual runtime verification steps required (death/respawn LOD, chunk unload/reload mount scenarios, multiplayer mount/dismounts, UAV/drone regression checks) are provided in the task description and should be executed in a Minecraft client + dedicated server environment; these were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b9689a45883238b692b1fc77bc418)