### PR TITLE
Hide smoke particles in thermal vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Client-side thermal particle visibility fix (PR pending)
+
+- Filter MCHeli smoke plus vanilla normal and large smoke at render time while the local active camera is in thermal mode.
+- Preserve particle spawning, lifetime, motion, networking, and world state so hidden smoke becomes visible again immediately after thermal vision ends.
+- Keep fire, flame, flashes, tracers, sparks, flares, debris, dust, and water particles unchanged.
+
 # Normal vehicle respawn ordering (PR pending)
 
 - Replaced failed tracker resend/repair logic from PRs #593–#598 with watched-chunk normal spawning, unwatched-chunk render-only LOD snapshots, and bounded observer-directed mount graphs.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -19,6 +19,7 @@ import mcheli.mob.MCH_GuiSpawnGunner;
 import mcheli.multiplay.MCH_GuiScoreboard;
 import mcheli.multiplay.MCH_GuiTargetMarker;
 import mcheli.multiplay.MCH_MultiplayClient;
+import mcheli.particles.MCH_ThermalParticleFilter;
 import mcheli.plane.MCP_ClientPlaneTickHandler;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.plane.MCP_GuiPlane;
@@ -680,6 +681,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
                cameraMode = 0;
             }
 
+            // Hide smoke only for drawing; particles keep updating so existing smoke returns
+            // immediately when the local camera leaves thermal vision.
+            MCH_ThermalParticleFilter.beginRender();
+
             MCH_EntityBaseVehicle var19 = zoomContext.vehicle;
 
             boolean var20 = false;
