### PR TITLE
Repair normal vehicle tracking after player respawn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+## PR #594 - Verify and Repair Respawn Tracking
+
+- Replaced PR #593's unverified one-tick global tracker reset with a 40-tick, chunk-ready, per-player targeted verification and repair.
+- Added bounded, always-visible `[MCH-RESPAWN-AUDIT]` server and client lifecycle evidence while preserving the 200-block LOD exclusion and UAV behavior.
+- Corrected the respawn tracking documentation to distinguish verified vanilla lifecycle behavior from the former stale-watcher theory.
+
 ## PR #593 - Restore Real Vehicle Tracking After Respawn
 
 - Rebuild the replacement server player's vanilla tracker membership once, after Forge's respawn or dimension-change lifecycle has installed the player and its watched chunks.

--- a/docs/vehicle-respawn-tracking.md
+++ b/docs/vehicle-respawn-tracking.md
@@ -1,59 +1,62 @@
 # Normal vehicle tracking across player respawn
 
-## Root cause and lifecycle fix
+## Corrected diagnosis
 
-Minecraft 1.7.10 replaces `EntityPlayerMP` on respawn while deliberately reusing
-the old player's numeric entity ID. `Entity.equals` and `hashCode` use that ID,
-and each `EntityTrackerEntry` stores its watching players in a `HashSet`. If an
-old watcher survives the replacement boundary, the set therefore reports that
-the replacement is already watching an existing vehicle. The normal spawn
-packet and Forge `StartTracking` event are then suppressed. The server vehicle
-continues to exist, but the client has no real entity to render, collide with,
-select, mount, or use.
+PR #593 / merge `1244d0ca86765817bf89e11b4a6079086bd2a7a5` claimed that a stale
+`EntityPlayerMP` remained in `EntityTrackerEntry.trackingPlayers`. The supplied run
+contains no lifecycle messages (they were hidden behind `EnableMCHLibDebugLog=false`),
+so that run neither proves the claim nor proves that the old refresh ran.
 
-The server now queues one refresh from Forge's `PlayerRespawnEvent` (and the
-corresponding dimension-change event). At the next server-tick end, after the
-replacement belongs to the world and `PlayerManager` has installed its watched
-chunks, the refresh removes only that player's membership from tracker entries
-and asks vanilla `EntityTracker` to rebuild memberships. Vanilla consequently
-sends the existing parent vehicle and dependent seat/hitbox entities with their
-original IDs and UUIDs. Their ordinary `StartTracking` events retain
-`syncCompleteAircraftState` as the post-spawn state synchronization step. The
-refresh is removed from the queue immediately and is never repeated per tick.
+The 1.7.10 source audit rejects the claim as a generally valid root cause. During
+`ServerConfigurationManager.respawnPlayer`, vanilla calls
+`removePlayerFromTrackers(oldPlayer)` before constructing and spawning the replacement.
+A reused numeric ID alone therefore does not leave an old watcher. A stale watcher is
+now reported if it actually occurs; it is not assumed.
 
-Enable `EnableMCHLibDebugLog` to record the debug-only
-`[MCH-RESPAWN-TRACK] queued`, `refreshed`, and `skipped stale refresh` lifecycle
-tags. These include player entity ID, UUID and object identity, world identity,
-dimension, chunk, and nearby normal-vehicle count without logging every vehicle
-on every tick.
+The failed fix introduced a deterministic tracking hole: one tick after respawn it
+sent destroy packets with `removePlayerFromTrackers(replacement)`, then called global
+`updateTrackedEntities()`. That update is movement-driven and does not promise to
+reconsider every stationary tracker entry for that player. It also removed the queue
+record regardless of the result. The first divergence created by that path is stage 3:
+the server vehicle and tracker entry exist, while the replacement player is absent
+from the entry; consequently no real client entity can remain after the destroy packet.
 
-## Synchronization audit
+## Repair
 
