### PR TITLE
Complete animated vehicle LOD model-part rendering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -348,3 +348,10 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 * Fixed aircraft LOD selection retaining render state across local-player death, respawn, world changes, and entity retracking.
 * Restored normal vehicle and passenger-seat mount relationships with an authoritative server notification and a bounded client retry when tracking packets arrive out of order.
 * Kept UAV and NewUAV mounting paths excluded from the new normal-vehicle correction flow.
+
+## Vehicle LOD named-part completion
+
+- Restored tracked and snapshot landing-gear rendering for separable plane models, including reverse, hatch, secondary-axis, and sliding gear definitions.
+- Added continuous snapshot propeller animation plus nozzle/nacelle, wing, pylon, and generic weapon rendering for planes and ships.
+- Added bounded, depth-first stationary-turret pose snapshots and recursive snapshot rendering for yaw, pitch, barrel rotation, recoil, cooldown visibility, and nested parts.
+- Resolved turret snapshot textures from each turret info's legacy `vehicles` or newer `turrets` asset directory.

--- a/docs/vehicle-lod-moving-part-audit.md
+++ b/docs/vehicle-lod-moving-part-audit.md
@@ -1,0 +1,26 @@
+# Vehicle LOD moving-part audit
+
+This audit compares the normal entity renderer, tracked-entity LOD hook, and entity-free snapshot renderer. Snapshot rendering is intentionally limited to separable models; monolithic models retain the safe all-model fallback because named bind-pose groups cannot be excluded.
+
+| Category | Configuration / part list | Normal renderer / state source | Tracked LOD | Snapshot LOD | Action |
+|---|---|---|---|---|---|
+| All base vehicles | `partWeapon` | `renderWeapon`; weapon-set pose | Existing common-part path | Missing outside tanks | Render bounded generic weapon poses for helicopter, plane, and ship; stationary turrets remain separate |
+| All base vehicles | `partRotPart` | `renderRotPart`; throttle/rotation counters | Existing common-part path | Not safely reconstructable from current synchronized state | Intentionally skipped pending an authoritative per-part state source |
+| All base vehicles | `hatchList`, `lightHatchList` | `renderHatch`, `renderLightHatch`; entity parts/searchlight | Existing common-part path | Primarily close-range/access or lighting state and not yet authoritative | Intentionally skipped rather than guess state |
+| Tanks | track rollers, crawler tracks, wheels | `renderTrackRoller`, `renderCrawlerTrack`, `renderWheel`; synchronized running gear | Working | Working | Preserved unchanged |
+| All base vehicles | steering wheel, throttle, camera | `renderSteeringWheel`, `renderThrottle`, `renderCamera`; rider/cockpit input | Existing common-part path | Cockpit-oriented and not meaningful at snapshot distance | Intentionally skipped |
+| Planes/ships | `landingGear` | `renderLandingGear`; current/previous gear rotation | Plane gear was missing | Missing | Added shared state overload and snapshot fields |
+| All base vehicles | weapon bays, canopy | `renderWeaponBay`, `renderCanopy`; entity `MCH_Parts` | Existing common-part path | Access/cockpit geometry lacks authoritative snapshot state | Intentionally skipped rather than render bind pose |
+| Planes | `nozzles` | `MCP_RenderPlane.renderNozzle`; nozzle rotation | Working in `renderBaseVehicle` | Missing | Added state overload and snapshot rendering |
+| Planes | `wingList` / pylons | `MCP_RenderPlane.renderWing`; wing rotation | Working in `renderBaseVehicle` | Missing | Added state overload preserving parent-child transforms |
+| Planes | `rotorList` / blades | `MCP_RenderPlane.renderRotor`; nozzle parent plus rotor phase | Working in `renderBaseVehicle` | Missing | Added state overload and continuous per-display phase |
+| Helicopters | rotor/blades | `MCH_RenderHeli.drawModelBlade`; rotor phase/fold state | Working | Working | Preserved unchanged |
+| Ships | nozzles, wings/pylons, rotors/blades | `MCH_RenderShip` plane-like methods; ship rotations | Working in `renderBaseVehicle` | Missing | Added type-safe ship state overloads and snapshot rendering |
+| Tanks | category LOD hook | `MCH_RenderTank.renderAircraftLODParts` | Working | Working | Preserved unchanged |
+| Stationary turrets | recursive `partList` | `MCH_RenderTurret.drawPart`; aim/weapon indexed state | Working | Missing | Added bounded DFS pose capture and entity-free recursive renderer |
+
+## Snapshot design notes
+
+Plane and ship propeller phase is not interpolated between one-second packet angles. Each display advances its own phase every render from the synchronized wrapped per-tick angular change, gently corrects toward each new authoritative phase, and clamps stale extrapolation. A synchronized zero angular change therefore stops the propeller.
+
+Stationary turret part poses are captured and consumed in the same stable configuration-order, depth-first traversal. Recoil/cooldown weapon indexes advance only for type 2 and type 3 parts, matching the normal renderer, while the packet's bounded pose array is keyed by traversal position rather than object identity.

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -15,6 +15,7 @@ import mcheli.plane.MCP_EntityPlane;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.tank.MCH_EntityTank;
 import mcheli.vehicle.MCH_EntityTurret;
