### PR TITLE
Audit tank laser warning receiver configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Audit tank laser-warning receiver configuration (PR pending)
+
+- Added an explicit `LWR` capability value to every tank configuration, enabling it only for exact vehicle variants with sufficiently reliable laser-warning receiver evidence.
+
 # Tank LWR alert opt-in (PR pending)
 
 - Added the shared `LWR` vehicle option, defaulting to false, and require tanks to enable it before direct, UAV, packet, or client-tick warning audio can play.

--- a/src/main/resources/assets/mcheli/tanks/2102.txt
+++ b/src/main/resources/assets/mcheli/tanks/2102.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = VAZ-2102
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = VAZ-2102
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/2105.txt
+++ b/src/main/resources/assets/mcheli/tanks/2105.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/2k22.txt
+++ b/src/main/resources/assets/mcheli/tanks/2k22.txt
@@ -26,6 +26,7 @@ CameraZoom = 8
 EnableNightVision = true
 CameraRotationSpeed = 48
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 MaxFuel         = 1800
 FuelConsumption = 2.4

--- a/src/main/resources/assets/mcheli/tanks/2s1-gvozdika.txt
+++ b/src/main/resources/assets/mcheli/tanks/2s1-gvozdika.txt
@@ -34,6 +34,7 @@ OnGroundRollFactor  = 1.0
 ;EnableGunnerMode = true
 SubmergedDamageHeight = 3
 EnableEntityRadar = false
+LWR = false
 HideEntity = true
 
 GravityInWater = -0.2

--- a/src/main/resources/assets/mcheli/tanks/2s19.txt
+++ b/src/main/resources/assets/mcheli/tanks/2s19.txt
@@ -25,6 +25,7 @@ CameraZoom = 3
 EnableNightVision = true
 CameraRotationSpeed = 12
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1800
 FuelConsumption = 2.4
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/2s25 sprut_sd.txt
+++ b/src/main/resources/assets/mcheli/tanks/2s25 sprut_sd.txt
@@ -30,6 +30,7 @@ CameraPosition = 0.00,  2.45, -0.0, true
 EnableNightVision = true
 CameraRotationSpeed = 21
 EnableEntityRadar = false
+LWR = true
 MaxFuel         = 1800
 FuelConsumption = 2.4
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/2s3.txt
+++ b/src/main/resources/assets/mcheli/tanks/2s3.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = true
+LWR = false
 CameraZoom = 5
 CameraRotationSpeed = 6
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/2s9.txt
+++ b/src/main/resources/assets/mcheli/tanks/2s9.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 
 DamageFactor = 0.8
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 8
 StepHeight = 1.8
 MinRotationPitch = -80

--- a/src/main/resources/assets/mcheli/tanks/350z.txt
+++ b/src/main/resources/assets/mcheli/tanks/350z.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Nissan 350Z
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Nissan 350Z
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/59d.txt
+++ b/src/main/resources/assets/mcheli/tanks/59d.txt
@@ -36,6 +36,7 @@ FlareType = 10
 ;EnableGunnerMode = true
 SubmergedDamageHeight = 3
 EnableEntityRadar = false
+LWR = false
 HideEntity = false
 
 ExplosionSizeByCrash = 25

--- a/src/main/resources/assets/mcheli/tanks/82ccv.txt
+++ b/src/main/resources/assets/mcheli/tanks/82ccv.txt
@@ -21,6 +21,7 @@ FuelConsumption = 1.9
 CameraZoom = 0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 ;CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/87rcv.txt
+++ b/src/main/resources/assets/mcheli/tanks/87rcv.txt
@@ -21,6 +21,7 @@ FuelConsumption = 1.9
 CameraZoom = 4
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/90tk.txt
+++ b/src/main/resources/assets/mcheli/tanks/90tk.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.25, 1.55, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 18
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/96wapc.txt
+++ b/src/main/resources/assets/mcheli/tanks/96wapc.txt
@@ -22,6 +22,7 @@ CameraPosition = -0.86, 2.80,  2.12, true
 CameraZoom = 0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 ;CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/99a2.txt
+++ b/src/main/resources/assets/mcheli/tanks/99a2.txt
@@ -36,6 +36,7 @@ FlareType = 10
 ;EnableGunnerMode = true
 SubmergedDamageHeight = 3
 EnableEntityRadar = false
+LWR = true
 HideEntity = true
 
 ExplosionSizeByCrash = 25

--- a/src/main/resources/assets/mcheli/tanks/a-27mcromwell.txt
+++ b/src/main/resources/assets/mcheli/tanks/a-27mcromwell.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 15
 DefaultFreeLook = true
 ThirdPersonDist = 12

--- a/src/main/resources/assets/mcheli/tanks/aav7.txt
+++ b/src/main/resources/assets/mcheli/tanks/aav7.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = 0.1
 DamageFactor = 0.8
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 20
 StepHeight = 1.8
 MinRotationPitch = -14

--- a/src/main/resources/assets/mcheli/tanks/ae86.txt
+++ b/src/main/resources/assets/mcheli/tanks/ae86.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Toyota Corolla AE86
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Toyota Corolla AE86
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/ags-17.txt
+++ b/src/main/resources/assets/mcheli/tanks/ags-17.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = 30mm AGS-17 Plamya Automatic Grenade Launcher
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = 30mm AGS-17 Plamya Automatic Grenade Launcher
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/altis.txt
+++ b/src/main/resources/assets/mcheli/tanks/altis.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = TOYOTA COROLLA 2014
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = TOYOTA COROLLA 2014
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/amx-30b.txt
+++ b/src/main/resources/assets/mcheli/tanks/amx-30b.txt
@@ -23,6 +23,7 @@ CameraPosition = 0.00,  3.2, 0.5, true
 EnableNightVision = true
 CameraRotationSpeed = 18
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 2400
 FuelConsumption = 3.2
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/amx13.txt
+++ b/src/main/resources/assets/mcheli/tanks/amx13.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = AMX-13/75 FL-10
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = AMX-13/75 FL-10
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/amx56.txt
+++ b/src/main/resources/assets/mcheli/tanks/amx56.txt
@@ -19,6 +19,7 @@ GravityInWater = -1.0
 DamageFactor = 0.00
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = true
 Sound = leclerc
 HUD = mbt_hud
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/ariete.txt
+++ b/src/main/resources/assets/mcheli/tanks/ariete.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 8
 CameraPosition = 1.2,  3.25, 1.2, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/armata.txt
+++ b/src/main/resources/assets/mcheli/tanks/armata.txt
@@ -33,6 +33,7 @@ CameraPosition = 0.00,  3.7, -0.0, true
 EnableNightVision = true
 CameraRotationSpeed = 30
 EnableEntityRadar = true
+LWR = true
 RadarType = MODERN_AA
 MaxFuel         = 2400
 FuelConsumption = 3.2

--- a/src/main/resources/assets/mcheli/tanks/aslav-c.txt
+++ b/src/main/resources/assets/mcheli/tanks/aslav-c.txt
@@ -16,6 +16,7 @@ DefaultFreelook = false
 EnableBack = true
 HUD = mbt_hudtwo, mbt_gnrtwo
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1300
 FuelConsumption = 1.9
 ;CameraZoom = 1

