### PR TITLE
Enable turret pop for detachable tank turrets

### DIFF
--- a/configreference/tanks/2s25 sprut_sd.txt
+++ b/configreference/tanks/2s25 sprut_sd.txt
@@ -1,4 +1,5 @@
 DisplayName = 2S25 Sprut-SD
+EnableTurretPop = true
 Weight = 39683
 NameOnEarlyASRadar = Artillery Vehicle
 NameOnModernASRadar = 2S25 Sprut-SD

--- a/configreference/tanks/59d.txt
+++ b/configreference/tanks/59d.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = ZTZ59D/Type 59D
+EnableTurretPop = true
 AddDisplayName = en_US, ZTZ59D/Type 59D
 AddDisplayName = zh_CN,  59D型坦克
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/82ccv.txt
+++ b/configreference/tanks/82ccv.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 82 CCV
+EnableTurretPop = true
 AddDisplayName = en_US, Type 82 CCV
 AddDisplayName = ja_JP, 82式指揮通信車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/87rcv.txt
+++ b/configreference/tanks/87rcv.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 87 RCV
+EnableTurretPop = true
 AddDisplayName = en_US, Type 87 RCV
 AddDisplayName = ja_JP, 87式偵察警戒車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/90tk.txt
+++ b/configreference/tanks/90tk.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 90 MBT
+EnableTurretPop = true
 AddDisplayName = en_US, Type 90 MBT
 AddDisplayName = ja_JP, 90式戦車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/99a2.txt
+++ b/configreference/tanks/99a2.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = ZTZ99 Stage 2
+EnableTurretPop = true
 AddDisplayName = en_US, ZTZ99 Stage 2
 AddDisplayName = ja_JP, ZTZ99
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/a-27mcromwell.txt
+++ b/configreference/tanks/a-27mcromwell.txt
@@ -1,5 +1,6 @@
 Weight = 61729
 ﻿DisplayName = A-27M Cromwell V
+EnableTurretPop = true
 AddDisplayName = en_US, A-27M Cromwell V
 AddDisplayName = ru_RU, A-27M Cromwell V
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/amx-30b.txt
+++ b/configreference/tanks/amx-30b.txt
@@ -1,5 +1,6 @@
 Weight = 79366
     DisplayName = AMX-30B
+EnableTurretPop = true
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = AMX-30B
 NameOnEarlyAARadar = Tank

--- a/configreference/tanks/amx13.txt
+++ b/configreference/tanks/amx13.txt
@@ -1,4 +1,5 @@
 DisplayName = AMX-13/75 FL-10
+EnableTurretPop = true
 Weight = 31967
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = AMX-13/75 FL-10

--- a/configreference/tanks/amx56.txt
+++ b/configreference/tanks/amx56.txt
@@ -1,4 +1,5 @@
 DisplayName = AMX56 Leclerc MBT
+EnableTurretPop = true
 AddDisplayName = zh_CN,AMX56 勒克莱尔主战坦克
 AddDisplayName = en_US, AMX56 Leclerc MBT
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/ariete.txt
+++ b/configreference/tanks/ariete.txt
@@ -1,4 +1,5 @@
 DisplayName = C1 Ariete PSO
+EnableTurretPop = true
 AddDisplayName = en_US, C1 Ariete PSO
 AddDisplayName = zh_CN,C1“公羊”主战坦克[城市战套件]
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/armata.txt
+++ b/configreference/tanks/armata.txt
@@ -1,4 +1,5 @@
 DisplayName = T-14 Armata
+EnableTurretPop = true
 AddDisplayName = en_US, T-14 Armata
 Weight = 121254
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/b2a5.txt
+++ b/configreference/tanks/b2a5.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 2A5
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 2A5
 AddDisplayName = zh_CN, 豹 2A5
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/b2a6.txt
+++ b/configreference/tanks/b2a6.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 2A6
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 2A6
 AddDisplayName = zh_CN, 豹 2A6 
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/b2a7.txt
+++ b/configreference/tanks/b2a7.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 2A7+
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 2A7+
 AddDisplayName = zh_CN, 豹 2A7+
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/bmp1.txt
+++ b/configreference/tanks/bmp1.txt
@@ -1,4 +1,5 @@
 DisplayName = BMP-1 IFV
