### PR TITLE
Fix Replay Mod playback camera ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Replay Mod playback camera ownership compatibility (PR pending)
+
+- Detect Replay Mod's playback-only `CameraEntity` without linking Replay Mod, release stale MCHeli chase/view state, and leave `renderViewEntity`, camera transforms, FOV, and view-mode ownership to Replay Mod.
+- Suppress local MCHeli vehicle controls, outbound control packets, recoil/bombsight mutations, and mounted-vehicle HUDs during playback while keeping passive vehicle state updates and rendering active.
+- Restore normal MCHeli camera handling automatically after playback ends; Replay Mod installation and live recording do not activate the compatibility path.
+
 # Tank countermeasure smoke thermal visibility (PR pending)
 
 - Keep smoke emitted by vehicle smoke weapons and countermeasure flares visible as cold smoke in thermal vision, without changing its normal particle lifetime, movement, scale, opacity, or fade.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -54,6 +54,7 @@ import org.lwjgl.opengl.Display;
 import mcheli.ship.MCH_ClientShipTickHandler;
 import mcheli.ship.MCH_EntityShip;
 import mcheli.ship.MCH_GuiShip;
+import mcheli.compat.MCH_ReplayModCompat;
 
 //Eventhooks, clientproxy, tickhandler, guis and config just to name a few inheritors
 @SideOnly(Side.CLIENT)
@@ -108,6 +109,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    private World dismountWorld;
    private Object dismountConnection;
    private boolean restoreMouseFocusAfterRender;
+   private boolean replayPlaybackActive;
 
 
 
@@ -242,6 +244,18 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onTickPre() {
+      boolean replayActive = MCH_ReplayModCompat.updatePlaybackState();
+      if(replayActive != this.replayPlaybackActive) {
+         this.replayPlaybackActive = replayActive;
+         if(replayActive) {
+            this.releaseCameraAndControlForReplay();
+         } else {
+            MCH_ReplayModCompat.logCameraHandlingRestored();
+         }
+      }
+      if(replayActive) {
+         return;
+      }
       if(super.mc.thePlayer != null && super.mc.theWorld != null) {
          this.updateDismountHoldState();
          this.onTick();
@@ -252,6 +266,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onTickPost() {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_PlayerViewHandler.clearRecoil();
+         return;
+      }
       if(super.mc.thePlayer != null && super.mc.theWorld != null) {
          MCH_GuiTargetMarker.onClientTick();
       }
@@ -643,6 +661,11 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onRenderTickPre(float partialTicks) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         ridingAircraft = null;
+         cameraMode = 0;
+         return;
+      }
       MCH_GuiTargetMarker.clearMarkEntityPos();
       if(!MCH_ServerSettings.enableDebugBoundingBox) {
          RenderManager.debugBoundingBox = false;
@@ -1010,6 +1033,14 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onRenderTickPost(float partialTicks) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ThermalParticleFilter.endRender();
+         if(this.restoreMouseFocusAfterRender) {
+            this.mc.inGameHasFocus = true;
+            this.restoreMouseFocusAfterRender = false;
+         }
+         return;
+      }
       MCH_ThermalParticleFilter.endRender();
       if(this.restoreMouseFocusAfterRender) {
          this.mc.inGameHasFocus = true;
@@ -1044,12 +1075,37 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public boolean drawGui(MCH_Gui gui, float partialTicks) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         return false;
+      }
       if(gui.isDrawGui(super.mc.thePlayer)) {
          gui.drawScreen(0, 0, partialTicks);
          return true;
       } else {
          return false;
       }
+   }
+
+   private void releaseCameraAndControlForReplay() {
+      MCP_PlaneChaseCamera.releaseForReplayPlayback(super.mc);
+      MCP_ClientPlaneTickHandler.resetBombReticleMode();
+      MCH_PlayerViewHandler.clearRecoil();
+      W_Reflection.clearMCHeliCameraRollForReplayPlayback();
+      MCH_Lib.enableFirstPersonItemRender();
+      ridingAircraft = null;
+      cameraMode = 0;
+      isRideAircraft = false;
+      isDrawScoreboard = false;
+      mouseDeltaX = mouseDeltaY = 0.0D;
+      prevMouseDeltaX = prevMouseDeltaY = 0.0D;
+      mouseRollDeltaX = mouseRollDeltaY = 0.0D;
+      this.resetDismountHoldState();
+      if(this.Keys != null) {
+         for(MCH_Key key : this.Keys) {
+            key.reset();
+         }
+      }
+      MCH_ReplayModCompat.logCameraOwnershipReleased();
    }
 
 }

