### PR TITLE
Fix catastrophic tank turret-pop rendering and physics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Catastrophic tank turret-pop correction (PR pending)
+
+- Detach the exact `$turret` model group with its configured weapon children, preserving the destruction-time turret yaw and gun elevation in synchronized/NBT state.
+- Add server-authoritative swept solid-block landing, unloaded-chunk protection, and a client-created dark smoke trail following the synchronized detached turret.
+- Keep the canonical turret suppressed in both close and LOD attached weapon passes while leaving unrelated turreted stations visible.
+
 # Audit tank laser-warning receiver configuration (PR pending)
 
 - Added an explicit `LWR` capability value to every tank configuration, enabling it only for exact vehicle variants with sufficiently reliable laser-warning receiver evidence.

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -291,7 +291,7 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `WeightType` | Tank | enum `normal`, `car`, `tank` | `normal`/0 | ground physics weight behavior |
 | `WeightedCenterZ` | Tank | float[-1000..1000] | 0.0 | fore/aft center of weight |
 | `TrackMaxHP` | Tank | int[1..1000000] | 100 | track durability |
-| `EnableTurretPop` | Tank | boolean | `false` | `true` enables the catastrophic detached-turret destruction effect; requires a configured dynamic turret assembly |
+| `EnableTurretPop` | Tank | boolean | `false` | `true` detaches the exact `$turret` model group and its main-gun child assembly on destruction; models without it skip the effect |
 | `AddTrackHitBox` | Tank | `x,y,z,width,height[,damageFactor]` | damageFactor 1.0 | track hitbox |
 | `canmove` | Turret/static | boolean | false | movable turret vehicle |
 | `canrotation` | Turret/static | boolean | false | base rotation enabled |

--- a/docs/vehicle-config/tanks.md
+++ b/docs/vehicle-config/tanks.md
@@ -50,4 +50,4 @@ AddTrackHitBox = -1.2, 0.0, 0.0, 0.5, 0.5, 1.0
 
 `WeightType`, `WeightedCenterZ`, `TrackMaxHP`, `AddTrackHitBox`, `EnableTurretPop`, and `LWR` are optional. Omitting `EnableTurretPop` keeps the turret attached when the tank is destroyed. Omitting `LWR` leaves tank alert audio disabled; omitting the other keys leaves default ground behavior and no explicit track hitboxes.
 
-`EnableTurretPop = true` enables a catastrophic destruction effect which launches the complete main dynamic turret weapon part and its configured child parts off the chassis. The tank must define a dynamic turret assembly with `AddPartTurretWeapon` or `AddPartTurretRotWeapon`; geometry baked into `$body` cannot be detached.
+`EnableTurretPop = true` enables a catastrophic destruction effect which launches the exact `$turret` model group and the main (`weapon0`) gun's configured child parts off the chassis. Models without `$turret` skip the effect safely; geometry baked into `$body` cannot be detached.

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -880,6 +880,30 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       renderWeapon(ac, info, tickTime, true);
    }
 
