### PR TITLE
Restore real vehicle entity tracking after player respawn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+## PR #593 - Restore Real Vehicle Tracking After Respawn
+
+- Rebuild the replacement server player's vanilla tracker membership once, after Forge's respawn or dimension-change lifecycle has installed the player and its watched chunks.
+- Remove the replacement player's stale watcher generation before the rebuild so existing vehicle, seat, passenger-seat, and hitbox spawn packets are not suppressed by Minecraft 1.7.10's entity-ID-based player equality.
+- Keep normal-range LOD snapshots suppressed and preserve UUID-validated mount correction, dead-rider cleanup, and all UAV and NewUAV paths.
+- Add debug-only `[MCH-RESPAWN-TRACK]` transition and failure diagnostics, including player/world identity, dimension, chunk, and nearby normal-vehicle count.
+
 # Fix Tank LOD Running-Gear Rendering
 
 - Restored track rollers, crawler tracks, and wheels in both tracked-entity and entity-free snapshot tank LOD passes without restoring the monolithic common-part renderer.

--- a/docs/vehicle-respawn-tracking.md
+++ b/docs/vehicle-respawn-tracking.md
@@ -1,0 +1,59 @@
+# Normal vehicle tracking across player respawn
+
+## Root cause and lifecycle fix
+
+Minecraft 1.7.10 replaces `EntityPlayerMP` on respawn while deliberately reusing
+the old player's numeric entity ID. `Entity.equals` and `hashCode` use that ID,
+and each `EntityTrackerEntry` stores its watching players in a `HashSet`. If an
+old watcher survives the replacement boundary, the set therefore reports that
+the replacement is already watching an existing vehicle. The normal spawn
+packet and Forge `StartTracking` event are then suppressed. The server vehicle
+continues to exist, but the client has no real entity to render, collide with,
+select, mount, or use.
+
+The server now queues one refresh from Forge's `PlayerRespawnEvent` (and the
+corresponding dimension-change event). At the next server-tick end, after the
+replacement belongs to the world and `PlayerManager` has installed its watched
+chunks, the refresh removes only that player's membership from tracker entries
+and asks vanilla `EntityTracker` to rebuild memberships. Vanilla consequently
+sends the existing parent vehicle and dependent seat/hitbox entities with their
+original IDs and UUIDs. Their ordinary `StartTracking` events retain
+`syncCompleteAircraftState` as the post-spawn state synchronization step. The
+refresh is removed from the queue immediately and is never repeated per tick.
+
+Enable `EnableMCHLibDebugLog` to record the debug-only
+`[MCH-RESPAWN-TRACK] queued`, `refreshed`, and `skipped stale refresh` lifecycle
+tags. These include player entity ID, UUID and object identity, world identity,
+dimension, chunk, and nearby normal-vehicle count without logging every vehicle
+on every tick.
+
+## Synchronization audit
+
+- `3509e4419f6f37ef238d730b151302eb934211e4` is the pre-synchronization base.
+- PR #587 (`1d293104335744b46da4cbf08dad58915f4dc3e9`, merged as
+  `3287a81d3bfe00fa15eaa520c1e11df15d2765f3`) cleared client LOD and pending
+  mount caches at death/world/player replacement, reset real vehicles' LOD
+  render flag on join, and added bounded normal-mount correction. Clearing the
+  render-only cache exposed the absent real entity; it did not remove a server
+  vehicle or cause the interaction failure.
+- PR #592 (`b328858acbf1b060be429d05cf3adbc2480558ac`, merged as
+  `c3add9e638143c8de3889f9d9e37a24ee9e52b4e`) excluded the normal 200-block
+  range from snapshots, keyed snapshots and mount generations by UUID, removed
+  the unsafe global tracker-range reflection, and cleaned dead normal riders.
+  The tighter snapshot boundary made the tracking hole unambiguous. The UUID,
+  mount-sequence, and dead-rider changes remain intact because none supplies or
+  replaces a missing entity spawn packet.
+
+The former LOD image was only plain render data, so it could visually mask the
+missing tracked entity while providing no collision or interaction target. This
+fix restores authoritative real entities; it does not restore snapshots inside
+200 blocks, create fake client entities, or make snapshots interactable. UAV and
+NewUAV code paths are unchanged.
+
+## Dedicated-server verification status
+
+The automated source environment does not provide two graphical Forge clients,
+so the full two-client death/respawn matrix must be exercised in a manual game
+session. The source-level audit verifies that the refresh uses Forge 1.7.10's
+server event bus and vanilla tracker APIs, is delayed until the player is in the
+world, preserves entity identity, and runs once per lifecycle transition.

