### PR TITLE
PR #597 - Correct normal-vehicle respawn repair identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## PR #597 - Correct Normal-Vehicle Respawn Repair Identity
+
+- Treat Forge numeric entity IDs plus MCHeli type, dimension, bounded position, and synchronized non-empty common ID as vehicle identity; keep vanilla UUID comparisons diagnostic.
+- Gate client readiness on the replacement player/world runtime objects and defer bounded parent-first tracker resends until the replacement watches the vehicle chunk.
+- Preserve age-60 probe results through an age-80 timeout and clear generation-scoped client resolution history on world unload.
+- Compilation passed; the required two-client graphical runtime verification remains outstanding, so runtime success is not claimed.
+
 ## PR #595 - Forge 1.7.10 Respawn Probe API Corrections
 
 - Corrected PR #595's incompatible `EntityTrackerEntry.removeFromTrackedPlayers` call to Forge 1.7.10's `EntityTrackerEntry.removeFromWatchingList` while retaining the normal `tryStartWachingThis` retrack path.

--- a/docs/vehicle-respawn-tracking.md
+++ b/docs/vehicle-respawn-tracking.md
@@ -1,3 +1,21 @@
+# PR #597 - Runtime-correct respawn identity and delayed targeted repair
+
+Commit `04542189dc3b28f9073d7e7ea40ed6f2f8edfe1d` (PR #596) did not fix the runtime issue. The supplied runtime log is authoritative: normal parent IDs 63, 198, and 6125 all started tracking while their chunks were not ready because `forceSpawn=true`. The first client probe nevertheless found the correct MCHeli objects, numeric IDs, classes, and aircraft types. Their vanilla client entity UUIDs differed from the server UUIDs. The failed probe called those differences ID collisions, required the replacement player's client UUID to equal its server UUID, consequently left replacement readiness false, prevented every targeted resend, and deleted the audit at age 60 before processing the final result.
+
+## Corrected client readiness and vehicle identity
+
+Replacement readiness now requires the current Minecraft player and world references, the replacement numeric player ID, the server dimension, object identity with the player observed by `MCH_ClientCommonTickHandler`, and a client respawn audit age of at least one tick. The server player UUID remains in the probe and its match is logged as diagnostic evidence only.
+
+A normal parent is resolved primarily with `WorldClient.getEntityByID`. Confirmation requires an MCHeli base vehicle at that ID, matching aircraft-info type, probe dimension, current client world, a position within 32 blocks, a live entity, usable aircraft info, normal rendering and collision state, and valid seat/hitbox parent references. Vanilla entity UUID agreement is diagnostic only and cannot create an ID-collision classification. Missing-after-create history is bounded to the current respawn generation and numeric entity IDs and is cleared on world unload.
+
+`commonUniqueId` was inspected rather than assumed: `MCH_EntityBaseVehicle.writeSpawnData` writes it and `readSpawnData` installs it on the spawned client vehicle. The probe therefore carries a non-empty server common ID as an additional synchronized MCHeli identity check; empty IDs do not block the numeric-ID/type/dimension/position rules. This is distinct from vanilla `Entity.getUniqueID()`.
+
+## Delayed targeted repair and timeout
+
+A ready client report of a genuinely missing or collided parent marks that parent repair-pending. The next server tick keeps it pending until the exact replacement player remains active, the original server vehicle remains alive, and `PlayerManager.isPlayerWatchingChunk` is true. It then removes the exact watcher object by identity (Forge 1.7.10's `HashSet.contains/remove` path uses equality), invokes the normal tracker removal/re-add path, verifies exact membership, resends the original parent before only its own seats and hitboxes, and schedules a post-resend probe. Confirmed parents are not retracked, UAV/NewUAV parents remain excluded, and each parent is limited to two attempts.
+
+Probe ages remain 1, 5, 10, 20, 40, and 60, but the hard timeout is age 80. Thus the age-60 response has a 20-tick processing window and is not made stale by same-tick audit deletion. LOD snapshots remain render-only and excluded inside 200 blocks. A full two-client graphical respawn test is still required; this source change does not claim runtime success.
+
 # Normal vehicle tracking across player respawn
 
 ## Proven evidence and diagnosis

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -117,6 +117,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       return instance == null ? -1 : instance.auditRespawnTicks;
    }
 
+   public static boolean isRespawnAuditPlayer(EntityClientPlayerMP player) {
+      return instance != null && instance.auditPlayer == player;
+   }
+
 
 
    public MCH_ClientCommonTickHandler(Minecraft minecraft, MCH_Config config) {

--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -183,6 +183,7 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
                Integer.valueOf(mcheli.network.packets.PacketVehicleRespawnProbe.getClientGeneration()));
          }
       }