+import mcheli.vehicle.MCH_TurretInfo;
 import mcheli.weapon.MCH_WeaponSet;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -94,6 +95,8 @@ public class MCH_ServerTickHandler {
          entry.pitch = vehicle.getRotPitch();
          entry.roll = vehicle.getRotRoll();
          entry.scale = 1.0F;
+         entry.landingGearRotation = vehicle.getLandingGearRotation();
+         entry.prevLandingGearRotation = vehicle.getPrevLandingGearRotation();
          if(entry.category == 3) {
             for(int side = 0; side < 2; ++side) {
                entry.trackRollerRotation[side] = vehicle.rotTrackRoller[side];
@@ -116,10 +119,65 @@ public class MCH_ServerTickHandler {
             if(entry.rotorAngularChange > 180.0F) entry.rotorAngularChange -= 360.0F;
             entry.rotorFolded = heli.isFoldBlades();
          }
+         if(vehicle instanceof MCP_EntityPlane) {
+            MCP_EntityPlane plane = (MCP_EntityPlane)vehicle;
+            capturePlaneLikeState(entry, plane.getNozzleRotation(), plane.getPrevNozzleRotation(),
+               plane.getWingRotation(), plane.getPrevWingRotation(), plane.rotationRotor, plane.prevRotationRotor);
+         } else if(vehicle instanceof MCH_EntityShip) {
+            MCH_EntityShip ship = (MCH_EntityShip)vehicle;
+            capturePlaneLikeState(entry, ship.getNozzleRotation(), ship.getPrevNozzleRotation(),
+               ship.getWingRotation(), ship.getPrevWingRotation(), ship.rotationRotor, ship.prevRotationRotor);
+         } else if(vehicle instanceof MCH_EntityTurret) {
+            captureTurretState(entry, (MCH_EntityTurret)vehicle);
+         }
          entry.packedLight = getPackedLight(world, vehicle);
          entries.add(entry);
       }
       return entries;
+   }
+
+   private static void capturePlaneLikeState(PacketVehicleLODSnapshot.Entry entry, float nozzle, float prevNozzle,
+      float wing, float prevWing, float rotor, float prevRotor) {
+      entry.nozzleRotation = nozzle;
+      entry.prevNozzleRotation = prevNozzle;
+      entry.wingRotation = wing;
+      entry.prevWingRotation = prevWing;
+      entry.rotorRotation = rotor;
+      entry.prevRotorRotation = prevRotor;
+      entry.rotorAngularChange = rotor - prevRotor;
+      if(entry.rotorAngularChange < -180.0F) entry.rotorAngularChange += 360.0F;
+      if(entry.rotorAngularChange > 180.0F) entry.rotorAngularChange -= 360.0F;
+   }
+
+   private static void captureTurretState(PacketVehicleLODSnapshot.Entry entry, MCH_EntityTurret turret) {
+      MCH_TurretInfo info = turret.getTurretInfo();
+      MCH_WeaponSet ws = turret.getFirstSeatWeapon();
+      entry.aimYaw = turret.getLastRiderYaw();
+      entry.prevAimYaw = turret.prevLastRiderYaw;
+      entry.aimPitch = turret.getLastRiderPitch();
+      entry.prevAimPitch = turret.prevLastRiderPitch;
+      if(info == null || ws == null) return;
+      entry.turretBarrelRotation = ws.rotBarrel;
+      entry.prevTurretBarrelRotation = ws.prevRotBarrel;
+      List<PacketVehicleLODSnapshot.TurretPartPose> poses = new ArrayList<PacketVehicleLODSnapshot.TurretPartPose>();
+      int index = 0;
+      for(Object object : info.partList) index = captureTurretPart((MCH_TurretInfo.VPart)object, turret, ws, index, poses);
+      entry.turretParts = poses.toArray(new PacketVehicleLODSnapshot.TurretPartPose[poses.size()]);
+   }
+
+   private static int captureTurretPart(MCH_TurretInfo.VPart part, MCH_EntityTurret turret, MCH_WeaponSet ws,
+      int index, List<PacketVehicleLODSnapshot.TurretPartPose> poses) {
+      if(poses.size() >= PacketVehicleLODSnapshot.MAX_TURRET_PARTS) return index;
+      PacketVehicleLODSnapshot.TurretPartPose pose = new PacketVehicleLODSnapshot.TurretPartPose();
+      poses.add(pose);
+      if(index < ws.getWeaponNum()) {
+         pose.recoil = ws.recoilBuf[index].recoilBuf;
+         pose.prevRecoil = ws.recoilBuf[index].prevRecoilBuf;
+      }
+      if(part.type == 2 || part.type == 3) ++index;
+      if(part.child != null) for(Object child : part.child) index = captureTurretPart((MCH_TurretInfo.VPart)child, turret, ws, index, poses);
+      pose.visible = part.type != 3 || !turret.isWeaponNotCooldown(ws, index);
+      return index;
    }
 
    private static PacketVehicleLODSnapshot.WeaponPose[] collectWeaponPoses(MCH_EntityBaseVehicle vehicle) {

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -1345,8 +1345,12 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
    public static void renderLandingGear(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime) {
       if (info.haveLandingGear() && ac.partLandingGear != null) {
-         float rot = ac.getLandingGearRotation();
-         float prevRot = ac.getPrevLandingGearRotation();
+         renderLandingGear(info, ac.getLandingGearRotation(), ac.getPrevLandingGearRotation(), tickTime);
+      }
+   }
+
+   public static void renderLandingGear(MCH_BaseVehicleInfo info, float rot, float prevRot, float tickTime) {
+      if (info.haveLandingGear()) {
          float revR = 90.0F - rot;
          float revPr = 90.0F - prevRot;
          float rot1 = prevRot + (rot - prevRot) * tickTime;

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -17,9 +17,15 @@ import mcheli.helicopter.MCH_HeliInfo;
 import mcheli.helicopter.MCH_RenderHeli;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.plane.MCP_PlaneInfoManager;
+import mcheli.plane.MCP_PlaneInfo;
+import mcheli.plane.MCP_RenderPlane;
 import mcheli.ship.MCH_ShipInfoManager;
+import mcheli.ship.MCH_ShipInfo;
+import mcheli.ship.MCH_RenderShip;
 import mcheli.tank.MCH_TankInfoManager;
 import mcheli.vehicle.MCH_TurretInfoManager;
+import mcheli.vehicle.MCH_TurretInfo;
+import mcheli.vehicle.MCH_RenderTurret;
 import mcheli.wrapper.W_MOD;
 import mcheli.wrapper.W_Render;
 import net.minecraft.client.Minecraft;
@@ -137,7 +143,7 @@ public final class MCH_VehicleLODManager {
 
     private static void render(Display display, double x, double y, double z, float interpolation, long now) {
         MCH_BaseVehicleInfo info = getInfo(display.category, display.typeName);
-        String textureFolder = getTextureFolder(display.category);
+        String textureFolder = info instanceof MCH_TurretInfo ? ((MCH_TurretInfo)info).getDirectoryName() : getTextureFolder(display.category);
         if (info == null || info.model == null || textureFolder == null) {
             return;
         }
@@ -175,6 +181,33 @@ public final class MCH_VehicleLODManager {
                         }
                     } else if (display.category == 0 && info instanceof MCH_HeliInfo) {
                         MCH_RenderHeli.drawSnapshotBlades((MCH_HeliInfo)info, display.getRotorPhase(now), display.rotorFolded);
+                    } else if (display.category == 1 && info instanceof MCP_PlaneInfo) {
+                        MCP_PlaneInfo plane = (MCP_PlaneInfo)info;
+                        MCP_RenderPlane.renderNozzle(plane, display.nozzleRotation, display.previousNozzleRotation, interpolation);
+                        MCP_RenderPlane.renderWing(plane, display.wingRotation, display.previousWingRotation, interpolation);
+                        float phase = display.getRotorPhase(now);
+                        MCP_RenderPlane.renderRotor(plane, display.nozzleRotation, display.previousNozzleRotation, phase, phase, interpolation);
+                        MCH_RenderBaseVehicle.renderLandingGear(info, display.landingGearRotation, display.previousLandingGearRotation, interpolation);
+                    } else if (display.category == 2 && info instanceof MCH_ShipInfo) {
+                        MCH_ShipInfo ship = (MCH_ShipInfo)info;
+                        MCH_RenderShip.renderNozzle(ship, display.nozzleRotation, display.previousNozzleRotation, interpolation);
+                        MCH_RenderShip.renderWing(ship, display.wingRotation, display.previousWingRotation, interpolation);
+                        float phase = display.getRotorPhase(now);
+                        MCH_RenderShip.renderRotor(ship, display.nozzleRotation, display.previousNozzleRotation, phase, phase, interpolation);
+                        MCH_RenderBaseVehicle.renderLandingGear(info, display.landingGearRotation, display.previousLandingGearRotation, interpolation);
+                    } else if (display.category == 4 && info instanceof MCH_TurretInfo) {
+                        MCH_RenderTurret.drawSnapshotParts((MCH_TurretInfo)info,
+                            interpolateAngle(display.previousYaw, display.yaw, interpolation),
+                            interpolateAngle(display.previousPitch, display.pitch, interpolation),
+                            interpolateAngle(display.previousAimYaw, display.aimYaw, interpolation),
+                            display.previousAimPitch + (display.aimPitch - display.previousAimPitch) * interpolation,
+                            interpolateAngle(display.previousTurretBarrelRotation, display.turretBarrelRotation, interpolation),
+                            display.turretParts, interpolation);
+                    }
+                    if (display.category != 3 && display.category != 4) {
+                        int weaponCount = Math.min(info.partWeapon.size(), display.weaponPoses.length);
+                        for (int i = 0; i < weaponCount; ++i) MCH_RenderBaseVehicle.renderSnapshotWeapon(info,
+                            (MCH_BaseVehicleInfo.PartWeapon)info.partWeapon.get(i), display.weaponPoses[i], interpolation);
                     }
                 } else {
                     // Legacy monolithic models cannot exclude bind-pose groups safely.
@@ -274,6 +307,11 @@ public final class MCH_VehicleLODManager {
         private float rotorPhase;
         private float rotorAngularChange;
         private boolean rotorFolded;
+        private float landingGearRotation, previousLandingGearRotation;
+        private float nozzleRotation, previousNozzleRotation, wingRotation, previousWingRotation;
+        private float aimYaw, previousAimYaw, aimPitch, previousAimPitch;
+        private float turretBarrelRotation, previousTurretBarrelRotation;
+        private PacketVehicleLODSnapshot.TurretPartPose[] turretParts = new PacketVehicleLODSnapshot.TurretPartPose[0];
         private long rotorPhaseTimeMs;
         private long previousUpdateMs;
         private long lastUpdateMs;
@@ -318,6 +356,7 @@ public final class MCH_VehicleLODManager {
                 this.rotorPhaseTimeMs = 0L;
                 this.rotorAngularChange = 0.0F;
                 this.runningGearInitialized = false;
+                this.turretParts = new PacketVehicleLODSnapshot.TurretPartPose[0];
             }
             if (entry.category == 3) {
                 for (int side = 0; side < 2; ++side) {
@@ -368,7 +407,27 @@ public final class MCH_VehicleLODManager {
                 }
             }
             this.weaponPoses = incoming;
-            if (entry.category == 0) {
+            this.previousLandingGearRotation = (categoryChanged || oldTypeName == null) ? entry.prevLandingGearRotation : this.landingGearRotation;
+            this.landingGearRotation = entry.landingGearRotation;
+            this.previousNozzleRotation = (categoryChanged || oldTypeName == null) ? entry.prevNozzleRotation : this.nozzleRotation;
+            this.nozzleRotation = entry.nozzleRotation;
+            this.previousWingRotation = (categoryChanged || oldTypeName == null) ? entry.prevWingRotation : this.wingRotation;
+            this.wingRotation = entry.wingRotation;
+            this.previousAimYaw = (categoryChanged || oldTypeName == null) ? entry.prevAimYaw : this.aimYaw;
+            this.aimYaw = entry.aimYaw;
+            this.previousAimPitch = (categoryChanged || oldTypeName == null) ? entry.prevAimPitch : this.aimPitch;
+            this.aimPitch = entry.aimPitch;
+            this.previousTurretBarrelRotation = (categoryChanged || oldTypeName == null) ? entry.prevTurretBarrelRotation : this.turretBarrelRotation;
+            this.turretBarrelRotation = entry.turretBarrelRotation;
+            PacketVehicleLODSnapshot.TurretPartPose[] incomingTurretParts = entry.turretParts == null
+                ? new PacketVehicleLODSnapshot.TurretPartPose[0] : entry.turretParts;
+            if (!categoryChanged && oldTypeName != null) {
+                for (int i = 0; i < incomingTurretParts.length && i < this.turretParts.length; ++i) {
+                    incomingTurretParts[i].prevRecoil = this.turretParts[i].recoil;
+                }
+            }
+            this.turretParts = incomingTurretParts;
+            if (entry.category == 0 || entry.category == 1 || entry.category == 2) {
                 if (this.rotorPhaseTimeMs == 0L) {
                     this.rotorPhase = entry.rotorRotation;
                 } else {

--- a/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java
@@ -21,6 +21,7 @@ public class PacketVehicleLODSnapshot extends PacketBase {
     private static final int MAX_ENTRIES = 512;
     private static final int MAX_STRING_BYTES = 128;
     public static final int MAX_WEAPON_POSES = 64;
+    public static final int MAX_TURRET_PARTS = 128;
 
     public int dimension;
     public List<Entry> entries = Collections.emptyList();
@@ -83,6 +84,25 @@ public class PacketVehicleLODSnapshot extends PacketBase {
             data.writeFloat(entry.prevRotorRotation);
             data.writeFloat(entry.rotorAngularChange);
             data.writeBoolean(entry.rotorFolded);
+            data.writeFloat(entry.landingGearRotation);
+            data.writeFloat(entry.prevLandingGearRotation);
+            data.writeFloat(entry.nozzleRotation);
+            data.writeFloat(entry.prevNozzleRotation);
+            data.writeFloat(entry.wingRotation);
+            data.writeFloat(entry.prevWingRotation);
+            data.writeFloat(entry.aimYaw);
+            data.writeFloat(entry.prevAimYaw);
+            data.writeFloat(entry.aimPitch);
+            data.writeFloat(entry.prevAimPitch);
+            data.writeFloat(entry.turretBarrelRotation);
+            data.writeFloat(entry.prevTurretBarrelRotation);
+            int turretCount = entry.turretParts == null ? 0 : Math.min(entry.turretParts.length, MAX_TURRET_PARTS);
+            data.writeByte(turretCount);
+            for (int partIndex = 0; partIndex < turretCount; ++partIndex) {
+                data.writeFloat(entry.turretParts[partIndex].recoil);
+                data.writeFloat(entry.turretParts[partIndex].prevRecoil);
+                data.writeBoolean(entry.turretParts[partIndex].visible);
+            }
             data.writeInt(entry.packedLight);
         }
     }
@@ -143,6 +163,28 @@ public class PacketVehicleLODSnapshot extends PacketBase {
             entry.prevRotorRotation = data.readFloat();
             entry.rotorAngularChange = data.readFloat();
             entry.rotorFolded = data.readBoolean();
+            entry.landingGearRotation = data.readFloat();
+            entry.prevLandingGearRotation = data.readFloat();
+            entry.nozzleRotation = data.readFloat();
+            entry.prevNozzleRotation = data.readFloat();
+            entry.wingRotation = data.readFloat();
+            entry.prevWingRotation = data.readFloat();
+            entry.aimYaw = data.readFloat();
+            entry.prevAimYaw = data.readFloat();
+            entry.aimPitch = data.readFloat();
+            entry.prevAimPitch = data.readFloat();
+            entry.turretBarrelRotation = data.readFloat();
+            entry.prevTurretBarrelRotation = data.readFloat();
+            int turretCount = data.readUnsignedByte();
+            if (turretCount > MAX_TURRET_PARTS) throw new IllegalArgumentException("Vehicle LOD turret part count exceeds " + MAX_TURRET_PARTS);
+            entry.turretParts = new TurretPartPose[turretCount];
+            for (int partIndex = 0; partIndex < turretCount; ++partIndex) {
+                TurretPartPose pose = new TurretPartPose();
+                pose.recoil = data.readFloat();
+                pose.prevRecoil = data.readFloat();
+                pose.visible = data.readBoolean();
+                entry.turretParts[partIndex] = pose;
+            }
             entry.packedLight = data.readInt();
             decoded.add(entry);
         }
@@ -199,6 +241,12 @@ public class PacketVehicleLODSnapshot extends PacketBase {
         public float prevRotorRotation;
         public float rotorAngularChange;
         public boolean rotorFolded;
+        public float landingGearRotation, prevLandingGearRotation;
+        public float nozzleRotation, prevNozzleRotation;
+        public float wingRotation, prevWingRotation;
+        public float aimYaw, prevAimYaw, aimPitch, prevAimPitch;
+        public float turretBarrelRotation, prevTurretBarrelRotation;
+        public TurretPartPose[] turretParts = new TurretPartPose[0];
         public int packedLight;
     }
 
@@ -214,6 +262,12 @@ public class PacketVehicleLODSnapshot extends PacketBase {
         public float defaultRotationYaw;
         public float barrelRotation;
         public float prevBarrelRotation;
+        public float recoil;
+        public float prevRecoil;
+        public boolean visible = true;
+    }
+
+    public static class TurretPartPose {
         public float recoil;
         public float prevRecoil;
         public boolean visible = true;

--- a/src/main/java/mcheli/plane/MCP_RenderPlane.java
+++ b/src/main/java/mcheli/plane/MCP_RenderPlane.java
@@ -56,8 +56,11 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
    }
 
    public void renderRotor(MCP_EntityPlane plane, MCP_PlaneInfo planeInfo, float tickTime) {
-      float rot = plane.getNozzleRotation();
-      float prevRot = plane.getPrevNozzleRotation();
+      renderRotor(planeInfo, plane.getNozzleRotation(), plane.getPrevNozzleRotation(),
+         plane.rotationRotor, plane.prevRotationRotor, tickTime);
+   }
+
+   public static void renderRotor(MCP_PlaneInfo planeInfo, float rot, float prevRot, float rotorPhase, float prevRotorPhase, float tickTime) {
       Iterator i$ = planeInfo.rotorList.iterator();
 
       while(i$.hasNext()) {
@@ -71,8 +74,7 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
 
          while(i$1.hasNext()) {
             MCP_PlaneInfo.Blade b = (MCP_PlaneInfo.Blade)i$1.next();
-            float br = plane.prevRotationRotor;
-            br += (plane.rotationRotor - plane.prevRotationRotor) * tickTime;
+            float br = prevRotorPhase + (rotorPhase - prevRotorPhase) * tickTime;
             GL11.glPushMatrix();
             GL11.glTranslated(b.pos.xCoord, b.pos.yCoord, b.pos.zCoord);
             GL11.glRotatef(br, (float)b.rot.xCoord, (float)b.rot.yCoord, (float)b.rot.zCoord);
@@ -94,8 +96,10 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
    }
 
    public void renderWing(MCP_EntityPlane plane, MCP_PlaneInfo planeInfo, float tickTime) {
-      float rot = plane.getWingRotation();
-      float prevRot = plane.getPrevWingRotation();
+      renderWing(planeInfo, plane.getWingRotation(), plane.getPrevWingRotation(), tickTime);
+   }
+
+   public static void renderWing(MCP_PlaneInfo planeInfo, float rot, float prevRot, float tickTime) {
 
       for(Iterator i$ = planeInfo.wingList.iterator(); i$.hasNext(); GL11.glPopMatrix()) {
          MCP_PlaneInfo.Wing w = (MCP_PlaneInfo.Wing)i$.next();
@@ -122,8 +126,10 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
    }
 
    public void renderNozzle(MCP_EntityPlane plane, MCP_PlaneInfo planeInfo, float tickTime) {
-      float rot = plane.getNozzleRotation();
-      float prevRot = plane.getPrevNozzleRotation();
+      renderNozzle(planeInfo, plane.getNozzleRotation(), plane.getPrevNozzleRotation(), tickTime);
+   }
+
+   public static void renderNozzle(MCP_PlaneInfo planeInfo, float rot, float prevRot, float tickTime) {
       Iterator i$ = planeInfo.nozzles.iterator();
 
       while(i$.hasNext()) {
@@ -136,6 +142,11 @@ public class MCP_RenderPlane extends MCH_RenderBaseVehicle {
          GL11.glPopMatrix();
       }
 
+   }
+
+   @Override
+   protected void renderAircraftLODParts(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, double x, double y, double z, float tickTime) {
+      renderLandingGear(ac, info, tickTime);
    }
 
    protected ResourceLocation getEntityTexture(Entity entity) {

--- a/src/main/java/mcheli/ship/MCH_RenderShip.java
+++ b/src/main/java/mcheli/ship/MCH_RenderShip.java
@@ -53,8 +53,10 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
     }
 
     public void renderRotor(MCH_EntityShip ship, MCH_ShipInfo shipInfo, float tickTime) {
-        float rot = ship.getNozzleRotation();
-        float prevRot = ship.getPrevNozzleRotation();
+        renderRotor(shipInfo, ship.getNozzleRotation(), ship.getPrevNozzleRotation(), ship.rotationRotor, ship.prevRotationRotor, tickTime);
+    }
+
+    public static void renderRotor(MCH_ShipInfo shipInfo, float rot, float prevRot, float rotorPhase, float prevRotorPhase, float tickTime) {
         Iterator i$ = shipInfo.rotorList.iterator();
 
         while(i$.hasNext()) {
@@ -68,8 +70,7 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
 
             while(i$1.hasNext()) {
                 MCH_ShipInfo.Blade b = (MCH_ShipInfo.Blade)i$1.next();
-                float br = ship.prevRotationRotor;
-                br += (ship.rotationRotor - ship.prevRotationRotor) * tickTime;
+                float br = prevRotorPhase + (rotorPhase - prevRotorPhase) * tickTime;
                 GL11.glPushMatrix();
                 GL11.glTranslated(b.pos.xCoord, b.pos.yCoord, b.pos.zCoord);
                 GL11.glRotatef(br, (float)b.rot.xCoord, (float)b.rot.yCoord, (float)b.rot.zCoord);
@@ -91,8 +92,10 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
     }
 
     public void renderWing(MCH_EntityShip plane, MCH_ShipInfo planeInfo, float tickTime) {
-        float rot = plane.getWingRotation();
-        float prevRot = plane.getPrevWingRotation();
+        renderWing(planeInfo, plane.getWingRotation(), plane.getPrevWingRotation(), tickTime);
+    }
+
+    public static void renderWing(MCH_ShipInfo planeInfo, float rot, float prevRot, float tickTime) {
 
         for(Iterator i$ = planeInfo.wingList.iterator(); i$.hasNext(); GL11.glPopMatrix()) {
             MCH_ShipInfo.Wing w = (MCH_ShipInfo.Wing)i$.next();
@@ -119,8 +122,10 @@ public class MCH_RenderShip extends MCH_RenderBaseVehicle {
     }
 
     public void renderNozzle(MCH_EntityShip ship, MCH_ShipInfo shipInfo, float tickTime) {
-        float rot = ship.getNozzleRotation();
-        float prevRot = ship.getPrevNozzleRotation();
+        renderNozzle(shipInfo, ship.getNozzleRotation(), ship.getPrevNozzleRotation(), tickTime);
+    }
+
+    public static void renderNozzle(MCH_ShipInfo shipInfo, float rot, float prevRot, float tickTime) {
         Iterator i$ = shipInfo.nozzles.iterator();
 
         while(i$.hasNext()) {

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -10,6 +10,7 @@ import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.vehicle.MCH_EntityTurret;
 import mcheli.vehicle.MCH_TurretInfo;
 import mcheli.weapon.MCH_WeaponSet;
+import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.wrapper.W_Lib;
 import mcheli.wrapper.W_Render;
 import net.minecraft.entity.Entity;
@@ -116,6 +117,44 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
       GL11.glPopMatrix();
       return index;
    }
+
+   public static void drawSnapshotParts(MCH_TurretInfo info, float hullYaw, float hullPitch, float aimYaw,
+      float aimPitch, float barrelRotation, PacketVehicleLODSnapshot.TurretPartPose[] poses, float tickTime) {
+      SnapshotCursor cursor = new SnapshotCursor();
+      for(Object object : info.partList) drawSnapshotPart((MCH_TurretInfo.VPart)object, info, hullYaw, hullPitch,
+         aimYaw, aimPitch, barrelRotation, poses, tickTime, cursor);
+   }
+
+   private static void drawSnapshotPart(MCH_TurretInfo.VPart part, MCH_TurretInfo info, float hullYaw,
+      float hullPitch, float aimYaw, float aimPitch, float barrelRotation,
+      PacketVehicleLODSnapshot.TurretPartPose[] poses, float tickTime, SnapshotCursor cursor) {
+      int poseIndex = cursor.part++;
+      PacketVehicleLODSnapshot.TurretPartPose pose = poseIndex < poses.length ? poses[poseIndex] : null;
+      GL11.glPushMatrix();
+      try {
+         if(part.rotPitch || part.rotYaw || part.type == 1) {
+            GL11.glTranslated(part.pos.xCoord, part.pos.yCoord, part.pos.zCoord);
+            if(part.rotYaw) GL11.glRotatef(-aimYaw + hullYaw, 0.0F, 1.0F, 0.0F);
+            if(part.rotPitch) GL11.glRotatef(MCH_Lib.RNG(aimPitch, info.minRotationPitch, info.maxRotationPitch) - hullPitch, 1.0F, 0.0F, 0.0F);
+            if(part.type == 1) GL11.glRotatef(barrelRotation, 0.0F, 0.0F, -1.0F);
+            GL11.glTranslated(-part.pos.xCoord, -part.pos.yCoord, -part.pos.zCoord);
+         }
+         if(part.type == 2 && pose != null) {
+            float recoil = pose.prevRecoil + (pose.recoil - pose.prevRecoil) * tickTime;
+            GL11.glTranslated(0.0D, 0.0D, -part.recoilBuf * recoil);
+         }
+         if(part.child != null) for(Object child : part.child) drawSnapshotPart((MCH_TurretInfo.VPart)child,
+            info, hullYaw, hullPitch, aimYaw, aimPitch, barrelRotation, poses, tickTime, cursor);
+         if(pose == null || pose.visible) {
+            renderPart(part.model, info.model, part.modelName);
+            MCH_ModelManager.render(info.getDirectoryName(), part.modelName);
+         }
+      } finally {
+         GL11.glPopMatrix();
+      }
+   }
+
+   private static final class SnapshotCursor { private int part; }
 
    protected ResourceLocation getEntityTexture(Entity entity) {
       return W_Render.TEX_DEFAULT;


### PR DESCRIPTION
### Motivation

- Fix snapshot-only LOD loss of plane landing gear and propellers and restore full named-part rendering for stationary turrets so distant separable models animate correctly.
- Ensure snapshot packets carry all required plane/ship/turret animation state without regressing the already-correct tank and helicopter snapshot behavior.
- Keep the safe monolithic `renderAllModel` fallback and avoid recreating old unconditional entity-based rendering hacks.

### Description

- Added snapshot state fields and bounded turret-part arrays to `PacketVehicleLODSnapshot` and updated encode/decode to preserve exact field order and enforce count limits.
- Server-side snapshot capture now records plane/ship nozzle/wing/rotor state, landing-gear rotations, turret aim/yaw/pitch/barrel and traversal-indexed recoil/visibility entries; the client `Display` stores and interpolates these values with a continuous per-display rotor phase extrapolation logic in `MCH_VehicleLODManager`.
- Implemented state-based landing-gear rendering (entity renderer delegates to it), static overloads for plane/ship rotor/nozzle/wing rendering, and a recursive turret snapshot renderer that consumes a depth-first, index-stable pose array so turret part indexes remain consistent with the normal renderer.
- Preserved existing features and safety: tank/helicopter logic unchanged, skin overlays and Angelica compatibility preserved, monolithic-model fallback retained, and separable-body snapshot render order prevents duplicate bind-pose geometry.
- Documentation and audit: updated `changelog.md` and added `docs/vehicle-lod-moving-part-audit.md` summarizing the audit, decisions, and intentionally deferred close-range/entity-dependent parts.
- Key changed files: `src/main/java/mcheli/lod/MCH_VehicleLODManager.java`, `src/main/java/mcheli/network/packets/PacketVehicleLODSnapshot.java`, `src/main/java/mcheli/MCH_ServerTickHandler.java`, `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/plane/MCP_RenderPlane.java`, `src/main/java/mcheli/ship/MCH_RenderShip.java`, `src/main/java/mcheli/vehicle/MCH_RenderTurret.java`, plus documentation updates.

### Testing

- Automated packet and encode/decode audit: verified new fields are written and read in identical order with bounded array counts (success).
- Static repository checks: ran `git diff --check` and a brace-balance sanity script over changed sources; no new issues were reported (success).
- Code review and local inspection of render paths: verified separable-body snapshot render order, preservation of monolithic fallback, and that entity renderers delegate to state-based overloads (manual checks passed).
- Not run here: full Gradle build and in-game visual verification (dedicated-server + two clients, tracked-to-snapshot boundary tests) were not executed in this non-interactive environment and should be performed during CI or local integration testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bed037cb88323809e6824ef526402)