+EnableTurretPop = true
 AddDisplayName = en_US, BMP-1 IFV
 AddDisplayName = ja_JP, BMP-1 歩兵戦闘車
 Weight = 29000

--- a/configreference/tanks/bmp2.txt
+++ b/configreference/tanks/bmp2.txt
@@ -1,5 +1,6 @@
 Weight = 31747
 ﻿DisplayName = BMP-2 IFV
+EnableTurretPop = true
 AddDisplayName = en_US, BMP-2 IFV
 AddDisplayName = ja_JP, BMP-2 歩兵戦闘車
 NameOnEarlyASRadar = Air Defense Vehicle

--- a/configreference/tanks/bmp3.txt
+++ b/configreference/tanks/bmp3.txt
@@ -1,5 +1,6 @@
 Weight = 41226
 ﻿DisplayName = BMP-3 IFV
+EnableTurretPop = true
 AddDisplayName = en_US, BMP-3 IFV
 AddDisplayName = ja_JP, BMP-3 歩兵戦闘車
 NameOnEarlyASRadar = Air Defense Vehicle

--- a/configreference/tanks/bradley.txt
+++ b/configreference/tanks/bradley.txt
@@ -1,4 +1,5 @@
 DisplayName = M3A3 Bradley IFV
+EnableTurretPop = true
 AddDisplayName = en_US, M3A3 Bradley IFV
 AddDisplayName = ru_RU, M3 Брэдли
 Weight = 56000

--- a/configreference/tanks/bradleym2.txt
+++ b/configreference/tanks/bradleym2.txt
@@ -1,4 +1,5 @@
 DisplayName = M2A1 Bradley IFV
+EnableTurretPop = true
 AddDisplayName = en_US, M2A1 Bradley IFV
 AddDisplayName = ru_RU, M2A1 Брэдли
 Weight = 50200

--- a/configreference/tanks/bt-2.txt
+++ b/configreference/tanks/bt-2.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = BT-2
+EnableTurretPop = true
 AddDisplayName = ja_JP, BT-2
 AddDisplayName = en_US, BT-2
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/bt-5.txt
+++ b/configreference/tanks/bt-5.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = BT-5
+EnableTurretPop = true
 AddDisplayName = ja_JP, BT-5
 AddDisplayName = en_US, BT-5
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/btr3.txt
+++ b/configreference/tanks/btr3.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = BTR-3 APC
+EnableTurretPop = true
 AddDisplayName = ru_RU, BTR-3 APC
 AddDisplayName = en_US, BTR-3 APC
 NameOnEarlyASRadar = Armored Vehicle

--- a/configreference/tanks/btr4.txt
+++ b/configreference/tanks/btr4.txt
@@ -1,4 +1,5 @@
 DisplayName = BTR-4-E Bucefal
+EnableTurretPop = true
 NameOnEarlyASRadar = Armored Vehicle
 NameOnModernASRadar = BTR-4-E Bucefal
 NameOnEarlyAARadar = Armored Vehicle

--- a/configreference/tanks/btr82.txt
+++ b/configreference/tanks/btr82.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = BTR-82 APC
+EnableTurretPop = true
 AddDisplayName = ru_RU, BTR-82 APC
 AddDisplayName = en_US, BTR-82 APC
 NameOnEarlyASRadar = Armored Vehicle

--- a/configreference/tanks/btr90.txt
+++ b/configreference/tanks/btr90.txt
@@ -1,5 +1,6 @@
 Weight = 45900
 ﻿DisplayName = BTR-90 APC
+EnableTurretPop = true
 AddDisplayName = en_US, BTR-90 APC
 NameOnEarlyASRadar = Armored Vehicle
 NameOnModernASRadar = BTR-90 APC

--- a/configreference/tanks/c1.txt
+++ b/configreference/tanks/c1.txt
@@ -1,4 +1,5 @@
 DisplayName = Challenger Mk.2 MBT
+EnableTurretPop = true
 AddDisplayName = en_US, Challenger Mk.2 MBT
 AddDisplayName = ja_JP, チャレンジャーMk.2
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/c2.txt
+++ b/configreference/tanks/c2.txt
@@ -1,4 +1,5 @@
 DisplayName = Challenger 2 MBT
