### PR TITLE
Add opt-in LWR tank warning alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Tank LWR alert opt-in (PR pending)
+
+- Added the shared `LWR` vehicle option, defaulting to false, and require tanks to enable it before direct, UAV, packet, or client-tick warning audio can play.
+- Decoupled tank warning detection and audio from flare availability without changing flare deployment or missile-destruction behavior; non-tank alert behavior remains unchanged.
+
 # Optional NEI Vehicle Ammunition Compatibility (PR pending)
 
 - Added an optional, client-only NotEnoughItems category relating complete weapon reload inputs to helicopters, planes, ships, tanks, vehicles, and turrets.

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -99,6 +99,7 @@ For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is
 |---|---|---:|---|
 | `RadarType` | enum | `EARLY_AA` | Invalid values fall back to `MODERN_AA`. |
 | `RWRType` | enum | `NONE` | Invalid values fall back to `NONE`; set `DIGITAL` to enable the current RWR display. |
+| `LWR` | boolean | false | Controls the tank laser warning alert sound. Tanks play the warning only when this is `true`; it is separate from `RWRType`, flares, chaff, APS, and smoke launchers. |
 | `NameOnModernAARadar`, `NameOnEarlyAARadar`, `NameOnModernASRadar`, `NameOnEarlyASRadar` | string | `?` | Radar labels. |
 | `Stealth` | float[0..1] | 0 | Visibility modifier. |
 | `UAV`, `SmallUAV`, `NewUAV`, `NewSmallUAV`, `TargetDrone` | boolean | false | UAV/NewUAV force camera view and add a hidden seat when needed. UAV vehicle items skip normal hold-to-deploy placement: large UAVs tell players to use a UAV Station, while small UAVs tell players to use a UAV Station or Portable UAV Controller. `TargetDrone` also sets `UAV`. |

--- a/docs/vehicle-config/tanks.md
+++ b/docs/vehicle-config/tanks.md
@@ -2,6 +2,8 @@
 
 Tanks inherit all shared keys from `base.md` and add track/weight keys. Tank `speed` is multiplied by global `AllTankSpeed` during validation.
 
+Set the shared `LWR = true` option to enable the existing tank laser warning alert sound. Its default is `false`, so `LWR = false`, an invalid value, or an omitted entry disables that sound. LWR detection does not require flares and does not grant or alter flares, chaff, APS, smoke launchers, or the separate `RWRType` radar warning receiver.
+
 ## Tank-only keys
 
 | Key | Type/range | Default | Notes |
@@ -37,10 +39,11 @@ maxhp = 250
 speed = 0.35
 WeightType = tank
 TrackMaxHP = 120
