### PR TITLE
Fix zoom sensitivity input routing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `EnableDebugBoundingBox` | `false` | Enables debug bounding boxes. Can be toggled in memory with `/mcheli showboundingbox`. |
 | `InvertMouse` | `false` | Inverts aircraft mouse controls. |
 | `MouseSensitivity` | `30.0` | MCHeli mouse sensitivity. |
-| `ZoomSensitivityEffect` | `100.0` | Client-side MCHeli mouse-input zoom reduction, valid from `0` to `100`. `0` keeps the old sensitivity behavior, while `100` scales sensitivity fully against optical magnification; intermediate values blend the two behaviors. This does not modify vanilla Minecraft sensitivity. |
+| `ZoomSensitivityEffect` | `100.0` | Client-side MCHeli mouse-input zoom reduction, valid from `0` to `100`. `0` keeps the old sensitivity behavior, while `100` scales sensitivity fully against optical magnification; intermediate values blend the two behaviors. It applies to vehicle cameras (including seats, turrets, and UAV control), GLTDs, scoped light weapons, and the rangefinder without modifying vanilla Minecraft sensitivity. |
 | `MouseControlStickModeHeli` | `false` | Enables stick-style mouse mode for helicopters. |
 | `MouseControlStickModePlane` | `false` | Enables stick-style mouse mode for planes. |
 | `MouseControlFlightSimMode` | `true` | Flight-sim mouse mode (`Yaw:key, Roll=mouse` per source comment). |

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -29,9 +29,7 @@ import mcheli.tool.MCH_ClientToolTickHandler;
 import mcheli.tool.MCH_GuiWrench;
 import mcheli.tool.MCH_ItemWrench;
 import mcheli.tool.rangefinder.MCH_GuiRangeFinder;
-import mcheli.uav.MCH_EntityUavStation;
 import mcheli.vehicle.MCH_ClientTurretTickHandler;
-import mcheli.vehicle.MCH_EntityTurret;
 import mcheli.vehicle.MCH_GuiTurret;
 import mcheli.weapon.MCH_WeaponSet;
 import mcheli.wrapper.W_Lib;
@@ -108,6 +106,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private EntityClientPlayerMP dismountPlayer;
    private World dismountWorld;
    private Object dismountConnection;
+   private boolean restoreMouseFocusAfterRender;
 
 
 
@@ -281,24 +280,15 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public static double getZoomSensitivityMultiplier(Entity player) {
-      MCH_EntityBaseVehicle vehicle = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
-      if(vehicle == null || vehicle.camera == null) {
-         return 1.0D;
-      }
-
-      float cameraZoom = vehicle.camera.getCameraZoom();
-      if(Float.isNaN(cameraZoom) || Float.isInfinite(cameraZoom)) {
-         return 1.0D;
-      }
-
-      double zoom = Math.max(1.0D, (double)cameraZoom);
-      double clampedEffect = Math.max(0.0D, Math.min(100.0D, MCH_Config.ZoomSensitivityEffect.prmDouble));
-      // Zero preserves legacy input; 100 applies the full inverse optical magnification.
-      double effect = clampedEffect / 100.0D;
-      return 1.0D / (1.0D + (zoom - 1.0D) * effect);
+      return player instanceof EntityPlayer?MCH_ZoomContext.resolve(Minecraft.getMinecraft(), (EntityPlayer)player).getSensitivityMultiplier():1.0D;
    }
 
    public void updateMouseDelta(boolean stickMode, float partialTicks) {
+      MCH_ZoomContext context = MCH_ZoomContext.resolve(super.mc, super.mc.thePlayer);
+      this.updateMouseDelta(stickMode, partialTicks, context.getSensitivityMultiplier());
+   }
+
+   private void updateMouseDelta(boolean stickMode, float partialTicks, double zoomSensitivityMultiplier) {
       prevMouseDeltaX = mouseDeltaX;
       prevMouseDeltaY = mouseDeltaY;
       mouseDeltaX = 0.0D;
@@ -321,7 +311,6 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          double ms = MCH_Config.MouseSensitivity.prmDouble * 0.1D;
          mouseDeltaX = ms * (double)super.mc.mouseHelper.deltaX * (double)f2;
          mouseDeltaY = ms * (double)super.mc.mouseHelper.deltaY * (double)f2;
-         double zoomSensitivityMultiplier = getZoomSensitivityMultiplier(super.mc.thePlayer);
          mouseDeltaX *= zoomSensitivityMultiplier;
          mouseDeltaY *= zoomSensitivityMultiplier;
          byte inv = 1;
@@ -351,6 +340,29 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
          }
       }
 