--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -9,6 +9,8 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_EntitySeat;
+import mcheli.aircraft.MCH_EntityHitBox;
+import mcheli.aircraft.MCH_EntityPSeat;
 import mcheli.aircraft.MCH_ItemBaseVehicle;
 import mcheli.uav.MCH_EntityUavStation;
 import mcheli.uav.MCH_UavInventory;
@@ -186,12 +188,31 @@ public class MCH_EventHook extends W_EventHook {
    public void onLivingDeathEvent(LivingDeathEvent event) {
       if(event.entity instanceof EntityPlayerMP) {
          EntityPlayerMP player = (EntityPlayerMP)event.entity;
+         MCH_Lib.DbgLog(player.worldObj,
+            "[MCH-RESPAWN-TRACK] death player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
+            new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
+               Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
+               Integer.valueOf(System.identityHashCode(player.worldObj)), Integer.valueOf(player.chunkCoordX),
+               Integer.valueOf(player.chunkCoordZ)});
          MCH_UavInventory.restorePilotInventory(player, "player_death");
          for(Object object : player.worldObj.loadedEntityList) {
             if(object instanceof MCH_EntityBaseVehicle) {
                ((MCH_EntityBaseVehicle)object).clearDeadNormalVehicleRider(player);
             }
          }
+      }
+   }
+
+   @SubscribeEvent
+   public void onPlayerClone(PlayerEvent.Clone event) {
+      if(event.entityPlayer instanceof EntityPlayerMP && !event.entityPlayer.worldObj.isRemote) {
+         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
+            "[MCH-RESPAWN-TRACK] clone oldId=%d oldUuid=%s oldObject=%x newId=%d newUuid=%s newObject=%x dim=%d world=%x death=%s",
+            new Object[]{Integer.valueOf(event.original.getEntityId()), event.original.getUniqueID(),
+               Integer.valueOf(System.identityHashCode(event.original)), Integer.valueOf(event.entityPlayer.getEntityId()),
+               event.entityPlayer.getUniqueID(), Integer.valueOf(System.identityHashCode(event.entityPlayer)),
+               Integer.valueOf(event.entityPlayer.dimension), Integer.valueOf(System.identityHashCode(event.entityPlayer.worldObj)),
+               Boolean.valueOf(event.wasDeath)});
       }
    }
 
@@ -220,8 +241,40 @@ public class MCH_EventHook extends W_EventHook {
       }
 
       if(aircraft != null) {
+         this.logTrackingTransition("start", (EntityPlayerMP)event.entityPlayer, event.target, aircraft);
          aircraft.syncCompleteAircraftState((EntityPlayerMP)event.entityPlayer);
+         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
+            "[MCH-RESPAWN-TRACK] syncCompleteAircraftState playerId=%d targetId=%d vehicleId=%d vehicleUuid=%s",
+            new Object[]{Integer.valueOf(event.entityPlayer.getEntityId()), Integer.valueOf(event.target.getEntityId()),
+               Integer.valueOf(aircraft.getEntityId()), aircraft.getUniqueID()});
+      } else if(event.target instanceof MCH_EntityHitBox) {
+         this.logTrackingTransition("start-unresolved", (EntityPlayerMP)event.entityPlayer, event.target,
+            ((MCH_EntityHitBox)event.target).parent);
       }
