### PR TITLE
Snapshot-only Tank Turret and Helicopter Rotor Animation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
-# Fix Tank LOD Part Transforms
+# Snapshot-only Tank Turret and Helicopter Rotor Animation
+
+- Extended distant-vehicle packets with bounded, index-stable tank weapon poses and helicopter rotor phase, per-tick angular change, and folded state.
+- Changed the entity-free snapshot renderer to separate `$body` from animated tank weapons and helicopter rotor blades while preserving external models, embedded named parts, skin overlays, and the monolithic-model fallback.
+- Added per-display weapon interpolation and continuously advanced, smoothly corrected rotor phases so one-second snapshots do not alias fast rotors.
+- Documented that the earlier real-entity LOD change could not affect vehicles which had already left client tracking.
+
+## Fix Tank LOD Part Transforms
 
 - Made the tank far-model pass render all configured dynamic named parts through the same common-part renderers used by the full-detail pass.
 - Preserved the interpolated hull transform as the parent of turret, weapon, recoil, hatch, wheel, track, suspension, and nested weapon-part transforms while retaining per-part matrix isolation and optional-part handling.

--- a/docs/overdrive-features.md
+++ b/docs/overdrive-features.md
@@ -112,7 +112,7 @@ Conventional guided-bomb and normal ballistic bomb references use real standard 
 
 **Why it exists:** Large combined-arms servers often need aircraft, ships, tanks, and turrets to remain visually identifiable at distances where full entity tracking/rendering is too expensive or unreliable.
 
-**How it differs from original MCHeli:** Overdrive adds a dedicated snapshot packet and client LOD manager. Snapshots include entity identity, category, type, texture, position, rotation, scale, and sampled world lighting, and the render path switches to cheaper displays beyond `AircraftLODStartDistance`.
+**How it differs from original MCHeli:** Overdrive adds a dedicated snapshot packet and client LOD manager. Snapshots include entity identity, category, type, texture, hull transform, sampled world lighting, indexed tank weapon poses, and helicopter rotor phase/speed/fold state. Beyond `AircraftLODStartDistance`, tracked entities still use the normal entity LOD renderer; after an entity leaves client tracking, the snapshot manager renders the named `$body` and animated named parts without creating a proxy entity. Monolithic models without a separable `$body` retain their safe all-model fallback and therefore cannot receive snapshot-only named-part animation.
 
 **Configuration:** Users/server owners configure `EnableAircraftLODRender`, `AircraftLODStartDistance`, and `AircraftLODFarDistance`. `AircraftLODFarDistance` also guides the extended tracking range helper so the render-only system has useful data without replacing real entity simulation.
 

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -8,12 +8,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.tank.MCH_EntityTank;
 import mcheli.vehicle.MCH_EntityTurret;
+import mcheli.weapon.MCH_WeaponSet;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.MathHelper;
@@ -91,10 +94,71 @@ public class MCH_ServerTickHandler {
          entry.pitch = vehicle.getRotPitch();
          entry.roll = vehicle.getRotRoll();
          entry.scale = 1.0F;
+         entry.weaponPoses = collectWeaponPoses(vehicle);
+         if(vehicle instanceof MCH_EntityHeli) {
+            MCH_EntityHeli heli = (MCH_EntityHeli)vehicle;
+            entry.rotorRotation = (float)heli.rotationRotor;
+            entry.prevRotorRotation = (float)heli.prevRotationRotor;
+            entry.rotorAngularChange = entry.rotorRotation - entry.prevRotorRotation;
+            if(entry.rotorAngularChange < -180.0F) entry.rotorAngularChange += 360.0F;
+            if(entry.rotorAngularChange > 180.0F) entry.rotorAngularChange -= 360.0F;
+            entry.rotorFolded = heli.isFoldBlades();
+         }
          entry.packedLight = getPackedLight(world, vehicle);
          entries.add(entry);
       }
       return entries;