--- a/src/main/java/mcheli/MCH_ClientEventHook.java
+++ b/src/main/java/mcheli/MCH_ClientEventHook.java
@@ -25,6 +25,7 @@ import mcheli.plane.client.MCP_NewPlaneOverlayRenderer;
 import mcheli.tool.rangefinder.MCH_ItemRangeFinder;
 import mcheli.wrapper.W_ClientEventHook;
 import mcheli.wrapper.W_Reflection;
+import mcheli.compat.MCH_ReplayModCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.renderer.OpenGlHelper;
@@ -110,6 +111,9 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
    }
 
    public void mouseEvent(MouseEvent event) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         return;
+      }
       if(MCH_ClientTickHandlerBase.updateMouseWheel(event.dwheel)) {
          event.setCanceled(true);
       }
@@ -194,23 +198,33 @@ public class MCH_ClientEventHook extends W_ClientEventHook {
 
    @SubscribeEvent
    public void onRenderOverlayPre(RenderGameOverlayEvent.Pre event) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         return;
+      }
       this.newPlaneOverlayRenderer.onRenderOverlayPre(event);
    }
 
    @SubscribeEvent
    public void onRenderOverlayPost(RenderGameOverlayEvent.Post event) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         return;
+      }
       this.newPlaneOverlayRenderer.onRenderOverlayPost(event);
    }
 
    @SubscribeEvent
    public void onFovUpdate(FOVUpdateEvent event) {
-      if(event != null && MCP_PlaneChaseCamera.isFovOverrideActive()) {
+      if(event != null && !MCH_ReplayModCompat.isReplayPlaybackActive() && MCP_PlaneChaseCamera.isFovOverrideActive()) {
          event.newfov = MCP_PlaneChaseCamera.applyFovOverride(event.newfov);
       }
    }
 
    @SubscribeEvent
    public void renderTick(TickEvent.RenderTickEvent event) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCP_PlaneChaseCamera.releaseForReplayPlayback(Minecraft.getMinecraft());
+         return;
+      }
       switch (event.phase) {
          case START:
             smoothing = event.renderTickTime;

--- a/src/main/java/mcheli/MCH_Key.java
+++ b/src/main/java/mcheli/MCH_Key.java
@@ -43,6 +43,11 @@ public class MCH_Key {
       }
    }
 
+   public void reset() {
+      this.isPress = false;
+      this.isBeforePress = false;
+   }
+
    public static boolean isKeyDown(int key) {
       return key > 0?Keyboard.isKeyDown(key):(key < 0?Mouse.isButtonDown(key + 100):false);
    }