--- a/src/main/resources/assets/mcheli/tanks/b2a5.txt
+++ b/src/main/resources/assets/mcheli/tanks/b2a5.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00, 3.8241, 0, false
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/b2a6.txt
+++ b/src/main/resources/assets/mcheli/tanks/b2a6.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00, 3.8241, 0, false
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/b2a7.txt
+++ b/src/main/resources/assets/mcheli/tanks/b2a7.txt
@@ -25,6 +25,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00, 3.8241, 0, false
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 StepHeight = 1.5
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/bal.txt
+++ b/src/main/resources/assets/mcheli/tanks/bal.txt
@@ -19,6 +19,7 @@ FuelConsumption = 2.8
 CameraPosition = 0.0, 4.2, -1, false
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/bcnr33.txt
+++ b/src/main/resources/assets/mcheli/tanks/bcnr33.txt
@@ -25,6 +25,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = true
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/bearcat.txt
+++ b/src/main/resources/assets/mcheli/tanks/bearcat.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Lenco Bearcat F-550
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Lenco Bearcat F-550
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/bm21.txt
+++ b/src/main/resources/assets/mcheli/tanks/bm21.txt
@@ -23,6 +23,7 @@ GravityInWater = -1.0
 DamageFactor = 1.0
 CameraZoom = 4
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 50
 MaxFuel         = 2200
 FuelConsumption = 2.8

--- a/src/main/resources/assets/mcheli/tanks/bmp-t.txt
+++ b/src/main/resources/assets/mcheli/tanks/bmp-t.txt
@@ -30,6 +30,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = true
 DefaultFreelook = true
 CameraRotationSpeed = 22
 SubmergedDamageHeight = 2

--- a/src/main/resources/assets/mcheli/tanks/bmp1.txt
+++ b/src/main/resources/assets/mcheli/tanks/bmp1.txt
@@ -25,6 +25,7 @@ Category = AIFV/AAPC
 GravityInWater = -0.2
 DamageFactor = 0.8
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 12
 StepHeight = 1.8
 MinRotationPitch = -33

--- a/src/main/resources/assets/mcheli/tanks/bmp2.txt
+++ b/src/main/resources/assets/mcheli/tanks/bmp2.txt
@@ -26,6 +26,7 @@ Category = AIFV/AAPC
 GravityInWater = -0.2
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 18
 StepHeight = 1.8
 MinRotationPitch = -75

--- a/src/main/resources/assets/mcheli/tanks/bmp3.txt
+++ b/src/main/resources/assets/mcheli/tanks/bmp3.txt
@@ -25,6 +25,7 @@ Category = AIFV/AAPC
 GravityInWater = -0.2
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 21
 StepHeight = 1.8
 MinRotationPitch = -60

--- a/src/main/resources/assets/mcheli/tanks/bnr32.txt
+++ b/src/main/resources/assets/mcheli/tanks/bnr32.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.00
 EnableNightVision = true
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 ThirdPersonDist = 8

--- a/src/main/resources/assets/mcheli/tanks/bnr32_police.txt
+++ b/src/main/resources/assets/mcheli/tanks/bnr32_police.txt
@@ -25,6 +25,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.00
 EnableNightVision = true
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/bnr34.txt
+++ b/src/main/resources/assets/mcheli/tanks/bnr34.txt
@@ -25,6 +25,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = true
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/bradley.txt
+++ b/src/main/resources/assets/mcheli/tanks/bradley.txt
@@ -38,6 +38,7 @@ DamageFactor = 0.0
 EnableNightVision = true
 CameraRotationSpeed = 36
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1300
 FuelConsumption = 1.9
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/bradleym2.txt
+++ b/src/main/resources/assets/mcheli/tanks/bradleym2.txt
@@ -38,6 +38,7 @@ DamageFactor = 0.0
 EnableNightVision = true
 CameraRotationSpeed = 36
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1300
 FuelConsumption = 1.9
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/brdm-s.txt
+++ b/src/main/resources/assets/mcheli/tanks/brdm-s.txt
@@ -24,6 +24,7 @@ Category = AASC
 PivotTurnThrottle = 0.1
 
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1600
 FuelConsumption = 2.2
 

--- a/src/main/resources/assets/mcheli/tanks/brdm2.txt
+++ b/src/main/resources/assets/mcheli/tanks/brdm2.txt
@@ -19,6 +19,7 @@ FuelConsumption = 2.2
 CameraZoom = 0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -0.2
 CameraRotationSpeed = 10

--- a/src/main/resources/assets/mcheli/tanks/bt-2.txt
+++ b/src/main/resources/assets/mcheli/tanks/bt-2.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = bmptwoeng
 
 ExplosionSizeByCrash = 8

--- a/src/main/resources/assets/mcheli/tanks/bt-5.txt
+++ b/src/main/resources/assets/mcheli/tanks/bt-5.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = bmptwoeng
 HUD = ww2tank_hud
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/btr3.txt
+++ b/src/main/resources/assets/mcheli/tanks/btr3.txt
@@ -20,6 +20,7 @@ FuelConsumption = 1.9
 CameraZoom = 8
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 30

--- a/src/main/resources/assets/mcheli/tanks/btr4.txt
+++ b/src/main/resources/assets/mcheli/tanks/btr4.txt
@@ -49,6 +49,7 @@ TurretPosition = -0.0761, 3.31, -1.30
 
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = true
 ; Tank or Car or Unknown    
 WeightType = Tank
 

--- a/src/main/resources/assets/mcheli/tanks/btr80.txt
+++ b/src/main/resources/assets/mcheli/tanks/btr80.txt
@@ -20,6 +20,7 @@ FuelConsumption = 1.9
 CameraZoom = 6
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 16

--- a/src/main/resources/assets/mcheli/tanks/btr82.txt
+++ b/src/main/resources/assets/mcheli/tanks/btr82.txt
@@ -20,6 +20,7 @@ FuelConsumption = 1.9
 CameraZoom = 5
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -0.2
 CameraRotationSpeed = 18

--- a/src/main/resources/assets/mcheli/tanks/btr90.txt
+++ b/src/main/resources/assets/mcheli/tanks/btr90.txt
@@ -22,6 +22,7 @@ CameraZoom = 6
 
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 CameraRotationSpeed = 20
 ;should be same as bmp-2
 GravityInWater = -1.0

--- a/src/main/resources/assets/mcheli/tanks/bugattichiron.txt
+++ b/src/main/resources/assets/mcheli/tanks/bugattichiron.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Bugatti Chiron
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Bugatti Chiron
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/c1.txt
+++ b/src/main/resources/assets/mcheli/tanks/c1.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.50, 1.55, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 18
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/c2.txt
+++ b/src/main/resources/assets/mcheli/tanks/c2.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 3
 CameraPosition = 0.00,  3.50, 1.55, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 18
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/carrera_gt.txt
+++ b/src/main/resources/assets/mcheli/tanks/carrera_gt.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Porsche Carrera GT
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Porsche Carrera GT
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/centauro.txt
+++ b/src/main/resources/assets/mcheli/tanks/centauro.txt
@@ -26,6 +26,7 @@ ExplosionSizeByCrash = 18
 
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 14

--- a/src/main/resources/assets/mcheli/tanks/centauro120.txt
+++ b/src/main/resources/assets/mcheli/tanks/centauro120.txt
@@ -26,6 +26,7 @@ ExplosionSizeByCrash = 18
 
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 17

--- a/src/main/resources/assets/mcheli/tanks/centurion3.txt
+++ b/src/main/resources/assets/mcheli/tanks/centurion3.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Centurion Mk 3
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Centurion Mk 3
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/challenger.txt
+++ b/src/main/resources/assets/mcheli/tanks/challenger.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Dodge Challenger R/T
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Dodge Challenger R/T
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/chi-he.txt
+++ b/src/main/resources/assets/mcheli/tanks/chi-he.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = Tank
 HUD = ww2tank_hud, vehiclescoped, vehiclescoped
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/chi-nu.txt
+++ b/src/main/resources/assets/mcheli/tanks/chi-nu.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = Tank
 HUD = ww2tank_hud, vehiclescoped, vehiclescoped
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/czech.txt
+++ b/src/main/resources/assets/mcheli/tanks/czech.txt
@@ -28,6 +28,7 @@ Category = LT
 EnableNightVision = false
 CameraRotationSpeed = 10
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1400
 FuelConsumption = 1.8
 StepHeight = 1.5

