### PR TITLE
Fix long-range vehicle LOD optical visibility

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,8 +93,15 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `HideKeybind` | `false` | Hides keybind display/help where implemented. |
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |
-| `AircraftLODStartDistance` | `256.0` | Distance where tracked vehicles switch to cheaper model-only rendering. |
-| `AircraftLODFarDistance` | `4096.0` | Maximum distance for client-only LOD snapshots. If positive and below start distance, it is corrected upward. |
+| `AircraftLODStartDistance` | `140.0` | Distance where tracked vehicles switch to cheaper model-only rendering, with the existing hysteresis around the transition. |
+| `AircraftLODFarDistance` | `4800.0` | Hard maximum detection range for render-only vehicle snapshots; this is not a full-detail visibility distance. |
+| `AircraftLODVisibilityDistance` | `4800.0` | Clear/hazy atmospheric visibility distance where Koschmieder contrast transmission reaches approximately two percent. |
+| `AircraftLODRainVisibilityMultiplier` | `0.70` | Multiplier applied to atmospheric visibility distance in rain. |
+| `AircraftLODThunderVisibilityMultiplier` | `0.45` | Multiplier applied to atmospheric visibility distance in thunder. |
+| `AircraftLODThermalContrastExponent` | `0.35` | Raises atmospheric transmission to this exponent in thermal mode, improving contrast without extending the hard range. |
+| `AircraftLODOpticalMinPixels` | `0.75` | Minimum projected target dimension in pixels for normal optical detection. |
+| `AircraftLODThermalMinPixels` | `0.35` | Minimum projected target dimension in pixels for thermal detection. |
+| `DebugVehicleLODVisibility` | `false` | Logs at most one snapshot visibility decision per second, including projection, atmosphere, projected size, camera, weather, and skip reason. |
 | `MobRenderDistanceWeight` | `10.0` | Mob render-distance weight; clamped to 0.1-100. |
 | `CreativeTabIconItem` | `fuel` | Icon item for general tab. |
 | `CreativeTabIconHeli` | `ah-64` | Icon item for helicopter tab. |