+EnableTurretPop = true
 AddDisplayName = en_US, Challenger 2 MBT
 AddDisplayName = ja_JP, チャレンジャー2
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/centauro.txt
+++ b/configreference/tanks/centauro.txt
@@ -1,4 +1,5 @@
 DisplayName = B1 Centauro 105mm
+EnableTurretPop = true
 AddDisplayName = en_US, B1 Centauro 105mm
 AddDisplayName = ja_JP, チェンタウロ偵察戦闘車 105mm
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/centauro120.txt
+++ b/configreference/tanks/centauro120.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = B1 Centauro 120mm
+EnableTurretPop = true
 AddDisplayName = en_US, B1 Centauro 120mm
 AddDisplayName = ja_JP, チェンタウロ偵察戦闘車 120mm
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/centurion3.txt
+++ b/configreference/tanks/centurion3.txt
@@ -1,4 +1,5 @@
 DisplayName = Centurion Mk 3
+EnableTurretPop = true
 AddDisplayName = ja_JP, Centurion Mk 3
 AddDisplayName = en_US, Centurion Mk 3
 Weight = 112436

--- a/configreference/tanks/chi-he.txt
+++ b/configreference/tanks/chi-he.txt
@@ -1,4 +1,5 @@
 DisplayName = Type 1 Chi-He
+EnableTurretPop = true
 AddDisplayName = ja_JP, 一式中戦車 チへ
 AddDisplayName = en_US, Type 1 Chi-He
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/chi-nu.txt
+++ b/configreference/tanks/chi-nu.txt
@@ -1,4 +1,5 @@
 DisplayName = Type 3 Chi-Nu
+EnableTurretPop = true
 AddDisplayName = ja_JP, 三式中戦車 チヌ
 AddDisplayName = en_US, Type 3 Chi-Nu
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/czech.txt
+++ b/configreference/tanks/czech.txt
@@ -1,4 +1,5 @@
 DisplayName = Pz.38(t) A
+EnableTurretPop = true
 AddDisplayName = Pz.38(t) A
 Weight = 21500
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/ikv91.txt
+++ b/configreference/tanks/ikv91.txt
@@ -1,4 +1,5 @@
 DisplayName = Ikv 91 (Infanterikanonvagn 91)
+EnableTurretPop = true
 Weight = 36376
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Ikv 91 (Infanterikanonvagn 91)

--- a/configreference/tanks/is-1.txt
+++ b/configreference/tanks/is-1.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = IS-1
+EnableTurretPop = true
 AddDisplayName = ja_JP, IS-1
 AddDisplayName = en_US, IS-1
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/is-2.txt
+++ b/configreference/tanks/is-2.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = IS-2 (1944)
+EnableTurretPop = true
 AddDisplayName = ja_JP, IS-2 (1944)
 AddDisplayName = en_US, IS-2 (1944)
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/jgsdf-mcv.txt
+++ b/configreference/tanks/jgsdf-mcv.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 16 Maneuver Combat Vehicle
+EnableTurretPop = true
 AddDisplayName = en_US, Type 16 Maneuver Combat Vehicle
 AddDisplayName = ja_JP, 陸上自衛隊 機動戦闘車
 NameOnEarlyASRadar = Air Defense Vehicle

--- a/configreference/tanks/ktorosomak.txt
+++ b/configreference/tanks/ktorosomak.txt
@@ -1,4 +1,5 @@
 DisplayName = KTO Rosomak 'Wolverine' with Oto Melara Hitfist
+EnableTurretPop = true
 Weight = 48502
 NameOnEarlyASRadar = Air Defense Vehicle
 NameOnModernASRadar = KTO Rosomak 'Wolverine' with Oto Melara Hitfist

--- a/configreference/tanks/kv-1.txt
+++ b/configreference/tanks/kv-1.txt
@@ -1,4 +1,5 @@
 DisplayName = KV-1 Model 1939 (L-11)
+EnableTurretPop = true
 AddDisplayName = en_US, KV-1 Model 1939 (L-11)
 AddDisplayName = ja_JP, KV-1 Model 1939 (L-11)
 Weight = 99000

--- a/configreference/tanks/kv-2.txt
+++ b/configreference/tanks/kv-2.txt
@@ -1,4 +1,5 @@
 DisplayName = KV-2 'Gigant' (1940)