--- a/src/main/resources/assets/mcheli/tanks/dacia.txt
+++ b/src/main/resources/assets/mcheli/tanks/dacia.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Dacia Sandero (2009)
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Dacia Sandero (2009)
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/davycrockett.txt
+++ b/src/main/resources/assets/mcheli/tanks/davycrockett.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M-29 Davy Crockett
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M-29 Davy Crockett
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/delorean.txt
+++ b/src/main/resources/assets/mcheli/tanks/delorean.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = DMC-12 DeLorean
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = DMC-12 DeLorean
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/df41.txt
+++ b/src/main/resources/assets/mcheli/tanks/df41.txt
@@ -18,6 +18,7 @@ MaxFuel         = 2200
 FuelConsumption = 2.8
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/dra_vdv.txt
+++ b/src/main/resources/assets/mcheli/tanks/dra_vdv.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 1.0
 EnableNightVision = false 
+LWR = false
 MaxFuel = 900
 FuelConsumption = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/elbrus.txt
+++ b/src/main/resources/assets/mcheli/tanks/elbrus.txt
@@ -23,6 +23,7 @@ GravityInWater = -1.0
 DamageFactor = 0.8
 ;CameraZoom = 3
 EnableNightVision = false
+LWR = false
 ;CameraRotationSpeed = 35
 MaxFuel = 2200
 FuelConsumption = 2.8

--- a/src/main/resources/assets/mcheli/tanks/fh77.txt
+++ b/src/main/resources/assets/mcheli/tanks/fh77.txt
@@ -7,6 +7,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = 155mm Haubits BW L/52 FH-77
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = 155mm Haubits BW L/52 FH-77
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/flarakrad.txt
+++ b/src/main/resources/assets/mcheli/tanks/flarakrad.txt
@@ -21,6 +21,7 @@ DamageFactor = 0.8
 CameraZoom = 4
 CameraPosition = 0.00,  5.0, 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 50
 FlareType = 10
 MaxFuel         = 2200

--- a/src/main/resources/assets/mcheli/tanks/fordpolice.txt
+++ b/src/main/resources/assets/mcheli/tanks/fordpolice.txt
@@ -43,6 +43,7 @@ DamageFactor = 0.8
 ;MinRotationPitch = -90
 ;MaxRotationPitch = 60
 EnableEntityRadar = false
+LWR = false
 HUD = s15_hud, none, none,none, none
 SetWheelPos =  0.85,  -0.2,  2.11, -2.06
 

--- a/src/main/resources/assets/mcheli/tanks/fresh_auto.txt
+++ b/src/main/resources/assets/mcheli/tanks/fresh_auto.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = VAZ 2105 "Tsar Zhiga" (Fresh Auto Team, Drift Car)
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = VAZ 2105 "Tsar Zhiga" (Fresh Auto Team, Drift Car)
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/g250-wolf.txt
+++ b/src/main/resources/assets/mcheli/tanks/g250-wolf.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/gaz66zu23.txt
+++ b/src/main/resources/assets/mcheli/tanks/gaz66zu23.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 10

--- a/src/main/resources/assets/mcheli/tanks/gepard.txt
+++ b/src/main/resources/assets/mcheli/tanks/gepard.txt
@@ -27,6 +27,7 @@ CameraZoom = 6
 EnableNightVision = true
 CameraRotationSpeed = 54
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 MaxFuel         = 1800
 FuelConsumption = 2.4

--- a/src/main/resources/assets/mcheli/tanks/gepard2.txt
+++ b/src/main/resources/assets/mcheli/tanks/gepard2.txt
@@ -27,6 +27,7 @@ CameraZoom = 6
 EnableNightVision = true
 CameraRotationSpeed = 54
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 MaxFuel         = 1800
 FuelConsumption = 2.4

--- a/src/main/resources/assets/mcheli/tanks/growler.txt
+++ b/src/main/resources/assets/mcheli/tanks/growler.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/hel.txt
+++ b/src/main/resources/assets/mcheli/tanks/hel.txt
@@ -25,6 +25,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 1.00
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/hel2.txt
+++ b/src/main/resources/assets/mcheli/tanks/hel2.txt
@@ -24,6 +24,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 1.00
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/hemtt.txt
+++ b/src/main/resources/assets/mcheli/tanks/hemtt.txt
@@ -22,6 +22,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 1600
 FuelConsumption   = 1.8
 ThirdPersonDist = 8

--- a/src/main/resources/assets/mcheli/tanks/hetzer.txt
+++ b/src/main/resources/assets/mcheli/tanks/hetzer.txt
@@ -17,6 +17,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = hetzer
 HUD = ww2tank_hud, ww2tank_hud
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/humvee_mk19.txt
+++ b/src/main/resources/assets/mcheli/tanks/humvee_mk19.txt
@@ -24,6 +24,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 0.95
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/humvee_tow.txt
+++ b/src/main/resources/assets/mcheli/tanks/humvee_tow.txt
@@ -24,6 +24,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/humveewithm240.txt
+++ b/src/main/resources/assets/mcheli/tanks/humveewithm240.txt
@@ -24,6 +24,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/humveewithweapon.txt
+++ b/src/main/resources/assets/mcheli/tanks/humveewithweapon.txt
@@ -24,6 +24,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/humveewithweaponrws.txt
+++ b/src/main/resources/assets/mcheli/tanks/humveewithweaponrws.txt
@@ -26,6 +26,7 @@ Gravity        = -0.61
 GravityInWater = -1
 DamageFactor   = 0.0
 EnableNightVision = true
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/ikv91.txt
+++ b/src/main/resources/assets/mcheli/tanks/ikv91.txt
@@ -16,6 +16,7 @@ CameraPosition = 0.00,  2.72, -0.304, true
 EnableNightVision = true
 CameraRotationSpeed = 15
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1200
 FuelConsumption = 1.6
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/iltis-kdow.txt
+++ b/src/main/resources/assets/mcheli/tanks/iltis-kdow.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 4

--- a/src/main/resources/assets/mcheli/tanks/impreza.txt
+++ b/src/main/resources/assets/mcheli/tanks/impreza.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Subaru Impreza
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Subaru Impreza
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/imshorad.txt
+++ b/src/main/resources/assets/mcheli/tanks/imshorad.txt
@@ -20,6 +20,7 @@ CameraPosition = 0.1048,  3.95, -2.8476, true
 CameraZoom = 10
 EnableNightVision = true
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 Gravity = -0.61
 GravityInWater = -1.0

--- a/src/main/resources/assets/mcheli/tanks/is-1.txt
+++ b/src/main/resources/assets/mcheli/tanks/is-1.txt
@@ -31,6 +31,7 @@ DamageFactor = 0.0
 CameraZoom = 4
 CameraPosition = 0.00,  3.50, 0.90, true
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 9
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/is-2.txt
+++ b/src/main/resources/assets/mcheli/tanks/is-2.txt
@@ -30,6 +30,7 @@ DamageFactor = 0.0
 CameraZoom = 4
 CameraPosition = 0.00,  3.50, 0.90, true
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 9
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/jagdpanther.txt
+++ b/src/main/resources/assets/mcheli/tanks/jagdpanther.txt
@@ -17,6 +17,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = Tank
 HUD = ww2tank_hud, vehiclescoped
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/jgsdf-mcv.txt
+++ b/src/main/resources/assets/mcheli/tanks/jgsdf-mcv.txt
@@ -40,6 +40,7 @@ CameraRotationSpeed = 18
 ;EnableGunnerMode = true
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = true
 
 
 