+LWR = false
 AddTrackHitBox = 1.2, 0.0, 0.0, 0.5, 0.5, 1.0
 AddTrackHitBox = -1.2, 0.0, 0.0, 0.5, 0.5, 1.0
 ```
 
 ## Safe-to-omit notes
 
-`WeightType`, `WeightedCenterZ`, `TrackMaxHP`, and `AddTrackHitBox` are optional. Omitting them leaves default ground behavior and no explicit track hitboxes.
+`WeightType`, `WeightedCenterZ`, `TrackMaxHP`, `AddTrackHitBox`, and `LWR` are optional. Omitting `LWR` leaves tank alert audio disabled; omitting the other keys leaves default ground behavior and no explicit track hitboxes.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -230,8 +230,10 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       if(var7 != null && var11 != null && !var11.isDestroyed()) {
          if(isLocked && lockedSoundCount == 0) {
             isLocked = false;
-            lockedSoundCount = 20;
-            MCH_ClientTickHandlerBase.playSound("locked");
+            if(var11.canPlayAlertSound()) {
+               lockedSoundCount = 20;
+               MCH_ClientTickHandlerBase.playSound("locked");
+            }
          }
       } else {
          lockedSoundCount = 0;

--- a/src/main/java/mcheli/MCH_CommonPacketHandler.java
+++ b/src/main/java/mcheli/MCH_CommonPacketHandler.java
@@ -92,7 +92,7 @@ public class MCH_CommonPacketHandler {
                   ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(target);
                }
 
-               if(ac != null && ac.haveFlare() && !ac.isDestroyed()) {
+               if(ac != null && ac.canNotifyLock() && !ac.isDestroyed()) {
                   for(int i = 0; i < 2; ++i) {
                      Entity entity = ac.getEntityBySeatId(i);
                      if(entity instanceof EntityPlayerMP) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -40,7 +40,8 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public String displayName;
    public HashMap displayNameLang;
    public int itemID;
-   public boolean hasalert = true;
+   /** Enables the tank laser-warning alert sound. */
+   public boolean LWR = false;
    /** Enables client-side CCIP bomb impact reticle for plane HUDs. */
    public boolean hasBallisticComputer = false;
    /** Enables first-person gunner bombsight mode when ballistic prediction is available. */
@@ -676,6 +677,9 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
             } catch (Exception e) {
                this.rwrType = EnumRWRType.NONE;
             }
+         }
+         else if(item.equalsIgnoreCase("LWR")) {
+            this.LWR = this.toBool(data);
          }
          else if(item.equalsIgnoreCase("NameOnModernAARadar")) {
             nameOnModernAARadar = data;

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -9028,13 +9028,24 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return "?";
    }
 
-   public boolean hasalert() {
-      if (this.acInfo.hasalert) {
-         return true;
-      }
+   /** Returns whether this vehicle has an enabled laser warning receiver. */
+   public boolean hasLWR() {
+      return this.getAcInfo() != null && this.getAcInfo().LWR;
+   }
 
-      return false;
-      //temp
+   /** Keeps legacy warning audio for non-tanks while making tanks opt in with LWR. */
+   public boolean canPlayAlertSound() {
+      return !(this instanceof MCH_EntityTank) || this.hasLWR();
+   }
+
+   /** Lock packets historically required flares; tank LWR is independent of them. */
+   public boolean canNotifyLock() {
+      return this instanceof MCH_EntityTank ? this.hasLWR() : this.haveFlare();
+   }
+
+   /** Tank warning detection may run without flares only when LWR is enabled. */
+   public boolean canDetectWarning() {
+      return this.haveFlare() || this instanceof MCH_EntityTank && this.hasLWR();
    }
 
    public class WeaponBay {

--- a/src/main/java/mcheli/aircraft/MCH_MissileDetector.java
+++ b/src/main/java/mcheli/aircraft/MCH_MissileDetector.java
@@ -50,31 +50,32 @@ public class MCH_MissileDetector {
     }
 
     public void update() {
-        if (this.ac.haveFlare()) {
-            if (this.alertCount > 0) {
-                --this.alertCount;
-            }
+        if (!this.ac.canDetectWarning()) {
+            return;
+        }
 
-            boolean isLocked = this.ac.getEntityData().getBoolean("Tracking");
-            if (isLocked) {
-                this.ac.getEntityData().setBoolean("Tracking", false);
-            }
+        if (this.alertCount > 0) {
+            --this.alertCount;
+        }
 
-            if (this.ac.getEntityData().getBoolean("LockOn")) {
-                if (this.alertCount == 0) {
-                    this.alertCount = 10;
-                    if (this.ac != null && this.ac.haveFlare() && !this.ac.isDestroyed()) {
-                        for (int rider = 0; rider < 2; ++rider) {
-                            Entity entity = this.ac.getEntityBySeatId(rider);
-                            if (entity instanceof EntityPlayerMP) {
-                                MCH_PacketNotifyLock.sendToPlayer((EntityPlayerMP) entity);
-                            }
-                        }
+        boolean isLocked = this.ac.getEntityData().getBoolean("Tracking");
+        if (isLocked) {
+            this.ac.getEntityData().setBoolean("Tracking", false);
+        }
+
+        if (this.ac.getEntityData().getBoolean("LockOn")) {
+            if (this.alertCount == 0 && this.ac.canNotifyLock() && !this.ac.isDestroyed()) {
+                this.alertCount = 10;
+                for (int rider = 0; rider < 2; ++rider) {
+                    Entity entity = this.ac.getEntityBySeatId(rider);
+                    if (entity instanceof EntityPlayerMP) {
+                        MCH_PacketNotifyLock.sendToPlayer((EntityPlayerMP) entity);
                     }
                 }
-
-                this.ac.getEntityData().setBoolean("LockOn", false);
             }
+
+            this.ac.getEntityData().setBoolean("LockOn", false);
+        }
 
             if (!this.ac.isDestroyed()) {
                 Entity var4 = this.ac.getRiddenByEntity();
@@ -83,20 +84,18 @@ public class MCH_MissileDetector {
                 }
 
                 if (var4 != null) {
-                    if (this.ac.isFlareUsing()) {
+                    if (this.ac.haveFlare() && this.ac.isFlareUsing()) {
 
 
 
                         this.destroyMissile();
                     } else if (!this.ac.isUAV() && !this.world.isRemote) {
 
-                        //if (this.hasalert())
-
-                            if (this.alertCount == 0 && ((isLocked || this.isLockedByMissile() || this.isLockedByHMGVT())) && this.hasalert()) {
-                                this.alertCount = 20;
-                                W_WorldFunc.MOD_playSoundAtEntity(this.ac, "alert", 50.0F, 1.0F);
-                            }
-                    } else if (this.ac.isUAV() && this.world.isRemote && this.alertCount == 0 && ((isLocked || this.isLockedByMissile() || this.isLockedByHMGVT())) && this.hasalert()) {
+                        if (this.alertCount == 0 && ((isLocked || this.isLockedByMissile() || this.isLockedByHMGVT())) && this.ac.canPlayAlertSound()) {
+                            this.alertCount = 20;
+                            W_WorldFunc.MOD_playSoundAtEntity(this.ac, "alert", 50.0F, 1.0F);
+                        }
+                    } else if (this.ac.isUAV() && this.world.isRemote && this.alertCount == 0 && ((isLocked || this.isLockedByMissile() || this.isLockedByHMGVT())) && this.ac.canPlayAlertSound()) {
                         this.alertCount = 20;
                         if (W_Lib.isClientPlayer(var4)) {
                             W_McClient.MOD_playSoundFX("alert", 50.0F, 1.0F);
@@ -108,7 +107,6 @@ public class MCH_MissileDetector {
 
 
             }
-        }
     }
 
     private static void initHMG() {
@@ -291,15 +289,6 @@ public class MCH_MissileDetector {
                     return true;
                 }
             }
-        }
-
-        return false;
-    }
-
-
-    public boolean hasalert() {
-        if (this.ac.hasalert()) {
-            return true;
         }
 
         return false;

--- a/src/test/java/mcheli/tank/MCH_TankInfoLWRTest.java
+++ b/src/test/java/mcheli/tank/MCH_TankInfoLWRTest.java
@@ -1,0 +1,30 @@
+package mcheli.tank;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MCH_TankInfoLWRTest {
+
+    @Test
+    public void lwrDefaultsToFalseAndParsesTrueCaseInsensitively() {
+        MCH_TankInfo info = new MCH_TankInfo("lwr_test");
+
+        assertFalse(info.LWR);
+        info.loadItemData("lWr", "TrUe");
+        assertTrue(info.LWR);
+    }
+
+    @Test
+    public void falseAndInvalidValuesDisableLwr() {
+        MCH_TankInfo info = new MCH_TankInfo("lwr_test");
+
+        info.loadItemData("LWR", "true");
+        info.loadItemData("LWR", "false");
+        assertFalse(info.LWR);
+
+        info.loadItemData("LWR", "invalid");
+        assertFalse(info.LWR);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a per-vehicle config key to gate the tank laser-warning alert sound so tanks only play the alert when explicitly enabled. 
- Keep existing non-tank alert behavior unchanged while decoupling detection/audio from flare availability where appropriate. 
- Preserve existing volumes, pitches, repetition rates, and flare/chaff/APS behavior while preventing packets or client-tick playback from bypassing the tank opt-in.

### Description

- Added a boolean `LWR` field to `MCH_BaseVehicleInfo` with default `false` and integrated it into the existing parser using the project's boolean parser style (`toBool`) so `LWR = true` / `LWR = false` are accepted case-insensitively.
- Replaced the legacy always-true `hasalert` usage with null-safe accessors on `MCH_EntityBaseVehicle`: `hasLWR()`, `canPlayAlertSound()`, `canNotifyLock()`, and `canDetectWarning()` to centralize tank-specific logic and avoid repeated config lookups.
- Updated `MCH_MissileDetector.update()` to skip detection for vehicles that cannot detect warnings, to preserve missile-destruction/flaring logic, and to gate server- and client-side alert playback with the new tank-aware checks (preserving existing alert sound params and repetition logic).
- Prevented lock-packet forwarding and client `locked` sound playback from bypassing tank `LWR` by using `canNotifyLock()` in `MCH_CommonPacketHandler` and `canPlayAlertSound()` in `MCH_ClientCommonTickHandler` respectively.
- Documentation updates: added `LWR` to `docs/vehicle-config/base.md` and `docs/vehicle-config/tanks.md` with default `false` and a note that `LWR` is separate from `RWRType`, flares, chaff, APS, and smoke launchers.
- Tests and changelog: added `src/test/java/mcheli/tank/MCH_TankInfoLWRTest.java` with focused parser checks and added a changelog entry describing the opt-in behavior.

### Testing

- Ran `git diff --check` and repository source-assertion checks which verified the `LWR` parser, default `false`, case-insensitive parsing, tank audio/packet gates, and removal of the dead `hasalert` usages.
- Ran repository scans to confirm no tank asset files were modified and no prohibited modern Java syntax was introduced.
- Added focused JUnit test `MCH_TankInfoLWRTest` covering default, true, false, and invalid parsing; the test sources are included for CI but were not executed locally because binary compilation and test runs were explicitly avoided.
- Did not run `./gradlew build` or `./gradlew test` in this environment per the no-binary restriction; runtime/integration verification (client/server) was traced in-source and left for in-environment testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e538fc6e88323a371ff62be278ec7)