+EnableTurretPop = true
 AddDisplayName = en_US, KV-2 'Gigant' (1940)
 AddDisplayName = ja_JP, KV-2 ギガント (1940)
 Weight = 114640

--- a/configreference/tanks/lav25.txt
+++ b/configreference/tanks/lav25.txt
@@ -1,4 +1,5 @@
 DisplayName = LAV-25
+EnableTurretPop = true
 Weight = 28000
 NameOnEarlyASRadar = Air Defense Vehicle
 NameOnModernASRadar = LAV-25

--- a/configreference/tanks/lav3.txt
+++ b/configreference/tanks/lav3.txt
@@ -1,4 +1,5 @@
 DisplayName = LAV III (Light Armoured Vehicle 3)
+EnableTurretPop = true
 Weight = 37000
 NameOnEarlyASRadar = Armored Vehicle
 NameOnModernASRadar = LAV III (Light Armoured Vehicle 3)

--- a/configreference/tanks/leopard1.txt
+++ b/configreference/tanks/leopard1.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 1A4
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 1A4
 AddDisplayName = ja_JP, レオパルト1A4
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/leopard1a1.txt
+++ b/configreference/tanks/leopard1a1.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 1A1
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 1A1
 AddDisplayName = ja_JP, レオパルト1A1
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/leopard2a4.txt
+++ b/configreference/tanks/leopard2a4.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Leopard 2A4 
+EnableTurretPop = true
 AddDisplayName = en_US, Leopard 2A4 
 AddDisplayName = ja_JP, レオパルト2 A4
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m1128.txt
+++ b/configreference/tanks/m1128.txt
@@ -1,4 +1,5 @@
 DisplayName = M1128 Stryker Mobile Gun System
+EnableTurretPop = true
 AddDisplayName = en_US, M1128 Stryker Mobile Gun System
 AddDisplayName = ja_JP, M1128ストライカー
 Weight = 41200

--- a/configreference/tanks/m18.txt
+++ b/configreference/tanks/m18.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M18 GMC 'Hellcat'
+EnableTurretPop = true
 AddDisplayName = en_US, M18 GMC 'Hellcat'
 AddDisplayName = ja_JP, M18 GMC ヘルキャット
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m1a1.txt
+++ b/configreference/tanks/m1a1.txt
@@ -1,4 +1,5 @@
 DisplayName = M1A1SA Abrams TUSK II
+EnableTurretPop = true
 AddDisplayName = ja_JP, M1A1SA エイブラムス TUSK II
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M1A1SA Abrams TUSK II

--- a/configreference/tanks/m1a1nt.txt
+++ b/configreference/tanks/m1a1nt.txt
@@ -1,4 +1,5 @@
 DisplayName = M1A1 Abrams
+EnableTurretPop = true
 AddDisplayName = ja_JP, M1A1 エイブラムス
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M1A1 Abrams

--- a/configreference/tanks/m1a2.txt
+++ b/configreference/tanks/m1a2.txt
@@ -1,4 +1,5 @@
 DisplayName = M1A2 Abrams SEPv3
+EnableTurretPop = true
 AddDisplayName = ja_JP, M1A2 エイブラムス SEPv3
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M1A2 Abrams SEPv3

--- a/configreference/tanks/m1a2tusk.txt
+++ b/configreference/tanks/m1a2tusk.txt
@@ -1,4 +1,5 @@
 DisplayName = M1A2 Abrams SEPv2 ARAT Reactive Armor TUSK II
+EnableTurretPop = true
 AddDisplayName = ja_JP, M1A2 SEPv2 エイブラムス ARAT Reactive Armor TUSK II
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M1A2 Abrams SEPv2 ARAT Reactive Armor TUSK II

--- a/configreference/tanks/m1abrams.txt
+++ b/configreference/tanks/m1abrams.txt
@@ -1,4 +1,5 @@
 DisplayName = M1 Abrams (105mm)
+EnableTurretPop = true
 AddDisplayName = ja_JP, M1 エイブラムス
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M1 Abrams (105mm)

--- a/configreference/tanks/m26.txt
+++ b/configreference/tanks/m26.txt
@@ -1,4 +1,5 @@
 DisplayName = M26 Pershing