--- a/src/main/resources/assets/mcheli/tanks/jtac.txt
+++ b/src/main/resources/assets/mcheli/tanks/jtac.txt
@@ -21,6 +21,7 @@ CameraZoom = 16
 MinRotationPitch = -10
 MaxRotationPitch = 30
 EnableNightVision = true
+LWR = false
 DefaultFreelook = true
 HUD = vehicle
 

--- a/src/main/resources/assets/mcheli/tanks/jtiger.txt
+++ b/src/main/resources/assets/mcheli/tanks/jtiger.txt
@@ -23,6 +23,7 @@ CameraZoom = 10
 CameraPosition = 0.00, 3.5, 1.00
 HideEntity = false
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 3
 MaxFuel         = 2400
 FuelConsumption = 3.2

--- a/src/main/resources/assets/mcheli/tanks/kamaz.txt
+++ b/src/main/resources/assets/mcheli/tanks/kamaz.txt
@@ -17,6 +17,7 @@ DefaultFreelook = false
 EnableBack = true
 HUD = super_duty_hud,none
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1600
 FuelConsumption = 1.8
 MobilityRoll = 0

--- a/src/main/resources/assets/mcheli/tanks/ktorosomak.txt
+++ b/src/main/resources/assets/mcheli/tanks/ktorosomak.txt
@@ -32,6 +32,7 @@ DamageFactor = 0.0
 CameraZoom = 8
 CameraPosition = -0.01,  3.5, -0.01, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 30
 FlareType = 10
 MaxFuel = 1300

--- a/src/main/resources/assets/mcheli/tanks/kub.txt
+++ b/src/main/resources/assets/mcheli/tanks/kub.txt
@@ -17,6 +17,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 15
 CameraZoom = 0
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/kurganets25.txt
+++ b/src/main/resources/assets/mcheli/tanks/kurganets25.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  2.99, 0.00
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 35
 FlareType = 10
 MaxFuel         = 1300

--- a/src/main/resources/assets/mcheli/tanks/kv-1.txt
+++ b/src/main/resources/assets/mcheli/tanks/kv-1.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = KV-1 Model 1939 (L-11)
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = KV-1 Model 1939 (L-11)
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.60

--- a/src/main/resources/assets/mcheli/tanks/kv-2.txt
+++ b/src/main/resources/assets/mcheli/tanks/kv-2.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = KV-2 'Gigant' (1940)
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = KV-2 'Gigant' (1940)
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.60

--- a/src/main/resources/assets/mcheli/tanks/lav25.txt
+++ b/src/main/resources/assets/mcheli/tanks/lav25.txt
@@ -22,6 +22,7 @@ DamageFactor = 0.8
 CameraZoom = 4
 CameraPosition = 0.65,  3.6, 0.5, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 20
 FlareType = 10
 MaxFuel = 1300

--- a/src/main/resources/assets/mcheli/tanks/lav3.txt
+++ b/src/main/resources/assets/mcheli/tanks/lav3.txt
@@ -22,6 +22,7 @@ DamageFactor = 0.8
 CameraZoom = 4
 CameraPosition = 0.65,  3.6, 0.5, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 20
 FlareType = 10
 MaxFuel = 1300

--- a/src/main/resources/assets/mcheli/tanks/leopard1.txt
+++ b/src/main/resources/assets/mcheli/tanks/leopard1.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.1
 CameraZoom = 10
 CameraPosition = 0.00,  3.50, 0.20, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/leopard1a1.txt
+++ b/src/main/resources/assets/mcheli/tanks/leopard1a1.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.1
 CameraZoom = 10
 CameraPosition = 0.00,  3.50, 0.20, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/leopard2a4.txt
+++ b/src/main/resources/assets/mcheli/tanks/leopard2a4.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.50, 1.00, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 25
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m101.txt
+++ b/src/main/resources/assets/mcheli/tanks/m101.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Artillery Vehicle
 NameOnModernASRadar = 105mm M119 Howitzer
 NameOnEarlyAARadar = Artillery Vehicle
 NameOnModernAARadar = 105mm M119 Howitzer
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/m106.txt
+++ b/src/main/resources/assets/mcheli/tanks/m106.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 1
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, gunnernvg, gunnernvg, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m109.txt
+++ b/src/main/resources/assets/mcheli/tanks/m109.txt
@@ -25,6 +25,7 @@ CameraZoom = 4
 EnableNightVision = true
 CameraRotationSpeed = 10
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1800
 FuelConsumption = 2.4
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/m109105.txt
+++ b/src/main/resources/assets/mcheli/tanks/m109105.txt
@@ -25,6 +25,7 @@ CameraZoom = 4
 EnableNightVision = true
 CameraRotationSpeed = 10
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1800
 FuelConsumption = 2.4
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/m1128.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1128.txt
@@ -20,6 +20,7 @@ FuelConsumption = 1.8
 ;CameraZoom = 3
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/m1129.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1129.txt
@@ -20,6 +20,7 @@ CameraPosition = 0.86, 2.80,  2.12, true
 CameraZoom = 0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/m113.txt
+++ b/src/main/resources/assets/mcheli/tanks/m113.txt
@@ -19,6 +19,7 @@ Float = false
 DamageFactor = 0.25
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, gunnernvg, none, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m113m2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m113m2.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 1
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, gunnernvg, none, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m113mk19.txt
+++ b/src/main/resources/assets/mcheli/tanks/m113mk19.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 1
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, gunnernvg, none, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m113unarmed.txt
+++ b/src/main/resources/assets/mcheli/tanks/m113unarmed.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 1
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, none, none, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m132.txt
+++ b/src/main/resources/assets/mcheli/tanks/m132.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 0.45
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = ww2tank_hud
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m142.txt
+++ b/src/main/resources/assets/mcheli/tanks/m142.txt
@@ -34,6 +34,7 @@ ArmorDamageFactor = 2.32
 
 CameraZoom = 10
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 25
 MaxFuel = 2200
 FuelConsumption = 2.8

--- a/src/main/resources/assets/mcheli/tanks/m142atacms.txt
+++ b/src/main/resources/assets/mcheli/tanks/m142atacms.txt
@@ -34,6 +34,7 @@ AddTexture = m142des
 
 CameraZoom = 8
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 25
 MaxFuel = 2200
 FuelConsumption = 2.8

--- a/src/main/resources/assets/mcheli/tanks/m150.txt
+++ b/src/main/resources/assets/mcheli/tanks/m150.txt
@@ -19,6 +19,7 @@ Float = true
 DamageFactor = 0.45
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Sound = moneonethreeapc
 HUD = mbt_hudtwo, gunnernvg, gunnernvg, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m151.txt
+++ b/src/main/resources/assets/mcheli/tanks/m151.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/m151_m2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m151_m2.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.00
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/m151a1c.txt
+++ b/src/main/resources/assets/mcheli/tanks/m151a1c.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/m151a2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m151a2.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/m163.txt
+++ b/src/main/resources/assets/mcheli/tanks/m163.txt
@@ -19,6 +19,7 @@ DamageFactor = 0.8
 CameraZoom = 6
 EnableNightVision = true
 EnableEntityRadar = true
+LWR = false
 RadarType = EARLY_AA
 Sound = moneonethreeapc
 ;HUD = mbt_hud, 

--- a/src/main/resources/assets/mcheli/tanks/m18.txt
+++ b/src/main/resources/assets/mcheli/tanks/m18.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 1.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 17
 StepHeight = 1.8
 MinRotationPitch = -70

--- a/src/main/resources/assets/mcheli/tanks/m1a1.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1a1.txt
@@ -26,6 +26,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = -1.00,  3.00, 0.90, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m1a1_cev.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1a1_cev.txt
@@ -27,6 +27,7 @@ DamageFactor = 0.2
 CameraZoom = 0
 CameraPosition = 0.00,  3.50, 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m1a1nt.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1a1nt.txt