+   }
+
+   @SubscribeEvent
+   public void onStopTracking(PlayerEvent.StopTracking event) {
+      if(!(event.entityPlayer instanceof EntityPlayerMP) || event.entityPlayer.worldObj.isRemote) return;
+      MCH_EntityBaseVehicle aircraft = event.target instanceof MCH_EntityBaseVehicle
+         ? (MCH_EntityBaseVehicle)event.target : null;
+      if(event.target instanceof MCH_EntitySeat) aircraft = ((MCH_EntitySeat)event.target).getParent();
+      else if(event.target instanceof MCH_EntityHitBox) aircraft = ((MCH_EntityHitBox)event.target).parent;
+      if(aircraft != null || event.target instanceof MCH_EntityHitBox) {
+         this.logTrackingTransition("stop", (EntityPlayerMP)event.entityPlayer, event.target, aircraft);
+      }
+   }
+
+   private void logTrackingTransition(String action, EntityPlayerMP player, Entity target,
+      MCH_EntityBaseVehicle aircraft) {
+      String kind = target instanceof MCH_EntityPSeat ? "passenger-seat"
+         : target instanceof MCH_EntitySeat ? "seat"
+         : target instanceof MCH_EntityHitBox ? "hitbox" : "vehicle";
+      MCH_Lib.DbgLog(player.worldObj,
+         "[MCH-RESPAWN-TRACK] %s kind=%s playerId=%d playerObject=%x targetId=%d targetUuid=%s parentId=%d parentRef=%x dead=%s",
+         new Object[]{action, kind, Integer.valueOf(player.getEntityId()), Integer.valueOf(System.identityHashCode(player)),
+            Integer.valueOf(target.getEntityId()), target.getUniqueID(), Integer.valueOf(aircraft != null ? aircraft.getEntityId() : -1),
+            Integer.valueOf(System.identityHashCode(aircraft)), Boolean.valueOf(target.isDead)});
    }
 
    @SubscribeEvent

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -1,12 +1,16 @@
 package mcheli;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
 import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import cpw.mods.fml.common.gameevent.TickEvent.ServerTickEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.helicopter.MCH_EntityHeli;
