### PR TITLE
Protect reconstructed smoke atlas content edges

### DIFF
--- a/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
+++ b/src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java
@@ -78,8 +78,7 @@ public final class MCH_ParticleTextureProcessor {
          for(int y = 0; y < cellHeight; ++y) {
             for(int x = 0; x < cellWidth; ++x) {
                int alpha = clamp((int)Math.round(scaled[y * cellWidth + x] * 255.0D));
-               if(x < OUTPUT_PADDING || x >= cellWidth - OUTPUT_PADDING ||
-                  y < OUTPUT_PADDING || y >= cellHeight - OUTPUT_PADDING || alpha <= 1) alpha = 0;
+               if(isProtectedTransparentBorder(x, y, cellWidth, cellHeight) || alpha <= 1) alpha = 0;
                atlas.setRGB(frame * cellWidth + x, y, alpha == 0 ? 0x00000000 : alpha << 24 | 0x00FFFFFF);
             }
          }
@@ -152,6 +151,11 @@ public final class MCH_ParticleTextureProcessor {
 
    private static double sample(double[] source, int width, int height, int x, int y) {
       return x < 0 || x >= width || y < 0 || y >= height ? 0.0D : source[y * width + x];
+   }
+
+   private static boolean isProtectedTransparentBorder(int x, int y, int width, int height) {
+      return x <= OUTPUT_PADDING || x >= width - OUTPUT_PADDING - 1 ||
+         y <= OUTPUT_PADDING || y >= height - OUTPUT_PADDING - 1;
    }
 
    private static int clamp(int value) { return Math.max(0, Math.min(255, value)); }


### PR DESCRIPTION
### Motivation
- Two unit tests were failing because reconstructed atlas pixels on the outer content-edge were non‑zero, violating the border contract introduced by earlier changes.  The first observed failing pixel was at atlas coordinate `(5, 2)`, ARGB `0x02FFFFFF`, frame `0`, categorized as the outer content edge. 
- Root cause: the processor only cleared coordinates strictly inside/outside the two‑pixel gutter (`x < padding` / `x >= width - padding`), leaving the content‑edge row/column (`x == padding`, `x == width - padding - 1`, etc.) eligible for tiny nonzero alpha from the reconstruction.
- The fix must preserve the two‑pixel transparent gutter and BINARY_DENSITY reconstruction while forcing the outer content edge to exact `0x00000000` without off‑by‑one errors.

### Description
- Centralized the protected border check in a named helper `isProtectedTransparentBorder(int x, int y, int width, int height)` and used it when writing atlas pixels. 
- Replaced the earlier inline bounds with the inclusive/offset logic (`x <= OUTPUT_PADDING` / `x >= width - OUTPUT_PADDING - 1` and analogous for `y`) to cover the outer content edge without an off‑by‑one error. 
- Ensured protected and negligible alpha pixels are written as exact `0x00000000` (zeroed ARGB) and left all other reconstruction behavior (global normalization, `BINARY_DENSITY`, `OUTPUT_PADDING == 2`, frame isolation, and direct‑use path for images with intermediate alpha) unchanged. 
- Modified file: `src/main/java/mcheli/particles/MCH_ParticleTextureProcessor.java` (no texture, test, or unrelated code changes).

### Testing
- JShell production‑processor validation passed and verified: atlas `288x36`, `padding == 2`, `reconstructionPath == BINARY_DENSITY`, exact transparent gutter and outer content edge for every frame, zero‑alpha == `0x00000000` RGB preservation, visible intermediate alpha in frames, global normalization ordering (first frame denser than final), and direct‑use behavior for intermediate‑alpha sources. 
- `git diff --check` passed and working tree is clean after the commit. 
- Attempted `./gradlew test --tests mcheli.particles.MCH_ParticleTextureProcessorTest`, `./gradlew test`, and `./gradlew build`, but the environment failed to resolve external test dependency `junit:junit:4.13.2` (HTTP 403 from configured repositories), so Gradle test tasks and the full build could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d6a676a908323b5a7fbb2ea1b4528)