### PR TITLE
Render tank countermeasure smoke in thermal vision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Tank countermeasure smoke thermal visibility (PR pending)
+
+- Keep smoke emitted by vehicle smoke weapons and countermeasure flares visible as cold smoke in thermal vision, without changing its normal particle lifetime, movement, scale, opacity, or fade.
+- Continue filtering unrelated MCHeli and vanilla smoke particles from the thermal render pass.
+
 # Client-side thermal particle visibility fix (PR pending)
 
 - Filter MCHeli smoke plus vanilla normal and large smoke at render time while the local active camera is in thermal mode.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -4929,6 +4929,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
                               prm.age = maxAge;
                               prm.toWhite = true;
                               prm.diffusible = true;
+                              prm.visibleInThermal = true;
                               MCH_ParticlesUtil.spawnParticle(prm);
                            }
                         }

--- a/src/main/java/mcheli/flare/MCH_EntityFlare.java
+++ b/src/main/java/mcheli/flare/MCH_EntityFlare.java
@@ -83,6 +83,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
             double y = (super.rand.nextDouble() - 0.5D) * 10.0D;
             double z = (super.rand.nextDouble() - 0.5D) * 10.0D;
             MCH_ParticleParam prm = new MCH_ParticleParam(super.worldObj, "smoke", super.posX + x, super.posY + y, super.posZ + z);
+            prm.visibleInThermal = this.countermeasure;
             prm.age = 200 + super.rand.nextInt(100);
             prm.size = (float)(20 + super.rand.nextInt(25));
             prm.motionX = (super.rand.nextDouble() - 0.5D) * 0.45D;