+EnableTurretPop = true
 AddDisplayName = ja_JP, M26 パーシング
 AddDisplayName = en_US, M26 Pershing
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m3_stuart.txt
+++ b/configreference/tanks/m3_stuart.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M3 Stuart
+EnableTurretPop = true
 AddDisplayName = ja_JP, M3 スチュアート
 AddDisplayName = en_US, M3 Stuart
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4.txt
+++ b/configreference/tanks/m4.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4 Sherman
+EnableTurretPop = true
 AddDisplayName = en_US, M4 Sherman
 AddDisplayName = ja_JP, M4 シャーマン
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4105.txt
+++ b/configreference/tanks/m4105.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4 Sherman (105mm)
+EnableTurretPop = true
 AddDisplayName = en_US, M4 Sherman (105mm)
 AddDisplayName = ja_JP, M4 シャーマン (105mm)
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m46.txt
+++ b/configreference/tanks/m46.txt
@@ -1,4 +1,5 @@
 DisplayName = M46 Patton
+EnableTurretPop = true
 AddDisplayName = ja_JP, M46 Patton
 AddDisplayName = en_US, M46 Patton
 Weight = 94600

--- a/configreference/tanks/m47.txt
+++ b/configreference/tanks/m47.txt
@@ -1,4 +1,5 @@
 DisplayName = M47 Patton
+EnableTurretPop = true
 AddDisplayName = ja_JP, M47 Patton
 AddDisplayName = en_US, M47 Patton
 Weight = 101000

--- a/configreference/tanks/m48.txt
+++ b/configreference/tanks/m48.txt
@@ -1,4 +1,5 @@
 DisplayName = M48A1 Patton
+EnableTurretPop = true
 AddDisplayName = zh_CN,M48A1 巴顿 主战坦克
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M48A1 Patton

--- a/configreference/tanks/m4_calliope.txt
+++ b/configreference/tanks/m4_calliope.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4 Sherman Calliope
+EnableTurretPop = true
 AddDisplayName = en_US, M4 Sherman Calliope
 AddDisplayName = ja_JP, シャーマン・カリオペ
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4a1.txt
+++ b/configreference/tanks/m4a1.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4A1 Sherman
+EnableTurretPop = true
 AddDisplayName = en_US, M4A1 Sherman
 AddDisplayName = ja_JP, M4A1 シャーマン
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4a176.txt
+++ b/configreference/tanks/m4a176.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4A1 Sherman 76W
+EnableTurretPop = true
 AddDisplayName = en_US, M4A1 Sherman 76W
 AddDisplayName = ja_JP, M4A1 シャーマン 76W
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4a3e2.txt
+++ b/configreference/tanks/m4a3e2.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4A3E2 Sherman
+EnableTurretPop = true
 AddDisplayName = en_US, M4A3E2 Sherman
 AddDisplayName = ja_JP, M4A3E2 シャーマン
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4a3e8.txt
+++ b/configreference/tanks/m4a3e8.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4A3E2 (76) Sherman
+EnableTurretPop = true
 AddDisplayName = en_US, M4A3E2 (76) Sherman
 AddDisplayName = ja_JP, M4A3E2 (76) シャーマン
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4firefly.txt
+++ b/configreference/tanks/m4firefly.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Sherman VC Firefly
+EnableTurretPop = true
 AddDisplayName = en_US, Sherman VC Firefly
 AddDisplayName = ja_JP, シャーマン VC Firefly
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m4zip.txt
+++ b/configreference/tanks/m4zip.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = M4 Zippo Flame Tank POA-CWS-H1
+EnableTurretPop = true
 AddDisplayName = en_US, M4 Zippo Flame Tank POA-CWS-H1
 AddDisplayName = ja_JP, M4 Zippo Flame Tank POA-CWS-H1
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m60a1.txt
+++ b/configreference/tanks/m60a1.txt
@@ -1,4 +1,5 @@
 DisplayName = M60A1 Patton
+EnableTurretPop = true
 AddDisplayName = zh_CN,M60A1 巴顿 主战坦克
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M60A1 Patton

--- a/configreference/tanks/m60pat.txt
+++ b/configreference/tanks/m60pat.txt
@@ -1,4 +1,5 @@
 DisplayName = M60 Patton