-- `3509e4419f6f37ef238d730b151302eb934211e4` is the pre-synchronization base.
-- PR #587 (`1d293104335744b46da4cbf08dad58915f4dc3e9`, merged as
-  `3287a81d3bfe00fa15eaa520c1e11df15d2765f3`) cleared client LOD and pending
-  mount caches at death/world/player replacement, reset real vehicles' LOD
-  render flag on join, and added bounded normal-mount correction. Clearing the
-  render-only cache exposed the absent real entity; it did not remove a server
-  vehicle or cause the interaction failure.
-- PR #592 (`b328858acbf1b060be429d05cf3adbc2480558ac`, merged as
-  `c3add9e638143c8de3889f9d9e37a24ee9e52b4e`) excluded the normal 200-block
-  range from snapshots, keyed snapshots and mount generations by UUID, removed
-  the unsafe global tracker-range reflection, and cleaned dead normal riders.
-  The tighter snapshot boundary made the tracking hole unambiguous. The UUID,
-  mount-sequence, and dead-rider changes remain intact because none supplies or
-  replaces a missing entity spawn packet.
+The unconditional destructive removal and global update are gone. A lifecycle record
+is keyed by UUID plus replacement-object identity and retains the exact replacement
+reference. For up to 40 server ticks it verifies, by exact object identity, every
+nearby normal parent vehicle in Forge's tracker view and independently verifies that
+`PlayerManager` watches its chunk. Missing entries are reconsidered only with
+`EntityTracker.func_85172_a(replacement, chunk)`, and only after that chunk is watched.
+The record ends immediately when all expected parents track the replacement, or logs a
+visible timeout. Ordinary `StartTracking` remains responsible for dependent entities
+and calls `syncCompleteAircraftState` only after the real parent starts tracking.
 
-The former LOD image was only plain render data, so it could visually mask the
-missing tracked entity while providing no collision or interaction target. This
-fix restores authoritative real entities; it does not restore snapshots inside
-200 blocks, create fake client entities, or make snapshots interactable. UAV and
-NewUAV code paths are unchanged.
+This does not expand tracker ranges or alter LOD snapshots. Snapshot displays remain
+render-only and excluded inside 200 blocks. UAV, NewUAV, station, inventory, remote
+camera, and safe-return paths are unchanged.
 
-## Dedicated-server verification status
+## Audit logging
 
-The automated source environment does not provide two graphical Forge clients,
-so the full two-client death/respawn matrix must be exercised in a manual game
-session. The source-level audit verifies that the refresh uses Forge 1.7.10's
-server event bus and vanilla tracker APIs, is delayed until the player is in the
-world, preserves entity identity, and runs once per lifecycle transition.
+Essential evidence uses the normal `mcheli` logger even when debug logging is off and
+has prefix `[MCH-RESPAWN-AUDIT]`:
+
+- startup `registered` lines identify the Forge and FML event buses;
+- `death`, `clone`, `queue`, and client `dead`/`replacement+N` lines delimit lifecycle;
+- `readiness`, `attempt`, `success`, and `timeout` show the bounded targeted repair;
+- `start`, `stop`, and `syncCompleteAircraftState` prove Forge tracking transitions;
+- client snapshots at replacement ticks 0, 1, 5, 20, and 40 report player/world/view
+  identity and real-vehicle versus LOD-display counts.
+
+A graphical dedicated-server/client run is still required to capture per-vehicle
+server/client resolution evidence. This repository change does not claim that such a
+run was performed in the source-only environment.
+
+## Commit and PR audit
+
+PR #587 (`1d293104...`, merge `3287a81...`) reset client LOD/mount caches and render
+state. PR #592 (`b328858...`, merge `c3add9e...`) restored the 200-block snapshot
+boundary and UUID mount generations. PR #593 (`75610d3...`, merge `1244d0c...`) added
+the unverified one-tick destructive refresh described above. The current repair keeps
+the useful #587/#592 LOD and mount behavior and replaces only #593's refresh.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -55,6 +55,7 @@ import org.lwjgl.opengl.Display;
 import mcheli.ship.MCH_ClientShipTickHandler;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.ship.MCH_GuiShip;