@@ -26,6 +26,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = -1.00,  3.00, 0.90, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m1a2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1a2.txt
@@ -26,6 +26,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = -1.00,  3.00, 0.90, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 25
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m1a2tusk.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1a2tusk.txt
@@ -26,6 +26,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = -1.00,  3.00, 0.90, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 25
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m1abrams.txt
+++ b/src/main/resources/assets/mcheli/tanks/m1abrams.txt
@@ -26,6 +26,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = -1.00,  3.00, 0.90, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/m2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m2.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 40
 MaxFuel           = 1200
 FuelConsumption   = 1.6

--- a/src/main/resources/assets/mcheli/tanks/m26.txt
+++ b/src/main/resources/assets/mcheli/tanks/m26.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M26 Pershing
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M26 Pershing
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/m3_stuart.txt
+++ b/src/main/resources/assets/mcheli/tanks/m3_stuart.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = stuart
 HUD = ww2tank_hud, gunner, gunner, gunner
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/m4.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m40.txt
+++ b/src/main/resources/assets/mcheli/tanks/m40.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = 155mm M40 Gun Motor Carriage
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = 155mm M40 Gun Motor Carriage
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/m4105.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4105.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.2
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 7
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m42.txt
+++ b/src/main/resources/assets/mcheli/tanks/m42.txt
@@ -32,6 +32,7 @@ HideEntity = false
 WeightType = tank
 HUD = ww2tank_hudtwo
 EnableNightVision = false
+LWR = false
 
 ExplosionSizeByCrash = 9
 

--- a/src/main/resources/assets/mcheli/tanks/m46.txt
+++ b/src/main/resources/assets/mcheli/tanks/m46.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M46 Patton
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M46 Patton
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.60

--- a/src/main/resources/assets/mcheli/tanks/m47.txt
+++ b/src/main/resources/assets/mcheli/tanks/m47.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M47 Patton
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M47 Patton
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.60

--- a/src/main/resources/assets/mcheli/tanks/m48.txt
+++ b/src/main/resources/assets/mcheli/tanks/m48.txt
@@ -31,6 +31,7 @@ ExplosionSizeByCrash = 17
 Category = MBT/MED
 
 EnableNightvision = false
+LWR = false
 ;nope!
 
 ;FlareType = 10

--- a/src/main/resources/assets/mcheli/tanks/m4_calliope.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4_calliope.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m4a1.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4a1.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m4a176.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4a176.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 17
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m4a3e2.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4a3e2.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 17
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m4a3e8.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4a3e8.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 17
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m4firefly.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4firefly.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -21

--- a/src/main/resources/assets/mcheli/tanks/m4zip.txt
+++ b/src/main/resources/assets/mcheli/tanks/m4zip.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 17
 StepHeight = 1.8
 MinRotationPitch = -25

--- a/src/main/resources/assets/mcheli/tanks/m50.txt
+++ b/src/main/resources/assets/mcheli/tanks/m50.txt
@@ -25,6 +25,7 @@ CameraZoom = 6
 EnableNightVision = false
 CameraRotationSpeed = 13
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 2200
 FuelConsumption = 2.8
 StepHeight = 1.5

--- a/src/main/resources/assets/mcheli/tanks/m60a1.txt
+++ b/src/main/resources/assets/mcheli/tanks/m60a1.txt
@@ -31,6 +31,7 @@ ExplosionSizeByCrash = 18
 Category = MBT
 
 EnableNightvision = true
+LWR = false
 
 FlareType = 10
 ThirdPersonDist = 12

--- a/src/main/resources/assets/mcheli/tanks/m60pat.txt
+++ b/src/main/resources/assets/mcheli/tanks/m60pat.txt
@@ -31,6 +31,7 @@ ExplosionSizeByCrash = 18
 Category = MBT
 
 EnableNightvision = true
+LWR = false
 
 FlareType = 10
 ThirdPersonDist = 12

--- a/src/main/resources/assets/mcheli/tanks/m67.txt
+++ b/src/main/resources/assets/mcheli/tanks/m67.txt
@@ -31,6 +31,7 @@ ExplosionSizeByCrash = 18
 Category = MFT/MED/FT
 
 EnableNightvision = false
+LWR = false
 ;nope!
 
 ;FlareType = 10

--- a/src/main/resources/assets/mcheli/tanks/m7.txt
+++ b/src/main/resources/assets/mcheli/tanks/m7.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M7 Priest
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M7 Priest
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/m777.txt
+++ b/src/main/resources/assets/mcheli/tanks/m777.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Artillery Vehicle
 NameOnModernASRadar = 155mm M777 Lightweight Towed Howitzer
 NameOnEarlyAARadar = Artillery Vehicle
 NameOnModernAARadar = 155mm M777 Lightweight Towed Howitzer
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/m8.txt
+++ b/src/main/resources/assets/mcheli/tanks/m8.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M8 Greyhound
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = M8 Greyhound
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/m_41_90.txt
+++ b/src/main/resources/assets/mcheli/tanks/m_41_90.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = leKPz M41 Walker Bulldog
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = leKPz M41 Walker Bulldog
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.60

--- a/src/main/resources/assets/mcheli/tanks/magach5.txt
+++ b/src/main/resources/assets/mcheli/tanks/magach5.txt
@@ -31,6 +31,7 @@ ExplosionSizeByCrash = 15
 Category = MBT/MED
 
 EnableNightvision = true
+LWR = false
 
 FlareType = 10
 

--- a/src/main/resources/assets/mcheli/tanks/marder.txt
+++ b/src/main/resources/assets/mcheli/tanks/marder.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.2
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 42
 
 ExplosionSizeByCrash = 15

--- a/src/main/resources/assets/mcheli/tanks/mc-tractor.txt
+++ b/src/main/resources/assets/mcheli/tanks/mc-tractor.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Generic Tractor
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Generic Tractor
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/mc_atv_normal.txt
+++ b/src/main/resources/assets/mcheli/tanks/mc_atv_normal.txt
@@ -28,6 +28,7 @@ StepHeight = 1.5
 MobilityYawOnGround = 12
 PivotTurnThrottle = 0.03
 EnableEntityRadar = false
+LWR = false
 MotionFactor = 0.91
 EnableBack = true
 ThirdPersonDist = 8

--- a/src/main/resources/assets/mcheli/tanks/mc_bicycle.txt
+++ b/src/main/resources/assets/mcheli/tanks/mc_bicycle.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Bicycle
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Bicycle
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/merkava_mk1.txt
+++ b/src/main/resources/assets/mcheli/tanks/merkava_mk1.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 8
 CameraPosition = 0.52, 3.70, -0.1, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 28
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/merkava_mk4.txt
+++ b/src/main/resources/assets/mcheli/tanks/merkava_mk4.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.52, 3.70, -0.1, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 23
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/merkava_mk4b.txt
+++ b/src/main/resources/assets/mcheli/tanks/merkava_mk4b.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.52, 3.70, -0.1, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 23
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/mlrs.txt
+++ b/src/main/resources/assets/mcheli/tanks/mlrs.txt
@@ -30,6 +30,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = true
+LWR = false
 MaxFuel           = 2200
 FuelConsumption   = 2.8
 ThirdPersonDist = 10

--- a/src/main/resources/assets/mcheli/tanks/mstab.txt
+++ b/src/main/resources/assets/mcheli/tanks/mstab.txt
@@ -22,6 +22,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 1.0
 EnableNightVision = false
+LWR = false
 DefaultFreelook = false
 
 ExplosionSizeByCrash = 12