+   /** Draws the canonical tank group and the configured children with a frozen pose. */
+   public static void renderDetachedTankTurret(mcheli.tank.MCH_EntityTank tank, MCH_BaseVehicleInfo info) {
+      MCH_BaseVehicleInfo.PartWeapon root = tank.getTurretPopRoot();
+      if(root == null) return;
+      GL11.glPushMatrix();
+      try {
+         GL11.glTranslated(info.turretPosition.xCoord, info.turretPosition.yCoord, info.turretPosition.zCoord);
+         GL11.glRotatef(tank.turretPopFrozenYaw, 0.0F, -1.0F, 0.0F);
+         GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
+         // The exact named model group is the detachable source of truth.
+         renderPart(null, info.model, "turret");
+         for(Object object : root.child) {
+            MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
+            GL11.glPushMatrix();
+            try {
+               GL11.glTranslated(child.pos.xCoord, child.pos.yCoord, child.pos.zCoord);
+               if(child.pitch) GL11.glRotatef(tank.turretPopFrozenPitch, 1.0F, 0.0F, 0.0F);
+               GL11.glTranslated(-child.pos.xCoord, -child.pos.yCoord, -child.pos.zCoord);
+               renderPart(child.model, info.model, child.modelName);
+            } finally { GL11.glPopMatrix(); }
+         }
+      } finally { GL11.glPopMatrix(); }
+   }
+
    private static void renderWeapon(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime, boolean detachedOnly) {
       MCH_WeaponSet beforeWs = null;
       Entity e = ac.getRiddenByEntity();

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -63,7 +63,10 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    public float turretPopYaw, turretPopPitch, turretPopRoll;
    public float prevTurretPopYaw, prevTurretPopPitch, prevTurretPopRoll;
    public float turretPopAngularYaw, turretPopAngularPitch, turretPopAngularRoll;
+   /** Frozen local pose of the canonical $turret assembly at destruction. */
+   public float turretPopFrozenYaw, turretPopFrozenPitch;
    public int turretPopAge;
+   private boolean turretPopMissingPartWarned;
 
    //TODO
    private int currentGear = 1;  // Starting gear
@@ -163,6 +166,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          par1NBTTagCompound.setDouble("TurretPopMX", this.turretPopMotionX); par1NBTTagCompound.setDouble("TurretPopMY", this.turretPopMotionY); par1NBTTagCompound.setDouble("TurretPopMZ", this.turretPopMotionZ);
          par1NBTTagCompound.setFloat("TurretPopYaw", this.turretPopYaw); par1NBTTagCompound.setFloat("TurretPopPitch", this.turretPopPitch); par1NBTTagCompound.setFloat("TurretPopRoll", this.turretPopRoll);
          par1NBTTagCompound.setFloat("TurretPopAY", this.turretPopAngularYaw); par1NBTTagCompound.setFloat("TurretPopAP", this.turretPopAngularPitch); par1NBTTagCompound.setFloat("TurretPopAR", this.turretPopAngularRoll);
+         par1NBTTagCompound.setFloat("TurretPopFrozenYaw", this.turretPopFrozenYaw); par1NBTTagCompound.setFloat("TurretPopFrozenPitch", this.turretPopFrozenPitch);
          par1NBTTagCompound.setInteger("TurretPopAge", this.turretPopAge);
       }
    }
@@ -177,6 +181,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          this.turretPopMotionX = par1NBTTagCompound.getDouble("TurretPopMX"); this.turretPopMotionY = par1NBTTagCompound.getDouble("TurretPopMY"); this.turretPopMotionZ = par1NBTTagCompound.getDouble("TurretPopMZ");
          this.turretPopYaw = this.prevTurretPopYaw = par1NBTTagCompound.getFloat("TurretPopYaw"); this.turretPopPitch = this.prevTurretPopPitch = par1NBTTagCompound.getFloat("TurretPopPitch"); this.turretPopRoll = this.prevTurretPopRoll = par1NBTTagCompound.getFloat("TurretPopRoll");
          this.turretPopAngularYaw = par1NBTTagCompound.getFloat("TurretPopAY"); this.turretPopAngularPitch = par1NBTTagCompound.getFloat("TurretPopAP"); this.turretPopAngularRoll = par1NBTTagCompound.getFloat("TurretPopAR"); this.turretPopAge = Math.max(0, par1NBTTagCompound.getInteger("TurretPopAge"));