@@ -31,13 +35,89 @@ public class MCH_ServerTickHandler {
    private static final int MAX_ENTRIES = 512;
    /** Must match the normal vehicle/seat registration range in MCH_MOD. */
    private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
+   private static final int TRACKING_REFRESH_DELAY_TICKS = 1;
+   private final Map<EntityPlayerMP, Integer> pendingTrackingRefreshes = new HashMap<EntityPlayerMP, Integer>();
    private int tick;
 
    @SubscribeEvent
-   public void onServerTickEvent(ServerTickEvent event) {
-      if(event.phase != Phase.END || ++this.tick < UPDATE_INTERVAL_TICKS) {
+   public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+      this.queueTrackingRefresh(event.player, "respawn");
+   }
+
+   @SubscribeEvent
+   public void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+      this.queueTrackingRefresh(event.player, "dimension " + event.fromDim + "->" + event.toDim);
+   }
+
+   private void queueTrackingRefresh(Entity playerEntity, String reason) {
+      if(!(playerEntity instanceof EntityPlayerMP) || playerEntity.worldObj.isRemote) {
          return;
       }
+      EntityPlayerMP player = (EntityPlayerMP)playerEntity;
+      this.pendingTrackingRefreshes.put(player, Integer.valueOf(TRACKING_REFRESH_DELAY_TICKS));
+      MCH_Lib.DbgLog(player.worldObj, "[MCH-RESPAWN-TRACK] queued %s refresh player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
+         new Object[]{reason, player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
+            Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
+            Integer.valueOf(System.identityHashCode(player.worldObj)), Integer.valueOf(player.chunkCoordX), Integer.valueOf(player.chunkCoordZ)});
+   }
+
+   private void refreshPendingPlayerTracking() {
+      Iterator<Map.Entry<EntityPlayerMP, Integer>> iterator = this.pendingTrackingRefreshes.entrySet().iterator();
+      while(iterator.hasNext()) {
+         Map.Entry<EntityPlayerMP, Integer> entry = iterator.next();
+         EntityPlayerMP player = entry.getKey();
+         int delay = entry.getValue().intValue() - 1;
+         if(delay > 0) {
+            entry.setValue(Integer.valueOf(delay));
+            continue;
+         }
+         iterator.remove();
+         if(player.isDead || !(player.worldObj instanceof WorldServer)
+            || !containsPlayerInstance(player.worldObj.playerEntities, player)) {
+            MCH_Lib.DbgLog(player.worldObj, "[MCH-RESPAWN-TRACK] skipped stale refresh player=%s id=%d object=%x dead=%s",
+               new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()),
+                  Integer.valueOf(System.identityHashCode(player)), Boolean.valueOf(player.isDead)});
+            continue;
+         }
+
+         WorldServer world = (WorldServer)player.worldObj;
+         int nearbyVehicles = 0;
+         for(Object object : world.loadedEntityList) {
+            if(object instanceof MCH_EntityBaseVehicle && !((MCH_EntityBaseVehicle)object).isDead
+               && ((MCH_EntityBaseVehicle)object).getDistanceSqToEntity(player) <= NORMAL_TRACKING_RANGE_SQ) {
+               ++nearbyVehicles;
+            }
+         }
+
+         // The replacement player deliberately reuses the dead player's entity ID.
+         // EntityTrackerEntry's watcher set can consequently regard a stale old
+         // player object as equal to the replacement and suppress its spawn packet.
+         // Remove that one player's watcher generation, then let vanilla rebuild it
+         // after PlayerManager has installed the replacement's watched chunks.
+         world.getEntityTracker().removePlayerFromTrackers(player);
+         world.getEntityTracker().updateTrackedEntities();
+         MCH_Lib.DbgLog(world, "[MCH-RESPAWN-TRACK] refreshed player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d nearbyVehicles=%d",
+            new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
+               Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
+               Integer.valueOf(System.identityHashCode(world)), Integer.valueOf(player.chunkCoordX),
+               Integer.valueOf(player.chunkCoordZ), Integer.valueOf(nearbyVehicles)});
+      }
+   }
+
+   private static boolean containsPlayerInstance(List<?> players, EntityPlayerMP player) {
+      for(Object candidate : players) {
+         if(candidate == player) return true;
+      }
+      return false;
+   }
+
+   @SubscribeEvent
+   public void onServerTickEvent(ServerTickEvent event) {
+      if(event.phase != Phase.END) {
+         return;
+      }
+      this.refreshPendingPlayerTracking();
+      if(++this.tick < UPDATE_INTERVAL_TICKS) return;
       this.tick = 0;
 
       MinecraftServer server = MinecraftServer.getServer();


### PR DESCRIPTION
### Motivation

- Fix a bug where normal vehicles became invisible and non-interactable for a local player after death+respawn due to stale tracker watcher membership caused by Minecraft 1.7.10 reusing the old player entity ID. 
- Preserve the post-PR #587/#592 LOD, UUID, and dead-rider correctness improvements while restoring authoritative real entities instead of reintroducing LOD fallbacks.

### Description

- Queue a one-shot server-side tracking refresh on `PlayerRespawnEvent` and `PlayerChangedDimensionEvent` that, once the replacement player is present, removes that player's stale watcher entries and calls vanilla `EntityTracker.updateTrackedEntities()` so existing vehicles, seats, passenger seats, and hitboxes receive their normal spawn and `StartTracking` synchronization. 
- Make the refresh lifecycle-safe and bounded by deferring the action to server-tick end, rejecting stale/dead player objects, and using an identity check helper to ensure the exact player instance is present before rebuilding tracking. 
- Add debug-gated diagnostics under the `[MCH-RESPAWN-TRACK]` prefix for death, clone, queued/refreshed/skipped tracking refreshes, and `StartTracking`/`StopTracking` transitions so failures can be audited without verbose per-entity logging. 
- Document the root cause, audit findings related to PR #587 and #592, and the verification/limitations in `docs/vehicle-respawn-tracking.md` and add a concise `changelog.md` entry describing the fix and preservation of LOD/UUID/mount behavior. 

### Testing

- Ran `git diff --check` and it completed without new whitespace errors. 
- Ran `python tools/validate_config_weights.py` which validated 501 weight entries successfully. 
- Ran `./gradlew compileJava --dry-run --no-daemon` to validate the Gradle task graph without producing binary artifacts and it completed successfully. 
- Ran `python tools/validate_plane_config_surface.py` which reported a pre-existing, unrelated config failure (`configreference/planes/b-21.txt` contains removed keys), and verified no binary files were introduced by this patch; the full two-client dedicated Forge gameplay matrix remains to be executed manually and is documented in the new `docs/vehicle-respawn-tracking.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c0f894c6883239083e9fbc5299e17)