+import mcheli.lod.MCH_VehicleLODManager;
 
 //Eventhooks, clientproxy, tickhandler, guis and config just to name a few inheritors
 @SideOnly(Side.CLIENT)
@@ -108,6 +109,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private EntityClientPlayerMP dismountPlayer;
    private World dismountWorld;
    private Object dismountConnection;
+   private EntityClientPlayerMP auditPlayer;
+   private int auditRespawnTicks = -1;
+   private boolean auditDeadLogged;
 
 
 
@@ -867,6 +871,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
    public void onPlayerTickPre(EntityPlayer player) {
       if(player == super.mc.thePlayer) {
+         this.auditRespawnState((EntityClientPlayerMP)player);
          MCH_BaseVehiclePacketHandler.tickPendingMounts(player);
          if(player.isDead) {
             MCH_MOD.proxy.clearVehicleLODSnapshots();
@@ -890,6 +895,34 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          }
       }
 
+   }
+
+   private void auditRespawnState(EntityClientPlayerMP player) {
+      if(player != this.auditPlayer) {
+         this.auditPlayer = player;
+         this.auditRespawnTicks = 0;
+         this.auditDeadLogged = false;
+         this.logClientAudit("replacement");
+      } else if(player.isDead && !this.auditDeadLogged) {
+         this.auditDeadLogged = true;
+         this.logClientAudit("dead");
+      } else if(this.auditRespawnTicks >= 0) {
+         ++this.auditRespawnTicks;
+         if(this.auditRespawnTicks == 1 || this.auditRespawnTicks == 5 || this.auditRespawnTicks == 20 || this.auditRespawnTicks == 40)
+            this.logClientAudit("replacement+" + this.auditRespawnTicks);
+         if(this.auditRespawnTicks >= 40) this.auditRespawnTicks = -1;
+      }
+   }
+
+   private void logClientAudit(String stage) {
+      int vehicles = 0;
+      if(super.mc.theWorld != null) for(Object value : super.mc.theWorld.loadedEntityList)
+         if(value instanceof MCH_EntityBaseVehicle) ++vehicles;
+      MCH_Lib.RespawnAuditLog("client %s playerId=%d playerObject=%x world=%x view=%x dim=%d pos=%.1f,%.1f,%.1f realVehicles=%d lodDisplays=%d",
+         stage, Integer.valueOf(this.auditPlayer.getEntityId()), Integer.valueOf(System.identityHashCode(this.auditPlayer)),
+         Integer.valueOf(System.identityHashCode(super.mc.theWorld)), Integer.valueOf(System.identityHashCode(super.mc.renderViewEntity)),
+         Integer.valueOf(this.auditPlayer.dimension), Double.valueOf(this.auditPlayer.posX), Double.valueOf(this.auditPlayer.posY),
+         Double.valueOf(this.auditPlayer.posZ), Integer.valueOf(vehicles), Integer.valueOf(MCH_VehicleLODManager.INSTANCE.getDisplayCountForAudit()));
    }
 
    public void onPlayerTickPost(EntityPlayer player) {

--- a/src/main/java/mcheli/MCH_CommonProxy.java
+++ b/src/main/java/mcheli/MCH_CommonProxy.java
@@ -44,6 +44,7 @@ public class MCH_CommonProxy {
 
    public void registerServerTick() {
       FMLCommonHandler.instance().bus().register(new MCH_ServerTickHandler());
+      MCH_Lib.RespawnAuditLog("registered FML server handlers: PlayerRespawnEvent, PlayerChangedDimensionEvent, ServerTickEvent");
    }
 
    public boolean isRemote() {

--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -188,12 +188,14 @@ public class MCH_EventHook extends W_EventHook {
    public void onLivingDeathEvent(LivingDeathEvent event) {
       if(event.entity instanceof EntityPlayerMP) {
          EntityPlayerMP player = (EntityPlayerMP)event.entity;
-         MCH_Lib.DbgLog(player.worldObj,
-            "[MCH-RESPAWN-TRACK] death player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
+         MCH_Lib.RespawnAuditLog(
+            "death player=%s id=%d uuid=%s object=%x dim=%d world=%x pos=%.1f,%.1f,%.1f chunk=%d,%d dead=%s net=%s exactWorldPlayer=%s",
             new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
                Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
-               Integer.valueOf(System.identityHashCode(player.worldObj)), Integer.valueOf(player.chunkCoordX),
-               Integer.valueOf(player.chunkCoordZ)});
+               Integer.valueOf(System.identityHashCode(player.worldObj)), Double.valueOf(player.posX), Double.valueOf(player.posY),
+               Double.valueOf(player.posZ), Integer.valueOf(player.chunkCoordX), Integer.valueOf(player.chunkCoordZ),
+               Boolean.valueOf(player.isDead), player.playerNetServerHandler == null ? "null" : "open",
+               Boolean.valueOf(containsExact(player.worldObj.playerEntities, player))});
          MCH_UavInventory.restorePilotInventory(player, "player_death");
          for(Object object : player.worldObj.loadedEntityList) {
             if(object instanceof MCH_EntityBaseVehicle) {
@@ -206,8 +208,8 @@ public class MCH_EventHook extends W_EventHook {
    @SubscribeEvent
    public void onPlayerClone(PlayerEvent.Clone event) {
       if(event.entityPlayer instanceof EntityPlayerMP && !event.entityPlayer.worldObj.isRemote) {
-         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
-            "[MCH-RESPAWN-TRACK] clone oldId=%d oldUuid=%s oldObject=%x newId=%d newUuid=%s newObject=%x dim=%d world=%x death=%s",
+         MCH_Lib.RespawnAuditLog(
+            "clone oldId=%d oldUuid=%s oldObject=%x newId=%d newUuid=%s newObject=%x dim=%d world=%x death=%s",
             new Object[]{Integer.valueOf(event.original.getEntityId()), event.original.getUniqueID(),
                Integer.valueOf(System.identityHashCode(event.original)), Integer.valueOf(event.entityPlayer.getEntityId()),
                event.entityPlayer.getUniqueID(), Integer.valueOf(System.identityHashCode(event.entityPlayer)),
@@ -243,8 +245,8 @@ public class MCH_EventHook extends W_EventHook {
       if(aircraft != null) {
          this.logTrackingTransition("start", (EntityPlayerMP)event.entityPlayer, event.target, aircraft);
          aircraft.syncCompleteAircraftState((EntityPlayerMP)event.entityPlayer);
-         MCH_Lib.DbgLog(event.entityPlayer.worldObj,
-            "[MCH-RESPAWN-TRACK] syncCompleteAircraftState playerId=%d targetId=%d vehicleId=%d vehicleUuid=%s",
+         MCH_Lib.RespawnAuditLog(
+            "syncCompleteAircraftState playerId=%d targetId=%d vehicleId=%d vehicleUuid=%s",
             new Object[]{Integer.valueOf(event.entityPlayer.getEntityId()), Integer.valueOf(event.target.getEntityId()),
                Integer.valueOf(aircraft.getEntityId()), aircraft.getUniqueID()});
       } else if(event.target instanceof MCH_EntityHitBox) {
@@ -270,11 +272,16 @@ public class MCH_EventHook extends W_EventHook {
       String kind = target instanceof MCH_EntityPSeat ? "passenger-seat"
          : target instanceof MCH_EntitySeat ? "seat"
          : target instanceof MCH_EntityHitBox ? "hitbox" : "vehicle";
-      MCH_Lib.DbgLog(player.worldObj,
-         "[MCH-RESPAWN-TRACK] %s kind=%s playerId=%d playerObject=%x targetId=%d targetUuid=%s parentId=%d parentRef=%x dead=%s",
+      MCH_Lib.RespawnAuditLog(
+         "%s kind=%s playerId=%d playerObject=%x targetId=%d targetUuid=%s parentId=%d parentRef=%x dead=%s",
          new Object[]{action, kind, Integer.valueOf(player.getEntityId()), Integer.valueOf(System.identityHashCode(player)),
             Integer.valueOf(target.getEntityId()), target.getUniqueID(), Integer.valueOf(aircraft != null ? aircraft.getEntityId() : -1),
             Integer.valueOf(System.identityHashCode(aircraft)), Boolean.valueOf(target.isDead)});
+   }
+
+   private static boolean containsExact(List<?> values, Object expected) {
+      for(Object value : values) if(value == expected) return true;
+      return false;
    }
 
    @SubscribeEvent

--- a/src/main/java/mcheli/MCH_Lib.java
+++ b/src/main/java/mcheli/MCH_Lib.java
@@ -243,6 +243,11 @@ public class MCH_Lib {
       LOGGER.info(side + " " + formatMessage(format, data));
    }
 
+   /** Lifecycle evidence which must remain visible when the debug logger is disabled. */
+   public static void RespawnAuditLog(String format, Object ... data) {
+      LOGGER.info("[MCH-RESPAWN-AUDIT] " + formatMessage(format, data));
+   }
+
    public static void Log(World world, String format, Object ... data) {
       if(world != null) {
          Log((world.isRemote?"[ClientWorld]":"[ServerWorld]") + " " + format, data);

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -314,6 +314,7 @@ public class MCH_MOD {
       MCH_Lib.Log("Register system", new Object[0]);
       W_NetworkRegistry.registerChannel(packetHandler, "MCHeli_CH");
       MinecraftForge.EVENT_BUS.register(new MCH_EventHook());
+      MCH_Lib.RespawnAuditLog("registered Forge handlers: LivingDeathEvent, Clone, StartTracking, StopTracking");
 
       proxy.registerClientTick();
 

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.helicopter.MCH_EntityHeli;
@@ -35,8 +36,8 @@ public class MCH_ServerTickHandler {
    private static final int MAX_ENTRIES = 512;
    /** Must match the normal vehicle/seat registration range in MCH_MOD. */
    private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
-   private static final int TRACKING_REFRESH_DELAY_TICKS = 1;
-   private final Map<EntityPlayerMP, Integer> pendingTrackingRefreshes = new HashMap<EntityPlayerMP, Integer>();
+   private static final int TRACKING_REFRESH_TIMEOUT_TICKS = 40;
+   private final Map<String, TrackingRefresh> pendingTrackingRefreshes = new HashMap<String, TrackingRefresh>();
    private int tick;
 
    @SubscribeEvent
@@ -54,54 +55,74 @@ public class MCH_ServerTickHandler {
          return;
       }
       EntityPlayerMP player = (EntityPlayerMP)playerEntity;
-      this.pendingTrackingRefreshes.put(player, Integer.valueOf(TRACKING_REFRESH_DELAY_TICKS));
-      MCH_Lib.DbgLog(player.worldObj, "[MCH-RESPAWN-TRACK] queued %s refresh player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
+      String key = player.getUniqueID().toString() + ":" + System.identityHashCode(player);
+      this.pendingTrackingRefreshes.put(key, new TrackingRefresh(player, reason));
+      MCH_Lib.RespawnAuditLog("queue reason=%s player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
          new Object[]{reason, player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
             Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
             Integer.valueOf(System.identityHashCode(player.worldObj)), Integer.valueOf(player.chunkCoordX), Integer.valueOf(player.chunkCoordZ)});
    }
 
    private void refreshPendingPlayerTracking() {
-      Iterator<Map.Entry<EntityPlayerMP, Integer>> iterator = this.pendingTrackingRefreshes.entrySet().iterator();
+      Iterator<Map.Entry<String, TrackingRefresh>> iterator = this.pendingTrackingRefreshes.entrySet().iterator();
       while(iterator.hasNext()) {
-         Map.Entry<EntityPlayerMP, Integer> entry = iterator.next();
-         EntityPlayerMP player = entry.getKey();
-         int delay = entry.getValue().intValue() - 1;
-         if(delay > 0) {
-            entry.setValue(Integer.valueOf(delay));
-            continue;
-         }
-         iterator.remove();
+         TrackingRefresh refresh = iterator.next().getValue();
+         EntityPlayerMP player = refresh.player;
+         ++refresh.age;
          if(player.isDead || !(player.worldObj instanceof WorldServer)
             || !containsPlayerInstance(player.worldObj.playerEntities, player)) {
-            MCH_Lib.DbgLog(player.worldObj, "[MCH-RESPAWN-TRACK] skipped stale refresh player=%s id=%d object=%x dead=%s",
+            iterator.remove();
+            MCH_Lib.RespawnAuditLog("timeout-stale player=%s id=%d object=%x dead=%s age=%d",
                new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()),
-                  Integer.valueOf(System.identityHashCode(player)), Boolean.valueOf(player.isDead)});
+                  Integer.valueOf(System.identityHashCode(player)), Boolean.valueOf(player.isDead), Integer.valueOf(refresh.age)});
             continue;
          }
 
          WorldServer world = (WorldServer)player.worldObj;
-         int nearbyVehicles = 0;
+         int nearbyVehicles = 0, trackedVehicles = 0, readyChunks = 0;
+         List<Chunk> repairChunks = new ArrayList<Chunk>();
          for(Object object : world.loadedEntityList) {
             if(object instanceof MCH_EntityBaseVehicle && !((MCH_EntityBaseVehicle)object).isDead
                && ((MCH_EntityBaseVehicle)object).getDistanceSqToEntity(player) <= NORMAL_TRACKING_RANGE_SQ) {
                ++nearbyVehicles;
+               MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)object;
+               boolean chunkReady = world.getPlayerManager().isPlayerWatchingChunk(player, vehicle.chunkCoordX, vehicle.chunkCoordZ);
+               if(chunkReady) ++readyChunks;
+               Set<?> watchers = world.getEntityTracker().getTrackingPlayers(vehicle);
+               if(containsPlayerInstance(new ArrayList<Object>(watchers), player)) {
+                  ++trackedVehicles;
+               } else if(chunkReady) {
+                  Chunk chunk = world.getChunkFromChunkCoords(vehicle.chunkCoordX, vehicle.chunkCoordZ);
+                  if(!repairChunks.contains(chunk)) repairChunks.add(chunk);
+               }
             }
          }
-
-         // The replacement player deliberately reuses the dead player's entity ID.
-         // EntityTrackerEntry's watcher set can consequently regard a stale old
-         // player object as equal to the replacement and suppress its spawn packet.
-         // Remove that one player's watcher generation, then let vanilla rebuild it
-         // after PlayerManager has installed the replacement's watched chunks.
-         world.getEntityTracker().removePlayerFromTrackers(player);
-         world.getEntityTracker().updateTrackedEntities();
-         MCH_Lib.DbgLog(world, "[MCH-RESPAWN-TRACK] refreshed player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d nearbyVehicles=%d",
-            new Object[]{player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
-               Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
-               Integer.valueOf(System.identityHashCode(world)), Integer.valueOf(player.chunkCoordX),
-               Integer.valueOf(player.chunkCoordZ), Integer.valueOf(nearbyVehicles)});
+         if(refresh.age == 1 || refresh.age == 5 || refresh.age == 20 || refresh.age == 40)
+            MCH_Lib.RespawnAuditLog("readiness player=%s age=%d nearby=%d chunkReady=%d tracked=%d",
+               player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(nearbyVehicles), Integer.valueOf(readyChunks), Integer.valueOf(trackedVehicles));
+         if(nearbyVehicles == trackedVehicles) {
+            iterator.remove();
+            MCH_Lib.RespawnAuditLog("success player=%s age=%d vehicles=%d targetedAttempts=%d",
+               player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(nearbyVehicles), Integer.valueOf(refresh.attempts));
+         } else if(!repairChunks.isEmpty()) {
+            ++refresh.attempts;
+            for(Chunk chunk : repairChunks) world.getEntityTracker().func_85172_a(player, chunk);
+            MCH_Lib.RespawnAuditLog("attempt player=%s age=%d chunks=%d missing=%d",
+               player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(repairChunks.size()), Integer.valueOf(nearbyVehicles - trackedVehicles));
+         } else if(refresh.age >= TRACKING_REFRESH_TIMEOUT_TICKS) {
+            iterator.remove();
+            MCH_Lib.RespawnAuditLog("timeout player=%s vehicles=%d tracked=%d ready=%d",
+               player.getCommandSenderName(), Integer.valueOf(nearbyVehicles), Integer.valueOf(trackedVehicles), Integer.valueOf(readyChunks));
+         }
       }
+   }
+
+   private static final class TrackingRefresh {
+      final EntityPlayerMP player;
+      final String reason;
+      int age;
+      int attempts;
+      TrackingRefresh(EntityPlayerMP player, String reason) { this.player = player; this.reason = reason; }
    }
 
    private static boolean containsPlayerInstance(List<?> players, EntityPlayerMP player) {

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -90,6 +90,10 @@ public final class MCH_VehicleLODManager {
         this.world = null;
     }
 
+    public synchronized int getDisplayCountForAudit() {
+        return this.displays.size();
+    }
+
     @SubscribeEvent
     public synchronized void onRenderWorldLast(RenderWorldLastEvent event) {
         Minecraft mc = Minecraft.getMinecraft();


### PR DESCRIPTION
### Motivation

- Prevent normal MCHeli vehicles from becoming invisible/non-interactable after the local player dies and respawns by replacing an unverified destructive one-tick global tracker refresh with a targeted, evidence-driven repair.
- Provide bounded, always-visible audit logging so server and client lifecycle transitions around death/respawn can be observed even when debug logging is disabled.

### Description

- Replace the previous speculative refresh with a per-player targeted repair in `MCH_ServerTickHandler` that keys lifecycle records by `UUID` + replacement-object identity, verifies exact watcher membership, retries only for watched vehicle chunks, invokes `EntityTracker.func_85172_a` per-chunk, and times out after 40 ticks. (`src/main/java/mcheli/MCH_ServerTickHandler.java`)
- Add an always-visible audit logger `MCH_Lib.RespawnAuditLog` and use it for essential lifecycle evidence (death, clone, queue/readiness/attempt/success/timeout, Start/StopTracking, `syncCompleteAircraftState`). (`src/main/java/mcheli/MCH_Lib.java`, `src/main/java/mcheli/MCH_EventHook.java`)
- Add lightweight client-side lifecycle snapshots that log replacement, death, and replacement+1/5/20/40 ticks with player/world/view identity and counts of real vehicles vs LOD displays. (`src/main/java/mcheli/MCH_ClientCommonTickHandler.java`, `src/main/java/mcheli/lod/MCH_VehicleLODManager.java`)
- Keep LOD behavior unchanged inside the normal 200-block tracking range and preserve all UAV/NewUAV behavior; update docs and `changelog.md` to remove the unverified stale-watcher root-cause claim and record the repair. (`docs/vehicle-respawn-tracking.md`, `changelog.md`)

### Testing

- Ran `git diff --check`, which passed with no whitespace errors.
- Ran repository validators: `python3 tools/validate_config_weights.py` succeeded and `python3 tools/validate_plane_config_surface.py` failed due to pre-existing removed keys in `configreference/planes/b-21.txt` (this is an upstream data/config issue, not caused by the code changes).
- Did not run Java/Gradle compilation or the dedicated Forge client/server graphical respawn matrix per instructions; the documentation explicitly states that manual graphical verification remains required and was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6c1591884c8323bfec4a115f21bb7d)