--- a/src/main/resources/assets/mcheli/tanks/mt-12_rapira.txt
+++ b/src/main/resources/assets/mcheli/tanks/mt-12_rapira.txt
@@ -4,6 +4,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = MT-12 2A29 100mm Anti-Tank Gun
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = MT-12 2A29 100mm Anti-Tank Gun
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/mxtmv.txt
+++ b/src/main/resources/assets/mcheli/tanks/mxtmv.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.2
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/mxtmv50.txt
+++ b/src/main/resources/assets/mcheli/tanks/mxtmv50.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.2
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/mxtmvbase.txt
+++ b/src/main/resources/assets/mcheli/tanks/mxtmvbase.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.2
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/mxtmvm240.txt
+++ b/src/main/resources/assets/mcheli/tanks/mxtmvm240.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.2
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/mxtmvrws.txt
+++ b/src/main/resources/assets/mcheli/tanks/mxtmvrws.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.2
 EnableNightVision = true
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/namer.txt
+++ b/src/main/resources/assets/mcheli/tanks/namer.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.2
 CameraZoom = 10
 CameraPosition = 1.04, 2.0923, 2.9883, true
 EnableNightVision = true
+LWR = false
 ;CameraRotationSpeed = 28
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/opel_blitz_fuel.txt
+++ b/src/main/resources/assets/mcheli/tanks/opel_blitz_fuel.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/p-s1.txt
+++ b/src/main/resources/assets/mcheli/tanks/p-s1.txt
@@ -19,6 +19,7 @@ FuelConsumption = 0.7
 CameraZoom = 6
 EnableNightVision = true
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 ;EnableGunnerMode = true
 Gravity = -0.61

--- a/src/main/resources/assets/mcheli/tanks/p4-pc.txt
+++ b/src/main/resources/assets/mcheli/tanks/p4-pc.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 4

--- a/src/main/resources/assets/mcheli/tanks/p40.txt
+++ b/src/main/resources/assets/mcheli/tanks/p40.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraZoom = 4
 CameraRotationSpeed = 10
 MinRotationPitch = -23

--- a/src/main/resources/assets/mcheli/tanks/panther.txt
+++ b/src/main/resources/assets/mcheli/tanks/panther.txt
@@ -38,6 +38,7 @@ AddRecipe = "ABC", "DA ", "   ", A, mcheli:mediumchassis, B, mcheli:cannon3, C, 
 
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 
 MobilityYawOnGround = 2.5
 MobilityYaw = 1.9

--- a/src/main/resources/assets/mcheli/tanks/panzerwerfer.txt
+++ b/src/main/resources/assets/mcheli/tanks/panzerwerfer.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = sdkfz
 HUD = ww2tank_hud, ww2tank_hud
 WeightType = Car

--- a/src/main/resources/assets/mcheli/tanks/patriot_t.txt
+++ b/src/main/resources/assets/mcheli/tanks/patriot_t.txt
@@ -29,6 +29,7 @@ CameraRotationSpeed = 15
 
 AddGunnerSeat = -2.65,  -0.35, -7.35, 0.0,  1.85, -0.86, false, -90, 5, false
 EnableNightVision = true
+LWR = false
 ThirdPersonDist = 12
 DefaultFreelook = true
 

--- a/src/main/resources/assets/mcheli/tanks/pgz-95.txt
+++ b/src/main/resources/assets/mcheli/tanks/pgz-95.txt
@@ -41,6 +41,7 @@ Category = SPAAG
 
 SubmergedDamageHeight = 2
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 
 

--- a/src/main/resources/assets/mcheli/tanks/phantom.txt
+++ b/src/main/resources/assets/mcheli/tanks/phantom.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Rolls-Royce Phantom
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Rolls-Royce Phantom
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/phantomarmored.txt
+++ b/src/main/resources/assets/mcheli/tanks/phantomarmored.txt
@@ -25,6 +25,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = true
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 FlareType = 10

--- a/src/main/resources/assets/mcheli/tanks/phz89.txt
+++ b/src/main/resources/assets/mcheli/tanks/phz89.txt
@@ -25,6 +25,7 @@ GravityInWater = -1.0
 DamageFactor = 0.2
 CameraPosition = 0.00, 7.3089, 0.00, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 10
 StepHeight = 1.8
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/pion.txt
+++ b/src/main/resources/assets/mcheli/tanks/pion.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 10
 StepHeight = 1.8
 MinRotationPitch = -60

--- a/src/main/resources/assets/mcheli/tanks/plz45.txt
+++ b/src/main/resources/assets/mcheli/tanks/plz45.txt
@@ -35,6 +35,7 @@ FlareType = 10
 ;EnableGunnerMode = true
 SubmergedDamageHeight = 2
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AS
 HideEntity = true
 

--- a/src/main/resources/assets/mcheli/tanks/puma.txt
+++ b/src/main/resources/assets/mcheli/tanks/puma.txt
@@ -21,6 +21,7 @@ GravityInWater = -1.0
 DamageFactor = 0.00
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = true
 Sound = puma
 HUD = mbt_hud
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/pumabase.txt
+++ b/src/main/resources/assets/mcheli/tanks/pumabase.txt
@@ -21,6 +21,7 @@ GravityInWater = -1.0
 DamageFactor = 0.00
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = true
 Sound = puma
 HUD = mbt_hud, none, none, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/rok_k2.txt
+++ b/src/main/resources/assets/mcheli/tanks/rok_k2.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.20, 1.80, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 24
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/rozvidka.txt
+++ b/src/main/resources/assets/mcheli/tanks/rozvidka.txt
@@ -33,6 +33,7 @@ Gravity = -0.1
 GravityInWater = 0.1
 MotionFactor = 0.93
 EnableNightVision = false
+LWR = false
 
 OnGroundPitchFactor = 0.01
 OnGroundRollFactor  = 1.0

--- a/src/main/resources/assets/mcheli/tanks/rx-8.txt
+++ b/src/main/resources/assets/mcheli/tanks/rx-8.txt
@@ -23,6 +23,7 @@ GravityInWater = -1.0
 DamageFactor   = 1.0
 HUD = bnr32_hud, none, none, none
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 ;CameraZoom = 8

--- a/src/main/resources/assets/mcheli/tanks/rx7.txt
+++ b/src/main/resources/assets/mcheli/tanks/rx7.txt
@@ -25,6 +25,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/s15.txt
+++ b/src/main/resources/assets/mcheli/tanks/s15.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Nissan Silvia S15
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Nissan Silvia S15
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/s500.txt
+++ b/src/main/resources/assets/mcheli/tanks/s500.txt
@@ -19,6 +19,7 @@ MaxFuel         = 2200
 FuelConsumption = 2.8
 EnableNightVision = true
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 Gravity = -0.61
 GravityInWater = -1

--- a/src/main/resources/assets/mcheli/tanks/sa8.txt
+++ b/src/main/resources/assets/mcheli/tanks/sa8.txt
@@ -29,6 +29,7 @@ EnableNightVision = true
 MaxFuel           = 2200
 FuelConsumption   = 2.8
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AA
 CameraPosition = -0.50, 1.8,  3.83, true
 

--- a/src/main/resources/assets/mcheli/tanks/sdkfz234_2.txt
+++ b/src/main/resources/assets/mcheli/tanks/sdkfz234_2.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 1.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = sdkfz
 HUD = ww2tank_hud, none, none, none, none
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/shkhondava.txt
+++ b/src/main/resources/assets/mcheli/tanks/shkhondava.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.8
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 10
 MaxFuel         = 900
 FuelConsumption = 1.1

--- a/src/main/resources/assets/mcheli/tanks/silvia_s14.txt
+++ b/src/main/resources/assets/mcheli/tanks/silvia_s14.txt
@@ -22,6 +22,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/spg-9.txt
+++ b/src/main/resources/assets/mcheli/tanks/spg-9.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = SPG-9
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = SPG-9
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/starion.txt
+++ b/src/main/resources/assets/mcheli/tanks/starion.txt
@@ -24,6 +24,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 