+EnableTurretPop = true
 AddDisplayName = zh_CN,M60 巴顿 主战坦克
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M60 Patton

--- a/configreference/tanks/m67.txt
+++ b/configreference/tanks/m67.txt
@@ -1,4 +1,5 @@
 DisplayName = M67 Flame Thrower Tank 'Zippo'
+EnableTurretPop = true
 AddDisplayName = zh_CN,M67 Zippo
 Weight = 104000
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/m8.txt
+++ b/configreference/tanks/m8.txt
@@ -1,4 +1,5 @@
 DisplayName = M8 Greyhound
+EnableTurretPop = true
 AddDisplayName = ru_RU, M8 Greyhound
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = M8 Greyhound

--- a/configreference/tanks/m_41_90.txt
+++ b/configreference/tanks/m_41_90.txt
@@ -1,4 +1,5 @@
 DisplayName = leKPz M41 Walker Bulldog
+EnableTurretPop = true
 Weight = 52000
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = leKPz M41 Walker Bulldog

--- a/configreference/tanks/magach5.txt
+++ b/configreference/tanks/magach5.txt
@@ -1,4 +1,5 @@
 DisplayName = Magach 5
+EnableTurretPop = true
 AddDisplayName = zh_CN,Magach 5 巴顿 主战坦克
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Magach 5

--- a/configreference/tanks/marder.txt
+++ b/configreference/tanks/marder.txt
@@ -1,5 +1,6 @@
 Weight = 45000
 ﻿DisplayName = SPz Marder 1A3 IFV
+EnableTurretPop = true
 AddDisplayName = en_US, SPz Marder 1A3 IFV
 AddDisplayName = ja_JP, マルダー1A3 歩兵戦闘車
 NameOnEarlyASRadar = Armored Vehicle

--- a/configreference/tanks/merkava_mk1.txt
+++ b/configreference/tanks/merkava_mk1.txt
@@ -1,4 +1,5 @@
 DisplayName = Merkava Mk.1
+EnableTurretPop = true
 AddDisplayName = ja_JP, Merkava Mk.1
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Merkava Mk.1

--- a/configreference/tanks/merkava_mk4.txt
+++ b/configreference/tanks/merkava_mk4.txt
@@ -1,4 +1,5 @@
 DisplayName = Merkava Mk.4 Baz
+EnableTurretPop = true
 AddDisplayName = ja_JP, Merkava Mk.4 Baz
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Merkava Mk.4 Baz

--- a/configreference/tanks/merkava_mk4b.txt
+++ b/configreference/tanks/merkava_mk4b.txt
@@ -1,4 +1,5 @@
 DisplayName = Merkava Mk.4 Barak
+EnableTurretPop = true
 AddDisplayName = ja_JP, Merkava Mk.4 Barak
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Merkava Mk.4 Barak

--- a/configreference/tanks/p40.txt
+++ b/configreference/tanks/p40.txt
@@ -1,4 +1,5 @@
 DisplayName = P26/40 Tank
+EnableTurretPop = true
 AddDisplayName = ja_JP, P40型 重戦車 
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = P26/40 Tank

--- a/configreference/tanks/panther.txt
+++ b/configreference/tanks/panther.txt
@@ -1,4 +1,5 @@
 DisplayName = Panther G
+EnableTurretPop = true
 AddDisplayName = Panther G
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Panther G

--- a/configreference/tanks/rok_k2.txt
+++ b/configreference/tanks/rok_k2.txt
@@ -1,4 +1,5 @@
 DisplayName = K2 Black Panther
+EnableTurretPop = true
 AddDisplayName = ja_JP, K2 黒豹
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = K2 Black Panther

--- a/configreference/tanks/sdkfz234_2.txt
+++ b/configreference/tanks/sdkfz234_2.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Sd.Kfz. 234/2 "Puma"
+EnableTurretPop = true
 AddDisplayName = en_US, Sd.Kfz. 234/2 "Puma"
 AddDisplayName = ja_JP, Sd Kfz 234/2 "Puma"
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/strf 9040b.txt
+++ b/configreference/tanks/strf 9040b.txt
@@ -1,4 +1,5 @@
 DisplayName = Strf 9040B
+EnableTurretPop = true
 Weight = 45000
 NameOnEarlyASRadar = Armored Vehicle
 NameOnModernASRadar = Strf 9040B