+      mcheli.network.packets.PacketVehicleRespawnProbe.clearClientResolutionState();
       MCH_ViewEntityDummy.onUnloadWorld();
       MCH_MOD.proxy.clearVehicleLODSnapshots();
       MCH_BaseVehiclePacketHandler.clearPendingMounts();

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -46,12 +46,13 @@ public class MCH_ServerTickHandler {
    private static final int MAX_ENTRIES = 512;
    /** Must match the normal vehicle/seat registration range in MCH_MOD. */
    private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
-   private static final int TRACKING_REFRESH_TIMEOUT_TICKS = 60;
+   private static final int TRACKING_REFRESH_TIMEOUT_TICKS = 80;
    private static int nextRespawnGeneration;
    private static final Queue<PendingProbeResult> PENDING_PROBE_RESULTS =
       new ConcurrentLinkedQueue<PendingProbeResult>();
    private final Map<String, TrackingRefresh> pendingTrackingRefreshes = new HashMap<String, TrackingRefresh>();
    private int tick;
+   private long respawnAuditTick;
 
    private static final class PendingProbeResult {
       final EntityPlayerMP player;
@@ -115,13 +116,14 @@ public class MCH_ServerTickHandler {
                if(containsPlayerInstance(new ArrayList<Object>(watchers), player)) {
                   ++trackedVehicles;
                }
-               if(!refresh.expected.containsKey(vehicle.getUniqueID()))
-                  refresh.expected.put(vehicle.getUniqueID(), new ExpectedVehicle(vehicle, !chunkReady));
+               if(!refresh.expected.containsKey(Integer.valueOf(vehicle.getEntityId())))
+                  refresh.expected.put(Integer.valueOf(vehicle.getEntityId()), new ExpectedVehicle(vehicle, !chunkReady));
             }
          }
          if(refresh.age == 1 || refresh.age == 5 || refresh.age == 20 || refresh.age == 40)
             MCH_Lib.RespawnAuditLog("readiness player=%s age=%d nearby=%d chunkReady=%d tracked=%d",
                player.getCommandSenderName(), Integer.valueOf(refresh.age), Integer.valueOf(nearbyVehicles), Integer.valueOf(readyChunks), Integer.valueOf(trackedVehicles));
+         this.executePendingRepairs(refresh, world);
          if(shouldSendProbe(refresh.age) || refresh.probeRequested) {
             refresh.probeRequested = false;
             this.sendProbe(refresh);
@@ -147,8 +149,8 @@ public class MCH_ServerTickHandler {
       int age;
       int attempts;
       final int generation;
-      final Map<java.util.UUID, ExpectedVehicle> expected = new HashMap<java.util.UUID, ExpectedVehicle>();
-      boolean confirmedAll, probeRequested, resultReceived;
+      final Map<Integer, ExpectedVehicle> expected = new HashMap<Integer, ExpectedVehicle>();
+      boolean confirmedAll, probeRequested, resultReceived, replacementReady;
       TrackingRefresh(EntityPlayerMP player, String reason, int generation) { this.player = player; this.reason = reason; this.generation = generation; }
    }
 
@@ -156,6 +158,9 @@ public class MCH_ServerTickHandler {
       final MCH_EntityBaseVehicle vehicle;
       final boolean premature;
       int resendAttempts;
+      boolean clientReportedMissing, clientReportedCollision, clientConfirmed, repairPending;
+      long repairNotBeforeTick;
+      String lastClassification = "not-probed";
       ExpectedVehicle(MCH_EntityBaseVehicle vehicle, boolean premature) { this.vehicle = vehicle; this.premature = premature; }
    }
 
@@ -173,6 +178,7 @@ public class MCH_ServerTickHandler {
          PacketVehicleRespawnProbe.Entry entry = new PacketVehicleRespawnProbe.Entry();
          entry.entityId=vehicle.getEntityId(); entry.uuid=vehicle.getUniqueID();
          entry.typeName=vehicle.getAcInfo()==null?vehicle.getClass().getSimpleName():vehicle.getAcInfo().name;
+         entry.commonUniqueId=vehicle.getCommonUniqueId()==null?"":vehicle.getCommonUniqueId();
          entry.x=vehicle.posX; entry.y=vehicle.posY; entry.z=vehicle.posZ; entry.chunkX=vehicle.chunkCoordX; entry.chunkZ=vehicle.chunkCoordZ;
          packet.vehicles.add(entry);
       }
@@ -213,74 +219,131 @@ public class MCH_ServerTickHandler {
 
    private void handleProbeResult(EntityPlayerMP player, PacketVehicleRespawnProbeResult result) {
       TrackingRefresh refresh = null;
-      for(TrackingRefresh candidate : this.pendingTrackingRefreshes.values())
-         if(candidate.player == player && candidate.generation == result.generation) { refresh = candidate; break; }
-      if(refresh == null) {
-         MCH_Lib.RespawnAuditLog("probe-result-stale generation=%d playerId=%d", Integer.valueOf(result.generation), Integer.valueOf(player.getEntityId())); return;
+      for(TrackingRefresh candidate : this.pendingTrackingRefreshes.values()) {
+         if(candidate.player == player && candidate.generation == result.generation) {
+            refresh = candidate;
+            break;
+         }
       }
-      boolean all = result.replacementProcessed;
+      if(refresh == null) {
+         MCH_Lib.RespawnAuditLog("probe-result-stale generation=%d playerId=%d", Integer.valueOf(result.generation), Integer.valueOf(player.getEntityId()));
+         return;
+      }
       refresh.resultReceived = true;
-      MCH_Lib.RespawnAuditLog("probe-result generation=%d ready=%s clientPlayer=%d playerObject=%x world=%x view=%x age=%d vehicles=%d",
-         Integer.valueOf(result.generation), Boolean.valueOf(result.replacementProcessed), Integer.valueOf(result.clientPlayerId),
-         Integer.valueOf(result.clientPlayerIdentity), Integer.valueOf(result.clientWorldIdentity), Integer.valueOf(result.renderViewIdentity),
-         Integer.valueOf(result.respawnAge), Integer.valueOf(result.vehicles.size()));
-      if(!result.replacementProcessed)
+      refresh.replacementReady = result.replacementProcessed;
+      boolean all = result.replacementProcessed;
+      MCH_Lib.RespawnAuditLog("probe-result generation=%d ready=%s playerPresent=%s worldPresent=%s playerIdMatches=%s playerUuidDiagnostic=%s dimensionMatches=%s auditPlayerMatches=%s respawnAgeReady=%s age=%d vehicles=%d",
+         Integer.valueOf(result.generation), Boolean.valueOf(result.replacementProcessed), Boolean.valueOf(result.playerPresent), Boolean.valueOf(result.worldPresent),
+         Boolean.valueOf(result.playerIdMatches), Boolean.valueOf(result.playerUuidMatchesDiagnostic), Boolean.valueOf(result.dimensionMatches),
+         Boolean.valueOf(result.auditPlayerMatches), Boolean.valueOf(result.respawnAgeReady), Integer.valueOf(result.respawnAge), Integer.valueOf(result.vehicles.size()));
+      if(!result.playerPresent || !result.worldPresent) {
          MCH_Lib.RespawnAuditLog("probe-divergence generation=%d classification=2-probe-before-replacement-world", Integer.valueOf(result.generation));
+      }
       for(PacketVehicleRespawnProbeResult.Entry entry : result.vehicles) {
-         ExpectedVehicle expected = refresh.expected.get(entry.expectedUuid);
-         String classification = classify(entry);
-         boolean correct = entry.foundByUuid && entry.foundId == entry.expectedId && entry.expectedUuid.equals(entry.foundUuid)
-            && !entry.dead && entry.addedToChunk && !"null".equals(entry.acInfo) && entry.collidable
-            && !entry.skipNormalRender && entry.validSeatParents == entry.seatCount && entry.validHitboxParents >= entry.hitboxCount;
+         ExpectedVehicle expected = refresh.expected.get(Integer.valueOf(entry.expectedId));
+         String classification = classify(entry, result.respawnAge);
+         boolean correct = "confirmed".equals(classification);
          all &= correct;
-         MCH_Lib.RespawnAuditLog("probe-vehicle generation=%d expectedId=%d expectedUuid=%s class=%s foundId=%d foundUuid=%s object=%x world=%x dead=%s chunk=%s acInfo=%s lod=%s skip=%s collide=%s box=%s seats=%d/%d hitboxes=%d/%d classification=%s",
-            Integer.valueOf(result.generation), Integer.valueOf(entry.expectedId), entry.expectedUuid, entry.foundClass, Integer.valueOf(entry.foundId), entry.foundUuid,
-            Integer.valueOf(entry.objectIdentity), Integer.valueOf(entry.worldIdentity), Boolean.valueOf(entry.dead), Boolean.valueOf(entry.addedToChunk), entry.acInfo,
-            Boolean.valueOf(entry.renderingLod), Boolean.valueOf(entry.skipNormalRender), Boolean.valueOf(entry.collidable), entry.boundingBox,
-            Integer.valueOf(entry.validSeatParents), Integer.valueOf(entry.seatCount), Integer.valueOf(entry.validHitboxParents), Integer.valueOf(entry.hitboxCount), classification);
-         if(result.replacementProcessed && expected != null && ("3-missing-entity".equals(classification)
-            || "4-id-collision".equals(classification) || "5-removed-after-create".equals(classification)))
-            this.targetedResend(refresh, expected);
+         MCH_Lib.RespawnAuditLog("probe-vehicle generation=%d expectedId=%d expectedType=%s serverUuid=%s class=%s foundId=%d foundType=%s clientUuidDiagnostic=%s uuidMatchesDiagnostic=%s positionDelta=%.2f previouslyConfirmedById=%s chunk=%s repairPending=%s classification=%s",
+            Integer.valueOf(result.generation), Integer.valueOf(entry.expectedId), entry.expectedType, entry.expectedUuid, entry.foundClass,
+            Integer.valueOf(entry.foundId), entry.foundType, entry.foundUuid, Boolean.valueOf(entry.uuidMatchesDiagnostic),
+            Double.valueOf(Math.sqrt(entry.positionDeltaSq)), Boolean.valueOf(entry.previouslyFound), Boolean.valueOf(entry.addedToChunk),
+            Boolean.valueOf(expected != null && expected.repairPending), classification);
+         if(expected != null) {
+            expected.lastClassification = classification;
+            expected.clientConfirmed = correct;
+            if(correct) {
+               expected.repairPending = false;
+            } else if(result.replacementProcessed && ("3-missing-entity".equals(classification) || "4-id-collision".equals(classification) || "5-removed-after-create".equals(classification))) {
+               expected.clientReportedMissing |= !entry.foundById;
+               expected.clientReportedCollision |= "4-id-collision".equals(classification);
+               expected.repairPending = expected.resendAttempts < 2;
+               expected.repairNotBeforeTick = this.respawnAuditTick + 1L;
+               MCH_Lib.RespawnAuditLog("repair-pending generation=%d vehicleId=%d classification=%s pending=%s",
+                  Integer.valueOf(refresh.generation), Integer.valueOf(entry.expectedId), classification, Boolean.valueOf(expected.repairPending));
+            }
+         }
       }
       refresh.confirmedAll = all && result.vehicles.size() == refresh.expected.size();
    }
 
-   private static String classify(PacketVehicleRespawnProbeResult.Entry e) {
-      if(!e.foundById && !e.foundByUuid && e.previouslyFound) return "5-removed-after-create";
-      if(!e.foundById && !e.foundByUuid) return "3-missing-entity";
-      if(e.foundById && !e.foundByUuid) return "4-id-collision";
-      if(e.dead) return "6-dead"; if(!e.addedToChunk) return "7-not-in-chunk"; if("null".equals(e.acInfo)) return "8-no-ac-info";
-      if(e.skipNormalRender) return "9-render-skipped"; if(!e.collidable || "null".equals(e.boundingBox)) return "10-invalid-collision";
+   private static String classify(PacketVehicleRespawnProbeResult.Entry e, int respawnAge) {
+      if(!e.foundById && e.previouslyFound) return "5-removed-after-create";
+      if(!e.foundById) return "3-missing-entity";
+      if(!e.baseVehicle || e.foundId != e.expectedId || !e.typeMatches || !e.dimensionMatches || !e.positionMatches || !e.currentWorld || !e.commonIdMatches) return "4-id-collision";
+      if(e.dead) return "6-dead";
+      if(!e.addedToChunk && respawnAge >= 10) return "7-not-in-chunk";
+      if("null".equals(e.foundType)) return "8-no-ac-info";
+      if(e.skipNormalRender) return "9-render-skipped";
+      if(!e.collidable || "null".equals(e.boundingBox)) return "10-invalid-collision";
       if(e.validSeatParents != e.seatCount || e.validHitboxParents < e.hitboxCount) return "11-invalid-dependent-parent";
       return "confirmed";
    }
 
-   private void targetedResend(TrackingRefresh refresh, ExpectedVehicle expected) {
-      if(expected.resendAttempts >= 2 || expected.vehicle.isDead) return;
-      EntityTrackerEntry parentEntry = trackerEntry((WorldServer)refresh.player.worldObj, expected.vehicle.getEntityId());
-      if(parentEntry == null) { MCH_Lib.RespawnAuditLog("resend-no-entry generation=%d vehicleId=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId())); return; }
-      ++expected.resendAttempts; ++refresh.attempts;
-      parentEntry.removeFromWatchingList(refresh.player);
-      parentEntry.tryStartWachingThis(refresh.player);
-      for(Object object : refresh.player.worldObj.loadedEntityList) {
+   private void executePendingRepairs(TrackingRefresh refresh, WorldServer world) {
+      for(ExpectedVehicle expected : refresh.expected.values()) {
+         if(!expected.repairPending || expected.clientConfirmed || expected.resendAttempts >= 2) continue;
+         if(this.respawnAuditTick < expected.repairNotBeforeTick) continue;
+         if(!refresh.replacementReady || refresh.player.isDead || refresh.player.worldObj != world || !containsPlayerInstance(world.playerEntities, refresh.player)) continue;
+         if(expected.vehicle.isDead || expected.vehicle.worldObj != world) {
+            expected.repairPending = false;
+            continue;
+         }
+         if(!world.getPlayerManager().isPlayerWatchingChunk(refresh.player, expected.vehicle.chunkCoordX, expected.vehicle.chunkCoordZ)) {
+            MCH_Lib.RespawnAuditLog("repair-wait generation=%d vehicleId=%d reason=chunk-not-watched", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()));
+            continue;
+         }
+         this.targetedResend(refresh, expected, world);
+      }
+   }
+
+   private void targetedResend(TrackingRefresh refresh, ExpectedVehicle expected, WorldServer world) {
+      EntityTrackerEntry parentEntry = trackerEntry(world, expected.vehicle.getEntityId());
+      if(parentEntry == null) {
+         MCH_Lib.RespawnAuditLog("resend-no-entry generation=%d vehicleId=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()));
+         return;
+      }
+      ++expected.resendAttempts; ++refresh.attempts; expected.repairPending = false;
+      removeAndReaddWatcher(parentEntry, refresh.player, refresh.generation, expected.vehicle.getEntityId());
+      MCH_Lib.RespawnAuditLog("targeted-resend generation=%d vehicleId=%d attempt=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()), Integer.valueOf(expected.resendAttempts));
+      for(Object object : world.loadedEntityList) {
          boolean dependent = object instanceof MCH_EntitySeat && ((MCH_EntitySeat)object).getParent() == expected.vehicle
             || object instanceof MCH_EntityHitBox && ((MCH_EntityHitBox)object).parent == expected.vehicle;
          if(dependent) {
-            Entity dependentEntity = (Entity)object;
-            EntityTrackerEntry entry = trackerEntry(
-               (WorldServer)refresh.player.worldObj,
-               dependentEntity.getEntityId());
-
+            Entity entity = (Entity)object;
+            EntityTrackerEntry entry = trackerEntry(world, entity.getEntityId());
             if(entry != null) {
-               entry.removeFromWatchingList(refresh.player);
-               entry.tryStartWachingThis(refresh.player);
+               removeAndReaddWatcher(entry, refresh.player, refresh.generation, entity.getEntityId());
+               MCH_Lib.RespawnAuditLog("dependent-resend generation=%d parentId=%d dependentId=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()), Integer.valueOf(entity.getEntityId()));
             }
          }
       }
       refresh.probeRequested = true;
-      MCH_Lib.RespawnAuditLog("targeted-resend generation=%d vehicleId=%d uuid=%s attempt=%d premature=%s",
-         Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()), expected.vehicle.getUniqueID(),
-         Integer.valueOf(expected.resendAttempts), Boolean.valueOf(expected.premature));
+      MCH_Lib.RespawnAuditLog("post-resend-probe generation=%d vehicleId=%d", Integer.valueOf(refresh.generation), Integer.valueOf(expected.vehicle.getEntityId()));
+   }
+
+   private static void removeAndReaddWatcher(EntityTrackerEntry entry, EntityPlayerMP player, int generation, int vehicleId) {
+      Set watchers = ObfuscationReflectionHelper.getPrivateValue(EntityTrackerEntry.class, entry, "trackingPlayers", "field_73134_o");
+      int before = watchers == null ? -1 : watchers.size();
+      boolean exactRemoved = false;
+      if(watchers != null) {
+         Iterator iterator = watchers.iterator();
+         while(iterator.hasNext()) {
+            if(iterator.next() == player) {
+               iterator.remove(); exactRemoved = true; break;
+            }
+         }
+      } else {
+         MCH_Lib.RespawnAuditLog("watcher-reflection-failure generation=%d vehicleId=%d", Integer.valueOf(generation), Integer.valueOf(vehicleId));
+      }
+      entry.removeFromWatchingList(player);
+      if(exactRemoved) player.func_152339_d(entry.myEntity);
+      int after = watchers == null ? -1 : watchers.size();
+      MCH_Lib.RespawnAuditLog("watcher-remove generation=%d vehicleId=%d exactRemoved=%s watchersBefore=%d watchersAfter=%d", Integer.valueOf(generation), Integer.valueOf(vehicleId), Boolean.valueOf(exactRemoved), Integer.valueOf(before), Integer.valueOf(after));
+      entry.tryStartWachingThis(player);
+      boolean exactPresent = false;
+      if(watchers != null) for(Object watcher : watchers) if(watcher == player) { exactPresent = true; break; }
+      MCH_Lib.RespawnAuditLog("watcher-readd generation=%d vehicleId=%d exactPresent=%s", Integer.valueOf(generation), Integer.valueOf(vehicleId), Boolean.valueOf(exactPresent));
    }
 
    private static EntityTrackerEntry trackerEntry(WorldServer world, int entityId) {
@@ -300,6 +363,7 @@ public class MCH_ServerTickHandler {
       if(event.phase != Phase.END) {
          return;
       }
+      ++this.respawnAuditTick;
       this.processPendingProbeResults();
       this.refreshPendingPlayerTracking();
       if(++this.tick < UPDATE_INTERVAL_TICKS) return;

--- a/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbe.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbe.java
@@ -5,10 +5,11 @@ import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_Lib;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
@@ -22,17 +23,20 @@ import net.minecraft.util.AxisAlignedBB;
 /** A bounded, server-authored inventory of real vehicles expected after respawn. */
 public class PacketVehicleRespawnProbe extends PacketBase {
     public static final int MAX_VEHICLES = 128;
+    private static final double POSITION_TOLERANCE_SQ = 32.0D * 32.0D;
     public int generation, playerId, dimension, serverWorldIdentity;
     public UUID playerUuid = new UUID(0L, 0L);
     public List<Entry> vehicles = new ArrayList<Entry>();
     private static int clientGeneration;
-    private static final Set<UUID> previouslyResolved = new HashSet<UUID>();
+    private static final Set<Integer> previouslyResolvedIds = new HashSet<Integer>();
+
     public static int getClientGeneration() { return clientGeneration; }
+    public static void clearClientResolutionState() { clientGeneration = 0; previouslyResolvedIds.clear(); }
 
     public static class Entry {
         public int entityId, chunkX, chunkZ;
         public UUID uuid;
-        public String typeName;
+        public String typeName, commonUniqueId = "";
         public double x, y, z;
     }
 
@@ -40,11 +44,10 @@ public class PacketVehicleRespawnProbe extends PacketBase {
     public void encodeInto(ChannelHandlerContext context, ByteBuf data) {
         data.writeInt(generation); data.writeInt(playerId); writeUuid(data, playerUuid);
         data.writeInt(dimension); data.writeInt(serverWorldIdentity);
-        int count = Math.min(vehicles.size(), MAX_VEHICLES);
-        data.writeShort(count);
+        int count = Math.min(vehicles.size(), MAX_VEHICLES); data.writeShort(count);
         for(int i = 0; i < count; ++i) {
             Entry entry = vehicles.get(i);
-            data.writeInt(entry.entityId); writeUuid(data, entry.uuid); writeUTF(data, entry.typeName);
+            data.writeInt(entry.entityId); writeUuid(data, entry.uuid); writeUTF(data, entry.typeName); writeUTF(data, entry.commonUniqueId);
             data.writeDouble(entry.x); data.writeDouble(entry.y); data.writeDouble(entry.z);
             data.writeInt(entry.chunkX); data.writeInt(entry.chunkZ);
         }
@@ -54,11 +57,10 @@ public class PacketVehicleRespawnProbe extends PacketBase {
     public void decodeInto(ChannelHandlerContext context, ByteBuf data) {
         generation = data.readInt(); playerId = data.readInt(); playerUuid = readUuid(data);
         dimension = data.readInt(); serverWorldIdentity = data.readInt();
-        int count = Math.min(data.readUnsignedShort(), MAX_VEHICLES);
-        vehicles = new ArrayList<Entry>(count);
+        int count = Math.min(data.readUnsignedShort(), MAX_VEHICLES); vehicles = new ArrayList<Entry>(count);
         for(int i = 0; i < count; ++i) {
             Entry entry = new Entry();
-            entry.entityId = data.readInt(); entry.uuid = readUuid(data); entry.typeName = readUTF(data);
+            entry.entityId = data.readInt(); entry.uuid = readUuid(data); entry.typeName = readUTF(data); entry.commonUniqueId = readUTF(data);
             entry.x = data.readDouble(); entry.y = data.readDouble(); entry.z = data.readDouble();
             entry.chunkX = data.readInt(); entry.chunkZ = data.readInt(); vehicles.add(entry);
         }
@@ -66,8 +68,7 @@ public class PacketVehicleRespawnProbe extends PacketBase {
 
     @Override public void handleServerSide(EntityPlayerMP player) {}
 
-    @Override
-    @SideOnly(Side.CLIENT)
+    @Override @SideOnly(Side.CLIENT)
     public void handleClientSide(EntityPlayer ignored) {
         final PacketVehicleRespawnProbe packet = this;
         Minecraft.getMinecraft().func_152344_a(new Runnable() {
@@ -77,59 +78,61 @@ public class PacketVehicleRespawnProbe extends PacketBase {
 
     @SideOnly(Side.CLIENT)
     private void inspectClientWorld() {
-        clientGeneration = generation;
+        if(generation != clientGeneration) {
+            previouslyResolvedIds.clear();
+            clientGeneration = generation;
+        }
         Minecraft mc = Minecraft.getMinecraft();
         PacketVehicleRespawnProbeResult result = new PacketVehicleRespawnProbeResult();
         result.generation = generation;
-        result.clientPlayerId = mc.thePlayer == null ? -1 : mc.thePlayer.getEntityId();
+        result.playerPresent = mc.thePlayer != null;
+        result.worldPresent = mc.theWorld != null;
+        result.playerIdMatches = result.playerPresent && mc.thePlayer.getEntityId() == playerId;
+        result.playerUuidMatchesDiagnostic = result.playerPresent && playerUuid.equals(mc.thePlayer.getUniqueID());
+        result.dimensionMatches = result.worldPresent && mc.theWorld.provider.dimensionId == dimension;
+        result.auditPlayerMatches = result.playerPresent && MCH_ClientCommonTickHandler.isRespawnAuditPlayer(mc.thePlayer);
+        result.respawnAge = MCH_ClientCommonTickHandler.getRespawnAuditAge();
+        result.respawnAgeReady = result.respawnAge >= 1;
+        result.replacementProcessed = result.playerPresent && result.worldPresent && result.playerIdMatches
+            && result.dimensionMatches && result.auditPlayerMatches && result.respawnAgeReady;
+        result.clientPlayerId = result.playerPresent ? mc.thePlayer.getEntityId() : -1;
         result.clientPlayerIdentity = System.identityHashCode(mc.thePlayer);
         result.clientWorldIdentity = System.identityHashCode(mc.theWorld);
         result.renderViewIdentity = System.identityHashCode(mc.renderViewEntity);
-        result.respawnAge = mcheli.MCH_ClientCommonTickHandler.getRespawnAuditAge();
-        result.replacementProcessed = mc.thePlayer != null && mc.theWorld != null
-            && mc.thePlayer.getEntityId() == playerId && playerUuid.equals(mc.thePlayer.getUniqueID())
-            && mc.theWorld.provider.dimensionId == dimension;
-        for(Entry expected : vehicles) result.vehicles.add(inspect(expected, mc));
-        MCH_Lib.RespawnAuditLog("client-probe generation=%d ready=%s playerId=%d world=%x vehicles=%d",
-            Integer.valueOf(generation), Boolean.valueOf(result.replacementProcessed), Integer.valueOf(result.clientPlayerId),
-            Integer.valueOf(result.clientWorldIdentity), Integer.valueOf(result.vehicles.size()));
+        for(Entry expected : vehicles) result.vehicles.add(inspect(expected, mc, dimension));
+        MCH_Lib.RespawnAuditLog("client-readiness generation=%d playerPresent=%s worldPresent=%s playerIdMatches=%s playerUuidDiagnostic=%s dimensionMatches=%s auditPlayerMatches=%s respawnAgeReady=%s ready=%s",
+            Integer.valueOf(generation), Boolean.valueOf(result.playerPresent), Boolean.valueOf(result.worldPresent), Boolean.valueOf(result.playerIdMatches),
+            Boolean.valueOf(result.playerUuidMatchesDiagnostic), Boolean.valueOf(result.dimensionMatches), Boolean.valueOf(result.auditPlayerMatches),
+            Boolean.valueOf(result.respawnAgeReady), Boolean.valueOf(result.replacementProcessed));
         MCH_MOD.getPacketHandler().sendToServer(result);
     }
 
     @SideOnly(Side.CLIENT)
-    private static PacketVehicleRespawnProbeResult.Entry inspect(Entry expected, Minecraft mc) {
+    private static PacketVehicleRespawnProbeResult.Entry inspect(Entry expected, Minecraft mc, int probeDimension) {
         PacketVehicleRespawnProbeResult.Entry out = new PacketVehicleRespawnProbeResult.Entry();
-        out.expectedId = expected.entityId; out.expectedUuid = expected.uuid;
-        Entity byId = mc.theWorld == null ? null : mc.theWorld.getEntityByID(expected.entityId);
-        Entity byUuid = null;
-        if(mc.theWorld != null) for(Object value : mc.theWorld.loadedEntityList) {
-            Entity entity = (Entity)value;
-            if(expected.uuid.equals(entity.getUniqueID())) { byUuid = entity; break; }
-        }
-        out.foundById = byId != null; out.foundByUuid = byUuid != null;
-        out.previouslyFound = previouslyResolved.contains(expected.uuid);
-        if(byUuid != null) previouslyResolved.add(expected.uuid);
-        Entity found = byUuid != null ? byUuid : byId;
+        out.expectedId = expected.entityId; out.expectedUuid = expected.uuid; out.expectedType = expected.typeName;
+        Entity found = mc.theWorld == null ? null : mc.theWorld.getEntityByID(expected.entityId);
+        out.foundById = found != null; out.previouslyFound = previouslyResolvedIds.contains(Integer.valueOf(expected.entityId));
         if(found != null) {
-            out.foundClass = found.getClass().getName(); out.foundId = found.getEntityId();
-            out.foundUuid = found.getUniqueID(); out.objectIdentity = System.identityHashCode(found);
-            out.worldIdentity = System.identityHashCode(found.worldObj); out.dead = found.isDead;
-            out.addedToChunk = found.addedToChunk; out.collidable = found.canBeCollidedWith();
+            out.foundClass = found.getClass().getName(); out.foundId = found.getEntityId(); out.foundUuid = found.getUniqueID();
+            out.uuidMatchesDiagnostic = expected.uuid.equals(out.foundUuid); out.objectIdentity = System.identityHashCode(found);
+            out.worldIdentity = System.identityHashCode(found.worldObj); out.currentWorld = found.worldObj == mc.theWorld;
+            out.dimensionMatches = found.dimension == probeDimension; out.dead = found.isDead; out.addedToChunk = found.addedToChunk;
+            out.collidable = found.canBeCollidedWith();
+            double dx = found.posX - expected.x, dy = found.posY - expected.y, dz = found.posZ - expected.z;
+            out.positionDeltaSq = dx * dx + dy * dy + dz * dz; out.positionMatches = out.positionDeltaSq <= POSITION_TOLERANCE_SQ;
             AxisAlignedBB box = found.getBoundingBox();
-            out.boundingBox = box == null ? "null" : String.format(java.util.Locale.ROOT, "%.2f,%.2f,%.2f..%.2f,%.2f,%.2f",
-                box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
+            out.boundingBox = box == null ? "null" : String.format(java.util.Locale.ROOT, "%.2f,%.2f,%.2f..%.2f,%.2f,%.2f", box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
         }
         if(found instanceof MCH_EntityBaseVehicle) {
             MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)found;
-            out.acInfo = vehicle.getAcInfo() == null ? "null" : vehicle.getAcInfo().name;
-            out.renderingLod = vehicle.isRenderingLOD; out.skipNormalRender = vehicle.isSkipNormalRender();
-            out.seatCount = vehicle.getSeats().length;
+            out.baseVehicle = true; out.foundType = vehicle.getAcInfo() == null ? "null" : vehicle.getAcInfo().name;
+            out.typeMatches = expected.typeName.equals(out.foundType); out.commonUniqueId = vehicle.getCommonUniqueId() == null ? "" : vehicle.getCommonUniqueId();
+            out.commonIdMatches = expected.commonUniqueId.length() == 0 || expected.commonUniqueId.equals(out.commonUniqueId);
+            out.renderingLod = vehicle.isRenderingLOD; out.skipNormalRender = vehicle.isSkipNormalRender(); out.seatCount = vehicle.getSeats().length;
             for(mcheli.aircraft.MCH_EntitySeat seat : vehicle.getSeats()) if(seat != null && seat.getParent() == vehicle) ++out.validSeatParents;
-            for(Object entity : mc.theWorld.loadedEntityList) {
-                if(entity instanceof mcheli.aircraft.MCH_EntityHitBox && ((mcheli.aircraft.MCH_EntityHitBox)entity).parent == vehicle) {
-                    ++out.hitboxCount; ++out.validHitboxParents;
-                }
-            }
+            for(Object entity : mc.theWorld.loadedEntityList) if(entity instanceof mcheli.aircraft.MCH_EntityHitBox && ((mcheli.aircraft.MCH_EntityHitBox)entity).parent == vehicle) { ++out.hitboxCount; ++out.validHitboxParents; }
+            if(out.foundId == expected.entityId && out.typeMatches && out.dimensionMatches && out.positionMatches && out.currentWorld && out.commonIdMatches) previouslyResolvedIds.add(Integer.valueOf(expected.entityId));
         }
         return out;
     }

--- a/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbeResult.java
+++ b/src/main/java/mcheli/network/packets/PacketVehicleRespawnProbeResult.java
@@ -15,42 +15,53 @@ import net.minecraft.entity.player.EntityPlayerMP;
 /** Client resolution evidence returned to the authoritative server audit. */
 public class PacketVehicleRespawnProbeResult extends PacketBase {
     public int generation, clientPlayerId, clientPlayerIdentity, clientWorldIdentity, renderViewIdentity, respawnAge;
-    public boolean replacementProcessed;
+    public boolean replacementProcessed, playerPresent, worldPresent, playerIdMatches, playerUuidMatchesDiagnostic;
+    public boolean dimensionMatches, auditPlayerMatches, respawnAgeReady;
     public List<Entry> vehicles = new ArrayList<Entry>();
     public static class Entry {
         public int expectedId, foundId = -1, objectIdentity, worldIdentity, seatCount, validSeatParents, hitboxCount, validHitboxParents;
         public UUID expectedUuid, foundUuid;
-        public boolean foundById, foundByUuid, previouslyFound, dead, addedToChunk, collidable, renderingLod, skipNormalRender;
-        public String foundClass = "null", acInfo = "null", boundingBox = "null";
+        public boolean foundById, previouslyFound, uuidMatchesDiagnostic, baseVehicle, typeMatches, dimensionMatches;
+        public boolean positionMatches, currentWorld, commonIdMatches, dead, addedToChunk, collidable, renderingLod, skipNormalRender;
+        public double positionDeltaSq;
+        public String expectedType = "", foundType = "null", commonUniqueId = "", foundClass = "null", boundingBox = "null";
     }
     @Override public void encodeInto(ChannelHandlerContext c, ByteBuf d) {
         d.writeInt(generation); d.writeInt(clientPlayerId); d.writeInt(clientPlayerIdentity); d.writeInt(clientWorldIdentity);
         d.writeInt(renderViewIdentity); d.writeInt(respawnAge); d.writeBoolean(replacementProcessed);
+        d.writeBoolean(playerPresent); d.writeBoolean(worldPresent); d.writeBoolean(playerIdMatches); d.writeBoolean(playerUuidMatchesDiagnostic);
+        d.writeBoolean(dimensionMatches); d.writeBoolean(auditPlayerMatches); d.writeBoolean(respawnAgeReady);
         int count = Math.min(vehicles.size(), PacketVehicleRespawnProbe.MAX_VEHICLES); d.writeShort(count);
-        for(int i=0;i<count;++i) writeEntry(d, vehicles.get(i));
+        for(int i = 0; i < count; ++i) writeEntry(d, vehicles.get(i));
     }
     @Override public void decodeInto(ChannelHandlerContext c, ByteBuf d) {
         generation=d.readInt(); clientPlayerId=d.readInt(); clientPlayerIdentity=d.readInt(); clientWorldIdentity=d.readInt();
         renderViewIdentity=d.readInt(); respawnAge=d.readInt(); replacementProcessed=d.readBoolean();
+        playerPresent=d.readBoolean(); worldPresent=d.readBoolean(); playerIdMatches=d.readBoolean(); playerUuidMatchesDiagnostic=d.readBoolean();
+        dimensionMatches=d.readBoolean(); auditPlayerMatches=d.readBoolean(); respawnAgeReady=d.readBoolean();
         int count=Math.min(d.readUnsignedShort(), PacketVehicleRespawnProbe.MAX_VEHICLES); vehicles=new ArrayList<Entry>(count);
         for(int i=0;i<count;++i) vehicles.add(readEntry(d));
     }
     private void writeEntry(ByteBuf d, Entry e) {
-        d.writeInt(e.expectedId); PacketVehicleRespawnProbe.writeUuid(d,e.expectedUuid); d.writeBoolean(e.foundById); d.writeBoolean(e.foundByUuid); d.writeBoolean(e.previouslyFound);
-        writeUTF(d,e.foundClass); d.writeInt(e.foundId); d.writeBoolean(e.foundUuid!=null); if(e.foundUuid!=null) PacketVehicleRespawnProbe.writeUuid(d,e.foundUuid);
-        d.writeInt(e.objectIdentity); d.writeInt(e.worldIdentity); d.writeBoolean(e.dead); d.writeBoolean(e.addedToChunk); writeUTF(d,e.acInfo);
+        d.writeInt(e.expectedId); PacketVehicleRespawnProbe.writeUuid(d,e.expectedUuid); d.writeBoolean(e.foundById); d.writeBoolean(e.previouslyFound);
+        writeUTF(d,e.expectedType); writeUTF(d,e.foundType); writeUTF(d,e.commonUniqueId); writeUTF(d,e.foundClass); d.writeInt(e.foundId);
+        d.writeBoolean(e.foundUuid!=null); if(e.foundUuid!=null) PacketVehicleRespawnProbe.writeUuid(d,e.foundUuid);
+        d.writeBoolean(e.uuidMatchesDiagnostic); d.writeBoolean(e.baseVehicle); d.writeBoolean(e.typeMatches); d.writeBoolean(e.dimensionMatches);
+        d.writeBoolean(e.positionMatches); d.writeDouble(e.positionDeltaSq); d.writeBoolean(e.currentWorld); d.writeBoolean(e.commonIdMatches);
+        d.writeInt(e.objectIdentity); d.writeInt(e.worldIdentity); d.writeBoolean(e.dead); d.writeBoolean(e.addedToChunk);
         d.writeBoolean(e.renderingLod); d.writeBoolean(e.skipNormalRender); d.writeBoolean(e.collidable); writeUTF(d,e.boundingBox);
         d.writeInt(e.seatCount); d.writeInt(e.validSeatParents); d.writeInt(e.hitboxCount); d.writeInt(e.validHitboxParents);
     }
     private Entry readEntry(ByteBuf d) {
-        Entry e=new Entry(); e.expectedId=d.readInt(); e.expectedUuid=PacketVehicleRespawnProbe.readUuid(d); e.foundById=d.readBoolean(); e.foundByUuid=d.readBoolean(); e.previouslyFound=d.readBoolean();
-        e.foundClass=readUTF(d); e.foundId=d.readInt(); if(d.readBoolean()) e.foundUuid=PacketVehicleRespawnProbe.readUuid(d);
-        e.objectIdentity=d.readInt(); e.worldIdentity=d.readInt(); e.dead=d.readBoolean(); e.addedToChunk=d.readBoolean(); e.acInfo=readUTF(d);
+        Entry e=new Entry(); e.expectedId=d.readInt(); e.expectedUuid=PacketVehicleRespawnProbe.readUuid(d); e.foundById=d.readBoolean(); e.previouslyFound=d.readBoolean();
+        e.expectedType=readUTF(d); e.foundType=readUTF(d); e.commonUniqueId=readUTF(d); e.foundClass=readUTF(d); e.foundId=d.readInt();
+        if(d.readBoolean()) e.foundUuid=PacketVehicleRespawnProbe.readUuid(d);
+        e.uuidMatchesDiagnostic=d.readBoolean(); e.baseVehicle=d.readBoolean(); e.typeMatches=d.readBoolean(); e.dimensionMatches=d.readBoolean();
+        e.positionMatches=d.readBoolean(); e.positionDeltaSq=d.readDouble(); e.currentWorld=d.readBoolean(); e.commonIdMatches=d.readBoolean();
+        e.objectIdentity=d.readInt(); e.worldIdentity=d.readInt(); e.dead=d.readBoolean(); e.addedToChunk=d.readBoolean();
         e.renderingLod=d.readBoolean(); e.skipNormalRender=d.readBoolean(); e.collidable=d.readBoolean(); e.boundingBox=readUTF(d);
         e.seatCount=d.readInt(); e.validSeatParents=d.readInt(); e.hitboxCount=d.readInt(); e.validHitboxParents=d.readInt(); return e;
     }
-    @Override public void handleServerSide(EntityPlayerMP player) {
-        MCH_ServerTickHandler.enqueueProbeResult(player, this);
-    }
+    @Override public void handleServerSide(EntityPlayerMP player) { MCH_ServerTickHandler.enqueueProbeResult(player, this); }
     @Override @SideOnly(Side.CLIENT) public void handleClientSide(EntityPlayer player) {}
 }


### PR DESCRIPTION
### Motivation

- Repair the respawn audit and targeted-repair logic so a killed-and-respawned player can see and interact with normal vehicles by removing incorrect UUID equality requirements and using stable runtime state for readiness.
- Prevent premature classification of correct client entities as ID collisions by making numeric entity ID the primary identity and using a bounded position/type/dimension/common-id validation instead of vanilla `Entity.getUniqueID()` equality.
- Delay and bound targeted resends until the replacement player is demonstrably ready and watching the vehicle chunk to avoid same-tick probe/timeoout races that previously deleted audits before results could be processed.
- Add clearer diagnostic logging and generation-scoped client confirmation state to make post-mortem analysis and safe retries reliable.

### Description

- Replace client readiness checks in `PacketVehicleRespawnProbe` with runtime predicates that require the current `Minecraft.thePlayer`/`theWorld`, numeric replacement player entity ID, matching dimension, observed audit-player object identity via `MCH_ClientCommonTickHandler.isRespawnAuditPlayer`, and a minimum respawn audit age, while keeping server UUIDs as diagnostic only. 
- Change vehicle resolution to prefer `WorldClient.getEntityByID` and validate found entities by MCHeli class/type, probe dimension, a position tolerance (~32 blocks), current client world, alive state, rendering/collision state, and an optional synchronized `commonUniqueId` rather than requiring vanilla entity UUID equality, and replace the previous global UUID-based cache with generation-scoped numeric-ID state cleared on world unload. 
- Rework server-side tracking in `MCH_ServerTickHandler` to key expected vehicles by numeric entity ID, add per-vehicle repair state (`repairPending`, `clientReportedMissing`, `repairNotBeforeTick`, `lastClassification`), postpone repair actions to a dedicated `executePendingRepairs` run on the next server tick, wait for `PlayerManager.isPlayerWatchingChunk` before resend, and cap retries to two attempts per generation. 
- Implement precise watcher removal/re-add logic that removes the exact watcher object by identity (via iterator/reflection when necessary), calls the Forge 1.7.10 `EntityTrackerEntry` paths to re-send the original server entity, retracks dependents (seats/hitboxes) after the parent, verifies exact watcher membership, and schedules a post-resend probe; add `respawnAuditTick` to avoid same-tick races. 
- Extend the probe schedule and timeout behavior to keep probe ages at `1,5,10,20,40,60` but set the hard timeout to at least age `80` so an age-60 response is processed before audit expiry. 
- Expose `MCH_ClientCommonTickHandler.isRespawnAuditPlayer(EntityClientPlayerMP)` and clear client resolution state during client world unload in `MCH_ClientEventHook`; add and document `commonUniqueId` inspection and comprehensive `[MCH-RESPAWN-AUDIT]` logging in `docs/vehicle-respawn-tracking.md` and add a `CHANGELOG.md` entry. 

### Testing

- Ran `git diff --check` and found no style/whitespace issues; the check passed. 
- Compiled the project with `./gradlew compileJava --no-daemon` and compilation completed successfully. 
- Executed `python3 tools/validate_config_weights.py` which passed validation. 
- Executed `python3 tools/validate_plane_config_surface.py` which failed with a known, unrelated B-21 removed-key validation error (`ClimbEnergyLoss`, `DiveEnergyGain`, `TakeoffDistanceMultiplier`), and the B-21 files were not modified by this change. 
- No graphical two-client dedicated-server runtime verification was performed in this environment, so runtime visibility/interaction results remain unverified and are not claimed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ce9c4041c8323a29903053c2d2e3a)