@@ -142,6 +143,7 @@ public class MCH_EntityFlare extends W_Entity implements IEntityAdditionalSpawnD
 
             for(int i = 0; i < 2; ++i) {
                MCH_ParticleParam prm = new MCH_ParticleParam(super.worldObj, "smoke", super.prevPosX + x * (double)i, super.prevPosY + y * (double)i, super.prevPosZ + z * (double)i);
+               prm.visibleInThermal = this.countermeasure;
                prm.size = 6.0F + super.rand.nextFloat();
                if(this.size < 5.0F) {
                   prm.a = (float)((double)prm.a * 0.75D);

--- a/src/main/java/mcheli/flare/MCH_Flare.java
+++ b/src/main/java/mcheli/flare/MCH_Flare.java
@@ -73,6 +73,7 @@ public class MCH_Flare {
 
          for(int i = 0; i < num; ++i) {
             MCH_ParticleParam prm = new MCH_ParticleParam(this.worldObj, "smoke", this.aircraft.prevPosX + x * (double)i, this.aircraft.prevPosY + y * (double)i, this.aircraft.prevPosZ + z * (double)i);
+            prm.visibleInThermal = true;
             prm.size = size + this.rand.nextFloat();
             MCH_ParticlesUtil.spawnParticle(prm);
          }

--- a/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
+++ b/src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java
@@ -12,12 +12,22 @@ import org.lwjgl.opengl.GL11;
 
 public class MCH_EntityParticleSmoke extends MCH_EntityParticleBase implements MCH_ISmokeParticle {
 
+   private boolean visibleInThermal;
+
    public MCH_EntityParticleSmoke(World par1World, double x, double y, double z, double mx, double my, double mz) {
       super(par1World, x, y, z, mx, my, mz);
       super.particleRed = super.particleGreen = super.particleBlue = super.rand.nextFloat() * 0.3F + 0.7F;
       this.setParticleScale(super.rand.nextFloat() * 0.5F + 5.0F);
       this.setParticleMaxAge((int)(16.0D / ((double)super.rand.nextFloat() * 0.8D + 0.2D)) + 2);
       super.noClip = true;
+   }
+
+   public void setVisibleInThermal(boolean visible) {
+      this.visibleInThermal = visible;
+   }
+
+   public boolean isVisibleInThermal() {
+      return this.visibleInThermal;
    }
 
    public void onUpdate() {

--- a/src/main/java/mcheli/particles/MCH_ISmokeParticle.java
+++ b/src/main/java/mcheli/particles/MCH_ISmokeParticle.java
@@ -1,4 +1,7 @@
 package mcheli.particles;
 
 /** Identifies an MCHeli particle whose visual effect is smoke. */
-public interface MCH_ISmokeParticle {}
+public interface MCH_ISmokeParticle {
+
+   boolean isVisibleInThermal();
+}

--- a/src/main/java/mcheli/particles/MCH_ParticleParam.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleParam.java
@@ -21,6 +21,7 @@ public class MCH_ParticleParam {
    public int age;
    public boolean diffusible;
    public boolean toWhite;
+   public boolean visibleInThermal;
    public float gravity;
    public float motionYUpAge;
 
@@ -38,6 +39,7 @@ public class MCH_ParticleParam {
       this.age = 0;
       this.diffusible = false;
       this.toWhite = false;
+      this.visibleInThermal = false;
       this.gravity = 0.0F;
       this.motionYUpAge = 2.0F;
       this.world = w;

--- a/src/main/java/mcheli/particles/MCH_ParticlesUtil.java
+++ b/src/main/java/mcheli/particles/MCH_ParticlesUtil.java
@@ -307,6 +307,9 @@ public class MCH_ParticlesUtil {
          ((MCH_EntityParticleBase)entityFX).isEffectedWind = p.isEffectWind;
          ((MCH_EntityParticleBase)entityFX).diffusible = p.diffusible;
          ((MCH_EntityParticleBase)entityFX).toWhite = p.toWhite;
+         if(entityFX instanceof MCH_EntityParticleSmoke) {
+            ((MCH_EntityParticleSmoke)entityFX).setVisibleInThermal(p.visibleInThermal);
+         }
          if(p.diffusible) {
             ((MCH_EntityParticleBase)entityFX).setParticleScale(p.size * 0.2F);
             ((MCH_EntityParticleBase)entityFX).particleMaxScale = p.size * 2.0F;

--- a/src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java
+++ b/src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java
@@ -27,6 +27,12 @@ public final class MCH_ThermalParticleFilter {
       return particle instanceof MCH_ISmokeParticle || particle instanceof EntitySmokeFX;
    }
 
+   /** Countermeasure smoke remains a cold, opaque smoke visual in thermal vision. */
+   public static boolean shouldHideSmokeParticle(EntityFX particle) {
+      return isSmokeParticle(particle) && (!(particle instanceof MCH_ISmokeParticle)
+         || !((MCH_ISmokeParticle)particle).isVisibleInThermal());
+   }
+
    public static void beginRender() {
       restoreSmokeAlpha();
       if(!MCH_ThermalVision.isActiveCameraThermal()) {
@@ -46,7 +52,7 @@ public final class MCH_ThermalParticleFilter {
             Iterator iterator = layer.iterator();
             while(iterator.hasNext()) {
                Object value = iterator.next();
-               if(value instanceof EntityFX && isSmokeParticle((EntityFX)value)) {
+               if(value instanceof EntityFX && shouldHideSmokeParticle((EntityFX)value)) {
                   EntityFX particle = (EntityFX)value;
                   Float alpha = (Float)ObfuscationReflectionHelper.getPrivateValue(EntityFX.class,
                      particle, new String[]{"field_82339_as", "particleAlpha"});


### PR DESCRIPTION
### Motivation

- Thermal render pass previously zeroed alpha for every smoke particle class, which hid tank flare and countermeasure smoke during thermal vision while leaving normal rendering and particle updates unchanged. 
- The intent is to make countermeasure and vehicle smoke visible in thermal mode without changing spawn behavior, lifetime, motion, scale, opacity, fade, or general smoke renderer semantics. 
- The change must be narrowly scoped so unrelated smoke and vanilla particles remain filtered and no GL state or rendering behavior is leaked.

### Description

- Added an opt-in `visibleInThermal` flag to `MCH_ParticleParam` and propagated it into `MCH_EntityParticleSmoke` via `MCH_ParticlesUtil` so smoke instances can be marked at spawn time. 
- Introduced `MCH_ISmokeParticle.isVisibleInThermal()` and stored the flag on `MCH_EntityParticleSmoke` so the particle instance can report its thermal visibility. 
- Reworked the thermal filter in `MCH_ThermalParticleFilter` to only hide smoke particles that are not explicitly marked visible in thermal mode by using `shouldHideSmokeParticle(...)`, preserving the existing alpha-hide-and-restore approach for all other smoke. 
- Marked vehicle-emitted smoke and flare/countermeasure smoke at spawn sites (`MCH_EntityBaseVehicle`, `MCH_EntityFlare`, and `MCH_Flare`) so tank smoke and countermeasure smoke remain visible when the local camera is in thermal vision. 
- Updated `CHANGELOG.md` to document the targeted fix. 
- Changed files: `CHANGELOG.md`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/flare/MCH_EntityFlare.java`, `src/main/java/mcheli/flare/MCH_Flare.java`, `src/main/java/mcheli/particles/MCH_EntityParticleSmoke.java`, `src/main/java/mcheli/particles/MCH_ISmokeParticle.java`, `src/main/java/mcheli/particles/MCH_ParticleParam.java`, `src/main/java/mcheli/particles/MCH_ParticlesUtil.java`, and `src/main/java/mcheli/particles/MCH_ThermalParticleFilter.java`.

### Testing

- Ran `git diff --check` and `git status` and inspected diffs; these checks succeeded. 
- Performed source-level verification with `rg`/searches for `visibleInThermal`, `shouldHideSmokeParticle`, and `isVisibleInThermal` to confirm propagation and use; inspection succeeded. 
- No Gradle/Forge client or server runtime builds or in-game tests were executed because the environment and instructions prohibit producing or committing compiled binaries; runtime verification (Forge 1.7.10 client/server, smoke deployment, thermal obscuration, repeated-deployment performance, and OpenGL error checks) remains to be run in a proper test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d50667d488323aa509b000314c0a6)