+   }
+
+   /** Consumes the render-frame mouse sample before EntityRenderer can apply it a second time. */
+   private void updateVanillaLook(MCH_ZoomContext context) {
+      double multiplier = context.getSensitivityMultiplier();
+      if(context.inputPath != MCH_ZoomContext.InputPath.VANILLA_LOOK || multiplier >= 1.0D ||
+            !super.mc.inGameHasFocus || !Display.isActive() || super.mc.currentScreen != null) {
+         return;
+      }
+
+      super.mc.mouseHelper.mouseXYChange();
+      float sensitivity = super.mc.gameSettings.mouseSensitivity * 0.6F + 0.2F;
+      float curve = sensitivity * sensitivity * sensitivity * 8.0F;
+      float yaw = (float)((double)super.mc.mouseHelper.deltaX * (double)curve * multiplier);
+      float pitch = (float)((double)super.mc.mouseHelper.deltaY * (double)curve * multiplier);
+      if(super.mc.gameSettings.invertMouse) {
+         pitch = -pitch;
+      }
+      super.mc.thePlayer.setAngles(yaw, pitch);
+      // EntityRenderer runs after RenderTickEvent.START. Suppress only its mouse branch so
+      // the raw sample consumed above cannot be applied again during this render frame.
+      super.mc.inGameHasFocus = false;
+      this.restoreMouseFocusAfterRender = true;
    }
 
    /** Returns elapsed render time in Minecraft ticks; visual interpolation still uses raw partialTicks. */
@@ -656,7 +668,9 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                W_Reflection.setItemRendererProgress(1.0F);
             }
 
-            ridingAircraft = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(var17);
+            MCH_ZoomContext zoomContext = MCH_ZoomContext.resolve(super.mc, var17);
+            this.updateVanillaLook(zoomContext);
+            ridingAircraft = zoomContext.vehicle;
             if(ridingAircraft != null) {
                cameraMode = ridingAircraft.getCameraMode(var17);
             } else if(var17.ridingEntity instanceof MCH_EntityGLTD) {
@@ -666,17 +680,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                cameraMode = 0;
             }
 
-            MCH_EntityBaseVehicle var19 = null;
-            if(!(var17.ridingEntity instanceof MCH_EntityHeli) && !(var17.ridingEntity instanceof MCP_EntityPlane) && !(var17.ridingEntity instanceof MCH_EntityShip) && !(var17.ridingEntity instanceof MCH_EntityTank)) {
-               if(var17.ridingEntity instanceof MCH_EntityUavStation) {
-                  var19 = ((MCH_EntityUavStation)var17.ridingEntity).getControlAircract();
-               } else if(var17.ridingEntity instanceof MCH_EntityTurret) {
-                  MCH_EntityBaseVehicle stickMode = (MCH_EntityBaseVehicle)var17.ridingEntity;
-                  stickMode.setupAllRiderRenderPosition(partialTicks, var17);
-               }
-            } else {
-               var19 = (MCH_EntityBaseVehicle)var17.ridingEntity;
-            }
+            MCH_EntityBaseVehicle var19 = zoomContext.vehicle;
 
             boolean var20 = false;
             MCH_Config var10000;
@@ -692,13 +696,13 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
 
             float p;
             float r;