--- a/src/main/resources/assets/mcheli/tanks/strf 9040b.txt
+++ b/src/main/resources/assets/mcheli/tanks/strf 9040b.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.2
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 21
 StepHeight = 1.8
 CameraZoom = 8

--- a/src/main/resources/assets/mcheli/tanks/strv103.txt
+++ b/src/main/resources/assets/mcheli/tanks/strv103.txt
@@ -28,6 +28,7 @@ GravityInWater = -0.2
 CameraZoom = 10
 CameraPosition = 0.00,  2.0, -1.0
 EnableNightVision = true
+LWR = false
 HideEntity = true
 EnableBack = true
 DamageFactor = 0.0

--- a/src/main/resources/assets/mcheli/tanks/strykericv.txt
+++ b/src/main/resources/assets/mcheli/tanks/strykericv.txt
@@ -20,6 +20,7 @@ CameraPosition = 0.86, 2.80,  2.12
 CameraZoom = 10
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 CameraRotationSpeed = 35

--- a/src/main/resources/assets/mcheli/tanks/t-34-85.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-34-85.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraRotationSpeed = 14
 MinRotationPitch = -22
 MaxRotationPitch = 5

--- a/src/main/resources/assets/mcheli/tanks/t-72b.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-72b.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Sound = tseventytwopass
 HUD = mbt_hudtwo, gunnernvg
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/t-80u.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-80u.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -15

--- a/src/main/resources/assets/mcheli/tanks/t-90.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-90.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 14
 StepHeight = 1.8
 MinRotationPitch = -14

--- a/src/main/resources/assets/mcheli/tanks/t-90a.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-90a.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 14
 FlareType = 10
 

--- a/src/main/resources/assets/mcheli/tanks/t-90s.txt
+++ b/src/main/resources/assets/mcheli/tanks/t-90s.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 14
 FlareType = 10
 DefaultFreelook = true

--- a/src/main/resources/assets/mcheli/tanks/t26.txt
+++ b/src/main/resources/assets/mcheli/tanks/t26.txt
@@ -24,6 +24,7 @@ CameraPosition = 0.25,  2.70,  0.00, true
 EnableNightVision = false
 CameraRotationSpeed = 10
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 1400
 FuelConsumption = 1.8
 StepHeight = 1.5

--- a/src/main/resources/assets/mcheli/tanks/t55.txt
+++ b/src/main/resources/assets/mcheli/tanks/t55.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 7
 CameraPosition = 0.00,  3.15, 1.30, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 6
 ;EnableEntityRadar = true
 MaxFuel         = 1400

--- a/src/main/resources/assets/mcheli/tanks/t62.txt
+++ b/src/main/resources/assets/mcheli/tanks/t62.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraZoom = 7
 CameraPosition = 0.00,  2.70, -0.0555, true
 CameraRotationSpeed = 10

--- a/src/main/resources/assets/mcheli/tanks/t64b.txt
+++ b/src/main/resources/assets/mcheli/tanks/t64b.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 9
 CameraPosition = 0.0,  3.5, 0, true
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 14
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/t64bm.txt
+++ b/src/main/resources/assets/mcheli/tanks/t64bm.txt
@@ -25,6 +25,7 @@ CameraPosition = 0.0,  3.5, 0, true
 EnableNightVision = true
 CameraRotationSpeed = 14
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 2400
 FuelConsumption = 3.2
 StepHeight = 1.8

--- a/src/main/resources/assets/mcheli/tanks/t64bv.txt
+++ b/src/main/resources/assets/mcheli/tanks/t64bv.txt
@@ -28,6 +28,7 @@ DamageFactor = 0.0
 CameraZoom = 9
 CameraPosition = 0.0,  3.5, 0, true
 EnableEntityRadar = false
+LWR = false
 EnableNightVision = true
 CameraRotationSpeed = 14
 ;EnableEntityRadar = true

--- a/src/main/resources/assets/mcheli/tanks/t64u.txt
+++ b/src/main/resources/assets/mcheli/tanks/t64u.txt
@@ -25,6 +25,7 @@ CameraPosition = 0.0,  3.5, 0, true
 EnableNightVision = true
 CameraRotationSpeed = 14
 EnableEntityRadar = true
+LWR = true
 RadarType = MODERN_AA
 MaxFuel         = 2400
 FuelConsumption = 3.2

--- a/src/main/resources/assets/mcheli/tanks/t72b3real.txt
+++ b/src/main/resources/assets/mcheli/tanks/t72b3real.txt
@@ -18,6 +18,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 24
 StepHeight = 1.8
 MinRotationPitch = -14

--- a/src/main/resources/assets/mcheli/tanks/t84.txt
+++ b/src/main/resources/assets/mcheli/tanks/t84.txt
@@ -24,6 +24,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.50, 0.25, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 14
 FlareType = 10
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/tiger1.txt
+++ b/src/main/resources/assets/mcheli/tanks/tiger1.txt
@@ -21,6 +21,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 Sound = V12TIGER
 HUD = ww2tank_hud, gunner
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/tiger2.txt
+++ b/src/main/resources/assets/mcheli/tanks/tiger2.txt
@@ -35,6 +35,7 @@ HUD = ww2tank_hud, gunner
 unmountposition = -0.0,  1.50,  -0
 EnableNightVision = false
 EnableEntityRadar = false
+LWR = false
 
 MobilityYawOnGround = 1.8
 MobilityYaw = 2.0

--- a/src/main/resources/assets/mcheli/tanks/tigr-a.txt
+++ b/src/main/resources/assets/mcheli/tanks/tigr-a.txt
@@ -23,6 +23,7 @@ Category = IMV
 WeightType = car
 
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 900
 FuelConsumption = 1.1
 unmountposition = -0.0,  1.50,  -2.12

--- a/src/main/resources/assets/mcheli/tanks/tigr-k.txt
+++ b/src/main/resources/assets/mcheli/tanks/tigr-k.txt
@@ -22,6 +22,7 @@ WeightType = car
 ExplosionSizeByCrash = 8
 
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 900
 FuelConsumption = 1.1
 

--- a/src/main/resources/assets/mcheli/tanks/tigr-m.txt
+++ b/src/main/resources/assets/mcheli/tanks/tigr-m.txt
@@ -22,6 +22,7 @@ WeightType = car
 ExplosionSizeByCrash = 3
 
 EnableEntityRadar = false
+LWR = false
 MaxFuel         = 900
 FuelConsumption = 1.1
 unmountposition = -0.0,  1.50,  -2.12

--- a/src/main/resources/assets/mcheli/tanks/tigr.txt
+++ b/src/main/resources/assets/mcheli/tanks/tigr.txt
@@ -27,6 +27,7 @@ WeightType = car
 Category = IMV
 
 EnableEntityRadar = true
+LWR = false
 RadarType = MODERN_AS
 MaxFuel         = 900
 FuelConsumption = 1.1

--- a/src/main/resources/assets/mcheli/tanks/tochkau.txt
+++ b/src/main/resources/assets/mcheli/tanks/tochkau.txt
@@ -30,6 +30,7 @@ Float = true
 
 DamageFactor = 0.8
 EnableNightVision = true
+LWR = false
 DefaultFreelook = false
 
 SubmergedDamageHeight = 4

--- a/src/main/resources/assets/mcheli/tanks/tos.txt
+++ b/src/main/resources/assets/mcheli/tanks/tos.txt
@@ -16,6 +16,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = false
 CameraRotationSpeed = 30
 StepHeight = 1.8
 MinRotationPitch = -60