+   }
+
+   private static PacketVehicleLODSnapshot.WeaponPose[] collectWeaponPoses(MCH_EntityBaseVehicle vehicle) {
+      MCH_BaseVehicleInfo info = vehicle.getAcInfo();
+      int count = Math.min(info.partWeapon.size(), PacketVehicleLODSnapshot.MAX_WEAPON_POSES);
+      PacketVehicleLODSnapshot.WeaponPose[] poses = new PacketVehicleLODSnapshot.WeaponPose[count];
+      Entity rider = vehicle.getRiddenByEntity();
+      MCH_WeaponSet before = null;
+      int weaponIndex = 0;
+      for(int i = 0; i < count; ++i) {
+         MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)info.partWeapon.get(i);
+         MCH_WeaponSet ws = vehicle.getWeaponByName(part.name[0]);
+         if(ws != before) {
+            weaponIndex = 0;
+            before = ws;
+         }
+         PacketVehicleLODSnapshot.WeaponPose pose = new PacketVehicleLODSnapshot.WeaponPose();
+         pose.turretYaw = vehicle.getLastRiderYaw() - vehicle.getRotYaw();
+         pose.prevTurretYaw = vehicle.prevLastRiderYaw - vehicle.prevRotationYaw;
+         if(ws != null) {
+            pose.yaw = ws.rotationYaw - ws.defaultRotationYaw;
+            pose.prevYaw = ws.prevRotationYaw - ws.defaultRotationYaw;
+            pose.pitch = ws.rotationPitch;
+            pose.prevPitch = ws.prevRotationPitch;
+            pose.rotationTurretYaw = ws.rotationTurretYaw;
+            pose.defaultRotationYaw = ws.defaultRotationYaw;
+            pose.barrelRotation = ws.rotBarrel;
+            pose.prevBarrelRotation = ws.prevRotBarrel;
+            MCH_WeaponSet.Recoil recoil = ws.recoilBuf[0];
+            for(int n = 0; n < part.name.length; ++n) {
+               MCH_WeaponSet candidate = vehicle.getWeaponByName(part.name[n]);
+               if(candidate != null && candidate.recoilBuf[0].recoilBuf > recoil.recoilBuf) recoil = candidate.recoilBuf[0];
+            }
+            pose.recoil = recoil.recoilBuf;
+            pose.prevRecoil = recoil.prevRecoilBuf;
+         } else if(rider != null) {
+            pose.yaw = rider.rotationYaw - vehicle.getRotYaw();
+            pose.prevYaw = rider.prevRotationYaw - vehicle.prevRotationYaw;
+            pose.pitch = rider.rotationPitch;
+            pose.prevPitch = rider.prevRotationPitch;
+         } else {
+            pose.yaw = pose.turretYaw;
+            pose.prevYaw = pose.prevTurretYaw;
+            pose.pitch = vehicle.getLastRiderPitch();
+            pose.prevPitch = vehicle.prevLastRiderPitch;
+         }
+         pose.visible = !part.isMissile || !vehicle.isWeaponNotCooldown(ws, weaponIndex);
+         poses[i] = pose;
+         ++weaponIndex;
+      }
+      return poses;
    }
 
    /**

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -620,6 +620,85 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
    }
 
+   /** True only when rendering the body separately cannot also draw named dynamic groups. */
+   public static boolean hasSeparableBody(IModelCustom model) {
+      return model instanceof W_ModelCustom && ((W_ModelCustom)model).containsPart("$body");
+   }
+
+   public static void renderSnapshotWeapon(MCH_BaseVehicleInfo info, MCH_BaseVehicleInfo.PartWeapon w,
+         mcheli.network.packets.PacketVehicleLODSnapshot.WeaponPose pose, float tickTime) {
+      if(info == null || w == null || pose == null || !pose.visible) return;
+      GL11.glPushMatrix();
+      try {
+         float turretYaw = interpolateSnapshotAngle(pose.prevTurretYaw, pose.turretYaw, tickTime);
+         if(w.turret) {
+            GL11.glTranslated(info.turretPosition.xCoord, info.turretPosition.yCoord, info.turretPosition.zCoord);
+            GL11.glRotatef(turretYaw, 0.0F, -1.0F, 0.0F);
+            GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
+         }
+         GL11.glTranslated(w.pos.xCoord, w.pos.yCoord, w.pos.zCoord);
+         if(w.yaw) GL11.glRotatef(interpolateSnapshotAngle(pose.prevYaw, pose.yaw, tickTime), 0.0F, -1.0F, 0.0F);
+         if(w.turret) GL11.glRotatef(-(turretYaw - pose.rotationTurretYaw), 0.0F, -1.0F, 0.0F);
+         boolean reversePitch = false;
+         if((int)pose.defaultRotationYaw != 0) {
+            float wrapped = MathHelper.wrapAngleTo180_float(pose.defaultRotationYaw);
+            reversePitch = wrapped >= 45.0F && wrapped <= 135.0F || wrapped <= -45.0F && wrapped >= -135.0F;
+            GL11.glRotatef(-pose.defaultRotationYaw, 0.0F, -1.0F, 0.0F);
+         }
+         if(w.pitch) {
+            float pitch = pose.prevPitch + (pose.pitch - pose.prevPitch) * tickTime;
+            GL11.glRotatef(reversePitch ? -pitch : pitch, 1.0F, 0.0F, 0.0F);
+         }
+         if(w.recoilBuf != 0.0F) {
+            float recoil = pose.prevRecoil + (pose.recoil - pose.prevRecoil) * tickTime;
+            GL11.glTranslated(0.0D, 0.0D, (double)(w.recoilBuf * recoil));
+         }
+         GL11.glRotatef(pose.defaultRotationYaw, 0.0F, -1.0F, 0.0F);
+         if(w.rotBarrel) {
+            GL11.glRotatef(interpolateSnapshotAngle(pose.prevBarrelRotation, pose.barrelRotation, tickTime),
+               (float)w.rot.xCoord, (float)w.rot.yCoord, (float)w.rot.zCoord);
+         }
+         GL11.glTranslated(-w.pos.xCoord, -w.pos.yCoord, -w.pos.zCoord);
+         renderPart(w.model, info.model, w.modelName);
+         for(int i = 0; i < w.child.size(); ++i) {
+            MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)w.child.get(i);
+            GL11.glPushMatrix();
+            try {
+               renderSnapshotWeaponChild(info, child, pose, tickTime);
+            } finally {
+               GL11.glPopMatrix();
+            }
+         }
+      } finally {
+         GL11.glPopMatrix();
+      }
+   }
+
+   private static void renderSnapshotWeaponChild(MCH_BaseVehicleInfo info, MCH_BaseVehicleInfo.PartWeaponChild w,
+         mcheli.network.packets.PacketVehicleLODSnapshot.WeaponPose pose, float tickTime) {
+      GL11.glTranslated(w.pos.xCoord, w.pos.yCoord, w.pos.zCoord);
+      if(w.yaw) GL11.glRotatef(interpolateSnapshotAngle(pose.prevYaw, pose.yaw, tickTime), 0.0F, -1.0F, 0.0F);
+      float wrapped = MathHelper.wrapAngleTo180_float(pose.defaultRotationYaw);
+      boolean reversePitch = wrapped >= 45.0F && wrapped <= 135.0F || wrapped <= -45.0F && wrapped >= -135.0F;
+      if((int)pose.defaultRotationYaw != 0) GL11.glRotatef(-pose.defaultRotationYaw, 0.0F, -1.0F, 0.0F);
+      if(w.pitch) {
+         float pitch = pose.prevPitch + (pose.pitch - pose.prevPitch) * tickTime;
+         GL11.glRotatef(reversePitch ? -pitch : pitch, 1.0F, 0.0F, 0.0F);
+      }
+      if(w.recoilBuf != 0.0F) {
+         float recoil = pose.prevRecoil + (pose.recoil - pose.prevRecoil) * tickTime;
+         GL11.glTranslated(0.0D, 0.0D, (double)(-w.recoilBuf * recoil));
+      }
+      GL11.glRotatef(pose.defaultRotationYaw, 0.0F, -1.0F, 0.0F);
+      GL11.glTranslated(-w.pos.xCoord, -w.pos.yCoord, -w.pos.zCoord);
+      renderPart(w.model, info.model, w.modelName);
+   }
+
+   private static float interpolateSnapshotAngle(float previous, float current, float partial) {
+      float delta = MathHelper.wrapAngleTo180_float(current - previous);
+      return previous + delta * partial;
+   }
+
    public static void renderAllModel(final IModelCustom model) {
       if(model != null) {
          model.renderAll();

--- a/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_RenderHeli.java
@@ -80,6 +80,41 @@ public class MCH_RenderHeli extends MCH_RenderBaseVehicle {
 
    }
 
+   /** Snapshot-only equivalent which needs no entity or simulated rotor objects. */
+   public static void drawSnapshotBlades(MCH_HeliInfo info, float phase, boolean folded) {
+      for(int rotorIndex = 0; rotorIndex < info.rotorList.size(); ++rotorIndex) {
+         MCH_HeliInfo.Rotor rotorInfo = (MCH_HeliInfo.Rotor)info.rotorList.get(rotorIndex);
+         GL11.glPushMatrix();
+         try {
+            if(rotorInfo.oldRenderMethod) {
+               GL11.glTranslated(rotorInfo.pos.xCoord, rotorInfo.pos.yCoord, rotorInfo.pos.zCoord);
+            }
+            for(int bladeIndex = 0; bladeIndex < rotorInfo.bladeNum; ++bladeIndex) {
+               GL11.glPushMatrix();
+               try {
+                  float angle = phase + (float)(bladeIndex * rotorInfo.bladeRot);
+                  if(folded && rotorInfo.haveFoldFunc) {
+                     float foldAngle = (float)(5 + bladeIndex * 3);
+                     angle = angle < 180.0F ? foldAngle : 360.0F - foldAngle;
+                  }
+                  if(!rotorInfo.oldRenderMethod) {
+                     GL11.glTranslated(rotorInfo.pos.xCoord, rotorInfo.pos.yCoord, rotorInfo.pos.zCoord);
+                  }
+                  GL11.glRotatef(angle, (float)rotorInfo.rot.xCoord, (float)rotorInfo.rot.yCoord, (float)rotorInfo.rot.zCoord);
+                  if(!rotorInfo.oldRenderMethod) {
+                     GL11.glTranslated(-rotorInfo.pos.xCoord, -rotorInfo.pos.yCoord, -rotorInfo.pos.zCoord);
+                  }
+                  renderPart(rotorInfo.model, info.model, rotorInfo.modelName);
+               } finally {
+                  GL11.glPopMatrix();
+               }
+            }
+         } finally {
+            GL11.glPopMatrix();
+         }
+      }
+   }
+
    protected ResourceLocation getEntityTexture(Entity entity) {
       return W_Render.TEX_DEFAULT;
    }

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -13,6 +13,8 @@ import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.helicopter.MCH_HeliInfoManager;
+import mcheli.helicopter.MCH_HeliInfo;
+import mcheli.helicopter.MCH_RenderHeli;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.plane.MCP_PlaneInfoManager;
 import mcheli.ship.MCH_ShipInfoManager;
@@ -129,11 +131,11 @@ public final class MCH_VehicleLODManager {
             if (x * x + y * y + z * z > farSq) {
                 continue;
             }
-            render(display, x, y, z, interpolation);
+            render(display, x, y, z, interpolation, now);
         }
     }
 
-    private static void render(Display display, double x, double y, double z, float interpolation) {
+    private static void render(Display display, double x, double y, double z, float interpolation, long now) {
         MCH_BaseVehicleInfo info = getInfo(display.category, display.typeName);
         String textureFolder = getTextureFolder(display.category);
         if (info == null || info.model == null || textureFolder == null) {
@@ -157,7 +159,21 @@ public final class MCH_VehicleLODManager {
                 Minecraft.getMinecraft().renderEngine.bindTexture(
                     new ResourceLocation(W_MOD.DOMAIN, "textures/" + textureFolder + "/"
                         + MCH_RenderBaseVehicle.getBaseTextureName(display.textureName) + ".png"));
-                MCH_RenderBaseVehicle.renderAllModel(info.model);
+                if (MCH_RenderBaseVehicle.hasSeparableBody(info.model)) {
+                    MCH_RenderBaseVehicle.renderBody(info.model);
+                    if (display.category == 3) {
+                        int weaponCount = Math.min(info.partWeapon.size(), display.weaponPoses.length);
+                        for (int i = 0; i < weaponCount; ++i) {
+                            MCH_RenderBaseVehicle.renderSnapshotWeapon(info,
+                                (MCH_BaseVehicleInfo.PartWeapon)info.partWeapon.get(i), display.weaponPoses[i], interpolation);
+                        }
+                    } else if (display.category == 0 && info instanceof MCH_HeliInfo) {
+                        MCH_RenderHeli.drawSnapshotBlades((MCH_HeliInfo)info, display.getRotorPhase(now), display.rotorFolded);
+                    }
+                } else {
+                    // Legacy monolithic models cannot exclude bind-pose groups safely.
+                    MCH_RenderBaseVehicle.renderAllModel(info.model);
+                }
             } finally {
                 MCH_RenderBaseVehicle.endSkinOverlayRender();
             }
@@ -238,6 +254,11 @@ public final class MCH_VehicleLODManager {
         private float roll;
         private float scale;
         private int packedLight;
+        private PacketVehicleLODSnapshot.WeaponPose[] weaponPoses = new PacketVehicleLODSnapshot.WeaponPose[0];
+        private float rotorPhase;
+        private float rotorAngularChange;
+        private boolean rotorFolded;
+        private long rotorPhaseTimeMs;
         private long previousUpdateMs;
         private long lastUpdateMs;
 
@@ -254,6 +275,8 @@ public final class MCH_VehicleLODManager {
 
         private void update(PacketVehicleLODSnapshot.Entry entry) {
             long now = System.currentTimeMillis();
+            byte oldCategory = this.category;
+            String oldTypeName = this.typeName;
             float partial = this.previousUpdateMs == 0L ? 1.0F : Math.min(1.0F, (float)(now - this.previousUpdateMs) / 1000.0F);
             this.previousX = this.previousX + (this.x - this.previousX) * partial;
             this.previousY = this.previousY + (this.y - this.previousY) * partial;
@@ -273,7 +296,64 @@ public final class MCH_VehicleLODManager {
             this.pitch = entry.pitch;
             this.roll = entry.roll;
             this.scale = entry.scale > 0.0F ? entry.scale : 1.0F;
+            boolean categoryChanged = oldTypeName != null && (oldCategory != entry.category || !oldTypeName.equals(entry.typeName));
+            if (categoryChanged) {
+                this.weaponPoses = new PacketVehicleLODSnapshot.WeaponPose[0];
+                this.rotorPhaseTimeMs = 0L;
+                this.rotorAngularChange = 0.0F;
+            }
+            PacketVehicleLODSnapshot.WeaponPose[] incoming = entry.weaponPoses == null
+                ? new PacketVehicleLODSnapshot.WeaponPose[0] : entry.weaponPoses;
+            for (int i = 0; i < incoming.length; ++i) {
+                PacketVehicleLODSnapshot.WeaponPose current = incoming[i];
+                if (!categoryChanged && i < this.weaponPoses.length) {
+                    PacketVehicleLODSnapshot.WeaponPose previous = this.weaponPoses[i];
+                    current.prevYaw = previous.yaw;
+                    current.prevPitch = previous.pitch;
+                    current.prevTurretYaw = previous.turretYaw;
+                    current.prevBarrelRotation = previous.barrelRotation;
+                    current.prevRecoil = previous.recoil;
+                } else {
+                    current.prevYaw = current.yaw;
+                    current.prevPitch = current.pitch;
+                    current.prevTurretYaw = current.turretYaw;
+                    current.prevBarrelRotation = current.barrelRotation;
+                    current.prevRecoil = current.recoil;
+                }
+            }
+            this.weaponPoses = incoming;
+            if (entry.category == 0) {
+                if (this.rotorPhaseTimeMs == 0L) {
+                    this.rotorPhase = entry.rotorRotation;
+                } else {
+                    float predicted = advanceRotorPhase(now);
+                    float error = interpolateAngle(predicted, entry.rotorRotation, 1.0F) - predicted;
+                    this.rotorPhase = predicted + error * 0.25F;
+                }
+                this.rotorPhaseTimeMs = now;
+                this.rotorAngularChange = entry.rotorAngularChange;
+                this.rotorFolded = entry.rotorFolded;
+            } else {
+                this.rotorPhaseTimeMs = 0L;
+                this.rotorAngularChange = 0.0F;
+                this.rotorFolded = false;
+            }
             this.packedLight = entry.packedLight;
+        }
+
+        private float getRotorPhase(long now) {
+            this.rotorPhase = advanceRotorPhase(now);
+            this.rotorPhaseTimeMs = now;
+            return this.rotorPhase;
+        }
+
+        private float advanceRotorPhase(long now) {
+            if (this.rotorPhaseTimeMs == 0L) return this.rotorPhase;
+            long elapsed = now - this.rotorPhaseTimeMs;
+            long snapshotAge = now - this.lastUpdateMs;
+            if (snapshotAge > 1250L) elapsed = Math.max(0L, 1250L - (this.rotorPhaseTimeMs - this.lastUpdateMs));
+            if (elapsed < 0L) elapsed = 0L;
+            return this.rotorPhase + this.rotorAngularChange * (float)elapsed / 50.0F;
         }
     }
 }

--- a/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
@@ -20,6 +20,7 @@ public class PacketVehicleLODSnapshot extends PacketBase {
     private static final Charset UTF_8 = Charset.forName("UTF-8");
     private static final int MAX_ENTRIES = 512;
     private static final int MAX_STRING_BYTES = 128;
+    public static final int MAX_WEAPON_POSES = 64;
 
     public int dimension;
     public List<Entry> entries = Collections.emptyList();
@@ -52,6 +53,28 @@ public class PacketVehicleLODSnapshot extends PacketBase {
             data.writeFloat(entry.pitch);
             data.writeFloat(entry.roll);
             data.writeFloat(entry.scale);
+            int weaponCount = entry.weaponPoses == null ? 0 : Math.min(entry.weaponPoses.length, MAX_WEAPON_POSES);
+            data.writeByte(weaponCount);
+            for (int weaponIndex = 0; weaponIndex < weaponCount; ++weaponIndex) {
+                WeaponPose pose = entry.weaponPoses[weaponIndex];
+                data.writeFloat(pose.yaw);
+                data.writeFloat(pose.prevYaw);
+                data.writeFloat(pose.pitch);
+                data.writeFloat(pose.prevPitch);
+                data.writeFloat(pose.turretYaw);
+                data.writeFloat(pose.prevTurretYaw);
+                data.writeFloat(pose.rotationTurretYaw);
+                data.writeFloat(pose.defaultRotationYaw);
+                data.writeFloat(pose.barrelRotation);
+                data.writeFloat(pose.prevBarrelRotation);
+                data.writeFloat(pose.recoil);
+                data.writeFloat(pose.prevRecoil);
+                data.writeBoolean(pose.visible);
+            }
+            data.writeFloat(entry.rotorRotation);
+            data.writeFloat(entry.prevRotorRotation);
+            data.writeFloat(entry.rotorAngularChange);
+            data.writeBoolean(entry.rotorFolded);
             data.writeInt(entry.packedLight);
         }
     }
@@ -59,7 +82,10 @@ public class PacketVehicleLODSnapshot extends PacketBase {
     @Override
     public void decodeInto(ChannelHandlerContext ctx, ByteBuf data) {
         this.dimension = data.readInt();
-        int count = Math.min(data.readUnsignedShort(), MAX_ENTRIES);
+        int count = data.readUnsignedShort();
+        if (count > MAX_ENTRIES) {
+            throw new IllegalArgumentException("Vehicle LOD snapshot entry count exceeds " + MAX_ENTRIES);
+        }
         List<Entry> decoded = new ArrayList<Entry>(count);
         for (int i = 0; i < count; ++i) {
             Entry entry = new Entry();
@@ -75,6 +101,32 @@ public class PacketVehicleLODSnapshot extends PacketBase {
             entry.pitch = data.readFloat();
             entry.roll = data.readFloat();
             entry.scale = data.readFloat();
+            int weaponCount = data.readUnsignedByte();
+            if (weaponCount > MAX_WEAPON_POSES) {
+                throw new IllegalArgumentException("Vehicle LOD weapon pose count exceeds " + MAX_WEAPON_POSES);
+            }
+            entry.weaponPoses = new WeaponPose[weaponCount];
+            for (int weaponIndex = 0; weaponIndex < weaponCount; ++weaponIndex) {
+                WeaponPose pose = new WeaponPose();
+                pose.yaw = data.readFloat();
+                pose.prevYaw = data.readFloat();
+                pose.pitch = data.readFloat();
+                pose.prevPitch = data.readFloat();
+                pose.turretYaw = data.readFloat();
+                pose.prevTurretYaw = data.readFloat();
+                pose.rotationTurretYaw = data.readFloat();
+                pose.defaultRotationYaw = data.readFloat();
+                pose.barrelRotation = data.readFloat();
+                pose.prevBarrelRotation = data.readFloat();
+                pose.recoil = data.readFloat();
+                pose.prevRecoil = data.readFloat();
+                pose.visible = data.readBoolean();
+                entry.weaponPoses[weaponIndex] = pose;
+            }
+            entry.rotorRotation = data.readFloat();
+            entry.prevRotorRotation = data.readFloat();
+            entry.rotorAngularChange = data.readFloat();
+            entry.rotorFolded = data.readBoolean();
             entry.packedLight = data.readInt();
             decoded.add(entry);
         }
@@ -118,6 +170,28 @@ public class PacketVehicleLODSnapshot extends PacketBase {
         public float pitch;
         public float roll;
         public float scale = 1.0F;
+        public WeaponPose[] weaponPoses = new WeaponPose[0];
+        public float rotorRotation;
+        public float prevRotorRotation;
+        public float rotorAngularChange;
+        public boolean rotorFolded;
         public int packedLight;
+    }
+
+    /** Render-only pose at the matching index in MCH_BaseVehicleInfo.partWeapon. */
+    public static class WeaponPose {
+        public float yaw;
+        public float prevYaw;
+        public float pitch;
+        public float prevPitch;
+        public float turretYaw;
+        public float prevTurretYaw;
+        public float rotationTurretYaw;
+        public float defaultRotationYaw;
+        public float barrelRotation;
+        public float prevBarrelRotation;
+        public float recoil;
+        public float prevRecoil;
+        public boolean visible = true;
     }
 }


### PR DESCRIPTION
### Motivation

- Fix distant-vehicle snapshot rendering because the earlier change only touched the real-entity LOD path and did not affect the snapshot-only renderer used after the entity leaves client tracking. 
- Ensure tank turrets and helicopter rotors animate correctly for snapshot-only displays without creating proxy entities or adding snapshot objects to a `World`.

### Description

- Extended the snapshot packet `PacketVehicleLODSnapshot.Entry` with a bounded, index-stable `weaponPoses` array and helicopter rotor fields (`rotorRotation`, `prevRotorRotation`, `rotorAngularChange`, `rotorFolded`) and added a `WeaponPose` helper class to carry per-part pose state. 
- Populated new snapshot fields in `MCH_ServerTickHandler.collectSnapshots` using the stable order of `MCH_BaseVehicleInfo.partWeapon` and the same `MCH_WeaponSet` / rider fallback logic used by the full-detail renderer, and derived rotor state directly from the helicopter rotor update state. 
- Reworked the snapshot-only renderer in `MCH_VehicleLODManager` to stop calling `renderAllModel(info.model)` unconditionally, instead rendering the separable `$body` via `MCH_RenderBaseVehicle.renderBody(info.model)` and then rendering animated named parts: snapshot tank weapons via a new `renderSnapshotWeapon` path and snapshot helicopter rotors via `MCH_RenderHeli.drawSnapshotBlades`; legacy monolithic models keep the safe `renderAllModel` fallback. 
- Implemented per-display interpolation and time-based rotor-phase advancement with smooth correction and stale-extrapolation limits inside `MCH_VehicleLODManager.Display` so snapshot rotors advance and remain smooth across one-second server snapshots without aliasing. 
- Added reusable snapshot weapon/child render helpers to `MCH_RenderBaseVehicle` that apply transforms in the same order and with the same pivot/axis logic as the full-detail `renderWeapon` path while preserving `renderPart` semantics, skin-overlay rendering, and per-part matrix isolation. 
- Enforced strict bounds and decode-time checks for variable-length packet fields (max entries and `MAX_WEAPON_POSES`) and kept the packet string length limits and dedicated-server safety. 
- Updated documentation and `changelog.md` to record the snapshot-only animation support and the new packet fields. 

Files changed: `changelog.md`, `docs/overdrive-features.md`, `src/main/java/mcheli/MCH_ServerTickHandler.java`, `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/helicopter/MCH_RenderHeli.java`, `src/main/java/mcheli/lod/MCH_VehicleLODManager.java`, and `src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java`.

### Testing

- Ran `git diff --check` and fixed/verified there are no whitespace/overlap warnings, and the check passed. 
- Executed a lightweight delimiter-balance script (`python3` snippet) to confirm bracket/parenthesis balancing for all modified Java files, and the check passed. 
- Verified repository status and created a single commit for these changes, and the working tree is clean after the commit. 
- The project build and the full dedicated-server/two-client runtime tests (`./gradlew build` and the runtime verification matrix) were not executed in this environment per the provided instructions that prohibit compiling binaries and running interactive multiplayer scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc90b993c8323bb586caa88257250)