+         this.turretPopFrozenYaw = par1NBTTagCompound.getFloat("TurretPopFrozenYaw"); this.turretPopFrozenPitch = par1NBTTagCompound.getFloat("TurretPopFrozenPitch");
       }
       if(this.tankInfo == null) {
          this.tankInfo = MCH_TankInfoManager.get(this.getTypeName());
@@ -217,6 +222,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          super.prevPosZ = super.posZ;
       } else {
          if(!super.worldObj.isRemote) this.updateTurretPop();
+         else this.updateTurretPopSmoke();
          if(!super.isRequestedSyncStatus) {
             super.isRequestedSyncStatus = true;
             if(super.worldObj.isRemote) {
@@ -838,17 +844,32 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       super.rotDestroyedPitch = 0.0F;
       super.rotDestroyedRoll = 0.0F;
       super.rotDestroyedYaw = 0.0F;
-      if(!super.worldObj.isRemote && !this.turretPopStarted && this.tankInfo != null && this.tankInfo.enableTurretPop && this.getTurretPopRoot() != null) {
-         this.startTurretPop();
+      if(!super.worldObj.isRemote && !this.turretPopStarted && this.tankInfo != null && this.tankInfo.enableTurretPop) {
+         if(this.getTurretPopRoot() != null) this.startTurretPop();
+         else this.warnMissingTurretPart();
       }
    }
 
    public MCH_BaseVehicleInfo.PartWeapon getTurretPopRoot() {
-      if(this.tankInfo != null) for(Object o : this.tankInfo.partWeapon) {
-         MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)o;
-         if(part.turret) return part;
+      boolean canonicalModel = this.tankInfo != null && (!super.worldObj.isRemote
+            || this.tankInfo.model instanceof mcheli.wrapper.modelloader.W_ModelCustom
+            && ((mcheli.wrapper.modelloader.W_ModelCustom)this.tankInfo.model).containsPart("$turret"));
+      if(canonicalModel) {
+         /* weapon0 is the repository convention for the main gun/turret assembly;
+          * the model group, rather than the 'turret' aiming flag, is authoritative. */
+         for(Object o : this.tankInfo.partWeapon) {
+            MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)o;
+            if("weapon0".equalsIgnoreCase(part.modelName)) return part;
+         }
       }
       return null;
+   }
+
+   private void warnMissingTurretPart() {
+      if(!this.turretPopMissingPartWarned) {
+         this.turretPopMissingPartWarned = true;
+         MCH_Lib.Log((Entity)this, "Turret pop disabled for tank '%s': loaded model has no canonical $turret part", new Object[]{this.getTypeName()});
+      }
    }
 
    private void startTurretPop() {
@@ -859,6 +880,10 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       double speed = 0.18D + super.rand.nextDouble() * 0.16D;
       this.turretPopMotionX = Math.cos(a) * speed; this.turretPopMotionY = 1.05D + super.rand.nextDouble() * 0.35D; this.turretPopMotionZ = Math.sin(a) * speed;
       this.turretPopYaw = this.prevTurretPopYaw = this.getRotYaw(); this.turretPopPitch = this.prevTurretPopPitch = 0.0F; this.turretPopRoll = this.prevTurretPopRoll = 0.0F;
+      this.turretPopFrozenYaw = MathHelper.wrapAngleTo180_float(this.getLastRiderYaw() - this.getRotYaw());
+      MCH_BaseVehicleInfo.PartWeapon root = this.getTurretPopRoot();
+      MCH_WeaponSet weapon = root != null ? this.getWeaponByName(root.name[0]) : null;
+      this.turretPopFrozenPitch = weapon != null ? weapon.rotationPitch : this.getLastRiderPitch();
       this.turretPopAngularYaw = 8.0F + super.rand.nextFloat() * 12.0F; this.turretPopAngularPitch = (super.rand.nextFloat() - 0.5F) * 24.0F; this.turretPopAngularRoll = (super.rand.nextFloat() - 0.5F) * 30.0F;
       MCH_PacketTurretPop.send(this);
    }
@@ -872,14 +897,22 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.turretPopYaw += this.turretPopAngularYaw; this.turretPopPitch += this.turretPopAngularPitch; this.turretPopRoll += this.turretPopAngularRoll;
       ++this.turretPopAge;
       int bx = MathHelper.floor_double(this.turretPopX), by = MathHelper.floor_double(this.turretPopY), bz = MathHelper.floor_double(this.turretPopZ);
-      int previousY = MathHelper.floor_double(this.prevTurretPopY);
-      int groundY = Integer.MIN_VALUE;
-      if(this.turretPopMotionY <= 0.0D) for(int testY = previousY; testY >= by; --testY) {
-         if(!super.worldObj.isAirBlock(bx, testY, bz)) { groundY = testY; break; }
+      double groundTop = Double.NEGATIVE_INFINITY;
+      if(!super.worldObj.blockExists(bx, 0, bz)) {
+         this.turretPopX = this.prevTurretPopX; this.turretPopY = this.prevTurretPopY; this.turretPopZ = this.prevTurretPopZ;
+         this.turretPopMotionY = 0.0D;
+         return;
+      }
+      if(this.turretPopMotionY <= 0.0D) for(int testY = MathHelper.floor_double(this.prevTurretPopY); testY >= by - 1; --testY) {
+         Block block = super.worldObj.getBlock(bx, testY, bz);
+         AxisAlignedBB box = block.getCollisionBoundingBoxFromPool(super.worldObj, bx, testY, bz);
+         if(box != null && block.getMaterial().blocksMovement() && box.maxY <= this.prevTurretPopY && box.maxY >= this.turretPopY - 0.35D) { groundTop = box.maxY; break; }
       }
       boolean timedOut = this.turretPopAge >= 600;
-      if(groundY != Integer.MIN_VALUE || timedOut) {
-         this.turretPopY = (timedOut?super.worldObj.getHeightValue(bx, bz):groundY + 1) + 0.02D; this.turretPopMotionX = this.turretPopMotionY = this.turretPopMotionZ = 0.0D;
+      if(groundTop != Double.NEGATIVE_INFINITY || timedOut) {
+         // Models expose no group bounds, so 0.35 is a conservative pivot-to-bottom clearance.
+         this.turretPopY = (timedOut ? super.worldObj.getHeightValue(bx, bz) : groundTop) + 0.35D;
+         this.turretPopMotionY = 0.0D; this.turretPopMotionX *= 0.15D; this.turretPopMotionZ *= 0.15D;
          this.turretPopAngularYaw *= 0.08F; this.turretPopAngularPitch *= 0.08F; this.turretPopAngularRoll *= 0.08F; this.turretPopLanded = true;
       }
       if((this.turretPopAge % 3) == 0 || this.turretPopLanded) MCH_PacketTurretPop.send(this);
@@ -890,6 +923,19 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.prevTurretPopYaw = this.turretPopStarted?this.turretPopYaw:p.yaw; this.prevTurretPopPitch = this.turretPopStarted?this.turretPopPitch:p.pitch; this.prevTurretPopRoll = this.turretPopStarted?this.turretPopRoll:p.roll;
       this.turretPopStarted = true; this.turretPopLanded = p.landed; this.turretPopX=p.x; this.turretPopY=p.y; this.turretPopZ=p.z; this.turretPopYaw=p.yaw; this.turretPopPitch=p.pitch; this.turretPopRoll=p.roll; this.turretPopAge=p.age;
       this.turretPopMotionX=p.mx; this.turretPopMotionY=p.my; this.turretPopMotionZ=p.mz; this.turretPopAngularYaw=p.ay; this.turretPopAngularPitch=p.ap; this.turretPopAngularRoll=p.ar;
+      this.turretPopFrozenYaw=p.frozenYaw; this.turretPopFrozenPitch=p.frozenPitch;
+   }
+
+   private void updateTurretPopSmoke() {
+      if(!this.turretPopStarted || (this.turretPopLanded && this.turretPopAge > 620)) return;
+      if(!this.turretPopLanded || this.turretPopAge % 5 == 0) {
+         MCH_ParticleParam prm = new MCH_ParticleParam(super.worldObj, "smoke", this.turretPopX, this.turretPopY, this.turretPopZ);
+         prm.motionX = (super.rand.nextDouble() - 0.5D) * 0.06D;
+         prm.motionY = 0.08D + super.rand.nextDouble() * 0.04D;
+         prm.motionZ = (super.rand.nextDouble() - 0.5D) * 0.06D;
+         prm.size = 3.0F + super.rand.nextFloat(); prm.age = 35; prm.setColor(0.85F, 0.12F, 0.12F, 0.12F);
+         MCH_ParticlesUtil.spawnParticle(prm);
+      }
    }
 
    public void writeSpawnData(ByteBuf buffer) { super.writeSpawnData(buffer); MCH_PacketTurretPop.writeState(buffer, this); }

--- a/src/main/java/mcheli/tank/MCH_PacketTurretPop.java
+++ b/src/main/java/mcheli/tank/MCH_PacketTurretPop.java
@@ -13,7 +13,7 @@ public class MCH_PacketTurretPop extends MCH_Packet {
    public int entityId, age;
    public boolean landed;
    public double x, y, z, mx, my, mz;
-   public float yaw, pitch, roll, ay, ap, ar;
+   public float yaw, pitch, roll, ay, ap, ar, frozenYaw, frozenPitch;
 
    public int getMessageID() { return 268439650; }
 
@@ -22,6 +22,7 @@ public class MCH_PacketTurretPop extends MCH_Packet {
          this.entityId=in.readInt(); this.landed=in.readBoolean(); this.age=in.readInt();
          this.x=in.readDouble(); this.y=in.readDouble(); this.z=in.readDouble(); this.mx=in.readDouble(); this.my=in.readDouble(); this.mz=in.readDouble();
          this.yaw=in.readFloat(); this.pitch=in.readFloat(); this.roll=in.readFloat(); this.ay=in.readFloat(); this.ap=in.readFloat(); this.ar=in.readFloat();
+         this.frozenYaw=in.readFloat(); this.frozenPitch=in.readFloat();
       } catch(Exception e) { e.printStackTrace(); }
    }
 
@@ -30,13 +31,15 @@ public class MCH_PacketTurretPop extends MCH_Packet {
          out.writeInt(this.entityId); out.writeBoolean(this.landed); out.writeInt(this.age);
          out.writeDouble(this.x); out.writeDouble(this.y); out.writeDouble(this.z); out.writeDouble(this.mx); out.writeDouble(this.my); out.writeDouble(this.mz);
          out.writeFloat(this.yaw); out.writeFloat(this.pitch); out.writeFloat(this.roll); out.writeFloat(this.ay); out.writeFloat(this.ap); out.writeFloat(this.ar);
+         out.writeFloat(this.frozenYaw); out.writeFloat(this.frozenPitch);
       } catch(IOException e) { e.printStackTrace(); }
    }
 
    private static MCH_PacketTurretPop from(MCH_EntityTank tank) {
       MCH_PacketTurretPop p=new MCH_PacketTurretPop(); p.entityId=W_Entity.getEntityId(tank); p.landed=tank.turretPopLanded; p.age=tank.turretPopAge;
       p.x=tank.turretPopX; p.y=tank.turretPopY; p.z=tank.turretPopZ; p.mx=tank.turretPopMotionX; p.my=tank.turretPopMotionY; p.mz=tank.turretPopMotionZ;
-      p.yaw=tank.turretPopYaw; p.pitch=tank.turretPopPitch; p.roll=tank.turretPopRoll; p.ay=tank.turretPopAngularYaw; p.ap=tank.turretPopAngularPitch; p.ar=tank.turretPopAngularRoll; return p;
+      p.yaw=tank.turretPopYaw; p.pitch=tank.turretPopPitch; p.roll=tank.turretPopRoll; p.ay=tank.turretPopAngularYaw; p.ap=tank.turretPopAngularPitch; p.ar=tank.turretPopAngularRoll;
+      p.frozenYaw=tank.turretPopFrozenYaw; p.frozenPitch=tank.turretPopFrozenPitch; return p;
    }
 
    public static void send(MCH_EntityTank tank) { W_Network.sendToAllAround(from(tank), tank, 256.0D); }
@@ -45,12 +48,12 @@ public class MCH_PacketTurretPop extends MCH_Packet {
       out.writeBoolean(tank.turretPopStarted); if(!tank.turretPopStarted) return;
       MCH_PacketTurretPop p=from(tank); out.writeBoolean(p.landed); out.writeInt(p.age);
       out.writeDouble(p.x); out.writeDouble(p.y); out.writeDouble(p.z); out.writeDouble(p.mx); out.writeDouble(p.my); out.writeDouble(p.mz);
-      out.writeFloat(p.yaw); out.writeFloat(p.pitch); out.writeFloat(p.roll); out.writeFloat(p.ay); out.writeFloat(p.ap); out.writeFloat(p.ar);
+      out.writeFloat(p.yaw); out.writeFloat(p.pitch); out.writeFloat(p.roll); out.writeFloat(p.ay); out.writeFloat(p.ap); out.writeFloat(p.ar); out.writeFloat(tank.turretPopFrozenYaw); out.writeFloat(tank.turretPopFrozenPitch);
    }
 
    public static void readState(ByteBuf in, MCH_EntityTank tank) {
       if(!in.readBoolean()) return; MCH_PacketTurretPop p=new MCH_PacketTurretPop(); p.landed=in.readBoolean(); p.age=in.readInt();
       p.x=in.readDouble(); p.y=in.readDouble(); p.z=in.readDouble(); p.mx=in.readDouble(); p.my=in.readDouble(); p.mz=in.readDouble();
-      p.yaw=in.readFloat(); p.pitch=in.readFloat(); p.roll=in.readFloat(); p.ay=in.readFloat(); p.ap=in.readFloat(); p.ar=in.readFloat(); tank.applyTurretPopState(p);
+      p.yaw=in.readFloat(); p.pitch=in.readFloat(); p.roll=in.readFloat(); p.ay=in.readFloat(); p.ap=in.readFloat(); p.ar=in.readFloat(); p.frozenYaw=in.readFloat(); p.frozenPitch=in.readFloat(); tank.applyTurretPopState(p);
    }
 }

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -78,8 +78,7 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
       GL11.glRotatef(popYaw, 0.0F, -1.0F, 0.0F);
       GL11.glRotatef(popPitch, 1.0F, 0.0F, 0.0F);
       GL11.glRotatef(popRoll, 0.0F, 0.0F, 1.0F);
-      GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
-      renderDetachedTurretWeapon(tank, info, tickTime);
+      renderDetachedTankTurret(tank, info);
       GL11.glPopMatrix();
    }
 