@@ -118,6 +125,8 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `ReplaceRenderViewEntity` | `true` | Replaces render-view entity for MCHeli camera behavior. |
 | `ItemRecipe_*` | See generated config/source defaults | Recipe strings for core MCHeli items. |
 | `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
+
+Snapshot visibility uses the active projection matrix, so scopes and other FOV magnification increase projected target size naturally. Magnification does not change real distance or atmospheric transmission. Thermal vision lowers the projected-size threshold and improves contrast, but it never extends `AircraftLODFarDistance`. Snapshot rendering retains depth testing, allowing loaded nearby terrain and structures to occlude a target; unloaded terrain has no depth information and therefore cannot occlude this render-only data.
 
 ## Vehicle content-pack keys
 

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -140,6 +140,12 @@ public class MCH_Config {
    public static MCH_ConfigPrm EnableAircraftLODRender;
    public static MCH_ConfigPrm AircraftLODStartDistance;
    public static MCH_ConfigPrm AircraftLODFarDistance;
+   public static MCH_ConfigPrm AircraftLODVisibilityDistance;
+   public static MCH_ConfigPrm AircraftLODRainVisibilityMultiplier;
+   public static MCH_ConfigPrm AircraftLODThunderVisibilityMultiplier;
+   public static MCH_ConfigPrm AircraftLODThermalContrastExponent;
+   public static MCH_ConfigPrm AircraftLODOpticalMinPixels;
+   public static MCH_ConfigPrm AircraftLODThermalMinPixels;
    public static MCH_ConfigPrm MobRenderDistanceWeight;
    public static MCH_ConfigPrm CreativeTabIcon;
    public static MCH_ConfigPrm CreativeTabIconHeli;
@@ -263,6 +269,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm EnablePutRackInFlying;
    public static MCH_ConfigPrm EnableDebugBoundingBox;
    public static MCH_ConfigPrm DebugVehicleBoxCache;
+   public static MCH_ConfigPrm DebugVehicleLODVisibility;
    public static MCH_ConfigPrm DebugFlightControl;
 
    //TODOne mch1.0.5 -> mchr?
@@ -478,6 +485,13 @@ public class MCH_Config {
       AircraftLODStartDistance.desc = ";Distance in blocks where tracked aircraft rendering switches to its cheaper model-only pass.";
       AircraftLODFarDistance = new MCH_ConfigPrm("AircraftLODFarDistance", 4800.0D);
       AircraftLODFarDistance.desc = ";Maximum distance for client-only vehicle LOD snapshots. Real vehicle entity tracking remains unchanged and aligned with child seats.";
+      AircraftLODVisibilityDistance = new MCH_ConfigPrm("AircraftLODVisibilityDistance", 4800.0D);
+      AircraftLODVisibilityDistance.desc = ";Clear-air distance where snapshot optical contrast falls to approximately two percent.";
+      AircraftLODRainVisibilityMultiplier = new MCH_ConfigPrm("AircraftLODRainVisibilityMultiplier", 0.70D);
+      AircraftLODThunderVisibilityMultiplier = new MCH_ConfigPrm("AircraftLODThunderVisibilityMultiplier", 0.45D);
+      AircraftLODThermalContrastExponent = new MCH_ConfigPrm("AircraftLODThermalContrastExponent", 0.35D);
+      AircraftLODOpticalMinPixels = new MCH_ConfigPrm("AircraftLODOpticalMinPixels", 0.75D);
+      AircraftLODThermalMinPixels = new MCH_ConfigPrm("AircraftLODThermalMinPixels", 0.35D);
       MobRenderDistanceWeight = new MCH_ConfigPrm("MobRenderDistanceWeight", 10.0D);
       CreativeTabIcon = new MCH_ConfigPrm("CreativeTabIconItem", "fuel");
       CreativeTabIconHeli = new MCH_ConfigPrm("CreativeTabIconHeli", "ah-64");
@@ -664,6 +678,8 @@ public class MCH_Config {
       EnableDebugBoundingBox = new MCH_ConfigPrm("EnableDebugBoundingBox", false);
       DebugVehicleBoxCache = new MCH_ConfigPrm("DebugVehicleBoxCache", false);
       DebugVehicleBoxCache.desc = ";Print vehicle collision/hit box cache hits, rebuilds, invalidation reasons, and generated box counts.";
+      DebugVehicleLODVisibility = new MCH_ConfigPrm("DebugVehicleLODVisibility", false);
+      DebugVehicleLODVisibility.desc = ";Print one bounded distant snapshot visibility diagnostic per second.";
       DebugFlightControl = new MCH_ConfigPrm("DebugFlightControl", false);
       DebugFlightControl.desc = ";Print FPS, elapsed tick fraction, control inputs, angular velocity, pitch/yaw/roll, new-flight gravity/lift, and placement motion-lock state once per second while piloting.";
       DespawnCount = new MCH_ConfigPrm("DespawnCount", 25);
@@ -820,6 +836,13 @@ public class MCH_Config {
               EnableAircraftLODRender,
               AircraftLODStartDistance,
               AircraftLODFarDistance,
+              AircraftLODVisibilityDistance,
+              AircraftLODRainVisibilityMultiplier,
+              AircraftLODThunderVisibilityMultiplier,
+              AircraftLODThermalContrastExponent,
+              AircraftLODOpticalMinPixels,
+              AircraftLODThermalMinPixels,
+              DebugVehicleLODVisibility,
               MobRenderDistanceWeight,
               CreativeTabIcon,
               CreativeTabIconHeli,
@@ -1033,13 +1056,22 @@ public class MCH_Config {
          MobRenderDistanceWeight.prmDouble = 100.0D;
       }
 
-      if(AircraftLODStartDistance.prmDouble < 0.0D) {
-         AircraftLODStartDistance.prmDouble = 0.0D;
-      }
+      AircraftLODStartDistance.prmDouble = finiteRange(AircraftLODStartDistance.prmDouble, 0.0D, 4800.0D, 140.0D);
+
+      AircraftLODFarDistance.prmDouble = finiteRange(AircraftLODFarDistance.prmDouble, 1.0D, 4800.0D, 4800.0D);
 
       if(AircraftLODFarDistance.prmDouble > 0.0D && AircraftLODFarDistance.prmDouble < AircraftLODStartDistance.prmDouble) {
          AircraftLODFarDistance.prmDouble = AircraftLODStartDistance.prmDouble;
       }
+
+      AircraftLODVisibilityDistance.prmDouble = finitePositive(AircraftLODVisibilityDistance.prmDouble, 4800.0D);
+      AircraftLODRainVisibilityMultiplier.prmDouble = finiteRange(AircraftLODRainVisibilityMultiplier.prmDouble, 0.01D, 1.0D, 0.70D);
+      AircraftLODThunderVisibilityMultiplier.prmDouble = finiteRange(AircraftLODThunderVisibilityMultiplier.prmDouble, 0.01D, 1.0D, 0.45D);
+      AircraftLODThunderVisibilityMultiplier.prmDouble = Math.min(AircraftLODThunderVisibilityMultiplier.prmDouble,
+         AircraftLODRainVisibilityMultiplier.prmDouble);
+      AircraftLODThermalContrastExponent.prmDouble = finiteRange(AircraftLODThermalContrastExponent.prmDouble, 0.01D, 1.0D, 0.35D);
+      AircraftLODOpticalMinPixels.prmDouble = finiteRange(AircraftLODOpticalMinPixels.prmDouble, 0.0D, 64.0D, 0.75D);
+      AircraftLODThermalMinPixels.prmDouble = finiteRange(AircraftLODThermalMinPixels.prmDouble, 0.0D, 64.0D, 0.35D);
 
       Iterator isNoDamageVsSetting = CommandPermission.iterator();
 
@@ -1359,6 +1391,15 @@ public class MCH_Config {
 
    }
 
+
+   private static double finitePositive(double value, double fallback) {
+      return !Double.isNaN(value) && !Double.isInfinite(value) && value > 0.0D ? value : fallback;
+   }
+
+   private static double finiteRange(double value, double minimum, double maximum, double fallback) {
+      if(Double.isNaN(value) || Double.isInfinite(value)) return fallback;
+      return Math.max(minimum, Math.min(maximum, value));
+   }
 
    class DamageFactor {
 

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -88,8 +88,10 @@ public class MCH_ServerTickHandler {
       }
 
       double farDistance = MCH_Config.AircraftLODFarDistance != null
-         ? MCH_Config.AircraftLODFarDistance.prmDouble : 4096.0D;
-      double farDistanceSq = farDistance > 0.0D ? farDistance * farDistance : Double.MAX_VALUE;
+         ? MCH_Config.AircraftLODFarDistance.prmDouble : 4800.0D;
+      if(Double.isNaN(farDistance) || Double.isInfinite(farDistance) || farDistance <= 0.0D) farDistance = 4800.0D;
+      farDistance = Math.min(4800.0D, farDistance);
+      double farDistanceSq = farDistance * farDistance;
 
       for(WorldServer world : server.worldServers) {
          for(Object playerObject : world.playerEntities) {

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -4,10 +4,18 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import org.lwjgl.BufferUtils;
+import mcheli.MCH_ActiveRenderInfoHolder;
+import mcheli.MCH_Camera;
+import mcheli.MCH_ClientCommonTickHandler;
+import mcheli.MCH_Lib;
 import mcheli.MCH_Config;
 import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
@@ -28,6 +36,7 @@ import mcheli.vehicle.MCH_TurretInfo;
 import mcheli.vehicle.MCH_RenderTurret;
 import mcheli.wrapper.W_MOD;
 import mcheli.wrapper.W_Render;
+import mcheli.wrapper.modelloader.W_ModelCustom;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.entity.Entity;
@@ -46,6 +55,10 @@ public final class MCH_VehicleLODManager {
     public static final MCH_VehicleLODManager INSTANCE = new MCH_VehicleLODManager();
     private static final long STALE_AFTER_MS = 5000L;
     private static final LODRenderState RENDER_STATE = new LODRenderState();
+    private static final FloatBuffer FALLBACK_PROJECTION = BufferUtils.createFloatBuffer(16);
+    private static final IntBuffer FALLBACK_VIEWPORT = BufferUtils.createIntBuffer(16);
+    private static final Map<Object, Double> TARGET_DIMENSIONS = new IdentityHashMap<Object, Double>();
+    private static long nextDiagnosticMs;
     private final Map<UUID, Display> displays = new HashMap<UUID, Display>();
     private int dimension = Integer.MIN_VALUE;
     private World world;
@@ -117,8 +130,9 @@ public final class MCH_VehicleLODManager {
         double cameraX = camera.lastTickPosX + (camera.posX - camera.lastTickPosX) * event.partialTicks;
         double cameraY = camera.lastTickPosY + (camera.posY - camera.lastTickPosY) * event.partialTicks;
         double cameraZ = camera.lastTickPosZ + (camera.posZ - camera.lastTickPosZ) * event.partialTicks;
-        double far = MCH_Config.AircraftLODFarDistance != null ? MCH_Config.AircraftLODFarDistance.prmDouble : 4096.0D;
-        double farSq = far > 0.0D ? far * far : Double.MAX_VALUE;
+        double far = Math.min(4800.0D, config(MCH_Config.AircraftLODFarDistance, 4800.0D));
+        double farSq = far * far;
+        RenderContext context = captureRenderContext(mc, event.partialTicks);
 
         for (Display display : this.displays.values()) {
             if (now - display.lastUpdateMs > STALE_AFTER_MS || hasRealEntity(display, trackedAircraft)) {
@@ -131,11 +145,139 @@ public final class MCH_VehicleLODManager {
             double x = worldX - cameraX;
             double y = worldY - cameraY;
             double z = worldZ - cameraZ;
-            if (x * x + y * y + z * z > farSq) {
+            double distanceSq = x * x + y * y + z * z;
+            double realDistance = Math.sqrt(distanceSq);
+            if (distanceSq > farSq) {
+                diagnose(display, context, realDistance, far, 1.0D, display.scale, 0.0D, 0.0D, "hard_range", now);
                 continue;
             }
-            render(display, x, y, z, interpolation, now);
+            MCH_BaseVehicleInfo info = getInfo(display.category, display.typeName);
+            if (info == null || info.model == null) {
+                diagnose(display, context, realDistance, far, 1.0D, display.scale, 0.0D, 0.0D, "missing_model", now);
+                continue;
+            }
+            double projectedPixels = MCH_VehicleLODVisibility.projectedPixels(
+                targetDimension(info) * display.scale, realDistance, context.projection[5], context.viewportHeight);
+            double minimumPixels = context.thermal ? nonNegativeConfig(MCH_Config.AircraftLODThermalMinPixels, 0.35D)
+                : nonNegativeConfig(MCH_Config.AircraftLODOpticalMinPixels, 0.75D);
+            if (projectedPixels < minimumPixels) {
+                diagnose(display, context, realDistance, far, 1.0D, display.scale, 0.0D, projectedPixels, "projected_size", now);
+                continue;
+            }
+            double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance, 4800.0D) * context.weatherMultiplier;
+            double transmission = MCH_VehicleLODVisibility.transmission(realDistance, effectiveVisibility);
+            double alpha = context.thermal ? MCH_VehicleLODVisibility.thermalAlpha(transmission,
+                config(MCH_Config.AircraftLODThermalContrastExponent, 0.35D)) : transmission;
+            double depthScale = MCH_VehicleLODVisibility.depthScale(realDistance, context.safeProxyDepth);
+            if (alpha < 1.0D / 255.0D) {
+                diagnose(display, context, realDistance, far, depthScale, display.scale * depthScale,
+                    transmission, projectedPixels, "negligible_alpha", now);
+                continue;
+            }
+            render(display, info, x * depthScale, y * depthScale, z * depthScale,
+                (float)(display.scale * depthScale), (float)alpha, interpolation, now);
+            diagnose(display, context, realDistance, far, depthScale, display.scale * depthScale,
+                transmission, projectedPixels, "render", now);
         }
+    }
+
+    private static RenderContext captureRenderContext(Minecraft mc, float partialTicks) {
+        RenderContext context = new RenderContext();
+        boolean validProjection = copyProjection(MCH_ActiveRenderInfoHolder.projection, context.projection);
+        if (!validProjection) {
+            FALLBACK_PROJECTION.clear();
+            GL11.glGetFloat(GL11.GL_PROJECTION_MATRIX, FALLBACK_PROJECTION);
+            validProjection = copyProjection(FALLBACK_PROJECTION, context.projection);
+        }
+        double fallbackFar = Math.max(64.0D, (double)mc.gameSettings.renderDistanceChunks * 16.0D);
+        context.farPlane = validProjection
+            ? MCH_VehicleLODVisibility.projectionFarPlane(context.projection[10], context.projection[14], fallbackFar)
+            : fallbackFar;
+        context.safeProxyDepth = MCH_VehicleLODVisibility.safeProxyDepth(context.farPlane);
+        context.viewportHeight = copyViewportHeight(MCH_ActiveRenderInfoHolder.viewport);
+        if (context.viewportHeight <= 0) {
+            FALLBACK_VIEWPORT.clear();
+            GL11.glGetInteger(GL11.GL_VIEWPORT, FALLBACK_VIEWPORT);
+            context.viewportHeight = copyViewportHeight(FALLBACK_VIEWPORT);
+        }
+        if (context.viewportHeight <= 0) context.viewportHeight = Math.max(1, mc.displayHeight);
+        context.cameraMode = MCH_ClientCommonTickHandler.cameraMode;
+        context.thermal = context.cameraMode == MCH_Camera.MODE_THERMALVISION;
+        if (mc.theWorld.getWeightedThunderStrength(partialTicks) > 0.0F) {
+            context.weather = "thunder";
+            context.weatherMultiplier = config(MCH_Config.AircraftLODThunderVisibilityMultiplier, 0.45D);
+        } else if (mc.theWorld.getRainStrength(partialTicks) > 0.0F) {
+            context.weather = "rain";
+            context.weatherMultiplier = config(MCH_Config.AircraftLODRainVisibilityMultiplier, 0.70D);
+        } else {
+            context.weather = "clear";
+            context.weatherMultiplier = 1.0D;
+        }
+        return context;
+    }
+
+    private static boolean copyProjection(FloatBuffer source, float[] destination) {
+        if (source == null || source.capacity() < 16) return false;
+        for (int i = 0; i < 16; ++i) {
+            float value = source.get(i);
+            if (Float.isNaN(value) || Float.isInfinite(value)) return false;
+            destination[i] = value;
+        }
+        return Math.abs(destination[0]) > 1.0E-6F && Math.abs(destination[5]) > 1.0E-6F
+            && Math.abs(destination[11]) > 1.0E-6F;
+    }
+
+    private static int copyViewportHeight(IntBuffer viewport) {
+        return viewport != null && viewport.capacity() >= 4 ? viewport.get(3) : 0;
+    }
+
+    private static double targetDimension(MCH_BaseVehicleInfo info) {
+        Double cached = TARGET_DIMENSIONS.get(info);
+        if (cached != null) return cached.doubleValue();
+        double dimension = 1.0D;
+        if (info.model instanceof W_ModelCustom) {
+            W_ModelCustom model = (W_ModelCustom)info.model;
+            dimension = Math.max((double)model.sizeX, Math.max((double)model.sizeY, (double)model.sizeZ));
+        }
+        dimension = MCH_VehicleLODVisibility.positive(dimension, 1.0D);
+        TARGET_DIMENSIONS.put(info, Double.valueOf(dimension));
+        return dimension;
+    }
+
+    private static double config(mcheli.MCH_ConfigPrm parameter, double fallback) {
+        return parameter == null ? fallback : MCH_VehicleLODVisibility.positive(parameter.prmDouble, fallback);
+    }
+
+    private static double nonNegativeConfig(mcheli.MCH_ConfigPrm parameter, double fallback) {
+        if (parameter == null || Double.isNaN(parameter.prmDouble) || Double.isInfinite(parameter.prmDouble)) return fallback;
+        return Math.max(0.0D, parameter.prmDouble);
+    }
+
+    private static void diagnose(Display display, RenderContext context, double distance, double hardRange,
+        double depthScale, double renderScale, double transmission, double pixels, String reason, long now) {
+        if (MCH_Config.DebugVehicleLODVisibility == null || !MCH_Config.DebugVehicleLODVisibility.prmBool
+            || now < nextDiagnosticMs) return;
+        nextDiagnosticMs = now + 1000L;
+        double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance, 4800.0D) * context.weatherMultiplier;
+        double alpha = context.thermal ? MCH_VehicleLODVisibility.thermalAlpha(transmission,
+            config(MCH_Config.AircraftLODThermalContrastExponent, 0.35D)) : transmission;
+        MCH_Lib.DbgLog(true,
+            "VehicleLODVisibility type=%s distance=%.1f hardRange=%.1f farPlane=%.1f safeDepth=%.1f depthScale=%.5f renderScale=%.5f visibility=%.1f transmission=%.5f alpha=%.5f pixels=%.3f cameraMode=%d weather=%s result=%s",
+            new Object[]{display.typeName, Double.valueOf(distance), Double.valueOf(hardRange),
+                Double.valueOf(context.farPlane), Double.valueOf(context.safeProxyDepth), Double.valueOf(depthScale),
+                Double.valueOf(renderScale), Double.valueOf(effectiveVisibility), Double.valueOf(transmission),
+                Double.valueOf(alpha), Double.valueOf(pixels), Integer.valueOf(context.cameraMode), context.weather, reason});
+    }
+
+    private static final class RenderContext {
+        private final float[] projection = new float[16];
+        private int viewportHeight;
+        private double farPlane;
+        private double safeProxyDepth;
+        private int cameraMode;
+        private boolean thermal;
+        private String weather;
+        private double weatherMultiplier;
     }
 
     private static boolean hasRealEntity(Display display, List<MCH_EntityBaseVehicle> vehicles) {
@@ -148,8 +290,8 @@ public final class MCH_VehicleLODManager {
         return false;
     }
 
-    private static void render(Display display, double x, double y, double z, float interpolation, long now) {
-        MCH_BaseVehicleInfo info = getInfo(display.category, display.typeName);
+    private static void render(Display display, MCH_BaseVehicleInfo info, double x, double y, double z,
+        float renderScale, float alpha, float interpolation, long now) {
         String textureFolder = info instanceof MCH_TurretInfo ? ((MCH_TurretInfo)info).getDirectoryName() : getTextureFolder(display.category);
         if (info == null || info.model == null || textureFolder == null) {
             return;
@@ -157,16 +299,25 @@ public final class MCH_VehicleLODManager {
 
         float previousLightX = OpenGlHelper.lastBrightnessX;
         float previousLightY = OpenGlHelper.lastBrightnessY;
+        int previousMatrixMode = GL11.glGetInteger(GL11.GL_MATRIX_MODE);
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glMatrixMode(GL11.GL_MODELVIEW);
         RENDER_STATE.begin(info.smoothShading, display.packedLight);
         GL11.glPushMatrix();
         try {
-            // Keep the active world shader/fog state and use the normal aircraft model setup.
-            GL11.glColor4f(0.75F, 0.75F, 0.75F, 1.0F);
+            GL11.glDisable(GL11.GL_FOG);
+            GL11.glEnable(GL11.GL_BLEND);
+            GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+            GL11.glDisable(GL11.GL_ALPHA_TEST);
+            GL11.glEnable(GL11.GL_DEPTH_TEST);
+            GL11.glDepthFunc(GL11.GL_LEQUAL);
+            GL11.glDepthMask(false);
+            GL11.glColor4f(0.75F, 0.75F, 0.75F, alpha);
             GL11.glTranslated(x, y, z);
             GL11.glRotatef(interpolateAngle(display.previousYaw, display.yaw, interpolation), 0.0F, -1.0F, 0.0F);
             GL11.glRotatef(interpolateAngle(display.previousPitch, display.pitch, interpolation), 1.0F, 0.0F, 0.0F);
             GL11.glRotatef(interpolateAngle(display.previousRoll, display.roll, interpolation), 0.0F, 0.0F, 1.0F);
-            GL11.glScalef(display.scale, display.scale, display.scale);
+            GL11.glScalef(renderScale, renderScale, renderScale);
             MCH_RenderBaseVehicle.beginSkinOverlayRender(textureFolder, display.textureName);
             try {
                 Minecraft.getMinecraft().renderEngine.bindTexture(
@@ -227,6 +378,8 @@ public final class MCH_VehicleLODManager {
             GL11.glPopMatrix();
             RENDER_STATE.end();
             OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, previousLightX, previousLightY);
+            GL11.glPopAttrib();
+            GL11.glMatrixMode(previousMatrixMode);
         }
     }
 

--- a/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
@@ -1,0 +1,59 @@
+package mcheli.lod;
+
+/** Pure, deterministic visibility math shared by the snapshot renderer and tests. */
+public final class MCH_VehicleLODVisibility {
+    public static final double KOSCHMIEDER_CONSTANT = 3.912D;
+
+    private MCH_VehicleLODVisibility() {
+    }
+
+    public static boolean isFinite(double value) {
+        return !Double.isNaN(value) && !Double.isInfinite(value);
+    }
+
+    public static double projectionFarPlane(float element10, float element14, double fallback) {
+        double denominator = (double)element10 + 1.0D;
+        double far = Math.abs(denominator) > 1.0E-7D ? (double)element14 / denominator : Double.NaN;
+        return isFinite(far) && far > 0.0D ? far : positive(fallback, 256.0D);
+    }
+
+    public static double safeProxyDepth(double farPlane) {
+        return positive(farPlane, 256.0D) * 0.9D;
+    }
+
+    public static double depthScale(double realDistance, double safeDepth) {
+        if (!isFinite(realDistance) || realDistance <= 0.0D || !isFinite(safeDepth) || safeDepth <= 0.0D
+            || realDistance <= safeDepth) {
+            return 1.0D;
+        }
+        return safeDepth / realDistance;
+    }
+
+    public static double transmission(double realDistance, double effectiveVisibilityDistance) {
+        double distance = isFinite(realDistance) ? Math.max(0.0D, realDistance) : Double.MAX_VALUE;
+        double visibility = positive(effectiveVisibilityDistance, 1.0D);
+        double result = Math.exp(-KOSCHMIEDER_CONSTANT * distance / visibility);
+        return clamp(result, 0.0D, 1.0D);
+    }
+
+    public static double thermalAlpha(double transmission, double exponent) {
+        return clamp(Math.pow(clamp(transmission, 0.0D, 1.0D), clamp(exponent, 0.01D, 1.0D)), 0.0D, 1.0D);
+    }
+
+    public static double projectedPixels(double physicalSize, double realDistance, float projectionY, int viewportHeight) {
+        if (!isFinite(physicalSize) || physicalSize <= 0.0D || !isFinite(realDistance) || realDistance <= 0.0D
+            || Float.isNaN(projectionY) || Float.isInfinite(projectionY) || viewportHeight <= 0) {
+            return 0.0D;
+        }
+        return physicalSize * Math.abs((double)projectionY) * (double)viewportHeight / (2.0D * realDistance);
+    }
+
+    public static double positive(double value, double fallback) {
+        return isFinite(value) && value > 0.0D ? value : fallback;
+    }
+
+    public static double clamp(double value, double minimum, double maximum) {
+        if (!isFinite(value)) return minimum;
+        return Math.max(minimum, Math.min(maximum, value));
+    }
+}

--- a/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
+++ b/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
@@ -1,0 +1,51 @@
+package mcheli.lod;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class MCH_VehicleLODVisibilityTest {
+    @Test
+    public void extractsFarPlaneAndFallsBackForInvalidProjection() {
+        float m22 = (float)(-(400.0D + 0.1D) / (400.0D - 0.1D));
+        float m32 = (float)(-(2.0D * 400.0D * 0.1D) / (400.0D - 0.1D));
+        assertEquals(400.0D, MCH_VehicleLODVisibility.projectionFarPlane(m22, m32, 256.0D), 0.1D);
+        assertEquals(256.0D, MCH_VehicleLODVisibility.projectionFarPlane(Float.NaN, m32, 256.0D), 0.0D);
+    }
+
+    @Test
+    public void compressionPreservesAngularSizeAndLeavesNearTargetsAlone() {
+        assertEquals(1.0D, MCH_VehicleLODVisibility.depthScale(200.0D, 360.0D), 0.0D);
+        double scale = MCH_VehicleLODVisibility.depthScale(800.0D, 360.0D);
+        assertEquals(0.45D, scale, 0.0D);
+        assertEquals(4.0D / 800.0D, (4.0D * scale) / (800.0D * scale), 1.0E-12D);
+    }
+
+    @Test
+    public void atmosphereAndThermalFollowConfiguredContrastModel() {
+        assertEquals(1.0D, MCH_VehicleLODVisibility.transmission(0.0D, 4800.0D), 0.0D);
+        double clear = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D);
+        double rain = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D * 0.70D);
+        double thunder = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D * 0.45D);
+        assertEquals(0.02D, clear, 0.0001D);
+        assertTrue(rain < clear);
+        assertTrue(thunder < rain);
+        assertTrue(MCH_VehicleLODVisibility.thermalAlpha(clear, 0.35D) > clear);
+    }
+
+    @Test
+    public void projectionMagnificationIncreasesPixelSize() {
+        double normal = MCH_VehicleLODVisibility.projectedPixels(8.0D, 1000.0D, 1.0F, 1080);
+        double magnified = MCH_VehicleLODVisibility.projectedPixels(8.0D, 1000.0D, 4.0F, 1080);
+        assertEquals(normal * 4.0D, magnified, 0.0D);
+    }
+
+    @Test
+    public void validationClampsInvalidValues() {
+        assertEquals(4800.0D, MCH_VehicleLODVisibility.positive(Double.NaN, 4800.0D), 0.0D);
+        assertEquals(4800.0D, MCH_VehicleLODVisibility.positive(-1.0D, 4800.0D), 0.0D);
+        assertEquals(0.0D, MCH_VehicleLODVisibility.clamp(Double.NaN, 0.0D, 1.0D), 0.0D);
+        assertEquals(1.0D, MCH_VehicleLODVisibility.clamp(2.0D, 0.0D, 1.0D), 0.0D);
+    }
+}


### PR DESCRIPTION
### Motivation

- Distant render-only vehicle snapshots vanished near ~394 blocks due to clipping by the active OpenGL projection far plane instead of a server-side limit; snapshots need to remain detectable out to the configured hard range while avoiding changes to global far-plane or terrain distance. 
- Provide realistic optical/thermal detection behavior (gradual fade, magnification-aware projected size, weather attenuation) while preserving depth testing and the existing snapshot/packet policy. 

### Description

- Add deterministic visibility math in `mcheli.lod.MCH_VehicleLODVisibility` implementing far-plane extraction, safe-proxy depth, depth-compression scale, Koschmieder atmospheric transmission, thermal contrast transform, projected-pixel calculation, and robust validation.  
- Update `MCH_VehicleLODManager` to capture/validate the active projection and viewport once per `RenderWorldLastEvent`, compute a safe proxy depth (~90% of derived far plane), apply a local depth-compression transform (translation + model scale), run projected-pixel and real-distance checks, compute atmospheric/thermal alpha, isolate and restore OpenGL state for snapshot rendering, and skip renders with negligible alpha.  
- Add new client configuration parameters and validation in `MCH_Config` (`AircraftLODVisibilityDistance`, `AircraftLODRainVisibilityMultiplier`, `AircraftLODThunderVisibilityMultiplier`, `AircraftLODThermalContrastExponent`, `AircraftLODOpticalMinPixels`, `AircraftLODThermalMinPixels`, `DebugVehicleLODVisibility`) and clamp/validate `AircraftLODFarDistance`/`AircraftLODStartDistance` limits.  
- Ensure server snapshot send logic still uses the configured hard range (clamped to 4800 blocks) in `MCH_ServerTickHandler` and keep snapshot/real-entity suppression and 512-entry, 20-tick behavior unchanged.  
- Add unit tests `MCH_VehicleLODVisibilityTest` for far-plane extraction, depth compression, atmospheric transmission, thermal alpha, projection magnification, and validation; and update `docs/configuration.md` with the new options and behavioral notes.  

### Testing

- `git diff --cached --check` — passed.  
- Deterministic Python checks of visibility formulas and a small math sanity script (far-plane extraction, Koschmieder transmission ≈ 0.02 at 4800 m, ordering by rain/thunder, angular-size preservation) — passed.  
- Java source sanity scan (balanced braces, no Java-8+ forbidden constructs like lambdas/records/modern collection factories) — passed.  
- `./gradlew compileJava` / `./gradlew test` — not run because building/compiling class artifacts was explicitly prohibited in this environment.  
- Manual graphical acceptance tests (render-range sampling, weather, thermal/optical checks, occlusion, OpenGL leak checks, etc.) — not executed in this non-interactive environment and remain for in-game verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d2bf56f848323bc59a7946215aa4a)