### PR TITLE
Add catastrophic tank turret-pop destruction effect

### DIFF
--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -291,6 +291,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `WeightType` | Tank | enum `normal`, `car`, `tank` | `normal`/0 | ground physics weight behavior |
 | `WeightedCenterZ` | Tank | float[-1000..1000] | 0.0 | fore/aft center of weight |
 | `TrackMaxHP` | Tank | int[1..1000000] | 100 | track durability |
+| `EnableTurretPop` | Tank | boolean | `false` | `true` enables the catastrophic detached-turret destruction effect; requires a configured dynamic turret assembly |
 | `AddTrackHitBox` | Tank | `x,y,z,width,height[,damageFactor]` | damageFactor 1.0 | track hitbox |
 | `canmove` | Turret/static | boolean | false | movable turret vehicle |
 | `canrotation` | Turret/static | boolean | false | base rotation enabled |

--- a/docs/vehicle-config/tanks.md
+++ b/docs/vehicle-config/tanks.md
@@ -11,6 +11,7 @@ Set the shared `LWR = true` option to enable the existing tank laser warning ale
 | `WeightType` | enum `normal`, `car`, `tank` | `normal` / 0 | Parser maps `car` to 1 and `tank` to 2; any other text is 0. |
 | `WeightedCenterZ` | float[-1000..1000] | 0 | Moves the simulated center of weight forward/back. Positive/negative effect depends on model orientation. |
 | `TrackMaxHP` | int[1..1000000] | 100 | Track durability. |
+| `EnableTurretPop` | boolean | `false` | When `true`, enables the catastrophic detached-turret destruction effect. Requires a configured dynamic turret assembly. |
 | `AddTrackHitBox` | `x,y,z,width,height[,damageFactor]` | none; damage factor 1 | Adds a track-typed extra bounding box. |
 
 ## Tank defaults that differ from base
@@ -39,6 +40,7 @@ maxhp = 250
 speed = 0.35
 WeightType = tank
 TrackMaxHP = 120
+EnableTurretPop = false
 LWR = false
 AddTrackHitBox = 1.2, 0.0, 0.0, 0.5, 0.5, 1.0
 AddTrackHitBox = -1.2, 0.0, 0.0, 0.5, 0.5, 1.0
@@ -46,4 +48,6 @@ AddTrackHitBox = -1.2, 0.0, 0.0, 0.5, 0.5, 1.0
 
 ## Safe-to-omit notes
 
-`WeightType`, `WeightedCenterZ`, `TrackMaxHP`, `AddTrackHitBox`, and `LWR` are optional. Omitting `LWR` leaves tank alert audio disabled; omitting the other keys leaves default ground behavior and no explicit track hitboxes.
+`WeightType`, `WeightedCenterZ`, `TrackMaxHP`, `AddTrackHitBox`, `EnableTurretPop`, and `LWR` are optional. Omitting `EnableTurretPop` keeps the turret attached when the tank is destroyed. Omitting `LWR` leaves tank alert audio disabled; omitting the other keys leaves default ground behavior and no explicit track hitboxes.
+
+`EnableTurretPop = true` enables a catastrophic destruction effect which launches the complete main dynamic turret weapon part and its configured child parts off the chassis. The tank must define a dynamic turret assembly with `AddPartTurretWeapon` or `AddPartTurretRotWeapon`; geometry baked into `$body` cannot be detached.