--- a/configreference/tanks/t-34-85.txt
+++ b/configreference/tanks/t-34-85.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-34-85
+EnableTurretPop = true
 AddDisplayName = en_US, T-34-85
 AddDisplayName = ru_RU, T-34-85
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t-72b.txt
+++ b/configreference/tanks/t-72b.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-72A MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-72A
 AddDisplayName = ja_JP, T-72A ウラル 主力戦車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t-80u.txt
+++ b/configreference/tanks/t-80u.txt
@@ -1,5 +1,6 @@
 Weight = 101413
 ﻿DisplayName = T-80U MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-80U MBT
 AddDisplayName = ja_JP, T-80U 
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t-90.txt
+++ b/configreference/tanks/t-90.txt
@@ -1,4 +1,5 @@
 DisplayName = T-90 MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-90 MBT
 AddDisplayName = ja_JP, T-90 主力戦車
 Weight = 101000

--- a/configreference/tanks/t-90a.txt
+++ b/configreference/tanks/t-90a.txt
@@ -1,5 +1,6 @@
 Weight = 101000
 ﻿DisplayName = T-90A MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-90A MBT
 AddDisplayName = ja_JP, T-90A　主力戦車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t-90s.txt
+++ b/configreference/tanks/t-90s.txt
@@ -1,5 +1,6 @@
 Weight = 101000
 ﻿DisplayName = T-90MS MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-90MS MBT
 AddDisplayName = ja_JP, T-90S　主力戦車
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t26.txt
+++ b/configreference/tanks/t26.txt
@@ -1,4 +1,5 @@
 DisplayName = T-26 mod. 1939
+EnableTurretPop = true
 AddDisplayName = Т-26 (образец 1939 г.)
 Weight = 22500
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t55.txt
+++ b/configreference/tanks/t55.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-55
+EnableTurretPop = true
 AddDisplayName = ja_JP, T-55
 AddDisplayName = en_US, T-55
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t62.txt
+++ b/configreference/tanks/t62.txt
@@ -1,4 +1,5 @@
 DisplayName = T-62
+EnableTurretPop = true
 Weight = 81571
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = T-62

--- a/configreference/tanks/t64b.txt
+++ b/configreference/tanks/t64b.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-64B
+EnableTurretPop = true
 AddDisplayName = en_US, T-64B 
 AddDisplayName = ja_JP, T-64B
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t64bm.txt
+++ b/configreference/tanks/t64bm.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-64BV
+EnableTurretPop = true
 AddDisplayName = en_US, T-64BV
 AddDisplayName = ja_JP, T-64BV
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t64bv.txt
+++ b/configreference/tanks/t64bv.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-64BV Model 2017
+EnableTurretPop = true
 AddDisplayName = en_US, T-64BV Model 2017
 AddDisplayName = ja_JP, T-64BV Model 2017
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t64u.txt
+++ b/configreference/tanks/t64u.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = T-64BM Bulat
+EnableTurretPop = true
 AddDisplayName = en_US, T-64BM Bulat
 AddDisplayName = ja_JP, T-64BM Bulat
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/t72b3real.txt
+++ b/configreference/tanks/t72b3real.txt
@@ -1,4 +1,5 @@
 DisplayName = T-72B3 MBT
+EnableTurretPop = true
 AddDisplayName = en_US, T-72B3 MBT
 AddDisplayName = ja_JP, T-72B3 主力戦車
 Weight = 101000

--- a/configreference/tanks/t84.txt
+++ b/configreference/tanks/t84.txt
@@ -1,4 +1,5 @@
 DisplayName = T-84 Oplot-M
+EnableTurretPop = true
 AddDisplayName = en_US, T-84 Oplot-M
 AddDisplayName = ja_JP, T-84 オプロートM
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/tiger1.txt
+++ b/configreference/tanks/tiger1.txt
@@ -1,4 +1,5 @@
 DisplayName = Tiger H1
+EnableTurretPop = true
 AddDisplayName = ja_JP, タイガー H1
 AddDisplayName = en_US, Tiger H1
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/tiger2.txt
+++ b/configreference/tanks/tiger2.txt
@@ -1,4 +1,5 @@
 DisplayName = Tiger II (H)