-            if(var19 != null && var19.canMouseRot()) {
+            if(!(var17.ridingEntity instanceof MCH_EntitySeat) && var19 != null && var19.canMouseRot()) {
                if(!isRideAircraft) {
                   var19.onInteractFirst(var17);
                }
 
                isRideAircraft = true;
-               this.updateMouseDelta(var20, simDelta);
+               this.updateMouseDelta(var20, simDelta, zoomContext.getSensitivityMultiplier());
                boolean var22 = false;
                float var23 = 0.0F;
                float var25 = 0.0F;
@@ -760,7 +764,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
             } else {
                MCH_EntitySeat var21 = var17.ridingEntity instanceof MCH_EntitySeat?(MCH_EntitySeat)var17.ridingEntity:null;
                if(var21 != null && var21.getParent() != null) {
-                  this.updateMouseDelta(var20, simDelta);
+                  this.updateMouseDelta(var20, simDelta, zoomContext.getSensitivityMultiplier());
                   var19 = var21.getParent();
                   boolean wi = false;
                   MCH_SeatInfo seatInfo = var19.getSeatInfo(var17);
@@ -1001,6 +1005,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onRenderTickPost(float partialTicks) {
+      if(this.restoreMouseFocusAfterRender) {
+         this.mc.inGameHasFocus = true;
+         this.restoreMouseFocusAfterRender = false;
+      }
       if (this.mc.thePlayer != null) {
          MCH_ClientTickHandlerBase.applyRotLimit((Entity)this.mc.thePlayer);
          MCH_ViewEntityDummy mCH_ViewEntityDummy = MCH_ViewEntityDummy.getInstance(this.mc.thePlayer.worldObj);

--- a/src/main/java/mcheli/MCH_ZoomContext.java
+++ b/src/main/java/mcheli/MCH_ZoomContext.java
@@ -1,0 +1,84 @@
+package mcheli;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
+import mcheli.gltd.MCH_EntityGLTD;
+import mcheli.lweapon.MCH_ItemLightWeaponBase;
+import mcheli.tool.rangefinder.MCH_ItemRangeFinder;
+import mcheli.wrapper.W_Reflection;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+
+/** Resolves both the owner of MCHeli zoom and the code path which consumes mouse input. */
+@SideOnly(Side.CLIENT)
+public final class MCH_ZoomContext {
+   public static enum InputPath {
+      NONE,
+      VEHICLE,
+      VANILLA_LOOK
+   }
+
+   public final InputPath inputPath;
+   public final MCH_EntityBaseVehicle vehicle;
+   public final double zoom;
+
+   private MCH_ZoomContext(InputPath inputPath, MCH_EntityBaseVehicle vehicle, double zoom) {
+      this.inputPath = inputPath;
+      this.vehicle = vehicle;
+      this.zoom = sanitizeZoom(zoom);
+   }
+
+   public static MCH_ZoomContext resolve(Minecraft minecraft, EntityPlayer player) {
+      if(player == null) {
+         return none();
+      }
+
+      MCH_EntityBaseVehicle vehicle = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
+      if(vehicle != null) {
+         return new MCH_ZoomContext(InputPath.VEHICLE, vehicle, vehicle.camera != null?vehicle.camera.getCameraZoom():1.0D);
+      }
+
+      if(player.ridingEntity instanceof MCH_EntityGLTD) {
+         MCH_EntityGLTD gltd = (MCH_EntityGLTD)player.ridingEntity;
+         return new MCH_ZoomContext(InputPath.VANILLA_LOOK, null, gltd.camera != null?gltd.camera.getCameraZoom():1.0D);
+      }
+
+      ItemStack held = player.getCurrentEquippedItem();
+      if(held != null && held.getItem() instanceof MCH_ItemLightWeaponBase && player.getItemInUseDuration() > 10) {
+         return new MCH_ZoomContext(InputPath.VANILLA_LOOK, null, W_Reflection.getCameraZoom());
+      }
+
+      if(held != null && held.getItem() instanceof MCH_ItemRangeFinder && MCH_ItemRangeFinder.isUsingScope(player)) {
+         return new MCH_ZoomContext(InputPath.VANILLA_LOOK, null, W_Reflection.getCameraZoom());
+      }
+
+      return none();
+   }
+
+   public double getSensitivityMultiplier() {
+      double effectValue = MCH_Config.ZoomSensitivityEffect.prmDouble;
+      if(Double.isNaN(effectValue) || Double.isInfinite(effectValue)) {
+         effectValue = 100.0D;
+      }
+      return calculateSensitivityMultiplier(this.zoom, effectValue);
+   }
+
+   public static double calculateSensitivityMultiplier(double zoom, double effectValue) {
+      zoom = sanitizeZoom(zoom);
+      if(Double.isNaN(effectValue) || Double.isInfinite(effectValue)) {
+         effectValue = 100.0D;
+      }
+      double effect = Math.max(0.0D, Math.min(100.0D, effectValue)) / 100.0D;
+      return 1.0D / (1.0D + (zoom - 1.0D) * effect);
+   }
+
+   private static MCH_ZoomContext none() {
+      return new MCH_ZoomContext(InputPath.NONE, null, 1.0D);
+   }
+
+   private static double sanitizeZoom(double zoom) {
+      return Double.isNaN(zoom) || Double.isInfinite(zoom)?1.0D:Math.max(1.0D, zoom);
+   }
+}

--- a/src/main/java/mcheli/wrapper/W_Reflection.java
+++ b/src/main/java/mcheli/wrapper/W_Reflection.java
@@ -119,6 +119,16 @@ public class W_Reflection {
 	      setCameraZoom(1.0F);
 	   }
 
+	   public static float getCameraZoom() {
+	      try {
+	         Minecraft minecraft = Minecraft.getMinecraft();
+	         return ((Float)ObfuscationReflectionHelper.getPrivateValue(EntityRenderer.class, minecraft.entityRenderer, new String[]{"field_78503_V", "cameraZoom"})).floatValue();
+	      } catch (Exception e) {
+	         e.printStackTrace();
+	         return 1.0F;
+	      }
+	   }
+
 	   public static void setCameraZoom(float zoom) {
 	      try {
 	         Minecraft e = Minecraft.getMinecraft();


### PR DESCRIPTION
### Motivation

- The previous change exposed a `ZoomSensitivityEffect` setting and scaled `updateMouseDelta(...)`, but zoomed contexts (GLTD, scoped light weapons, rangefinder) and directly ridden turrets did not actually see the scaled deltas, producing no observable effect. 
- The intent is to resolve the true input context (vehicle vs vanilla-look) per-frame, read the effective zoom for that context, and apply a single, well-defined sensitivity multiplier consistently for all MCHeli zoom contexts.

### Description

- Add a client-side resolver `MCH_ZoomContext` that returns the resolved input path (`VEHICLE` or `VANILLA_LOOK`), the resolved `MCH_EntityBaseVehicle` when applicable, and a sanitized effective zoom value. (`src/main/java/mcheli/MCH_ZoomContext.java`)
- Centralize the sensitivity formula and clamping in the resolver and expose `calculateSensitivityMultiplier(...)`; the formula is `1.0 / (1.0 + (zoom - 1.0) * effect)` with `effect` clamped to `0..100`. This produces the exact expected cases (e.g. zoom 4.0, effect 100 -> 0.25). (`MCH_ZoomContext`) 
- Route vehicle control and zoom handling through the resolved vehicle instance so directly ridden turrets, seats, and UAV stations share the same resolved vehicle and zoom multiplier; remove the earlier branch that left directly ridden turrets unassigned. (`src/main/java/mcheli/MCH_ClientCommonTickHandler.java`)
- Apply the zoom multiplier after the vanilla sensitivity curve and `MCH_Config.MouseSensitivity` but before stick-mode accumulation and vehicle stick handling, and apply the same multiplier to horizontal and vertical deltas exactly once. (`MCH_ClientCommonTickHandler.updateMouseDelta`) 
- Add support for vanilla-look MCHeli contexts (GLTD, scoped light weapons, rangefinder) by consuming the render-frame mouse sample in `updateVanillaLook(...)`, applying the vanilla curve then the multiplier, and suppressing the vanilla `EntityRenderer` mouse branch for that frame so the input is not processed twice. (`MCH_ClientCommonTickHandler`) 
- Add `W_Reflection.getCameraZoom()` to read `EntityRenderer.cameraZoom` via reflection using the exact Forge 1.7.10 reflected names (`"field_78503_V", "cameraZoom"`). (`src/main/java/mcheli/wrapper/W_Reflection.java`) 
- Keep the `ZoomSensitivityEffect` config parameter, GUI slider, clamped range, and default; update `docs/configuration.md` to document the supported zoom contexts. (`src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/gui/MCH_ConfigGui.java`, `docs/configuration.md`) 

### Testing

- Ran repository checks: `git diff --check` and `git diff --cached --check` (both passed). 
- Verified the multiplier formula with a small script for the requested cases: zoom/effect pairs (1/0, 1/100, 2/100, 4/100, 4/50, 4/0) all produced the exact expected multipliers. (script run locally in repo)
- Confirmed no changelog or binary artifacts were added and that changed docs/configuration entry was updated. (`git status`, `git diff --name-only` checks)
- Did not perform a Gradle build or in-game runtime interaction tests because the task environment and instructions explicitly prohibit compiling binaries and a non-interactive environment prevents measuring yaw/pitch in-game; runtime verification (angle measurements, per-path behavior with vehicles, turrets, GLTD, light weapons, rangefinder) should be run in-game following the verification checklist in the task description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d46da82348323aa662191bc027605)