--- a/src/main/java/mcheli/MCH_PacketHandler.java
+++ b/src/main/java/mcheli/MCH_PacketHandler.java
@@ -71,6 +71,9 @@ public class MCH_PacketHandler extends W_PacketHandler {
       case 268439649:
          MCH_BaseVehiclePacketHandler.onPacketStatusResponse(entityPlayer, data);
          break;
+      case 268439650:
+         MCH_TankPacketHandler.onPacket_TurretPop(entityPlayer, data);
+         break;
       case 536872992:
          MCH_CommonPacketHandler.onPacketIndOpenScreen(entityPlayer, data);
          break;

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -873,6 +873,14 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    }
 
    public static void renderWeapon(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime) {
+      renderWeapon(ac, info, tickTime, false);
+   }
+
+   public static void renderDetachedTurretWeapon(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime) {
+      renderWeapon(ac, info, tickTime, true);
+   }
+
+   private static void renderWeapon(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime, boolean detachedOnly) {
       MCH_WeaponSet beforeWs = null;
       Entity e = ac.getRiddenByEntity();
       int weaponIndex = 0;
@@ -881,6 +889,12 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
       while(i$.hasNext()) {
          MCH_BaseVehicleInfo.PartWeapon w = (MCH_BaseVehicleInfo.PartWeapon)i$.next();
+         if(ac instanceof mcheli.tank.MCH_EntityTank && ((mcheli.tank.MCH_EntityTank)ac).turretPopStarted) {
+            MCH_BaseVehicleInfo.PartWeapon root = ((mcheli.tank.MCH_EntityTank)ac).getTurretPopRoot();
+            if((detachedOnly && w != root) || (!detachedOnly && w == root)) continue;
+         } else if(detachedOnly) {
+            continue;
+         }
          MCH_WeaponSet ws = ac.getWeaponByName(w.name[0]);
          boolean var10000;
          if(ws != null && ws.getFirstWeapon().onTurret) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -40,6 +40,7 @@ import net.minecraft.util.DamageSource;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
+import io.netty.buffer.ByteBuf;
 
 //the cursed extension
 //refactoring would be a fucking nightmare
@@ -54,6 +55,15 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    public final MCH_WheelManager WheelMng;
    public float partialTicks;
    private int trackDamageTaken;
+   public boolean turretPopStarted;
+   public boolean turretPopLanded;
+   public double turretPopX, turretPopY, turretPopZ;
+   public double prevTurretPopX, prevTurretPopY, prevTurretPopZ;
+   public double turretPopMotionX, turretPopMotionY, turretPopMotionZ;
+   public float turretPopYaw, turretPopPitch, turretPopRoll;
+   public float prevTurretPopYaw, prevTurretPopPitch, prevTurretPopRoll;
+   public float turretPopAngularYaw, turretPopAngularPitch, turretPopAngularRoll;
+   public int turretPopAge;
 
    //TODO
    private int currentGear = 1;  // Starting gear
@@ -78,6 +88,8 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.prevRotationRotor = 0.0F;
       this.WheelMng = new MCH_WheelManager(this);
       this.trackDamageTaken = 0;
+      this.turretPopStarted = false;
+      this.turretPopLanded = false;
    }
 
    //tracks are very broken
@@ -144,11 +156,28 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    protected void writeEntityToNBT(NBTTagCompound par1NBTTagCompound) {
       super.writeEntityToNBT(par1NBTTagCompound);
       par1NBTTagCompound.setInteger("TrackDamage", this.trackDamageTaken);
+      par1NBTTagCompound.setBoolean("TurretPopStarted", this.turretPopStarted);
+      if(this.turretPopStarted) {
+         par1NBTTagCompound.setBoolean("TurretPopLanded", this.turretPopLanded);
+         par1NBTTagCompound.setDouble("TurretPopX", this.turretPopX); par1NBTTagCompound.setDouble("TurretPopY", this.turretPopY); par1NBTTagCompound.setDouble("TurretPopZ", this.turretPopZ);
+         par1NBTTagCompound.setDouble("TurretPopMX", this.turretPopMotionX); par1NBTTagCompound.setDouble("TurretPopMY", this.turretPopMotionY); par1NBTTagCompound.setDouble("TurretPopMZ", this.turretPopMotionZ);
+         par1NBTTagCompound.setFloat("TurretPopYaw", this.turretPopYaw); par1NBTTagCompound.setFloat("TurretPopPitch", this.turretPopPitch); par1NBTTagCompound.setFloat("TurretPopRoll", this.turretPopRoll);
+         par1NBTTagCompound.setFloat("TurretPopAY", this.turretPopAngularYaw); par1NBTTagCompound.setFloat("TurretPopAP", this.turretPopAngularPitch); par1NBTTagCompound.setFloat("TurretPopAR", this.turretPopAngularRoll);
+         par1NBTTagCompound.setInteger("TurretPopAge", this.turretPopAge);
+      }
    }
 
    protected void readEntityFromNBT(NBTTagCompound par1NBTTagCompound) {
       super.readEntityFromNBT(par1NBTTagCompound);
       this.trackDamageTaken = Math.max(0, par1NBTTagCompound.getInteger("TrackDamage"));
+      this.turretPopStarted = par1NBTTagCompound.getBoolean("TurretPopStarted");
+      if(this.turretPopStarted) {
+         this.turretPopLanded = par1NBTTagCompound.getBoolean("TurretPopLanded");
+         this.turretPopX = this.prevTurretPopX = par1NBTTagCompound.getDouble("TurretPopX"); this.turretPopY = this.prevTurretPopY = par1NBTTagCompound.getDouble("TurretPopY"); this.turretPopZ = this.prevTurretPopZ = par1NBTTagCompound.getDouble("TurretPopZ");
+         this.turretPopMotionX = par1NBTTagCompound.getDouble("TurretPopMX"); this.turretPopMotionY = par1NBTTagCompound.getDouble("TurretPopMY"); this.turretPopMotionZ = par1NBTTagCompound.getDouble("TurretPopMZ");
+         this.turretPopYaw = this.prevTurretPopYaw = par1NBTTagCompound.getFloat("TurretPopYaw"); this.turretPopPitch = this.prevTurretPopPitch = par1NBTTagCompound.getFloat("TurretPopPitch"); this.turretPopRoll = this.prevTurretPopRoll = par1NBTTagCompound.getFloat("TurretPopRoll");
+         this.turretPopAngularYaw = par1NBTTagCompound.getFloat("TurretPopAY"); this.turretPopAngularPitch = par1NBTTagCompound.getFloat("TurretPopAP"); this.turretPopAngularRoll = par1NBTTagCompound.getFloat("TurretPopAR"); this.turretPopAge = Math.max(0, par1NBTTagCompound.getInteger("TurretPopAge"));
+      }
       if(this.tankInfo == null) {
          this.tankInfo = MCH_TankInfoManager.get(this.getTypeName());
          if(this.tankInfo == null) {
@@ -187,6 +216,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          super.prevPosY = super.posY;
          super.prevPosZ = super.posZ;
       } else {
+         if(!super.worldObj.isRemote) this.updateTurretPop();
          if(!super.isRequestedSyncStatus) {
             super.isRequestedSyncStatus = true;
             if(super.worldObj.isRemote) {
@@ -808,7 +838,62 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       super.rotDestroyedPitch = 0.0F;
       super.rotDestroyedRoll = 0.0F;
       super.rotDestroyedYaw = 0.0F;
+      if(!super.worldObj.isRemote && !this.turretPopStarted && this.tankInfo != null && this.tankInfo.enableTurretPop && this.getTurretPopRoot() != null) {
+         this.startTurretPop();
+      }
    }
+
+   public MCH_BaseVehicleInfo.PartWeapon getTurretPopRoot() {
+      if(this.tankInfo != null) for(Object o : this.tankInfo.partWeapon) {
+         MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)o;
+         if(part.turret) return part;
+      }
+      return null;
+   }
+
+   private void startTurretPop() {
+      Vec3 p = this.getTransformedPosition(this.tankInfo.turretPosition);
+      this.turretPopStarted = true; this.turretPopLanded = false; this.turretPopAge = 0;
+      this.turretPopX = this.prevTurretPopX = p.xCoord; this.turretPopY = this.prevTurretPopY = p.yCoord; this.turretPopZ = this.prevTurretPopZ = p.zCoord;
+      double a = super.rand.nextDouble() * Math.PI * 2.0D;
+      double speed = 0.18D + super.rand.nextDouble() * 0.16D;
+      this.turretPopMotionX = Math.cos(a) * speed; this.turretPopMotionY = 1.05D + super.rand.nextDouble() * 0.35D; this.turretPopMotionZ = Math.sin(a) * speed;
+      this.turretPopYaw = this.prevTurretPopYaw = this.getRotYaw(); this.turretPopPitch = this.prevTurretPopPitch = 0.0F; this.turretPopRoll = this.prevTurretPopRoll = 0.0F;
+      this.turretPopAngularYaw = 8.0F + super.rand.nextFloat() * 12.0F; this.turretPopAngularPitch = (super.rand.nextFloat() - 0.5F) * 24.0F; this.turretPopAngularRoll = (super.rand.nextFloat() - 0.5F) * 30.0F;
+      MCH_PacketTurretPop.send(this);
+   }
+
+   private void updateTurretPop() {
+      if(!this.turretPopStarted || this.turretPopLanded) return;
+      this.prevTurretPopX = this.turretPopX; this.prevTurretPopY = this.turretPopY; this.prevTurretPopZ = this.turretPopZ;
+      this.prevTurretPopYaw = this.turretPopYaw; this.prevTurretPopPitch = this.turretPopPitch; this.prevTurretPopRoll = this.turretPopRoll;
+      this.turretPopMotionY = Math.max(-1.5D, this.turretPopMotionY - 0.055D);
+      this.turretPopX += this.turretPopMotionX; this.turretPopY += this.turretPopMotionY; this.turretPopZ += this.turretPopMotionZ;
+      this.turretPopYaw += this.turretPopAngularYaw; this.turretPopPitch += this.turretPopAngularPitch; this.turretPopRoll += this.turretPopAngularRoll;
+      ++this.turretPopAge;
+      int bx = MathHelper.floor_double(this.turretPopX), by = MathHelper.floor_double(this.turretPopY), bz = MathHelper.floor_double(this.turretPopZ);
+      int previousY = MathHelper.floor_double(this.prevTurretPopY);
+      int groundY = Integer.MIN_VALUE;
+      if(this.turretPopMotionY <= 0.0D) for(int testY = previousY; testY >= by; --testY) {
+         if(!super.worldObj.isAirBlock(bx, testY, bz)) { groundY = testY; break; }
+      }
+      boolean timedOut = this.turretPopAge >= 600;
+      if(groundY != Integer.MIN_VALUE || timedOut) {
+         this.turretPopY = (timedOut?super.worldObj.getHeightValue(bx, bz):groundY + 1) + 0.02D; this.turretPopMotionX = this.turretPopMotionY = this.turretPopMotionZ = 0.0D;
+         this.turretPopAngularYaw *= 0.08F; this.turretPopAngularPitch *= 0.08F; this.turretPopAngularRoll *= 0.08F; this.turretPopLanded = true;
+      }
+      if((this.turretPopAge % 3) == 0 || this.turretPopLanded) MCH_PacketTurretPop.send(this);
+   }
+
+   public void applyTurretPopState(MCH_PacketTurretPop p) {
+      this.prevTurretPopX = this.turretPopStarted?this.turretPopX:p.x; this.prevTurretPopY = this.turretPopStarted?this.turretPopY:p.y; this.prevTurretPopZ = this.turretPopStarted?this.turretPopZ:p.z;
+      this.prevTurretPopYaw = this.turretPopStarted?this.turretPopYaw:p.yaw; this.prevTurretPopPitch = this.turretPopStarted?this.turretPopPitch:p.pitch; this.prevTurretPopRoll = this.turretPopStarted?this.turretPopRoll:p.roll;
+      this.turretPopStarted = true; this.turretPopLanded = p.landed; this.turretPopX=p.x; this.turretPopY=p.y; this.turretPopZ=p.z; this.turretPopYaw=p.yaw; this.turretPopPitch=p.pitch; this.turretPopRoll=p.roll; this.turretPopAge=p.age;
+      this.turretPopMotionX=p.mx; this.turretPopMotionY=p.my; this.turretPopMotionZ=p.mz; this.turretPopAngularYaw=p.ay; this.turretPopAngularPitch=p.ap; this.turretPopAngularRoll=p.ar;
+   }
+
+   public void writeSpawnData(ByteBuf buffer) { super.writeSpawnData(buffer); MCH_PacketTurretPop.writeState(buffer, this); }
+   public void readSpawnData(ByteBuf buffer) { super.readSpawnData(buffer); if(buffer.readableBytes() > 0) MCH_PacketTurretPop.readState(buffer, this); }
 
    public void performActionIfWeightTypeIsOne() {
       // Check if TankInfo exists and weightType is 1

--- a/src/main/java/mcheli/tank/MCH_PacketTurretPop.java
+++ b/src/main/java/mcheli/tank/MCH_PacketTurretPop.java
@@ -1,0 +1,56 @@
+package mcheli.tank;
+
+import com.google.common.io.ByteArrayDataInput;
+import io.netty.buffer.ByteBuf;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import mcheli.MCH_Packet;
+import mcheli.wrapper.W_Entity;
+import mcheli.wrapper.W_Network;
+
+/** Server-authored detached turret transform and velocity snapshot. */
+public class MCH_PacketTurretPop extends MCH_Packet {
+   public int entityId, age;
+   public boolean landed;
+   public double x, y, z, mx, my, mz;
+   public float yaw, pitch, roll, ay, ap, ar;
+
+   public int getMessageID() { return 268439650; }
+
+   public void readData(ByteArrayDataInput in) {
+      try {
+         this.entityId=in.readInt(); this.landed=in.readBoolean(); this.age=in.readInt();
+         this.x=in.readDouble(); this.y=in.readDouble(); this.z=in.readDouble(); this.mx=in.readDouble(); this.my=in.readDouble(); this.mz=in.readDouble();
+         this.yaw=in.readFloat(); this.pitch=in.readFloat(); this.roll=in.readFloat(); this.ay=in.readFloat(); this.ap=in.readFloat(); this.ar=in.readFloat();
+      } catch(Exception e) { e.printStackTrace(); }
+   }
+
+   public void writeData(DataOutputStream out) {
+      try {
+         out.writeInt(this.entityId); out.writeBoolean(this.landed); out.writeInt(this.age);
+         out.writeDouble(this.x); out.writeDouble(this.y); out.writeDouble(this.z); out.writeDouble(this.mx); out.writeDouble(this.my); out.writeDouble(this.mz);
+         out.writeFloat(this.yaw); out.writeFloat(this.pitch); out.writeFloat(this.roll); out.writeFloat(this.ay); out.writeFloat(this.ap); out.writeFloat(this.ar);
+      } catch(IOException e) { e.printStackTrace(); }
+   }
+
+   private static MCH_PacketTurretPop from(MCH_EntityTank tank) {
+      MCH_PacketTurretPop p=new MCH_PacketTurretPop(); p.entityId=W_Entity.getEntityId(tank); p.landed=tank.turretPopLanded; p.age=tank.turretPopAge;
+      p.x=tank.turretPopX; p.y=tank.turretPopY; p.z=tank.turretPopZ; p.mx=tank.turretPopMotionX; p.my=tank.turretPopMotionY; p.mz=tank.turretPopMotionZ;
+      p.yaw=tank.turretPopYaw; p.pitch=tank.turretPopPitch; p.roll=tank.turretPopRoll; p.ay=tank.turretPopAngularYaw; p.ap=tank.turretPopAngularPitch; p.ar=tank.turretPopAngularRoll; return p;
+   }
+
+   public static void send(MCH_EntityTank tank) { W_Network.sendToAllAround(from(tank), tank, 256.0D); }
+
+   public static void writeState(ByteBuf out, MCH_EntityTank tank) {
+      out.writeBoolean(tank.turretPopStarted); if(!tank.turretPopStarted) return;
+      MCH_PacketTurretPop p=from(tank); out.writeBoolean(p.landed); out.writeInt(p.age);
+      out.writeDouble(p.x); out.writeDouble(p.y); out.writeDouble(p.z); out.writeDouble(p.mx); out.writeDouble(p.my); out.writeDouble(p.mz);
+      out.writeFloat(p.yaw); out.writeFloat(p.pitch); out.writeFloat(p.roll); out.writeFloat(p.ay); out.writeFloat(p.ap); out.writeFloat(p.ar);
+   }
+
+   public static void readState(ByteBuf in, MCH_EntityTank tank) {
+      if(!in.readBoolean()) return; MCH_PacketTurretPop p=new MCH_PacketTurretPop(); p.landed=in.readBoolean(); p.age=in.readInt();
+      p.x=in.readDouble(); p.y=in.readDouble(); p.z=in.readDouble(); p.mx=in.readDouble(); p.my=in.readDouble(); p.mz=in.readDouble();
+      p.yaw=in.readFloat(); p.pitch=in.readFloat(); p.roll=in.readFloat(); p.ay=in.readFloat(); p.ap=in.readFloat(); p.ar=in.readFloat(); tank.applyTurretPopState(p);
+   }
+}

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -54,8 +54,33 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));
             }
             renderBodyWithSkinOverlay(tankInfo.model, "tanks", tank);
+            this.renderPoppedTurret(tank, tankInfo, yaw, pitch, roll, tickTime);
          }
       }
