### PR TITLE
Fix post-respawn vehicle tracking and mount generations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -349,6 +349,13 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 * Restored normal vehicle and passenger-seat mount relationships with an authoritative server notification and a bounded client retry when tracking packets arrive out of order.
 * Kept UAV and NewUAV mounting paths excluded from the new normal-vehicle correction flow.
 
+# Fix post-respawn vehicle tracking and mount generations
+
+* Removed the LOD-only reflection change to vanilla's global entity-tracker range; packet snapshots now begin outside MCHeli's normal 200-block vehicle tracking range.
+* Made snapshot handoff use the server vehicle UUID, preventing a reused entity ID from hiding an otherwise valid distant snapshot.
+* Added UUID- and sequence-validated normal-vehicle attach/detach corrections, bounded retries that contain IDs rather than entity references, and invalidation when the client player or world instance changes.
+* Cleared dead-player pilot and passenger back-references at the death lifecycle event while preserving UAV and NewUAV remote-control paths.
+
 ## Vehicle LOD named-part completion
 
 - Restored tracked and snapshot landing-gear rendering for separable plane models, including reverse, hatch, secondary-axis, and sliding gear definitions.

--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -1,7 +1,6 @@
 package mcheli;
 
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,12 +25,10 @@ import mcheli.wrapper.W_EventHook;
 import mcheli.wrapper.W_Lib;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityTracker;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraft.item.ItemStack;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.event.CommandEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 import net.minecraftforge.event.entity.EntityEvent.CanUpdate;
