### PR TITLE
Fix Tank LOD Part Transforms

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# Fix Tank LOD Part Transforms
+
+- Made the tank far-model pass render all configured dynamic named parts through the same common-part renderers used by the full-detail pass.
+- Preserved the interpolated hull transform as the parent of turret, weapon, recoil, hatch, wheel, track, suspension, and nested weapon-part transforms while retaining per-part matrix isolation and optional-part handling.
+
 ## Multiplayer Vehicle Yaw and Running-Gear Synchronization
 
 - Removed the tank's extra per-packet interpolation delay and made remote hull yaw corrections follow the shortest wrapped angle over the server-provided interpolation window.

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -158,8 +158,19 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       GL11.glDisable(GL11.GL_ALPHA_TEST);
       GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
       this.renderBaseVehicle(ac, posX, posY, posZ, yaw, pitch, roll, tickTime);
+      this.renderAircraftLODParts(ac, info, posX, posY, posZ, tickTime);
       GL11.glPopAttrib();
       GL11.glPopMatrix();
+   }
+
+   /**
+    * Renders dynamic parts required by a vehicle's far-model pass.  The base model
+    * renderer intentionally leaves the vehicle translation and interpolated hull
+    * rotations on the current matrix, just as it does before the normal common-part
+    * pass.  Subclasses can therefore reuse the normal part renderers without
+    * duplicating animation calculations.
+    */
+   protected void renderAircraftLODParts(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, double posX, double posY, double posZ, float tickTime) {
    }
 
    public static boolean shouldSkipRender(Entity entity) {

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import mcheli.MCH_Config;
 import mcheli.MCH_MOD;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.tank.MCH_EntityTank;
@@ -21,6 +22,14 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
 
    public MCH_RenderTank() {
       super.shadowSize = 2.0F;
+   }
+
+   @Override
+   protected void renderAircraftLODParts(MCH_EntityBaseVehicle tank, MCH_BaseVehicleInfo info, double posX, double posY, double posZ, float tickTime) {
+      // renderBaseVehicle leaves the interpolated hull transform active here.  Reuse
+      // the full-detail common-part pass so every configured tank part gets exactly
+      // the same turret, weapon, recoil, hatch, wheel, track, and child transforms.
+      this.renderCommonPart(tank, info, posX, posY, posZ, tickTime);
    }
 
    public void renderBaseVehicle(MCH_EntityBaseVehicle entity, double posX, double posY, double posZ, float yaw, float pitch, float roll, float tickTime) {


### PR DESCRIPTION
### Motivation
- Fix LOD rendering for tanks so named dynamic parts (turret, barrels, recoil, hatches, wheels, tracks, nested parts, etc.) receive the same interpolated parent/animation transforms used by the full-detail renderer.

### Description
- Add a post-body far-model hook `renderAircraftLODParts` to `MCH_RenderBaseVehicle` that runs while the interpolated hull transform is still active and is intended for per-vehicle overrides.
- Override the hook in `MCH_RenderTank` to call the existing `renderCommonPart` so all configured named parts reuse the exact full-detail transform and animation code instead of being skipped by the LOD path.
- Preserve existing `$body` rendering and per-part `glPushMatrix`/`glPopMatrix` isolation so transforms do not leak and optional/missing LOD parts are safely skipped.
- Document the fix in `changelog.md` (PR title used as the changelog heading) and commit the three modified files: `MCH_RenderBaseVehicle.java`, `MCH_RenderTank.java`, and `changelog.md`.

### Testing
- Ran `git diff --check` with no reported issues (success).
- Performed a source-level matrix balance check counting `GL11.glPushMatrix()`/`GL11.glPopMatrix()` and verified balanced counts in `MCH_RenderBaseVehicle` and `MCH_RenderTank` (success).
- Verified repository state and committed the change (commit created successfully); no build was executed per instructions (not run).
- Runtime in-game verification (LOD distance transitions, turret yaw/pitch, recoil, wheels/tracks, hatches, multiplayer interpolation) requires a Forge 1.7.10 client and was not executed in this non-interactive environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc16e30fc83238821485b21b8af0e)