+   }
+
+   private void renderPoppedTurret(MCH_EntityTank tank, MCH_TankInfo info, float hullYaw, float hullPitch, float hullRoll, float tickTime) {
+      if(!tank.turretPopStarted || tank.getTurretPopRoot() == null) return;
+      double x = tank.prevTurretPopX + (tank.turretPopX - tank.prevTurretPopX) * tickTime;
+      double y = tank.prevTurretPopY + (tank.turretPopY - tank.prevTurretPopY) * tickTime;
+      double z = tank.prevTurretPopZ + (tank.turretPopZ - tank.prevTurretPopZ) * tickTime;
+      float popYaw = tank.prevTurretPopYaw + (tank.turretPopYaw - tank.prevTurretPopYaw) * tickTime;
+      float popPitch = tank.prevTurretPopPitch + (tank.turretPopPitch - tank.prevTurretPopPitch) * tickTime;
+      float popRoll = tank.prevTurretPopRoll + (tank.turretPopRoll - tank.prevTurretPopRoll) * tickTime;
+      GL11.glPushMatrix();
+      GL11.glRotatef(-hullRoll, 0.0F, 0.0F, 1.0F);
+      GL11.glRotatef(-hullPitch, 1.0F, 0.0F, 0.0F);
+      GL11.glRotatef(-hullYaw, 0.0F, -1.0F, 0.0F);
+      double tankX = tank.prevPosX + (tank.posX - tank.prevPosX) * tickTime;
+      double tankY = tank.prevPosY + (tank.posY - tank.prevPosY) * tickTime;
+      double tankZ = tank.prevPosZ + (tank.posZ - tank.prevPosZ) * tickTime;
+      GL11.glTranslated(x - tankX, y - tankY, z - tankZ);
+      GL11.glRotatef(popYaw, 0.0F, -1.0F, 0.0F);
+      GL11.glRotatef(popPitch, 1.0F, 0.0F, 0.0F);
+      GL11.glRotatef(popRoll, 0.0F, 0.0F, 1.0F);
+      GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
+      renderDetachedTurretWeapon(tank, info, tickTime);
+      GL11.glPopMatrix();
    }
 
    public void renderWheel(MCH_EntityTank tank, double posX, double posY, double posZ) {

--- a/src/main/java/mcheli/tank/MCH_TankInfo.java
+++ b/src/main/java/mcheli/tank/MCH_TankInfo.java
@@ -17,6 +17,7 @@ public class MCH_TankInfo extends MCH_BaseVehicleInfo {
    public int weightType = 0;
    public float weightedCenterZ = 0.0F;
    public int trackMaxHP = 100;
+   public boolean enableTurretPop = false;
 
 
    public Item getItem() {
@@ -77,6 +78,8 @@ public class MCH_TankInfo extends MCH_BaseVehicleInfo {
          this.weightedCenterZ = this.toFloat(data, -1000.0F, 1000.0F);
       } else if(item.equalsIgnoreCase("TrackMaxHP")) {
          this.trackMaxHP = this.toInt(data, 1, 1000000);
+      } else if(item.equalsIgnoreCase("EnableTurretPop")) {
+         this.enableTurretPop = this.toBool(data, false);
       } else if(item.equalsIgnoreCase("AddTrackHitBox")) {
          String[] s = data.split("\\s*,\\s*");
          if(s.length >= 5) {

--- a/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
+++ b/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
@@ -10,6 +10,14 @@ import net.minecraft.entity.player.EntityPlayer;
 
 public class MCH_TankPacketHandler {
 
+   public static void onPacket_TurretPop(EntityPlayer player, ByteArrayDataInput data) {
+      if(player.worldObj.isRemote) {
+         MCH_PacketTurretPop packet = new MCH_PacketTurretPop(); packet.readData(data);
+         net.minecraft.entity.Entity entity = player.worldObj.getEntityByID(packet.entityId);
+         if(entity instanceof MCH_EntityTank) ((MCH_EntityTank)entity).applyTurretPopState(packet);
+      }
+   }
+
    public static void onPacket_PlayerControl(EntityPlayer player, ByteArrayDataInput data) {
       if(!player.worldObj.isRemote) {
          MCH_TankPacketPlayerControl pc = new MCH_TankPacketPlayerControl();


### PR DESCRIPTION
### Motivation

- Provide an optional, server-authoritative "turret pop" destruction effect that violently detaches the main dynamic turret assembly from enabled tanks and reproduces it identically on clients.
- Make the effect configurable per-tank via the vehicle text config and safe by default so existing tanks without the key or without a dynamic turret assembly keep current behavior.

### Description

- Add `enableTurretPop` (default `false`) and case-insensitive `EnableTurretPop` parsing to `MCH_TankInfo` so the option is applied only to tanks via `loadItemData` and the existing boolean helper.
- Add explicit turret-pop state, NBT persistence, spawn-data support, server-side activation on `destroyAircraft`, server-side physics `updateTurretPop`, and client synchronization via a new `MCH_PacketTurretPop` packet (and spawn-data helpers) in `MCH_EntityTank` and the new packet class.
- Select the main turret root as the first top-level `PartWeapon` with `turret == true`, move that root and its configured `PartWeaponChild` list as a single detached rigid assembly, and avoid detaching geometry baked into `$body` or unrelated weapons.
- Render the detached turret in a separate interpolated pass by suppressing the attached root in normal weapon rendering and adding a detached pass in `MCH_RenderTank`/`MCH_RenderBaseVehicle`, preserving LOD consistency, textures, lighting, and balanced GL pushes/pops.
- Implement motion: server-generated upward + horizontal impulse, independent 3-axis angular velocity, per-tick gravity, ground contact detection, landing stabilization and velocity damping, and a 600-tick safety timeout to prevent uncontrolled falling.
- Wire packet dispatch and handler (`MCH_PacketHandler` and `MCH_TankPacketHandler`) so joining or newly-tracking clients receive authoritative spawn/state snapshots.
- Document the option and behavior in `docs/vehicle-config/tanks.md` and `docs/vehicle-config-reference.md`, and add `EnableTurretPop = false` to the minimal tank example.

### Testing

- Ran `git diff --check` and committed the changes as `Add server-synced tank turret pop effect` with a clean working tree.
- Ran Python assertions that verify `EnableTurretPop` exists in `MCH_TankInfo`, is parsed with the boolean helper, appears in both documentation files, and that the minimal tank example contains `EnableTurretPop = false` (all checks passed).
- Performed static checks including packet ID existence (`rg`), simple brace/balance checks on changed Java sources, and created the PR metadata; all static checks succeeded.
- Did not run `./gradlew build` or in-game verification because the provided instructions prohibit compiling binaries and no interactive game/server environment was available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e62d3188c8323b1f4ca2d5524c085)