@@ -1005,6 +1010,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onRenderTickPost(float partialTicks) {
+      MCH_ThermalParticleFilter.endRender();
       if(this.restoreMouseFocusAfterRender) {
          this.mc.inGameHasFocus = true;
          this.restoreMouseFocusAfterRender = false;

--- a/src/main/java/mcheli/MCH_ThermalVision.java
+++ b/src/main/java/mcheli/MCH_ThermalVision.java
@@ -1,0 +1,18 @@
+package mcheli;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.Minecraft;
+
+@SideOnly(Side.CLIENT)
+public final class MCH_ThermalVision {
+
+   private MCH_ThermalVision() {}
+
+   /** Returns the thermal state of this client's active camera, never another player's camera. */
+   public static boolean isActiveCameraThermal() {
+      Minecraft mc = Minecraft.getMinecraft();
+      return mc != null && mc.thePlayer != null && mc.theWorld != null
+         && MCH_ClientCommonTickHandler.cameraMode == MCH_Camera.MODE_THERMALVISION;
+   }
+}

--- a/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
@@ -10,7 +10,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.world.World;
 import org.lwjgl.opengl.GL11;
 
-public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase {
+public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase implements MCH_ISmokeParticle {
 
    public MCH_EntityParticleSmoke(World par1World, double x, double y, double z, double mx, double my, double mz) {
       super(par1World, x, y, z, mx, my, mz);

--- a/src/main/java/mcheli/particles/MCH_ISmokeParticle.java
+++ b/src/main/java/mcheli/particles/MCH_ISmokeParticle.java
@@ -1,0 +1,4 @@
+package mcheli.particles;
+
+/** Identifies an MCHeli particle whose visual effect is smoke. */
+public interface MCH_ISmokeParticle {}

--- a/src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java
+++ b/src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java
@@ -1,0 +1,80 @@
+package mcheli.particles;
+
+import cpw.mods.fml.common.ObfuscationReflectionHelper;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import mcheli.MCH_Lib;
+import mcheli.MCH_ThermalVision;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.EffectRenderer;
+import net.minecraft.client.particle.EntityFX;
+import net.minecraft.client.particle.EntitySmokeFX;
+
+@SideOnly(Side.CLIENT)
+public final class MCH_ThermalParticleFilter {
+
+   private static final Map<EntityFX, Float> hiddenSmokeAlpha = new IdentityHashMap<EntityFX, Float>();
+   private static boolean reflectionWarningLogged;
+
+   private MCH_ThermalParticleFilter() {}
+
+   /** The single smoke classification used for both MCHeli and vanilla particles. */
+   public static boolean isSmokeParticle(EntityFX particle) {
+      return particle instanceof MCH_ISmokeParticle || particle instanceof EntitySmokeFX;
+   }
+
+   public static void beginRender() {
+      restoreSmokeAlpha();
+      if(!MCH_ThermalVision.isActiveCameraThermal()) {
+         return;
+      }
+
+      Minecraft mc = Minecraft.getMinecraft();
+      if(mc.effectRenderer == null) {
+         return;
+      }
+
+      try {
+         List[] layers = (List[])ObfuscationReflectionHelper.getPrivateValue(EffectRenderer.class,
+            mc.effectRenderer, new String[]{"field_78876_b", "fxLayers"});
+         for(int layerIndex = 0; layerIndex < layers.length; ++layerIndex) {
+            List layer = layers[layerIndex];
+            Iterator iterator = layer.iterator();
+            while(iterator.hasNext()) {
+               Object value = iterator.next();
+               if(value instanceof EntityFX && isSmokeParticle((EntityFX)value)) {
+                  EntityFX particle = (EntityFX)value;
+                  Float alpha = (Float)ObfuscationReflectionHelper.getPrivateValue(EntityFX.class,
+                     particle, new String[]{"field_82339_as", "particleAlpha"});
+                  hiddenSmokeAlpha.put(particle, alpha);
+                  particle.setAlphaF(0.0F);
+               }
+            }
+         }
+      } catch(RuntimeException e) {
+         restoreSmokeAlpha();
+         if(!reflectionWarningLogged) {
+            reflectionWarningLogged = true;
+            MCH_Lib.Log("Thermal smoke render filter could not inspect particle layers: %s", e.toString());
+         }
+      }
+   }
+
+   public static void endRender() {
+      restoreSmokeAlpha();
+   }
+
+   private static void restoreSmokeAlpha() {
+      Iterator<Map.Entry<EntityFX, Float>> iterator = hiddenSmokeAlpha.entrySet().iterator();
+      while(iterator.hasNext()) {
+         Map.Entry<EntityFX, Float> entry = iterator.next();
+         EntityFX particle = entry.getKey();
+         particle.setAlphaF(entry.getValue().floatValue());
+      }
+      hiddenSmokeAlpha.clear();
+   }
+}


### PR DESCRIPTION
### Motivation

- Prevent smoke particles from appearing while the local player is viewing through thermal vision by filtering them at render time rather than stopping their creation, preserving particle lifetimes and world state.

### Description

- Add a client-only helper `MCH_ThermalVision.isActiveCameraThermal()` to determine whether the active camera is in thermal mode. (F: `src/main/java/mcheli/MCH_ThermalVision.java`)
- Introduce a smoke marker interface `MCH_ISmokeParticle` and apply it to the mod's smoke class so MCHeli-specific smoke is identifiable without changing particle behavior. (F: `src/main/java/mcheli/particles/MCH_ISmokeParticle.java`, `src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java`)
- Implement `MCH_ThermalParticleFilter`, which inspects `EffectRenderer.fxLayers` via Forge reflection at render-tick START and temporarily sets matching smoke particles' alpha to zero, then restores their previous alpha at render-tick END; the filter treats both `MCH_ISmokeParticle` and vanilla `EntitySmokeFX` as smoke. (F: `src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java`)
- Wire the filter into the render lifecycle after the local camera mode is resolved in the client render tick so the rule only affects the local player's view and not particle creation, motion, networking, or other particle classes. (F: `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`)
- Add a changelog entry documenting this client-side thermal particle visibility fix and include a bounded reflection-failure log path to avoid noisy exceptions on unexpected mappings. (F: `CHANGELOG.md`, `src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java`)

### Testing

- Ran `./gradlew compileJava` and the build compilation completed successfully. 
- Ran `git diff --check` and staged-diff checks (pre-commit checks) with no reported problems. 
- Ran `./gradlew test` but the task failed to resolve `junit:junit:4.13.2` due to configured artifact repositories returning HTTP 403, so unit tests could not be executed in this environment. 
- Visual/runtime acceptance tests (in-game Forge client toggling, multi-client isolation, OpenGL state verification) could not be performed in the non-interactive environment and therefore remain manual verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d498e40f08323b8944316c7993ec8)