### PR TITLE
Add configurable MCHeli zoom sensitivity reduction

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,6 +71,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `EnableDebugBoundingBox` | `false` | Enables debug bounding boxes. Can be toggled in memory with `/mcheli showboundingbox`. |
 | `InvertMouse` | `false` | Inverts aircraft mouse controls. |
 | `MouseSensitivity` | `30.0` | MCHeli mouse sensitivity. |
+| `ZoomSensitivityEffect` | `100.0` | Client-side MCHeli mouse-input zoom reduction, valid from `0` to `100`. `0` keeps the old sensitivity behavior, while `100` scales sensitivity fully against optical magnification; intermediate values blend the two behaviors. This does not modify vanilla Minecraft sensitivity. |
 | `MouseControlStickModeHeli` | `false` | Enables stick-style mouse mode for helicopters. |
 | `MouseControlStickModePlane` | `false` | Enables stick-style mouse mode for planes. |
 | `MouseControlFlightSimMode` | `true` | Flight-sim mouse mode (`Yaw:key, Roll=mouse` per source comment). |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -280,6 +280,24 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       return 40.0D;
    }
 
+   public static double getZoomSensitivityMultiplier(Entity player) {
+      MCH_EntityBaseVehicle vehicle = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
+      if(vehicle == null || vehicle.camera == null) {
+         return 1.0D;
+      }
+
+      float cameraZoom = vehicle.camera.getCameraZoom();
+      if(Float.isNaN(cameraZoom) || Float.isInfinite(cameraZoom)) {
+         return 1.0D;
+      }
+
+      double zoom = Math.max(1.0D, (double)cameraZoom);
+      double clampedEffect = Math.max(0.0D, Math.min(100.0D, MCH_Config.ZoomSensitivityEffect.prmDouble));
+      // Zero preserves legacy input; 100 applies the full inverse optical magnification.
+      double effect = clampedEffect / 100.0D;
+      return 1.0D / (1.0D + (zoom - 1.0D) * effect);
+   }
+
    public void updateMouseDelta(boolean stickMode, float partialTicks) {
       prevMouseDeltaX = mouseDeltaX;
       prevMouseDeltaY = mouseDeltaY;
@@ -303,6 +321,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          double ms = MCH_Config.MouseSensitivity.prmDouble * 0.1D;
          mouseDeltaX = ms * (double)super.mc.mouseHelper.deltaX * (double)f2;
          mouseDeltaY = ms * (double)super.mc.mouseHelper.deltaY * (double)f2;
+         double zoomSensitivityMultiplier = getZoomSensitivityMultiplier(super.mc.thePlayer);
+         mouseDeltaX *= zoomSensitivityMultiplier;
+         mouseDeltaY *= zoomSensitivityMultiplier;
          byte inv = 1;
          if(super.mc.gameSettings.invertMouse) {
             inv = -1;

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -166,6 +166,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm BreakableOnlyPickaxe;
    public static MCH_ConfigPrm InvertMouse;
    public static MCH_ConfigPrm MouseSensitivity;
+   public static MCH_ConfigPrm ZoomSensitivityEffect;
    public static MCH_ConfigPrm MouseControlStickModeHeli;
    public static MCH_ConfigPrm MouseControlStickModePlane;
    public static MCH_ConfigPrm MouseControlFlightSimMode;
@@ -515,6 +516,7 @@ public class MCH_Config {
       BreakableOnlyPickaxe = new MCH_ConfigPrm("BreakableOnlyPickaxe", false);
       InvertMouse = new MCH_ConfigPrm("InvertMouse", false);
       MouseSensitivity = new MCH_ConfigPrm("MouseSensitivity", 30.0D);
+      ZoomSensitivityEffect = new MCH_ConfigPrm("ZoomSensitivityEffect", 100.0D);
       MouseControlStickModeHeli = new MCH_ConfigPrm("MouseControlStickModeHeli", false);
       MouseControlStickModePlane = new MCH_ConfigPrm("MouseControlStickModePlane", false);
       MouseControlFlightSimMode = new MCH_ConfigPrm("MouseControlFlightSimMode", true);
@@ -781,6 +783,7 @@ public class MCH_Config {
               null,
               InvertMouse,
               MouseSensitivity,
+              ZoomSensitivityEffect,
               MouseControlStickModeHeli,
               MouseControlStickModePlane,
               MouseControlFlightSimMode,
@@ -1026,6 +1029,7 @@ public class MCH_Config {
       NewPlaneCameraRollInfluence.prmDouble = MCH_Lib.RNG(NewPlaneCameraRollInfluence.prmDouble, 0.0D, 1.0D);
       AllTankSpeed.prmDouble = MCH_Lib.RNG(AllTankSpeed.prmDouble, 0.0D, 1000.0D);
       AllShipSpeed.prmDouble = MCH_Lib.RNG(AllShipSpeed.prmDouble, 0.0D, 1000.0D);
+      ZoomSensitivityEffect.prmDouble = finiteRange(ZoomSensitivityEffect.prmDouble, 0.0D, 100.0D, 100.0D);
       this.setBlockListFromString(bulletBreakableBlocks, BulletBreakableBlock.prmString);
       this.setBlockListFromString(carBreakableBlocks, Collision_Car_BreakableBlock.prmString);
       this.setBlockListFromString(carNoBreakableBlocks, Collision_Car_NoBreakableBlock.prmString);

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -62,6 +62,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
    private MCH_GuiSlider sliderEntityMarkerSize;
    private MCH_GuiSlider sliderBlockMarkerSize;
    private MCH_GuiSlider sliderSensitivity;
+   private MCH_GuiSlider sliderZoomSensitivityEffect;
    private MCH_GuiSlider[] sliderHitMark;
    private MCH_GuiOnOffButton buttonTestMode;
    private MCH_GuiOnOffButton buttonThrottleHeli;
@@ -125,6 +126,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.listControlButtons = new ArrayList();
       this.buttonMouseInv = new MCH_GuiOnOffButton(0, x1, y + 25, 150, 20, "Invert Mouse : ");
       this.sliderSensitivity = new MCH_GuiSlider(0, x1, y + 50, 150, 20, "Sensitivity : %.1f", 0.0F, 0.0F, 30.0F, 0.1F);
+      this.sliderZoomSensitivityEffect = new MCH_GuiSlider(0, x3, y + 50, 150, 20, "Zoom Sensitivity Effect : %.0f%%", 100.0F, 0.0F, 100.0F, 1.0F);
       this.buttonFlightSimMode = new MCH_GuiOnOffButton(0, x1, y + 75, 150, 20, "Mouse Flight Sim Mode : ");
       this.buttonHoldFreelook = new MCH_GuiOnOffButton(0, x1, y + 100, 150, 20, "Hold Free Look : ");
       this.buttonSwitchWeaponWheel = new MCH_GuiOnOffButton(0, x1, y + 125, 150, 20, "Switch Weapon Wheel : ");
@@ -142,6 +144,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.listControlButtons.add(this.buttonStickModeHeli);
       this.listControlButtons.add(this.buttonStickModePlane);
       this.listControlButtons.add(this.sliderSensitivity);
+      this.listControlButtons.add(this.sliderZoomSensitivityEffect);
       this.listControlButtons.add(this.buttonThrottleHeli);
       this.listControlButtons.add(this.buttonThrottlePlane);
       this.listControlButtons.add(this.buttonThrottleShip);
@@ -414,6 +417,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.buttonStickModePlane.setOnOff(config.MouseControlStickModePlane.prmBool);
 
       this.sliderSensitivity.setSliderValue((float) config.MouseSensitivity.prmDouble);
+      this.sliderZoomSensitivityEffect.setSliderValue((float)config.ZoomSensitivityEffect.prmDouble);
 
       this.buttonShowHUDTP.setOnOff(config.DisplayHUDThirdPerson.prmBool);
       this.buttonSmoothShading.setOnOff(config.SmoothShading.prmBool);
@@ -475,6 +479,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       config.SwitchWeaponWithMouseWheel.setPrm(buttonSwitchWeaponWheel.getOnOff());
 
       config.MouseSensitivity.setPrm(sliderSensitivity.getSliderValueInt(1));
+      config.ZoomSensitivityEffect.setPrm(sliderZoomSensitivityEffect.getSliderValueInt(0));
 
       config.DisplayHUDThirdPerson.setPrm(buttonShowHUDTP.getOnOff());
       config.SmoothShading.setPrm(buttonSmoothShading.getOnOff());


### PR DESCRIPTION
### Motivation
- Zooming kept field-of-view but did not reduce MCHeli mouse input, making high-magnification aiming imprecise. 
- Provide a client-side, configurable multiplier so players can reduce mouse sensitivity when zoomed without changing vanilla settings. 
- Expose an immediate, persistent UI control so players can tune the behavior in-game.

### Description
- Added a new client-only configuration parameter `ZoomSensitivityEffect` in `MCH_Config` with default `100.0` and clamped to `0.0..100.0`, and ensured it is included in generated config and corrected on load. (src/main/java/mcheli/MCH_Config.java)
- Implemented `getZoomSensitivityMultiplier(Entity)` in `MCH_ClientCommonTickHandler` which resolves the active vehicle via `getAircraft_RiddenOrControl(...)`, reads `vehicle.camera.getCameraZoom()`, validates it, clamps zoom >= 1.0, and computes the multiplier using the specified formula `1.0 / (1.0 + (zoom - 1.0) * (ZoomSensitivityEffect/100))`. (src/main/java/mcheli/MCH_ClientCommonTickHandler.java)
- Applied the multiplier once to both horizontal and vertical mouse deltas inside `updateMouseDelta(...)` after the vanilla sensitivity curve and `MCH_Config.MouseSensitivity`, and before inversion and stick accumulators, without touching `Minecraft.gameSettings.mouseSensitivity`. (src/main/java/mcheli/MCH_ClientCommonTickHandler.java)
- Added a `MCH_GuiSlider` labeled `Zoom Sensitivity Effect : %.0f%%` on the Controls screen beside the existing sensitivity slider, with range `0..100` and step `1`, and wired load/apply/save through the existing `getAllStatusFromConfig()` / `saveAndApplyConfig()` paths. (src/main/java/mcheli/gui/MCH_ConfigGui.java)
- Documented the setting in `docs/configuration.md` describing default, range, semantics, and that it does not change vanilla sensitivity. (docs/configuration.md)

### Testing
- Ran source assertions via a small `python3` check that verified the new parameter declaration, default, config registration, clamping, GUI load/apply wiring, single application of the X/Y multiplier, and all specified formula cases (zoom 1/2/4 and effects 0/50/100); assertions passed. (script run in repo workspace)
- Verified `git diff --check` and `git diff --numstat` to ensure no whitespace or binary problems and to list changed files; both checks passed. (commands run: `git diff --check`, `git diff --numstat`)
- Confirmed working commit and branch state via `git status --short --branch` and `git log -1 --oneline`; commit `Add configurable zoom sensitivity reduction` recorded. 
- Did not run `./gradlew build` or any binary builds because the task environment forbids compiling/publishing binaries, so runtime integration and in-game verification were not executed here.

Files changed: `src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`, `src/main/java/mcheli/gui/MCH_ConfigGui.java`, `docs/configuration.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d3f39e09083239e48e64f12f4f16a)