--- a/src/main/resources/assets/mcheli/tanks/toyota_dshk.txt
+++ b/src/main/resources/assets/mcheli/tanks/toyota_dshk.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Toyota Hilux with DSHK
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Toyota Hilux with DSHK
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/toyota_nurs.txt
+++ b/src/main/resources/assets/mcheli/tanks/toyota_nurs.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Toyota Hilux with B-8V20A
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Toyota Hilux with B-8V20A
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/toyota_ub32.txt
+++ b/src/main/resources/assets/mcheli/tanks/toyota_ub32.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Toyota Hilux with UB-32
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Toyota Hilux with UB-32
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/toyota_unarmed.txt
+++ b/src/main/resources/assets/mcheli/tanks/toyota_unarmed.txt
@@ -7,6 +7,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Toyota Hilux (1989)
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Toyota Hilux (1989)
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/type10.txt
+++ b/src/main/resources/assets/mcheli/tanks/type10.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.0
 CameraZoom = 10
 CameraPosition = 0.00,  3.30, 0, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 18
 ;EnableEntityRadar = true
 MaxFuel         = 2400

--- a/src/main/resources/assets/mcheli/tanks/type62.txt
+++ b/src/main/resources/assets/mcheli/tanks/type62.txt
@@ -6,6 +6,7 @@ NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Type 62
 NameOnEarlyAARadar = Tank
 NameOnModernAARadar = Type 62
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.40

--- a/src/main/resources/assets/mcheli/tanks/type74.txt
+++ b/src/main/resources/assets/mcheli/tanks/type74.txt
@@ -18,6 +18,7 @@ GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
 EnableEntityRadar = false
+LWR = false
 Sound = typeseventyfour
 HUD = mbt_hudtwo, mbt_hudtwo
 WeightType = Tank

--- a/src/main/resources/assets/mcheli/tanks/type89.txt
+++ b/src/main/resources/assets/mcheli/tanks/type89.txt
@@ -23,6 +23,7 @@ DamageFactor = 0.8
 CameraZoom = 8
 CameraPosition =  0.00,  2.77, 1.8, true
 EnableNightVision = true
+LWR = true
 CameraRotationSpeed = 18
 ;EnableEntityRadar = true
 MaxFuel         = 1300

--- a/src/main/resources/assets/mcheli/tanks/type95_lt.txt
+++ b/src/main/resources/assets/mcheli/tanks/type95_lt.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.6
 EnableNightVision = false
+LWR = false
 Gravity = -0.61
 CameraZoom = 4
 CameraRotationSpeed = 9

--- a/src/main/resources/assets/mcheli/tanks/type97_new.txt
+++ b/src/main/resources/assets/mcheli/tanks/type97_new.txt
@@ -19,6 +19,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = false
+LWR = false
 CameraZoom = 4
 CameraRotationSpeed = 9
 MinRotationPitch = -20

--- a/src/main/resources/assets/mcheli/tanks/uaz-469k-m-2.txt
+++ b/src/main/resources/assets/mcheli/tanks/uaz-469k-m-2.txt
@@ -22,6 +22,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 0.85
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/uaz_kpvt.txt
+++ b/src/main/resources/assets/mcheli/tanks/uaz_kpvt.txt
@@ -21,6 +21,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1.0
 EnableNightVision = false
+LWR = false
 MaxFuel           = 900
 FuelConsumption   = 1.1
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/uragan.txt
+++ b/src/main/resources/assets/mcheli/tanks/uragan.txt
@@ -28,6 +28,7 @@ CameraZoom = 4
 EnableNightVision = true
 CameraRotationSpeed = 40
 EnableEntityRadar = false
+LWR = false
 MaxFuel  = 2200
 FuelConsumption = 2.8
 CameraPosition = 0.00,  7.42, -2.52

--- a/src/main/resources/assets/mcheli/tanks/ural4320.txt
+++ b/src/main/resources/assets/mcheli/tanks/ural4320.txt
@@ -5,6 +5,7 @@ NameOnEarlyASRadar = Light Vehicle
 NameOnModernASRadar = Ural-4320
 NameOnEarlyAARadar = Light Vehicle
 NameOnModernAARadar = Ural-4320
+LWR = false
 ChaffWaitTime = 0
 ChaffUseTime = 0
 ThrottleDownFactor = 0.45

--- a/src/main/resources/assets/mcheli/tanks/vn4.txt
+++ b/src/main/resources/assets/mcheli/tanks/vn4.txt
@@ -18,6 +18,7 @@ MobilityYawOnGround = 6.5
 MaxFuel         = 900
 FuelConsumption = 1.1
 EnableEntityRadar = false
+LWR = false
 Gravity = -0.61
 GravityInWater = -1.0
 ;CameraRotationSpeed = 37

--- a/src/main/resources/assets/mcheli/tanks/w123.txt
+++ b/src/main/resources/assets/mcheli/tanks/w123.txt
@@ -20,6 +20,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1
 EnableNightVision = false
+LWR = false
 MaxFuel           = 650
 FuelConsumption   = 0.7
 ThirdPersonDist = 5

--- a/src/main/resources/assets/mcheli/tanks/zsu23.txt
+++ b/src/main/resources/assets/mcheli/tanks/zsu23.txt
@@ -26,6 +26,7 @@ CameraZoom = 6
 EnableNightVision = true
 CameraRotationSpeed = 42
 EnableEntityRadar = true
+LWR = false
 RadarType = EARLY_AA
 MaxFuel         = 1800
 FuelConsumption = 2.4

--- a/src/main/resources/assets/mcheli/tanks/ztz-96a.txt
+++ b/src/main/resources/assets/mcheli/tanks/ztz-96a.txt
@@ -22,6 +22,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor = 0.0
 EnableNightVision = true
+LWR = true
 StepHeight = 1.8
 DefaultFreelook = true
 OnGroundPitchFactor = 2.0

--- a/src/main/resources/assets/mcheli/tanks/zu23.txt
+++ b/src/main/resources/assets/mcheli/tanks/zu23.txt
@@ -23,6 +23,7 @@ Gravity = -0.61
 GravityInWater = -1.0
 DamageFactor   = 1
 EnableNightVision = false
+LWR = false
 MaxFuel           = 1300
 FuelConsumption   = 1.9
 ThirdPersonDist = 10


### PR DESCRIPTION
### Motivation

- Ensure every tank configuration explicitly declares whether a laser warning receiver is present so runtime behavior can be gated and audited. 
- Use each file's configured `DisplayName` as the authoritative vehicle identity when deciding whether `LWR` applies. 
- Enable `LWR` only where reliable variant-specific evidence shows a laser-warning receiver exists, and conservatively set it `false` otherwise. 

### Description

- Added a single `LWR = true` or `LWR = false` entry to every `.txt` in `src/main/resources/assets/mcheli/tanks/` (247 files total). 
- 23 configs were assigned `LWR = true` and 224 were assigned `LWR = false`, with `LWR` lines inserted adjacent to other sensor/capability settings (e.g. next to `EnableEntityRadar` or `EnableNightVision` when present). 
- Preserved all existing `DisplayName` values, comments, spacing, and other content; no Java source or files outside `src/main/resources/assets/mcheli/tanks/` were modified except `CHANGELOG.md`. 
- Documented the audit in `CHANGELOG.md` per project policy.

### Testing

- Enumerated all tank configs with `find src/main/resources/assets/mcheli/tanks -type f -name '*.txt'` and validated count is `247`. 
- Ran the insertion script `python3 /tmp/add_lwr.py` which added one `LWR` line to each file and reported `23` true / `224` false. 
- Automated validation checked every file contains exactly one active `LWR` entry and that every value is exactly `LWR = true` or `LWR = false`, and confirmed `DisplayName` lines remained unchanged by comparing the pre-change HEAD content. 
- Verified diff scope and hygiene with `rg`/`git diff --numstat`/`git diff --check` and other checks to ensure each tank file had exactly one inserted line and there were no whitespace errors; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e57890ffc832399f20c1654463fe7)