### PR TITLE
Fix normal vehicle tracking after player respawn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -375,3 +375,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Added continuous snapshot propeller animation plus nozzle/nacelle, wing, pylon, and generic weapon rendering for planes and ships.
 - Added bounded, depth-first stationary-turret pose snapshots and recursive snapshot rendering for yaw, pitch, barrel rotation, recoil, cooldown visibility, and nested parts.
 - Resolved turret snapshot textures from each turret info's legacy `vehicles` or newer `turrets` asset directory.
+
+# Client-confirmed normal vehicle respawn repair
+
+* Replaced watcher-only respawn success with bounded server-to-client probes and detailed client-to-server resolution evidence.
+* Targetedly resend only missing normal parents and then their dependents, with two-attempt and 60-tick limits; UAV paths remain unchanged.

--- a/docs/vehicle-respawn-tracking.md
+++ b/docs/vehicle-respawn-tracking.md
@@ -1,62 +1,30 @@
 # Normal vehicle tracking across player respawn
 
-## Corrected diagnosis
+## Proven evidence and diagnosis
 
-PR #593 / merge `1244d0ca86765817bf89e11b4a6079086bd2a7a5` claimed that a stale
-`EntityPlayerMP` remained in `EntityTrackerEntry.trackingPlayers`. The supplied run
-contains no lifecycle messages (they were hidden behind `EnableMCHLibDebugLog=false`),
-so that run neither proves the claim nor proves that the old refresh ran.
+Commit `769e711ad3b77d2063c99ec7265d1967e1e11d46` (PR #594) did not fix the issue. The supplied dedicated-server run is authoritative: the replacement player started tracking parent IDs 60, 206, and 2792, and all three received complete-state syncs. Its `nearby=3`, `tracked=3`, `targetedAttempts=0` result proves that the real server entities and replacement-player tracker memberships were already valid. Watcher membership is therefore not evidence that the replacement client has an entity.
 
-The 1.7.10 source audit rejects the claim as a generally valid root cause. During
-`ServerConfigurationManager.respawnPlayer`, vanilla calls
-`removePlayerFromTrackers(oldPlayer)` before constructing and spawning the replacement.
-A reused numeric ID alone therefore does not leave an old watcher. A stale watcher is
-now reported if it actually occurs; it is not assumed.
+The same run reports `tracked=3` with `chunkReady=0`. Parent `StartTracking` occurred before `PlayerRespawnEvent`, and seats began later. PR #594's watcher-only success condition was invalid. `MCH_EntityBaseVehicle.forceSpawn=true` permits this ordering: a parent can start tracking without `PlayerManager` watching its chunk. The tracker spawn path is independent of the subsequent `S07PacketRespawn`; client respawn handling replaces `Minecraft.theWorld`, so a parent inserted in the old `WorldClient` can be discarded. The server-only run establishes this timing hazard but cannot prove client packet handling order. The first proven client divergence is now recorded only when a probe result reaches the server.
 
-The failed fix introduced a deterministic tracking hole: one tick after respawn it
-sent destroy packets with `removePlayerFromTrackers(replacement)`, then called global
-`updateTrackedEntities()`. That update is movement-driven and does not promise to
-reconsider every stationary tracker entry for that player. It also removed the queue
-record regardless of the result. The first divergence created by that path is stage 3:
-the server vehicle and tracker entry exist, while the replacement player is absent
-from the entry; consequently no real client entity can remain after the destroy packet.
+## Client-confirmed protocol and repair
 
-## Repair
+For 60 server ticks after `PlayerRespawnEvent`, the server inventories at most 128 normal parent vehicles within 200 blocks. UAV and NewUAV parents are excluded. Probes are sent at ticks 1, 5, 10, 20, 40, and 60, plus after repair—not every tick. They carry the respawn generation, replacement player and server-world identities, and expected parent IDs, UUIDs, types, positions, and chunks.
 
-The unconditional destructive removal and global update are gone. A lifecycle record
-is keyed by UUID plus replacement-object identity and retains the exact replacement
-reference. For up to 40 server ticks it verifies, by exact object identity, every
-nearby normal parent vehicle in Forge's tracker view and independently verifies that
-`PlayerManager` watches its chunk. Missing entries are reconsidered only with
-`EntityTracker.func_85172_a(replacement, chunk)`, and only after that chunk is watched.
-The record ends immediately when all expected parents track the replacement, or logs a
-visible timeout. Ordinary `StartTracking` remains responsible for dependent entities
-and calls `syncCompleteAircraftState` only after the real parent starts tracking.
+Client inspection is scheduled with `Minecraft.func_152344_a`. It resolves each parent by numeric ID and independently by UUID and returns player/world/view identities, respawn readiness and age, entity lifecycle/chunk state, aircraft info, renderer flags, collision state and box, and seat/hitbox parent counts. Result handling is scheduled on the server thread. The audit classifies missing entities, ID collisions, dead or unchunked entities, missing aircraft info, render suppression, invalid collision, and invalid dependent parents. It succeeds only after the client confirms every original ID and UUID in the replacement world.
 
-This does not expand tracker ranges or alter LOD snapshots. Snapshot displays remain
-render-only and excluded inside 200 blocks. UAV, NewUAV, station, inventory, remote
-camera, and safe-return paths are unchanged.
+For a missing or ID-collided parent, the server removes only the exact replacement-player object from that parent's `EntityTrackerEntry`, then asks the same entry to watch the same original server entity. This uses the normal Forge spawn path and preserves the instance, ID, and UUID. The parent is resent before targeted reconsideration of its seats and hitboxes and complete-state synchronization. Correctly resolved parents and unrelated tracker entries are untouched. A parent receives at most two resends per respawn generation, all packet lists are bounded, and a visible timeout is logged at tick 60.
 
-## Audit logging
+`forceSpawn=true` remains because removing it without normal-boundary and distant-LOD runtime coverage risks a separate regression. LOD snapshots remain render-only and excluded inside the normal 200-block range; they are not a fallback for a missing real parent.
 
-Essential evidence uses the normal `mcheli` logger even when debug logging is off and
-has prefix `[MCH-RESPAWN-AUDIT]`:
+A graphical two-client dedicated-server run is still required to learn whether the first classification is `3-missing-entity` (proving premature spawn/world replacement), removal after creation, or later client-state corruption. This source change does not claim that run passed.
 
-- startup `registered` lines identify the Forge and FML event buses;
-- `death`, `clone`, `queue`, and client `dead`/`replacement+N` lines delimit lifecycle;
-- `readiness`, `attempt`, `success`, and `timeout` show the bounded targeted repair;
-- `start`, `stop`, and `syncCompleteAircraftState` prove Forge tracking transitions;
-- client snapshots at replacement ticks 0, 1, 5, 20, and 40 report player/world/view
-  identity and real-vehicle versus LOD-display counts.
+## Commit and pull-request audit
 
-A graphical dedicated-server/client run is still required to capture per-vehicle
-server/client resolution evidence. This repository change does not claim that such a
-run was performed in the source-only environment.
+* `3509e441...` only updated the uppercase changelog.
+* PR #587 (`1d293104...`, merge `3287a81...`) reset client LOD/mount caches and render state.
+* PR #592 (`b328858...`, merge `c3add9e...`) restored the 200-block snapshot boundary and UUID mount generations.
+* PR #593 (`75610d3...`, merge `1244d0c...`) added an unverified destructive global tracker refresh.
+* PR #594 (`7bb2b52...`, merge `769e711...`) removed that global refresh but incorrectly accepted tracker membership as success and logged client evidence only on the client.
+* Current commit `e6d4b10...` only updated the uppercase changelog.
 
-## Commit and PR audit
-
-PR #587 (`1d293104...`, merge `3287a81...`) reset client LOD/mount caches and render
-state. PR #592 (`b328858...`, merge `c3add9e...`) restored the 200-block snapshot
-boundary and UUID mount generations. PR #593 (`75610d3...`, merge `1244d0c...`) added
-the unverified one-tick destructive refresh described above. The current repair keeps
-the useful #587/#592 LOD and mount behavior and replaces only #593's refresh.
+This repair retains #587/#592's LOD and mount work, does not revive #593's global refresh, and replaces #594's incomplete audit with bounded client confirmation and targeted resend.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -113,10 +113,15 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private int auditRespawnTicks = -1;
    private boolean auditDeadLogged;
 
+   public static int getRespawnAuditAge() {
+      return instance == null ? -1 : instance.auditRespawnTicks;
+   }
+
 
 
    public MCH_ClientCommonTickHandler(Minecraft minecraft, MCH_Config config) {
       super(minecraft);
+      instance = this;
       this.gui_Common = new MCH_GuiCommon(minecraft);
       this.gui_Heli = new MCH_GuiHeli(minecraft);
       this.gui_Plane = new MCP_GuiPlane(minecraft);

--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -171,6 +171,18 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
    public void renderPlayerPost(net.minecraftforge.client.event.RenderPlayerEvent.Post event) {}
 
    public void worldEventUnload(Unload event) {
+      int logged = 0;
+      for(Object value : event.world.loadedEntityList) {
+         if(value instanceof MCH_EntityBaseVehicle && logged++ < 32) {
+            MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)value;
+            Minecraft mc = Minecraft.getMinecraft();
+            MCH_Lib.RespawnAuditLog("client-remove vehicleId=%d uuid=%s object=%x world=%x type=%s dead=%s stage=world-unload player=%x currentWorld=%x generation=%d",
+               Integer.valueOf(vehicle.getEntityId()), vehicle.getUniqueID(), Integer.valueOf(System.identityHashCode(vehicle)),
+               Integer.valueOf(System.identityHashCode(vehicle.worldObj)), vehicle.getAcInfo()==null?vehicle.getClass().getSimpleName():vehicle.getAcInfo().name,
+               Boolean.valueOf(vehicle.isDead), Integer.valueOf(System.identityHashCode(mc.thePlayer)), Integer.valueOf(System.identityHashCode(mc.theWorld)),
+               Integer.valueOf(mcheli.network.packets.PacketVehicleRespawnProbe.getClientGeneration()));
+         }
+      }
       MCH_ViewEntityDummy.onUnloadWorld();
       MCH_MOD.proxy.clearVehicleLODSnapshots();
       MCH_BaseVehiclePacketHandler.clearPendingMounts();

--- a/src/main/java/mcheli/MCH_EventHook.java
+++ b/src/main/java/mcheli/MCH_EventHook.java
@@ -272,11 +272,15 @@ public class MCH_EventHook extends W_EventHook {
       String kind = target instanceof MCH_EntityPSeat ? "passenger-seat"
          : target instanceof MCH_EntitySeat ? "seat"
          : target instanceof MCH_EntityHitBox ? "hitbox" : "vehicle";
+      boolean chunkReady = aircraft != null && player.worldObj instanceof net.minecraft.world.WorldServer
+         && ((net.minecraft.world.WorldServer)player.worldObj).getPlayerManager().isPlayerWatchingChunk(player, aircraft.chunkCoordX, aircraft.chunkCoordZ);
+      boolean premature = "start".equals(action) && aircraft != null && aircraft.forceSpawn && !chunkReady;
       MCH_Lib.RespawnAuditLog(
-         "%s kind=%s playerId=%d playerObject=%x targetId=%d targetUuid=%s parentId=%d parentRef=%x dead=%s",
+         "%s kind=%s playerId=%d playerObject=%x targetId=%d targetUuid=%s parentId=%d parentRef=%x dead=%s chunkReady=%s premature=%s forceSpawn=%s",
          new Object[]{action, kind, Integer.valueOf(player.getEntityId()), Integer.valueOf(System.identityHashCode(player)),
             Integer.valueOf(target.getEntityId()), target.getUniqueID(), Integer.valueOf(aircraft != null ? aircraft.getEntityId() : -1),
-            Integer.valueOf(System.identityHashCode(aircraft)), Boolean.valueOf(target.isDead)});
+            Integer.valueOf(System.identityHashCode(aircraft)), Boolean.valueOf(target.isDead), Boolean.valueOf(chunkReady),
+            Boolean.valueOf(premature), Boolean.valueOf(aircraft != null && aircraft.forceSpawn)});
    }
 
    private static boolean containsExact(List<?> values, Object expected) {

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -16,6 +16,10 @@ import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
+import mcheli.network.packets.PacketVehicleRespawnProbe;
+import mcheli.network.packets.PacketVehicleRespawnProbeResult;
+import mcheli.aircraft.MCH_EntitySeat;
+import mcheli.aircraft.MCH_EntityHitBox;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.tank.MCH_EntityTank;
@@ -29,6 +33,10 @@ import net.minecraft.util.MathHelper;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.WorldServer;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.entity.EntityTracker;
+import net.minecraft.entity.EntityTrackerEntry;
+import net.minecraft.util.IntHashMap;
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
 
 /** Sends render-only vehicle snapshots without changing Forge entity tracking. */
 public class MCH_ServerTickHandler {
@@ -36,9 +44,13 @@ public class MCH_ServerTickHandler {
    private static final int MAX_ENTRIES = 512;
    /** Must match the normal vehicle/seat registration range in MCH_MOD. */
    private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
-   private static final int TRACKING_REFRESH_TIMEOUT_TICKS = 40;
+   private static final int TRACKING_REFRESH_TIMEOUT_TICKS = 60;
+   private static int nextRespawnGeneration;
+   private static MCH_ServerTickHandler instance;
    private final Map<String, TrackingRefresh> pendingTrackingRefreshes = new HashMap<String, TrackingRefresh>();
    private int tick;
+
+   public MCH_ServerTickHandler() { instance = this; }
 
    @SubscribeEvent
    public void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
@@ -56,7 +68,7 @@ public class MCH_ServerTickHandler {
       }
       EntityPlayerMP player = (EntityPlayerMP)playerEntity;
       String key = player.getUniqueID().toString() + ":" + System.identityHashCode(player);
-      this.pendingTrackingRefreshes.put(key, new TrackingRefresh(player, reason));
+      this.pendingTrackingRefreshes.put(key, new TrackingRefresh(player, reason, ++nextRespawnGeneration));
       MCH_Lib.RespawnAuditLog("queue reason=%s player=%s id=%d uuid=%s object=%x dim=%d world=%x chunk=%d,%d",
          new Object[]{reason, player.getCommandSenderName(), Integer.valueOf(player.getEntityId()), player.getUniqueID(),
             Integer.valueOf(System.identityHashCode(player)), Integer.valueOf(player.dimension),
@@ -80,9 +92,9 @@ public class MCH_ServerTickHandler {
 
          WorldServer world = (WorldServer)player.worldObj;
          int nearbyVehicles = 0, trackedVehicles = 0, readyChunks = 0;
-         List<Chunk> repairChunks = new ArrayList<Chunk>();
          for(Object object : world.loadedEntityList) {
             if(object instanceof MCH_EntityBaseVehicle && !((MCH_EntityBaseVehicle)object).isDead
+               && !((MCH_EntityBaseVehicle)object).isUAV() && !((MCH_EntityBaseVehicle)object).isNewUAV()
                && ((MCH_EntityBaseVehicle)object).getDistanceSqToEntity(player) <= NORMAL_TRACKING_RANGE_SQ) {
                ++nearbyVehicles;
                MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)object;
@@ -91,28 +103,29 @@ public class MCH_ServerTickHandler {
                Set<?> watchers = world.getEntityTracker().getTrackingPlayers(vehicle);
                if(containsPlayerInstance(new ArrayList<Object>(watchers), player)) {
                   ++trackedVehicles;
-               } else if(chunkReady) {
-                  Chunk chunk = world.getChunkFromChunkCoords(vehicle.chunkCoordX, vehicle.chunkCoordZ);
-                  if(!repairChunks.contains(chunk)) repairChunks.add(chunk);
                }
+               if(!refresh.expected.containsKey(vehicle.getUniqueID()))
+                  refresh.expected.put(vehicle.getUniqueID(), new ExpectedVehicle(vehicle, !chunkReady));
             }
          }
          if(refresh.age == 1 || refresh.age == 5 || refresh.age == 20 || refresh.age == 40)
             MCH_Lib.RespawnAuditLog("readiness player=%s age=%d nearby=%d chunkReady=%d tracked=%d",
                player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(nearbyVehicles), Integer.valueOf(readyChunks), Integer.valueOf(trackedVehicles));
-         if(nearbyVehicles == trackedVehicles) {
+         if(shouldSendProbe(refresh.age) || refresh.probeRequested) {
+            refresh.probeRequested = false;
+            this.sendProbe(refresh);
+         }
+         if(refresh.confirmedAll) {
             iterator.remove();
-            MCH_Lib.RespawnAuditLog("success player=%s age=%d vehicles=%d targetedAttempts=%d",
-               player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(nearbyVehicles), Integer.valueOf(refresh.attempts));
-         } else if(!repairChunks.isEmpty()) {
-            ++refresh.attempts;
-            for(Chunk chunk : repairChunks) world.getEntityTracker().func_85172_a(player, chunk);
-            MCH_Lib.RespawnAuditLog("attempt player=%s age=%d chunks=%d missing=%d",
-               player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(repairChunks.size()), Integer.valueOf(nearbyVehicles - trackedVehicles));
+            MCH_Lib.RespawnAuditLog("success-confirmed generation=%d player=%s age=%d vehicles=%d targetedAttempts=%d",
+               Integer.valueOf(refresh.generation), player.getCommandSenderName(), Integer.valueOf(refresh.age),
+               Integer.valueOf(refresh.expected.size()), Integer.valueOf(refresh.attempts));
          } else if(refresh.age >= TRACKING_REFRESH_TIMEOUT_TICKS) {
             iterator.remove();
-            MCH_Lib.RespawnAuditLog("timeout player=%s vehicles=%d tracked=%d ready=%d",
-               player.getCommandSenderName(), Integer.valueOf(nearbyVehicles), Integer.valueOf(trackedVehicles), Integer.valueOf(readyChunks));
+            MCH_Lib.RespawnAuditLog("timeout generation=%d player=%s vehicles=%d tracked=%d ready=%d clientConfirmed=%s classification=%s",
+               Integer.valueOf(refresh.generation), player.getCommandSenderName(), Integer.valueOf(nearbyVehicles),
+               Integer.valueOf(trackedVehicles), Integer.valueOf(readyChunks), Boolean.valueOf(refresh.confirmedAll),
+               refresh.resultReceived ? "unconfirmed-after-probes" : "1-client-never-returned-probe");
          }
       }
    }
@@ -122,7 +135,112 @@ public class MCH_ServerTickHandler {
       final String reason;
       int age;
       int attempts;
-      TrackingRefresh(EntityPlayerMP player, String reason) { this.player = player; this.reason = reason; }
+      final int generation;
+      final Map<java.util.UUID, ExpectedVehicle> expected = new HashMap<java.util.UUID, ExpectedVehicle>();
+      boolean confirmedAll, probeRequested, resultReceived;
+      TrackingRefresh(EntityPlayerMP player, String reason, int generation) { this.player = player; this.reason = reason; this.generation = generation; }
+   }
+
+   private static final class ExpectedVehicle {
+      final MCH_EntityBaseVehicle vehicle;
+      final boolean premature;
+      int resendAttempts;
+      ExpectedVehicle(MCH_EntityBaseVehicle vehicle, boolean premature) { this.vehicle = vehicle; this.premature = premature; }
+   }
+
+   private static boolean shouldSendProbe(int age) { return age == 1 || age == 5 || age == 10 || age == 20 || age == 40 || age == 60; }
+
+   private void sendProbe(TrackingRefresh refresh) {
+      PacketVehicleRespawnProbe packet = new PacketVehicleRespawnProbe();
+      packet.generation = refresh.generation; packet.playerId = refresh.player.getEntityId();
+      packet.playerUuid = refresh.player.getUniqueID(); packet.dimension = refresh.player.dimension;
+      packet.serverWorldIdentity = System.identityHashCode(refresh.player.worldObj);
+      for(ExpectedVehicle expected : refresh.expected.values()) {
+         if(packet.vehicles.size() >= PacketVehicleRespawnProbe.MAX_VEHICLES) break;
+         MCH_EntityBaseVehicle vehicle = expected.vehicle;
+         if(vehicle.isDead || vehicle.worldObj != refresh.player.worldObj) continue;
+         PacketVehicleRespawnProbe.Entry entry = new PacketVehicleRespawnProbe.Entry();
+         entry.entityId=vehicle.getEntityId(); entry.uuid=vehicle.getUniqueID();
+         entry.typeName=vehicle.getAcInfo()==null?vehicle.getClass().getSimpleName():vehicle.getAcInfo().name;
+         entry.x=vehicle.posX; entry.y=vehicle.posY; entry.z=vehicle.posZ; entry.chunkX=vehicle.chunkCoordX; entry.chunkZ=vehicle.chunkCoordZ;
+         packet.vehicles.add(entry);
+      }
+      MCH_MOD.getPacketHandler().sendTo(packet, refresh.player);
+      MCH_Lib.RespawnAuditLog("probe-send generation=%d age=%d playerId=%d vehicles=%d", Integer.valueOf(refresh.generation),
+         Integer.valueOf(refresh.age), Integer.valueOf(refresh.player.getEntityId()), Integer.valueOf(packet.vehicles.size()));
+   }
+
+   public static void acceptProbeResult(EntityPlayerMP player, PacketVehicleRespawnProbeResult result) {
+      if(instance == null) return;
+      instance.handleProbeResult(player, result);
+   }
+
+   private void handleProbeResult(EntityPlayerMP player, PacketVehicleRespawnProbeResult result) {
+      TrackingRefresh refresh = null;
+      for(TrackingRefresh candidate : this.pendingTrackingRefreshes.values())
+         if(candidate.player == player && candidate.generation == result.generation) { refresh = candidate; break; }
+      if(refresh == null) {
+         MCH_Lib.RespawnAuditLog("probe-result-stale generation=%d playerId=%d", Integer.valueOf(result.generation), Integer.valueOf(player.getEntityId())); return;
+      }
+      boolean all = result.replacementProcessed;
+      refresh.resultReceived = true;
+      MCH_Lib.RespawnAuditLog("probe-result generation=%d ready=%s clientPlayer=%d playerObject=%x world=%x view=%x age=%d vehicles=%d",
+         Integer.valueOf(result.generation), Boolean.valueOf(result.replacementProcessed), Integer.valueOf(result.clientPlayerId),
+         Integer.valueOf(result.clientPlayerIdentity), Integer.valueOf(result.clientWorldIdentity), Integer.valueOf(result.renderViewIdentity),
+         Integer.valueOf(result.respawnAge), Integer.valueOf(result.vehicles.size()));
+      if(!result.replacementProcessed)
+         MCH_Lib.RespawnAuditLog("probe-divergence generation=%d classification=2-probe-before-replacement-world", Integer.valueOf(result.generation));
+      for(PacketVehicleRespawnProbeResult.Entry entry : result.vehicles) {
+         ExpectedVehicle expected = refresh.expected.get(entry.expectedUuid);
+         String classification = classify(entry);
+         boolean correct = entry.foundByUuid && entry.foundId == entry.expectedId && entry.expectedUuid.equals(entry.foundUuid)
+            && !entry.dead && entry.addedToChunk && !"null".equals(entry.acInfo) && entry.collidable
+            && !entry.skipNormalRender && entry.validSeatParents == entry.seatCount && entry.validHitboxParents >= entry.hitboxCount;
+         all &= correct;
+         MCH_Lib.RespawnAuditLog("probe-vehicle generation=%d expectedId=%d expectedUuid=%s class=%s foundId=%d foundUuid=%s object=%x world=%x dead=%s chunk=%s acInfo=%s lod=%s skip=%s collide=%s box=%s seats=%d/%d hitboxes=%d/%d classification=%s",
+            Integer.valueOf(result.generation), Integer.valueOf(entry.expectedId), entry.expectedUuid, entry.foundClass, Integer.valueOf(entry.foundId), entry.foundUuid,
+            Integer.valueOf(entry.objectIdentity), Integer.valueOf(entry.worldIdentity), Boolean.valueOf(entry.dead), Boolean.valueOf(entry.addedToChunk), entry.acInfo,
+            Boolean.valueOf(entry.renderingLod), Boolean.valueOf(entry.skipNormalRender), Boolean.valueOf(entry.collidable), entry.boundingBox,
+            Integer.valueOf(entry.validSeatParents), Integer.valueOf(entry.seatCount), Integer.valueOf(entry.validHitboxParents), Integer.valueOf(entry.hitboxCount), classification);
+         if(result.replacementProcessed && expected != null && ("3-missing-entity".equals(classification)
+            || "4-id-collision".equals(classification) || "5-removed-after-create".equals(classification)))
+            this.targetedResend(refresh, expected);
+      }
+      refresh.confirmedAll = all && result.vehicles.size() == refresh.expected.size();
+   }
+
+   private static String classify(PacketVehicleRespawnProbeResult.Entry e) {
+      if(!e.foundById && !e.foundByUuid && e.previouslyFound) return "5-removed-after-create";
+      if(!e.foundById && !e.foundByUuid) return "3-missing-entity";
+      if(e.foundById && !e.foundByUuid) return "4-id-collision";
+      if(e.dead) return "6-dead"; if(!e.addedToChunk) return "7-not-in-chunk"; if("null".equals(e.acInfo)) return "8-no-ac-info";
+      if(e.skipNormalRender) return "9-render-skipped"; if(!e.collidable || "null".equals(e.boundingBox)) return "10-invalid-collision";
+      if(e.validSeatParents != e.seatCount || e.validHitboxParents < e.hitboxCount) return "11-invalid-dependent-parent";
+      return "confirmed";
+   }
+
+   private void targetedResend(TrackingRefresh refresh, ExpectedVehicle expected) {
+      if(expected.resendAttempts >= 2 || expected.vehicle.isDead) return;
+      EntityTrackerEntry parentEntry = trackerEntry((WorldServer)refresh.player.worldObj, expected.vehicle.getEntityId());
+      if(parentEntry == null) { MCH_Lib.RespawnAuditLog("resend-no-entry generation=%d vehicleId=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId())); return; }
+      ++expected.resendAttempts; ++refresh.attempts;
+      parentEntry.removeFromTrackedPlayers(refresh.player);
+      parentEntry.tryStartWachingThis(refresh.player);
+      expected.vehicle.syncCompleteAircraftState(refresh.player);
+      for(Object object : refresh.player.worldObj.loadedEntityList) {
+         boolean dependent = object instanceof MCH_EntitySeat && ((MCH_EntitySeat)object).getParent() == expected.vehicle
+            || object instanceof MCH_EntityHitBox && ((MCH_EntityHitBox)object).parent == expected.vehicle;
+         if(dependent) { EntityTrackerEntry entry=trackerEntry((WorldServer)refresh.player.worldObj,((Entity)object).getEntityId()); if(entry!=null) { entry.removeFromTrackedPlayers(refresh.player); entry.tryStartWachingThis(refresh.player); } }
+      }
+      refresh.probeRequested = true;
+      MCH_Lib.RespawnAuditLog("targeted-resend generation=%d vehicleId=%d uuid=%s attempt=%d premature=%s",
+         Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()), expected.vehicle.getUniqueID(),
+         Integer.valueOf(expected.resendAttempts), Boolean.valueOf(expected.premature));
+   }
+
+   private static EntityTrackerEntry trackerEntry(WorldServer world, int entityId) {
+      IntHashMap map = ObfuscationReflectionHelper.getPrivateValue(EntityTracker.class, world.getEntityTracker(), "trackedEntityHashTable", "field_72794_c");
+      return map == null ? null : (EntityTrackerEntry)map.lookup(entityId);
    }
 
    private static boolean containsPlayerInstance(List<?> players, EntityPlayerMP player) {

--- a/src/main/java/mcheli/network/PacketHandler.java
+++ b/src/main/java/mcheli/network/PacketHandler.java
@@ -18,6 +18,8 @@ import mcheli.network.packets.PacketAPSState;
 import mcheli.network.packets.PacketLaserGuidanceTargeting;
 import mcheli.network.packets.PacketLockTarget;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
+import mcheli.network.packets.PacketVehicleRespawnProbe;
+import mcheli.network.packets.PacketVehicleRespawnProbeResult;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -126,6 +128,8 @@ public class PacketHandler extends MessageToMessageCodec<FMLProxyPacket, PacketB
         registerPacket(PacketLaserGuidanceTargeting.class);
         registerPacket(PacketLockTarget.class);
         registerPacket(PacketVehicleLODSnapshot.class);
+        registerPacket(PacketVehicleRespawnProbe.class);
+        registerPacket(PacketVehicleRespawnProbeResult.class);
     }
 
     /**

--- a/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbe.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbe.java
@@ -1,0 +1,139 @@
+package mcheli.network.packets;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.HashSet;
+import java.util.Set;
+import mcheli.MCH_Lib;
+import mcheli.MCH_MOD;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.network.PacketBase;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.AxisAlignedBB;
+
+/** A bounded, server-authored inventory of real vehicles expected after respawn. */
+public class PacketVehicleRespawnProbe extends PacketBase {
+    public static final int MAX_VEHICLES = 128;
+    public int generation, playerId, dimension, serverWorldIdentity;
+    public UUID playerUuid = new UUID(0L, 0L);
+    public List<Entry> vehicles = new ArrayList<Entry>();
+    private static int clientGeneration;
+    private static final Set<UUID> previouslyResolved = new HashSet<UUID>();
+    public static int getClientGeneration() { return clientGeneration; }
+
+    public static class Entry {
+        public int entityId, chunkX, chunkZ;
+        public UUID uuid;
+        public String typeName;
+        public double x, y, z;
+    }
+
+    @Override
+    public void encodeInto(ChannelHandlerContext context, ByteBuf data) {
+        data.writeInt(generation); data.writeInt(playerId); writeUuid(data, playerUuid);
+        data.writeInt(dimension); data.writeInt(serverWorldIdentity);
+        int count = Math.min(vehicles.size(), MAX_VEHICLES);
+        data.writeShort(count);
+        for(int i = 0; i < count; ++i) {
+            Entry entry = vehicles.get(i);
+            data.writeInt(entry.entityId); writeUuid(data, entry.uuid); writeUTF(data, entry.typeName);
+            data.writeDouble(entry.x); data.writeDouble(entry.y); data.writeDouble(entry.z);
+            data.writeInt(entry.chunkX); data.writeInt(entry.chunkZ);
+        }
+    }
+
+    @Override
+    public void decodeInto(ChannelHandlerContext context, ByteBuf data) {
+        generation = data.readInt(); playerId = data.readInt(); playerUuid = readUuid(data);
+        dimension = data.readInt(); serverWorldIdentity = data.readInt();
+        int count = Math.min(data.readUnsignedShort(), MAX_VEHICLES);
+        vehicles = new ArrayList<Entry>(count);
+        for(int i = 0; i < count; ++i) {
+            Entry entry = new Entry();
+            entry.entityId = data.readInt(); entry.uuid = readUuid(data); entry.typeName = readUTF(data);
+            entry.x = data.readDouble(); entry.y = data.readDouble(); entry.z = data.readDouble();
+            entry.chunkX = data.readInt(); entry.chunkZ = data.readInt(); vehicles.add(entry);
+        }
+    }
+
+    @Override public void handleServerSide(EntityPlayerMP player) {}
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void handleClientSide(EntityPlayer ignored) {
+        final PacketVehicleRespawnProbe packet = this;
+        Minecraft.getMinecraft().func_152344_a(new Runnable() {
+            @Override public void run() { packet.inspectClientWorld(); }
+        });
+    }
+
+    @SideOnly(Side.CLIENT)
+    private void inspectClientWorld() {
+        clientGeneration = generation;
+        Minecraft mc = Minecraft.getMinecraft();
+        PacketVehicleRespawnProbeResult result = new PacketVehicleRespawnProbeResult();
+        result.generation = generation;
+        result.clientPlayerId = mc.thePlayer == null ? -1 : mc.thePlayer.getEntityId();
+        result.clientPlayerIdentity = System.identityHashCode(mc.thePlayer);
+        result.clientWorldIdentity = System.identityHashCode(mc.theWorld);
+        result.renderViewIdentity = System.identityHashCode(mc.renderViewEntity);
+        result.respawnAge = mcheli.MCH_ClientCommonTickHandler.getRespawnAuditAge();
+        result.replacementProcessed = mc.thePlayer != null && mc.theWorld != null
+            && mc.thePlayer.getEntityId() == playerId && playerUuid.equals(mc.thePlayer.getUniqueID())
+            && mc.theWorld.provider.dimensionId == dimension;
+        for(Entry expected : vehicles) result.vehicles.add(inspect(expected, mc));
+        MCH_Lib.RespawnAuditLog("client-probe generation=%d ready=%s playerId=%d world=%x vehicles=%d",
+            Integer.valueOf(generation), Boolean.valueOf(result.replacementProcessed), Integer.valueOf(result.clientPlayerId),
+            Integer.valueOf(result.clientWorldIdentity), Integer.valueOf(result.vehicles.size()));
+        MCH_MOD.getPacketHandler().sendToServer(result);
+    }
+
+    @SideOnly(Side.CLIENT)
+    private static PacketVehicleRespawnProbeResult.Entry inspect(Entry expected, Minecraft mc) {
+        PacketVehicleRespawnProbeResult.Entry out = new PacketVehicleRespawnProbeResult.Entry();
+        out.expectedId = expected.entityId; out.expectedUuid = expected.uuid;
+        Entity byId = mc.theWorld == null ? null : mc.theWorld.getEntityByID(expected.entityId);
+        Entity byUuid = null;
+        if(mc.theWorld != null) for(Object value : mc.theWorld.loadedEntityList) {
+            Entity entity = (Entity)value;
+            if(expected.uuid.equals(entity.getUniqueID())) { byUuid = entity; break; }
+        }
+        out.foundById = byId != null; out.foundByUuid = byUuid != null;
+        out.previouslyFound = previouslyResolved.contains(expected.uuid);
+        if(byUuid != null) previouslyResolved.add(expected.uuid);
+        Entity found = byUuid != null ? byUuid : byId;
+        if(found != null) {
+            out.foundClass = found.getClass().getName(); out.foundId = found.getEntityId();
+            out.foundUuid = found.getUniqueID(); out.objectIdentity = System.identityHashCode(found);
+            out.worldIdentity = System.identityHashCode(found.worldObj); out.dead = found.isDead;
+            out.addedToChunk = found.addedToChunk; out.collidable = found.canBeCollidedWith();
+            AxisAlignedBB box = found.getBoundingBox();
+            out.boundingBox = box == null ? "null" : String.format(java.util.Locale.ROOT, "%.2f,%.2f,%.2f..%.2f,%.2f,%.2f",
+                box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
+        }
+        if(found instanceof MCH_EntityBaseVehicle) {
+            MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)found;
+            out.acInfo = vehicle.getAcInfo() == null ? "null" : vehicle.getAcInfo().name;
+            out.renderingLod = vehicle.isRenderingLOD; out.skipNormalRender = vehicle.isSkipNormalRender();
+            out.seatCount = vehicle.getSeats().length;
+            for(mcheli.aircraft.MCH_EntitySeat seat : vehicle.getSeats()) if(seat != null && seat.getParent() == vehicle) ++out.validSeatParents;
+            for(Object entity : mc.theWorld.loadedEntityList) {
+                if(entity instanceof mcheli.aircraft.MCH_EntityHitBox && ((mcheli.aircraft.MCH_EntityHitBox)entity).parent == vehicle) {
+                    ++out.hitboxCount; ++out.validHitboxParents;
+                }
+            }
+        }
+        return out;
+    }
+
+    static void writeUuid(ByteBuf data, UUID uuid) { data.writeLong(uuid.getMostSignificantBits()); data.writeLong(uuid.getLeastSignificantBits()); }
+    static UUID readUuid(ByteBuf data) { return new UUID(data.readLong(), data.readLong()); }
+}

--- a/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbeResult.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbeResult.java
@@ -1,0 +1,58 @@
+package mcheli.network.packets;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import mcheli.MCH_ServerTickHandler;
+import mcheli.network.PacketBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+
+/** Client resolution evidence returned to the authoritative server audit. */
+public class PacketVehicleRespawnProbeResult extends PacketBase {
+    public int generation, clientPlayerId, clientPlayerIdentity, clientWorldIdentity, renderViewIdentity, respawnAge;
+    public boolean replacementProcessed;
+    public List<Entry> vehicles = new ArrayList<Entry>();
+    public static class Entry {
+        public int expectedId, foundId = -1, objectIdentity, worldIdentity, seatCount, validSeatParents, hitboxCount, validHitboxParents;
+        public UUID expectedUuid, foundUuid;
+        public boolean foundById, foundByUuid, previouslyFound, dead, addedToChunk, collidable, renderingLod, skipNormalRender;
+        public String foundClass = "null", acInfo = "null", boundingBox = "null";
+    }
+    @Override public void encodeInto(ChannelHandlerContext c, ByteBuf d) {
+        d.writeInt(generation); d.writeInt(clientPlayerId); d.writeInt(clientPlayerIdentity); d.writeInt(clientWorldIdentity);
+        d.writeInt(renderViewIdentity); d.writeInt(respawnAge); d.writeBoolean(replacementProcessed);
+        int count = Math.min(vehicles.size(), PacketVehicleRespawnProbe.MAX_VEHICLES); d.writeShort(count);
+        for(int i=0;i<count;++i) writeEntry(d, vehicles.get(i));
+    }
+    @Override public void decodeInto(ChannelHandlerContext c, ByteBuf d) {
+        generation=d.readInt(); clientPlayerId=d.readInt(); clientPlayerIdentity=d.readInt(); clientWorldIdentity=d.readInt();
+        renderViewIdentity=d.readInt(); respawnAge=d.readInt(); replacementProcessed=d.readBoolean();
+        int count=Math.min(d.readUnsignedShort(), PacketVehicleRespawnProbe.MAX_VEHICLES); vehicles=new ArrayList<Entry>(count);
+        for(int i=0;i<count;++i) vehicles.add(readEntry(d));
+    }
+    private void writeEntry(ByteBuf d, Entry e) {
+        d.writeInt(e.expectedId); PacketVehicleRespawnProbe.writeUuid(d,e.expectedUuid); d.writeBoolean(e.foundById); d.writeBoolean(e.foundByUuid); d.writeBoolean(e.previouslyFound);
+        writeUTF(d,e.foundClass); d.writeInt(e.foundId); d.writeBoolean(e.foundUuid!=null); if(e.foundUuid!=null) PacketVehicleRespawnProbe.writeUuid(d,e.foundUuid);
+        d.writeInt(e.objectIdentity); d.writeInt(e.worldIdentity); d.writeBoolean(e.dead); d.writeBoolean(e.addedToChunk); writeUTF(d,e.acInfo);
+        d.writeBoolean(e.renderingLod); d.writeBoolean(e.skipNormalRender); d.writeBoolean(e.collidable); writeUTF(d,e.boundingBox);
+        d.writeInt(e.seatCount); d.writeInt(e.validSeatParents); d.writeInt(e.hitboxCount); d.writeInt(e.validHitboxParents);
+    }
+    private Entry readEntry(ByteBuf d) {
+        Entry e=new Entry(); e.expectedId=d.readInt(); e.expectedUuid=PacketVehicleRespawnProbe.readUuid(d); e.foundById=d.readBoolean(); e.foundByUuid=d.readBoolean(); e.previouslyFound=d.readBoolean();
+        e.foundClass=readUTF(d); e.foundId=d.readInt(); if(d.readBoolean()) e.foundUuid=PacketVehicleRespawnProbe.readUuid(d);
+        e.objectIdentity=d.readInt(); e.worldIdentity=d.readInt(); e.dead=d.readBoolean(); e.addedToChunk=d.readBoolean(); e.acInfo=readUTF(d);
+        e.renderingLod=d.readBoolean(); e.skipNormalRender=d.readBoolean(); e.collidable=d.readBoolean(); e.boundingBox=readUTF(d);
+        e.seatCount=d.readInt(); e.validSeatParents=d.readInt(); e.hitboxCount=d.readInt(); e.validHitboxParents=d.readInt(); return e;
+    }
+    @Override public void handleServerSide(final EntityPlayerMP player) {
+        final PacketVehicleRespawnProbeResult result=this;
+        MinecraftServer.getServer().func_152344_a(new Runnable(){ @Override public void run(){ MCH_ServerTickHandler.acceptProbeResult(player,result); }});
+    }
+    @Override @SideOnly(Side.CLIENT) public void handleClientSide(EntityPlayer player) {}
+}


### PR DESCRIPTION
### Motivation

- Server-side tracker membership alone was a false success condition because parent spawn packets can arrive before the client replacement world is ready (enabled by `forceSpawn=true`), causing the client to discard those entities during respawn and leaving normal vehicles invisible/uninteractable.
- The change implements a server-authoritative, client-confirmed audit and a narrowly targeted resend path so missing parents are repaired without global tracker rebuilds or broad mutations.

### Description

- Added `PacketVehicleRespawnProbe` and `PacketVehicleRespawnProbeResult` to probe the replacement client on the Minecraft client thread (via `Minecraft.func_152344_a`), resolve expected parents by ID and UUID, and return detailed lifecycle, rendering, collision, seat, and hitbox state to the server. (new files `src/main/java/mcheli/network/packets/PacketVehicleRespawnProbe*.java` and registration in `PacketHandler`.)
- Reworked `MCH_ServerTickHandler` to keep per-respawn `TrackingRefresh` records (generation keyed), inventory nearby normal parent vehicles (exclude UAV/NewUAV), send bounded probes at ticks 1,5,10,20,40,60 (and after repairs), classify client/server divergences, and only mark success after client confirmation. (updated `src/main/java/mcheli/MCH_ServerTickHandler.java`.)
- Implemented a targeted resend repair that removes only the exact replacement player object from a missing parent’s `EntityTrackerEntry`, asks the same entry to retrack the original server entity, resends the parent before dependents (seats/hitboxes), preserves entity ID/UUID/instance, and rate-limits to two resend attempts per parent per generation. (server-side logic and reflected `EntityTrackerEntry` lookup.)
- Improved audit logging and client-side auditing: added `chunkReady`, `premature`, and `forceSpawn` fields to start/stop tracking logs, added bounded client world-unload vehicle logging, and exposed the client respawn-audit age to the probe handler. (updates to `MCH_EventHook`, `MCH_ClientEventHook`, `MCH_ClientCommonTickHandler`, and docs.)
- Documented the diagnosis, protocol, retry/packet limits, and the reason for preserving `forceSpawn=true` in `docs/vehicle-respawn-tracking.md` and added an entry to `changelog.md`.

### Testing

- Ran `git diff --check` which passed.
- Ran repository validation scripts: `python3 tools/validate_config_weights.py` passed and `python3 tools/validate_plane_config_surface.py` reported a pre-existing failure (removed keys in `configreference/planes/b-21.txt`).
- Did not run a Java/Gradle compile in this environment and did not perform the dedicated Forge server + two-client runtime matrix; no runtime assertions are claimed here and the change requires the full dedicated-server/two-client verification described in the updated docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cd340bbd083238170b165b869122b)