### PR DESCRIPTION
### Motivation

- The previous turret-pop implementation updated detached state but often applied transforms to the wrong configured weapon part and did not render the actual model group named `$turret`.
- The fix must make the real `$turret` geometry detach, fly under server-authoritative physics, collide with solid ground, emit a smoke trail on clients, and remain visible when landed while preserving `EnableTurretPop` default behavior.

### Description

- Select the canonical detachable geometry only when the loaded model contains the exact `$turret` group and treat `weapon0` as the main gun assembly source for configured children; skip the effect and emit one guarded debug warning when `$turret` is absent (changes in `MCH_EntityTank.getTurretPopRoot` and added `warnMissingTurretPart`).
- Freeze destruction-time turret yaw and gun elevation and persist them in entity state and NBT via new fields `turretPopFrozenYaw`/`turretPopFrozenPitch`, extend the turret-pop packet and spawn-state sync to include the frozen pose, and restore interpolation after loading (changes in `MCH_EntityTank` and `MCH_PacketTurretPop`).
- Implement server-side launch motion and swept downward collision checks that detect the first supporting collision box top, apply a conservative pivot clearance on landing, stop vertical motion and damp velocities/rotation on impact, and avoid moving the parent hull or falling through unloaded chunks (changes in `MCH_EntityTank.updateTurretPop`).
- Render the detached effect by drawing the exact `$turret` group and its configured `PartWeaponChild` children under a detached transform using the frozen local pose, and suppress only the canonical main assembly in the normal attached pass so other weapons remain visible (changes in `MCH_RenderBaseVehicle` and `MCH_RenderTank`).
- Spawn a client-side dark smoke trail from the synchronized turret position (client update path) with upward motion, spread, finite lifetime and reduced spawn rate after landing (added `updateTurretPopSmoke` in `MCH_EntityTank`).
- Preserve `EnableTurretPop` behavior and document the exact `$turret` requirement and the change in `docs/vehicle-config/tanks.md`, `docs/vehicle-config-reference.md`, and `CHANGELOG.md`.

Files changed: `src/main/java/mcheli/tank/MCH_EntityTank.java`, `src/main/java/mcheli/tank/MCH_PacketTurretPop.java`, `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/tank/MCH_RenderTank.java`, `docs/vehicle-config/tanks.md`, `docs/vehicle-config-reference.md`, `CHANGELOG.md`.

### Testing

- Ran `git diff --check` and static checks to ensure no whitespace/format errors and found none (success).
- Performed a source brace-balance check across changed Java files using a small Python script to confirm no unmatched braces after edits (success).
- Used repository searches (`rg`) to verify model assets and that `type10` contains an exact `turret` object and that `EnableTurretPop` appears in config references (success).
- Verified no binary or generated files changed by checking `git diff` name filters for binaries (success).
- Did not run `./gradlew build` or in-game Forge/Minecraft runtime tests in this environment as compiling/running game binaries is prohibited by task instructions, so runtime behavior (cardinal directions, LOD transitions, chunk unload/reload, multi-client sync) remains to be validated in a running Forge 1.7.10 client/server environment (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e6bebb98c8323a87c2aac1250dd73)