@@ -48,45 +45,6 @@ public class MCH_EventHook extends W_EventHook {
 
    int acloaded = 0;
 
-
-   @SubscribeEvent
-   public void worldLoad(WorldEvent.Load event) {
-      if(event.world instanceof WorldServer && !event.world.isRemote) {
-         this.expandAircraftLODTrackingRange((WorldServer)event.world);
-      }
-
-   }
-
-   private void expandAircraftLODTrackingRange(WorldServer world) {
-      double farDistance = MCH_Config.AircraftLODFarDistance != null?MCH_Config.AircraftLODFarDistance.prmDouble:0.0D;
-      if(farDistance <= 0.0D) {
-         return;
-      }
-
-      int range = (int)Math.min(2147483647.0D, Math.max(600.0D, Math.ceil(farDistance)));
-      EntityTracker tracker = world.getEntityTracker();
-      Field[] fields = EntityTracker.class.getDeclaredFields();
-
-      for(int i = 0; i < fields.length; ++i) {
-         Field field = fields[i];
-         if(field.getType() == Integer.TYPE) {
-            try {
-               field.setAccessible(true);
-               int currentRange = field.getInt(tracker);
-               if(currentRange < range) {
-                  field.setInt(tracker, range);
-                  MCH_Lib.Log(world, "Expanded EntityTracker max range from %d to %d for aircraft LODs", new Object[]{Integer.valueOf(currentRange), Integer.valueOf(range)});
-               }
-            } catch(Exception e) {
-               MCH_Lib.Log(world, "Failed to expand EntityTracker range for aircraft LODs: %s", new Object[]{e.toString()});
-            }
-
-            return;
-         }
-      }
-
-      MCH_Lib.Log(world, "Failed to find EntityTracker max range field for aircraft LODs", new Object[0]);
-   }
 
    public void commandEvent(CommandEvent event) {
       MCH_Command.onCommandEvent(event);
@@ -227,7 +185,13 @@ public class MCH_EventHook extends W_EventHook {
    @SubscribeEvent
    public void onLivingDeathEvent(LivingDeathEvent event) {
       if(event.entity instanceof EntityPlayerMP) {
-         MCH_UavInventory.restorePilotInventory((EntityPlayerMP)event.entity, "player_death");
+         EntityPlayerMP player = (EntityPlayerMP)event.entity;
+         MCH_UavInventory.restorePilotInventory(player, "player_death");
+         for(Object object : player.worldObj.loadedEntityList) {
+            if(object instanceof MCH_EntityBaseVehicle) {
+               ((MCH_EntityBaseVehicle)object).clearDeadNormalVehicleRider(player);
+            }
+         }
       }
    }
 

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -29,6 +29,8 @@ import net.minecraft.world.chunk.Chunk;
 public class MCH_ServerTickHandler {
    private static final int UPDATE_INTERVAL_TICKS = 20;
    private static final int MAX_ENTRIES = 512;
+   /** Must match the normal vehicle/seat registration range in MCH_MOD. */
+   private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
    private int tick;
 
    @SubscribeEvent
@@ -65,7 +67,8 @@ public class MCH_ServerTickHandler {
          if(object instanceof MCH_EntityBaseVehicle) {
             MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)object;
             if(!vehicle.isDead && vehicle.getAcInfo() != null && categoryOf(vehicle) >= 0
-               && vehicle.getDistanceSqToEntity(player) <= farDistanceSq) {
+               && vehicle.getDistanceSqToEntity(player) <= farDistanceSq
+               && vehicle.getDistanceSqToEntity(player) > NORMAL_TRACKING_RANGE_SQ) {
                aircraft.add(vehicle);
             }
          }

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -4,6 +4,8 @@ import com.google.common.io.ByteArrayDataInput;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.HashMap;
+import java.util.Map;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
@@ -37,58 +39,83 @@ public class MCH_BaseVehiclePacketHandler {
    private static final int MAX_PENDING_MOUNTS = 64;
    private static final int PENDING_MOUNT_TICKS = 100;
    private static final List<PendingMount> pendingMounts = new ArrayList<PendingMount>();
-   private static Object pendingWorld;
+   private static int pendingWorldIdentity;
+   private static int pendingPlayerIdentity;
+   private static final Map<UUID, Integer> lastMountSequences = new HashMap<UUID, Integer>();
 
    private static final class PendingMount {
       final int aircraftId;
       final int riderId;
       final int seatId;
+      final UUID aircraftUUID;
+      final UUID riderUUID;
       int ticksLeft = PENDING_MOUNT_TICKS;
 
-      PendingMount(int aircraftId, int riderId, int seatId) {
-         this.aircraftId = aircraftId;
-         this.riderId = riderId;
-         this.seatId = seatId;
+      PendingMount(MCH_PacketNotifyOnMountEntity packet) {
+         this.aircraftId = packet.entityID_Ac;
+         this.riderId = packet.entityID_rider;
+         this.seatId = packet.seatID;
+         this.aircraftUUID = packet.aircraftUUID;
+         this.riderUUID = packet.riderUUID;
       }
    }
 
    public static void clearPendingMounts() {
       pendingMounts.clear();
-      pendingWorld = null;
+      lastMountSequences.clear();
+      pendingWorldIdentity = 0;
+      pendingPlayerIdentity = 0;
    }
 
    public static void tickPendingMounts(EntityPlayer player) {
       if(player == null || !player.worldObj.isRemote) return;
-      if(pendingWorld != player.worldObj) {
-         pendingMounts.clear();
-         pendingWorld = player.worldObj;
+      int worldIdentity = System.identityHashCode(player.worldObj);
+      int playerIdentity = System.identityHashCode(player);
+      if(pendingWorldIdentity != worldIdentity || pendingPlayerIdentity != playerIdentity) {
+         clearPendingMounts();
+         pendingWorldIdentity = worldIdentity;
+         pendingPlayerIdentity = playerIdentity;
       }
       for(int i = pendingMounts.size() - 1; i >= 0; --i) {
          PendingMount pending = pendingMounts.get(i);
-         if(applyMount(player, pending.aircraftId, pending.riderId, pending.seatId) || --pending.ticksLeft <= 0) {
+         if(applyMount(player, pending.aircraftId, pending.riderId, pending.seatId,
+               pending.aircraftUUID, pending.riderUUID) || --pending.ticksLeft <= 0) {
             pendingMounts.remove(i);
          }
       }
    }
 
-   private static void queueMount(EntityPlayer player, int aircraftId, int riderId, int seatId) {
-      if(pendingWorld != player.worldObj) clearPendingMounts();
-      pendingWorld = player.worldObj;
-      for(PendingMount pending : pendingMounts) {
-         if(pending.aircraftId == aircraftId && pending.riderId == riderId && pending.seatId == seatId) return;
+   private static void queueMount(EntityPlayer player, MCH_PacketNotifyOnMountEntity packet) {
+      int worldIdentity = System.identityHashCode(player.worldObj);
+      int playerIdentity = System.identityHashCode(player);
+      if(pendingWorldIdentity != worldIdentity || pendingPlayerIdentity != playerIdentity) {
+         clearPendingMounts();
+         pendingWorldIdentity = worldIdentity;
+         pendingPlayerIdentity = playerIdentity;
+      }
+      for(int i = pendingMounts.size() - 1; i >= 0; --i) {
+         if(pendingMounts.get(i).riderUUID.equals(packet.riderUUID)) pendingMounts.remove(i);
       }
       if(pendingMounts.size() >= MAX_PENDING_MOUNTS) pendingMounts.remove(0);
-      pendingMounts.add(new PendingMount(aircraftId, riderId, seatId));
+      pendingMounts.add(new PendingMount(packet));
    }
 
-   private static boolean applyMount(EntityPlayer player, int aircraftId, int riderId, int seatId) {
+   private static boolean applyMount(EntityPlayer player, int aircraftId, int riderId, int seatId,
+                                     UUID aircraftUUID, UUID riderUUID) {
       Entity aircraftEntity = player.worldObj.getEntityByID(aircraftId);
       Entity rider = player.worldObj.getEntityByID(riderId);
-      if(!(aircraftEntity instanceof MCH_EntityBaseVehicle) || rider == null || rider.isDead) return false;
+      if(rider == null || rider.isDead || !riderUUID.equals(rider.getUniqueID())) return false;
+      if(seatId < 0) {
+         if(rider.ridingEntity != null) rider.mountEntity((Entity)null);
+         return rider.ridingEntity == null;
+      }
+      if(!(aircraftEntity instanceof MCH_EntityBaseVehicle)
+            || !aircraftUUID.equals(aircraftEntity.getUniqueID())) return false;
       MCH_EntityBaseVehicle aircraft = (MCH_EntityBaseVehicle)aircraftEntity;
       if(aircraft.isUAV() || aircraft.isNewUAV()) return true;
       Entity mount = seatId == 0 ? aircraft : aircraft.getSeat(seatId - 1);
       if(mount == null || mount.isDead) return false;
+      if(mount instanceof MCH_EntitySeat && ((MCH_EntitySeat)mount).getParent() != aircraft) return false;
       if(rider.ridingEntity != mount) rider.mountEntity(mount);
       return rider.ridingEntity == mount && mount.riddenByEntity == rider;
    }
@@ -142,9 +169,17 @@ public class MCH_BaseVehiclePacketHandler {
          MCH_PacketNotifyOnMountEntity req = new MCH_PacketNotifyOnMountEntity();
          req.readData(data);
          MCH_Lib.DbgLog(player.worldObj, "onPacketOnMountEntity.rcv:%d, %d, %d, %d", new Object[]{Integer.valueOf(W_Entity.getEntityId(player)), Integer.valueOf(req.entityID_Ac), Integer.valueOf(req.entityID_rider), Integer.valueOf(req.seatID)});
-         if(req.entityID_Ac > 0 && req.entityID_rider > 0 && req.seatID >= 0
-               && !applyMount(player, req.entityID_Ac, req.entityID_rider, req.seatID)) {
-            queueMount(player, req.entityID_Ac, req.entityID_rider, req.seatID);
+         Integer lastSequence = req.riderUUID == null ? null : lastMountSequences.get(req.riderUUID);
+         if(req.entityID_Ac > 0 && req.entityID_rider > 0 && req.aircraftUUID != null && req.riderUUID != null
+               && (lastSequence == null || req.sequence > lastSequence.intValue())) {
+            if(lastMountSequences.size() >= MAX_PENDING_MOUNTS && !lastMountSequences.containsKey(req.riderUUID)) {
+               lastMountSequences.remove(lastMountSequences.keySet().iterator().next());
+            }
+            lastMountSequences.put(req.riderUUID, Integer.valueOf(req.sequence));
+            if(!applyMount(player, req.entityID_Ac, req.entityID_rider, req.seatID,
+                  req.aircraftUUID, req.riderUUID) && req.seatID >= 0) {
+               queueMount(player, req);
+            }
          }
       }
    }

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -2797,6 +2797,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.updatePartLightHatch();
       this.regenerationMob();
       if(this.getRiddenByEntity() == null && this.lastRiddenByEntity != null) {
+         if(!super.worldObj.isRemote && !this.isUAV() && !this.isNewUAV()
+               && this.lastRiddenByEntity instanceof EntityPlayer) {
+            MCH_PacketNotifyOnMountEntity.sendDismount(this, (EntityPlayer)this.lastRiddenByEntity);
+         }
          this.unmountEntity();
       }
 
@@ -5751,6 +5755,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       MCH_Lib.DbgLog(super.worldObj, "onUnmountPlayerSeat:%d", new Object[]{Integer.valueOf(W_Entity.getEntityId(entity))});
+      if(!super.worldObj.isRemote && !this.isUAV() && !this.isNewUAV() && entity instanceof EntityPlayer) {
+         MCH_PacketNotifyOnMountEntity.sendDismount(this, (EntityPlayer)entity);
+      }
       int sid = this.getSeatIdByEntity(entity);
       this.camera.initCamera(sid, entity);
       MCH_SeatInfo seatInfo = this.getSeatInfo(seat.seatID + 1);
@@ -7258,6 +7265,32 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
       for(int i = 0; i < this.getSeats().length; ++i) {
          this.clearInvalidSeatOccupant(this.getSeats()[i], i, context);
+      }
+   }
+
+   /**
+    * Breaks only invalid direct-riding relationships owned by a dying player.
+    * Remote UAV control is deliberately excluded because it is not a normal
+    * Entity riding relationship and has its own death/inventory lifecycle.
+    */
+   public void clearDeadNormalVehicleRider(EntityPlayerMP player) {
+      if(player == null || super.worldObj.isRemote || this.isUAV() || this.isNewUAV()) {
+         return;
+      }
+      if(super.riddenByEntity == player) {
+         super.riddenByEntity = null;
+         MCH_PacketNotifyOnMountEntity.sendDismount(this, player);
+      }
+      for(int i = 0; i < this.seats.length; ++i) {
+         MCH_EntitySeat seat = this.seats[i];
+         if(seat != null && seat.riddenByEntity == player) {
+            seat.riddenByEntity = null;
+            MCH_PacketNotifyOnMountEntity.sendDismount(this, player);
+         }
+      }
+      if(player.ridingEntity == this || player.ridingEntity instanceof MCH_EntitySeat
+            && ((MCH_EntitySeat)player.ridingEntity).getParent() == this) {
+         player.mountEntity((Entity)null);
       }
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketNotifyOnMountEntity.java
@@ -3,6 +3,8 @@ package mcheli.aircraft;
 import com.google.common.io.ByteArrayDataInput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import mcheli.MCH_Packet;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.wrapper.W_Entity;
@@ -15,6 +17,10 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
    public int entityID_Ac = -1;
    public int entityID_rider = -1;
    public int seatID = -1;
+   public UUID aircraftUUID;
+   public UUID riderUUID;
+   public int sequence;
+   private static final AtomicInteger NEXT_SEQUENCE = new AtomicInteger();
 
 
    public int getMessageID() {
@@ -26,6 +32,9 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
          this.entityID_Ac = data.readInt();
          this.entityID_rider = data.readInt();
          this.seatID = data.readShort();
+         this.aircraftUUID = new UUID(data.readLong(), data.readLong());
+         this.riderUUID = new UUID(data.readLong(), data.readLong());
+         this.sequence = data.readInt();
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -37,6 +46,11 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
          dos.writeInt(this.entityID_Ac);
          dos.writeInt(this.entityID_rider);
          dos.writeShort(this.seatID);
+         dos.writeLong(this.aircraftUUID.getMostSignificantBits());
+         dos.writeLong(this.aircraftUUID.getLeastSignificantBits());
+         dos.writeLong(this.riderUUID.getMostSignificantBits());
+         dos.writeLong(this.riderUUID.getLeastSignificantBits());
+         dos.writeInt(this.sequence);
       } catch (IOException var3) {
          var3.printStackTrace();
       }
@@ -51,6 +65,7 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
             s.entityID_Ac = W_Entity.getEntityId(ac);
             s.entityID_rider = W_Entity.getEntityId(rider);
             s.seatID = seatId;
+            populateIdentity(s, ac, rider);
             W_Network.sendToPlayer(s, (EntityPlayer)pilot);
          }
       }
@@ -62,6 +77,17 @@ public class MCH_PacketNotifyOnMountEntity extends MCH_Packet {
       packet.entityID_Ac = W_Entity.getEntityId(ac);
       packet.entityID_rider = W_Entity.getEntityId(rider);
       packet.seatID = seatId;
+      populateIdentity(packet, ac, rider);
       W_Network.sendToPlayer(packet, rider);
+   }
+
+   public static void sendDismount(MCH_EntityBaseVehicle ac, EntityPlayer rider) {
+      sendToRider(ac, rider, -1);
+   }
+
+   private static void populateIdentity(MCH_PacketNotifyOnMountEntity packet, MCH_EntityBaseVehicle ac, Entity rider) {
+      packet.aircraftUUID = ac.getUniqueID();
+      packet.riderUUID = rider.getUniqueID();
+      packet.sequence = NEXT_SEQUENCE.incrementAndGet();
    }
 }

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -104,11 +104,9 @@ public final class MCH_VehicleLODManager {
 
         long now = System.currentTimeMillis();
         Set<UUID> trackedAircraft = new HashSet<UUID>();
-        Set<Integer> trackedAircraftIds = new HashSet<Integer>();
         for (Object object : mc.theWorld.loadedEntityList) {
             if (object instanceof MCH_EntityBaseVehicle) {
                 trackedAircraft.add(((Entity)object).getUniqueID());
-                trackedAircraftIds.add(((Entity)object).getEntityId());
             }
         }
 
@@ -123,8 +121,7 @@ public final class MCH_VehicleLODManager {
         double farSq = far > 0.0D ? far * far : Double.MAX_VALUE;
 
         for (Display display : this.displays.values()) {
-            if (now - display.lastUpdateMs > STALE_AFTER_MS || trackedAircraft.contains(display.uuid)
-                || trackedAircraftIds.contains(display.entityId)) {
+            if (now - display.lastUpdateMs > STALE_AFTER_MS || trackedAircraft.contains(display.uuid)) {
                 continue;
             }
             float interpolation = Math.min(1.0F, (float)(now - display.previousUpdateMs) / 1000.0F);


### PR DESCRIPTION
### Motivation

- Prevent a render-only LOD snapshot from hiding a missing or stale real vehicle entity after local-player death and respawn. 
- Eliminate stale pilot/passenger back-references created across player replacement and ensure mount/dismount corrections are authoritative and ordered. 
- Keep UAV / NewUAV behavior unchanged while restoring correct normal-vehicle tracking and snapshot handoff. 

### Description

- Removed the reflection-based expansion of Forge's global `EntityTracker` range and made server LOD snapshot generation exclude vehicles inside the normal 200-block tracking range in `MCH_ServerTickHandler` and `MCH_VehicleLODManager`. 
- Made snapshot suppression and handoff use the vehicle UUID (not only entity ID) so snapshots cannot mask reused entity IDs, and stopped relying on client-side entity-id lists in `MCH_VehicleLODManager`. 
- Added UUID + monotonically increasing sequence fields to `MCH_PacketNotifyOnMountEntity` and introduced an authoritative dismount packet; packets are now identity- and sequence-checked before applying mounts. 
- Replaced the previous object-reference retry with a bounded, ID/UUID-only pending-mount queue in `MCH_BaseVehiclePacketHandler` that invalidates when the client world or player instance changes and validates parent/seat resolution before mounting. 
- Server-side cleanup on death now clears dead-player pilot/passenger back-references via `MCH_EventHook.onLivingDeathEvent` calling `MCH_EntityBaseVehicle.clearDeadNormalVehicleRider`, and normal vehicle code issues authoritative dismount notifications during unmounts. 
- Kept explicit exclusions for UAV and NewUAV paths so remote-control and station logic remain unchanged. 
- Documented the fix in `changelog.md` and kept the change surface focused to LOD, mount packets, pending-mount handling, and death cleanup (files changed include `MCH_EventHook`, `MCH_ServerTickHandler`, `MCH_VehicleLODManager`, `MCH_BaseVehiclePacketHandler`, `MCH_EntityBaseVehicle`, `MCH_PacketNotifyOnMountEntity`, and `changelog.md`).

### Testing

- `git diff --check` completed with no style errors. 
- `python3 tools/validate_config_weights.py` completed successfully and validated weight entries. 
- `python3 tools/validate_plane_config_surface.py` was run and failed due to pre-existing removed keys in `configreference/planes/b-21.txt`, which are unrelated to this change. 
- Gradle build and dedicated Forge server Merkava runtime reproduction were not run in this environment because building/running mod/server binaries is outside the allowed actions for this patch and must be validated on a Java 8 / Forge 1.7.10 dedicated test server following the provided reproduction matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c084671e0832398a87bf622f59c31)