--- a/src/main/java/mcheli/MCH_Lib.java
+++ b/src/main/java/mcheli/MCH_Lib.java
@@ -490,6 +490,10 @@ public class MCH_Lib {
    }
 
    public static void setRenderViewEntity(EntityLivingBase entity) {
+      if(mcheli.compat.MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         mcheli.compat.MCH_ReplayModCompat.logBlockedCameraWrite("MCH_Lib.setRenderViewEntity");
+         return;
+      }
       MCH_Config var10000 = MCH_MOD.config;
       if(MCP_PlaneChaseCamera.isAnyRenderCameraActive() && !MCP_PlaneChaseCamera.ownsRenderEntity(entity)) {
          MCP_PlaneChaseCamera.warnSkippedRenderViewRestore(entity, "MCH_Lib.setRenderViewEntity");

--- a/src/main/java/mcheli/MCH_PlayerViewHandler.java
+++ b/src/main/java/mcheli/MCH_PlayerViewHandler.java
@@ -32,6 +32,11 @@ public class MCH_PlayerViewHandler {
      */
     public static void onUpdate() {
 
+        if(mcheli.compat.MCH_ReplayModCompat.isReplayPlaybackActive()) {
+            clearRecoil();
+            return;
+        }
+
         if(minecraft.thePlayer == null) {
             return;
         }
@@ -52,5 +57,12 @@ public class MCH_PlayerViewHandler {
         antiRecoilYaw *= 0.8F;
 
         playerRecoilYaw *= 0.8F;
+    }
+
+    public static void clearRecoil() {
+        playerRecoilPitch = 0.0F;
+        playerRecoilYaw = 0.0F;
+        antiRecoilPitch = 0.0F;
+        antiRecoilYaw = 0.0F;
     }
 }

--- a/src/main/java/mcheli/MCH_RenderBVRLockBox.java
+++ b/src/main/java/mcheli/MCH_RenderBVRLockBox.java
@@ -8,6 +8,7 @@ import mcheli.vector.Vector3f;
 import mcheli.weapon.MCH_WeaponGuidanceSystem;
 import mcheli.weapon.MCH_WeaponInfo;
 import mcheli.wrapper.W_MOD;
+import mcheli.compat.MCH_ReplayModCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.client.gui.ScaledResolution;
@@ -33,6 +34,7 @@ public class MCH_RenderBVRLockBox {
 
     @SubscribeEvent
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
+        if (MCH_ReplayModCompat.isReplayPlaybackActive()) return;
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
 
         //Gets basic information

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -6,6 +6,7 @@ import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.wrapper.W_MOD;
+import mcheli.compat.MCH_ReplayModCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.Tessellator;
@@ -35,6 +36,7 @@ public class MCH_RenderRWR {
 
     @SubscribeEvent
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
+        if (MCH_ReplayModCompat.isReplayPlaybackActive()) return;
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
         //Gets basic information
         Minecraft mc = Minecraft.getMinecraft();

--- a/src/main/java/mcheli/compat/MCH_ReplayModCompat.java
+++ b/src/main/java/mcheli/compat/MCH_ReplayModCompat.java
@@ -1,0 +1,75 @@
+package mcheli.compat;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import mcheli.MCH_Config;
+import mcheli.MCH_Lib;
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.Entity;
+
+/** Optional, class-name-only integration with Replay Mod playback. */
+@SideOnly(Side.CLIENT)
+public final class MCH_ReplayModCompat {
+   private static final String CAMERA_ENTITY = "com.replaymod.replay.camera.CameraEntity";
+   private static Class lastPlayerClass;
+   private static boolean lastPlayerClassIsReplayCamera;
+   private static boolean playbackActive;
+   private static long nextBlockedWriteLogTime;
+
+   private MCH_ReplayModCompat() {}
+
+   public static boolean isReplayPlaybackActive() {
+      Minecraft mc = Minecraft.getMinecraft();
+      Entity player = mc != null?mc.thePlayer:null;
+      if(player == null) {
+         return false;
+      }
+      Class playerClass = player.getClass();
+      if(playerClass != lastPlayerClass) {
+         lastPlayerClass = playerClass;
+         lastPlayerClassIsReplayCamera = isReplayCameraClass(playerClass);
+      }
+      return lastPlayerClassIsReplayCamera;
+   }
+
+   private static boolean isReplayCameraClass(Class type) {
+      for(Class current = type; current != null; current = current.getSuperclass()) {
+         if(CAMERA_ENTITY.equals(current.getName())) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   /** Records playback transitions. State release is performed by the client tick owner. */
+   public static boolean updatePlaybackState() {
+      boolean active = isReplayPlaybackActive();
+      if(active != playbackActive) {
+         playbackActive = active;
+         debug(active?"Replay playback detected":"Replay playback ended");
+      }
+      return active;
+   }
+
+   public static void logCameraOwnershipReleased() {
+      debug("MCHeli camera ownership released");
+   }
+
+   public static void logCameraHandlingRestored() {
+      debug("Normal MCHeli camera handling restored");
+   }
+
+   public static void logBlockedCameraWrite(String owner) {
+      long now = System.currentTimeMillis();
+      if(now >= nextBlockedWriteLogTime) {
+         nextBlockedWriteLogTime = now + 1000L;
+         debug("Blocked camera write from %s while Replay Mod owns playback camera", owner);
+      }
+   }
+
+   private static void debug(String message, Object ... args) {
+      if(MCH_Config.EnableMCHLibDebugLog != null && MCH_Config.EnableMCHLibDebugLog.prmBool) {
+         MCH_Lib.DbgLog(true, "[ReplayModCompat] " + message, args);
+      }
+   }
+}

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -175,6 +175,10 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
 
 
    private void forceBombReticleCamera(EntityPlayer player, MCP_EntityPlane plane, boolean isPilot) {
+      if(mcheli.compat.MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         resetBombReticleMode();
+         return;
+      }
       if(player == null || plane == null || !isPilot || !isBombReticleMode(plane)) {
          clearBombReticleFallback(plane);
          return;

--- a/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
+++ b/src/main/java/mcheli/plane/MCP_PlaneChaseCamera.java
@@ -5,6 +5,7 @@ import mcheli.MCH_Lib;
 import mcheli.MCH_Key;
 import mcheli.MCH_ViewEntityDummy;
 import mcheli.aircraft.MCH_BoundingBox;
+import mcheli.compat.MCH_ReplayModCompat;
 import mcheli.wrapper.W_Reflection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
@@ -559,7 +560,7 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean isFovOverrideActive() {
-      return activeCamera != null && activeRenderPlane != null && MCH_Config.EnablePlaneChaseFOVOverride.prmBool;
+      return !MCH_ReplayModCompat.isReplayPlaybackActive() && activeCamera != null && activeRenderPlane != null && MCH_Config.EnablePlaneChaseFOVOverride.prmBool;
    }
 
    public static float applyFovOverride(float currentFov) {
@@ -612,6 +613,10 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean applyRenderStartCamera(Minecraft mc) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ReplayModCompat.logBlockedCameraWrite("MCP_PlaneChaseCamera.applyRenderStartCamera");
+         return false;
+      }
       if(activeCamera == null || activeRenderPlane == null || mc == null || mc.theWorld == null || activeRenderPlane.isDead) {
          logPhase("RENDER_START", mc, activeDummy, false, true);
          return false;
@@ -639,6 +644,10 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean applyActiveRenderCamera(Minecraft mc) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ReplayModCompat.logBlockedCameraWrite("MCP_PlaneChaseCamera.applyActiveRenderCamera");
+         return false;
+      }
       if(activeCamera == null || activeRenderPlane == null || mc == null || mc.theWorld == null || activeRenderPlane.isDead) {
          return false;
       }
@@ -662,6 +671,10 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean applyActiveRiderCamera(MCP_EntityPlane plane) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ReplayModCompat.logBlockedCameraWrite("MCP_PlaneChaseCamera.applyActiveRiderCamera");
+         return false;
+      }
       if(activeCamera == null || activeRenderPlane == null || activeRenderPlane != plane) {
          return false;
       }
@@ -713,6 +726,10 @@ public class MCP_PlaneChaseCamera {
    }
 
    public static boolean enforceActiveRenderCameraOwnership(Minecraft mc, String stage) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ReplayModCompat.logBlockedCameraWrite("MCP_PlaneChaseCamera.enforceActiveRenderCameraOwnership");
+         return false;
+      }
       if(activeCamera == null || activeRenderPlane == null || mc == null || mc.theWorld == null || activeRenderPlane.isDead) {
          return false;
       }
@@ -761,6 +778,10 @@ public class MCP_PlaneChaseCamera {
 
 
    public static void beginOrientCameraBypass(Minecraft mc, float partialTicks) {
+      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+         MCH_ReplayModCompat.logBlockedCameraWrite("MCP_PlaneChaseCamera.beginOrientCameraBypass");
+         return;
+      }
       if(activeCamera == null || activeRenderPlane == null || activeDummy == null || mc == null || mc.gameSettings == null) {
          return;
       }
@@ -785,6 +806,26 @@ public class MCP_PlaneChaseCamera {
       logPhase("RENDER_END", mc, activeDummy, false, false);
       renderStartAppliedThisPhase = false;
       renderTickBypassActive = false;
+   }
+
+   /** Drops only MCHeli-owned chase state; never writes renderViewEntity. */
+   public static void releaseForReplayPlayback(Minecraft mc) {
+      if(renderTickBypassActive) {
+         endOrientCameraBypass(mc);
+      }
+      if(activeCamera != null) {
+         activeCamera.reset();
+      }
+      activeCamera = null;
+      activeRenderPlane = null;
+      activeDummy = null;
+      consumedByRenderHook = false;
+      renderStartAppliedThisPhase = false;
+      renderTickBypassActive = false;
+      allowNextChaseDummyWrite = false;
+      pendingFreelookMouseX = 0.0D;
+      pendingFreelookMouseY = 0.0D;
+      currentOwner = "NONE";
    }
 
    private static void logOrientCameraBypass(Minecraft mc, float partialTicks, float beforeDistance, float beforeDistanceTemp, float afterDistance, float afterDistanceTemp, boolean bypassApplied) {

--- a/src/main/java/mcheli/wrapper/W_McClient.java
+++ b/src/main/java/mcheli/wrapper/W_McClient.java
@@ -3,6 +3,7 @@ package mcheli.wrapper;
 
 
 import mcheli.plane.MCP_PlaneChaseCamera;
+import mcheli.compat.MCH_ReplayModCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -47,8 +48,11 @@ public class W_McClient {
     }
 
     public static void setRenderEntity(EntityLivingBase entity) {
+        if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+            MCH_ReplayModCompat.logBlockedCameraWrite("W_McClient.setRenderEntity");
+            return;
+        }
         Minecraft.getMinecraft().renderViewEntity = entity;
         MCP_PlaneChaseCamera.logCameraWrite("W_McClient.setRenderEntity", entity != null?entity.getClass().getName():"null");
     }
 }
-

--- a/src/main/java/mcheli/wrapper/W_Network.java
+++ b/src/main/java/mcheli/wrapper/W_Network.java
@@ -19,11 +19,15 @@ import mcheli.wrapper.W_PacketBase;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
+import mcheli.compat.MCH_ReplayModCompat;
 
 public class W_Network {
     public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel("MCHeli_CH");
 
     public static void sendToServer(W_PacketBase pkt) {
+        if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+            return;
+        }
         INSTANCE.sendToServer((IMessage)pkt);
     }
 
@@ -42,4 +46,3 @@ public class W_Network {
         INSTANCE.sendToAll((IMessage)pkt);
     }
 }
-

--- a/src/main/java/mcheli/wrapper/W_Reflection.java
+++ b/src/main/java/mcheli/wrapper/W_Reflection.java
@@ -22,6 +22,7 @@ package mcheli.wrapper;
 import cpw.mods.fml.common.ObfuscationReflectionHelper;
 import java.util.List;
 import mcheli.plane.MCP_PlaneChaseCamera;
+import mcheli.compat.MCH_ReplayModCompat;
 import java.util.Queue;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.PlayerControllerMP;
@@ -94,6 +95,18 @@ public class W_Reflection {
 	   }
 
 	   public static void setCameraRoll(float roll) {
+	      if(MCH_ReplayModCompat.isReplayPlaybackActive()) {
+	         MCH_ReplayModCompat.logBlockedCameraWrite("W_Reflection.setCameraRoll");
+	         return;
+	      }
+	      setCameraRollUnchecked(roll);
+	   }
+
+	   public static void clearMCHeliCameraRollForReplayPlayback() {
+	      setCameraRollUnchecked(0.0F);
+	   }
+
+	   private static void setCameraRollUnchecked(float roll) {
 	      try {
 	         roll = MathHelper.wrapAngleTo180_float(roll);
 	         Minecraft e = Minecraft.getMinecraft();


### PR DESCRIPTION
### Motivation

- Replay Mod playback replaces `Minecraft.thePlayer` with a Replay camera entity which can retain a recorded mount; MCHeli treated that camera as a live mounted player and repeatedly reclaimed camera ownership, applied chase-camera transforms, rotated the camera, processed input, and sent vehicle control packets, trapping the replay viewer in a vehicle view.
- The change must let Replay Mod fully own the client view during playback while preserving passive vehicle rendering and normal MCHeli behavior outside playback.

### Description

- Add a small, client-only helper `mcheli.compat.MCH_ReplayModCompat` that detects Replay Mod playback by walking the active `mc.thePlayer` class hierarchy and matching the exact class name `com.replaymod.replay.camera.CameraEntity` without importing or requiring Replay Mod.
- When playback is active, prevent MCHeli from taking camera ownership and mutating the view by guarding `MCH_Lib.setRenderViewEntity`, `W_McClient.setRenderEntity`, plane chase-camera paths (`MCP_PlaneChaseCamera` render/start/enforce/orient code and FOV override), bombsight rotations, and calls that set camera roll or third-person distance; add a non-destructive cleanup path (`releaseForReplayPlayback`) that clears chase-camera state but never overwrites `renderViewEntity`.
- Suppress MCHeli local-player control and outbound vehicle-control packets by adding a top-level guard (`W_Network.sendToServer`) and by stopping HUD/overlay rendering while playback is active; reset recoil and camera roll and restore first-person item rendering on transition into playback to avoid leaving stale state.
- Add lightweight, rate-limited debug messages through the existing debug system for playback transitions and blocked camera writes; do not add a compile dependency on Replay Mod and do not alter Replay Mod or server-side logic.
- Files changed (high level): `CHANGELOG.md`; new `src/main/java/mcheli/compat/MCH_ReplayModCompat.java`; guarded/updated locations include `MCH_ClientCommonTickHandler.java`, `MCH_ClientEventHook.java`, `MCH_PlayerViewHandler.java`, `MCH_Lib.java`, `W_McClient.java`, `W_Network.java`, `W_Reflection.java`, `MCP_PlaneChaseCamera.java`, `MCP_ClientPlaneTickHandler.java`, plus a couple of HUD renderer guards (`MCH_RenderRWR.java`, `MCH_RenderBVRLockBox.java`).

### Testing

- Ran static and repository audits: `git diff --check` passed and the tree was audited for direct `renderViewEntity` writes and `sendToServer` call sites; results show all direct camera writes are now behind guards and `W_Network.sendToServer` provides a defensive backstop. (passed)
- Confirmed no `com.replaymod` imports were added and no Replay Mod classes were bundled or referenced; detection relies only on the runtime class-name check. (passed)
- Verified there are no binary diffs and working tree is clean after the changes. (passed)
- Attempted to fetch and inspect the requested Replay Mod commit remotely but the environment’s GitHub proxy returned HTTP 403, so the external-repo inspection step could not complete; implementation uses the exact class name you specified instead of depending on remote sources. (external fetch failed)
- Did not run a full project compile or the manual Forge/Replay Mod runtime matrix because the task explicitly prohibited compiling binary files in this environment and the environment lacks a graphical Forge 1.7.10 client; the repository `.java-version` also differs from the requested Java 8 runtime so automated builds were intentionally not executed. (skipped)

If you want, I can now: produce a concise list of the exact changed files for the PR description, or prepare a short testing checklist (commands and expected outputs) to run locally with Java 8 + Forge 1.7.10 + Replay Mod 2.5.2 so you can validate the manual scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d52cff08483238538126ce6a3c5ea)