+EnableTurretPop = true
 AddDisplayName = Tiger II (H)
 ;this is a comment, I like using comments
 AddDisplayName = en_US, Tiger II (H)

--- a/configreference/tanks/type10.txt
+++ b/configreference/tanks/type10.txt
@@ -1,4 +1,5 @@
 DisplayName = Type 10 MBT
+EnableTurretPop = true
 AddDisplayName = ja_JP, 10式戦車
 NameOnEarlyASRadar = Tank
 NameOnModernASRadar = Type 10 MBT

--- a/configreference/tanks/type62.txt
+++ b/configreference/tanks/type62.txt
@@ -1,5 +1,6 @@
 Weight = 46297
 ﻿DisplayName = Type 62
+EnableTurretPop = true
 AddDisplayName = ja_JP, Type 62
 AddDisplayName = en_US, Type 62 
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/type74.txt
+++ b/configreference/tanks/type74.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 74 C
+EnableTurretPop = true
 AddDisplayName = en_US, Type 74 C
 AddDisplayName = ja_JP, 74式戦車 C型
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/type89.txt
+++ b/configreference/tanks/type89.txt
@@ -1,4 +1,5 @@
 DisplayName = Type 89 IFV
+EnableTurretPop = true
 AddDisplayName = ja_JP, Type 89 IFV
 NameOnEarlyASRadar = Armored Vehicle
 NameOnModernASRadar = Type 89 IFV

--- a/configreference/tanks/type95_lt.txt
+++ b/configreference/tanks/type95_lt.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 95 Ha-Go
+EnableTurretPop = true
 AddDisplayName = en_US, Type 95 Ha-Go
 AddDisplayName = ru_RU, Type 95 Ro-Go
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/type97_new.txt
+++ b/configreference/tanks/type97_new.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = Type 97 Chi-Ha Kai
+EnableTurretPop = true
 AddDisplayName = en_US, Type 97 Chi-Ha Kai
 AddDisplayName = ru_RU, Type 97 Chi-Ha Kai
 NameOnEarlyASRadar = Tank

--- a/configreference/tanks/ztz-96a.txt
+++ b/configreference/tanks/ztz-96a.txt
@@ -1,4 +1,5 @@
 ﻿DisplayName = ZTZ-96A (Type 96A)
+EnableTurretPop = true
 AddDisplayName = en_US, ZTZ-96A (Type 96A)
 AddDisplayName = ja_JP, ZTZ-96A
 NameOnEarlyASRadar = Tank


### PR DESCRIPTION
### Motivation

- Enable the existing catastrophic detached-turret destruction effect for vehicles that have a separately modeled, dynamically detachable main turret. 
- The effect and parser are already implemented in `MCH_TankInfo`; configs must opt in with `EnableTurretPop = true` for eligible vehicles. 
- Changes follow the repository selection rules: use `DisplayName` as the vehicle identity and only enable for conventional turreted tanks/armored cannon vehicles.

### Description

- Added one line `EnableTurretPop = true` to 106 tank configuration files in `configreference/tanks/`, inserting the entry immediately after each file's `DisplayName` while preserving local capitalization and line endings. 
- Confirmed the existing parser field `EnableTurretPop` (in `src/main/java/mcheli/tank/MCH_TankInfo.java`) reads a boolean and defaults to `false`, so no Java source changes were required. 
- No models, textures, documentation files, or `CHANGELOG.md` were modified; all edits are confined to `configreference/tanks/*.txt`. 

### Testing

- Searched repository for exact occurrences using `rg` and verified there are exactly 106 `EnableTurretPop = true` entries under `configreference/tanks`. 
- Ran a Python-based audit that validated each changed path, ensured a single `EnableTurretPop = true` entry per file, confirmed presence of a readable `DisplayName`, and checked that each modified config declares a dynamic turret part (e.g. `AddPartTurretWeapon` / `AddPartTurretRotWeapon`).
- Ran `git diff --check` and `git status` to ensure no whitespace or diff errors and that the working tree was committed; all edits were committed in a single commit with message `Enable turret pop for detachable tank turrets`.
- Did not run the Gradle build because the task and repository instructions prohibit compiling binary artifacts; therefore no build was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e6722d9a48323b0716309ad1fbc40)