### PR TITLE
Fix tank turret-pop chassis rendering

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -620,6 +620,50 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
 
    }
 
+   /**
+    * Renders a popped tank's chassis without the canonical turret or the configured
+    * main-gun groups. The same runnable is used for the base texture and skin overlay,
+    * so neither pass can put the attached assembly back on the wreck.
+   */
+   public static void renderTankBodyWithoutPoppedTurret(final IModelCustom model,
+         MCH_BaseVehicleInfo.PartWeapon turretRoot) {
+      if(model == null) return;
+      final String[] excluded = getDetachedTankTurretGroups(turretRoot);
+      renderTankBodyModelWithoutPoppedTurret(model, excluded);
+      renderSkinOverlayPass(new RenderRunnable() {
+         public void render() {
+            renderTankBodyModelWithoutPoppedTurret(model, excluded);
+         }
+      });
+   }
+
+   private static void renderTankBodyModelWithoutPoppedTurret(IModelCustom model, String[] excluded) {
+      if(model instanceof W_ModelCustom) {
+         W_ModelCustom custom = (W_ModelCustom)model;
+         if(custom.containsPart("$body")) {
+            custom.renderPart("$body");
+         } else {
+            custom.renderAllExcept(excluded);
+         }
+      } else {
+         // Models without named-part support cannot contain the canonical $turret.
+         model.renderAll();
+      }
+   }
+
+   private static String[] getDetachedTankTurretGroups(MCH_BaseVehicleInfo.PartWeapon root) {
+      java.util.List groups = new java.util.ArrayList();
+      groups.add("$turret");
+      if(root != null) {
+         groups.add("$" + root.modelName);
+         for(Object object : root.child) {
+            MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
+            groups.add("$" + child.modelName);
+         }
+      }
+      return (String[])groups.toArray(new String[groups.size()]);
+   }
+
    /** True only when rendering the body separately cannot also draw named dynamic groups. */
    public static boolean hasSeparableBody(IModelCustom model) {
       return model instanceof W_ModelCustom && ((W_ModelCustom)model).containsPart("$body");
@@ -891,12 +935,15 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
          GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
          // The exact named model group is the detachable source of truth.
          renderPart(null, info.model, "turret");
+         GL11.glTranslated(root.pos.xCoord, root.pos.yCoord, root.pos.zCoord);
+         if(root.pitch) GL11.glRotatef(tank.turretPopFrozenPitch, 1.0F, 0.0F, 0.0F);
+         GL11.glTranslated(-root.pos.xCoord, -root.pos.yCoord, -root.pos.zCoord);
+         renderPart(root.model, info.model, root.modelName);
          for(Object object : root.child) {
             MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
             GL11.glPushMatrix();
             try {
                GL11.glTranslated(child.pos.xCoord, child.pos.yCoord, child.pos.zCoord);
-               if(child.pitch) GL11.glRotatef(tank.turretPopFrozenPitch, 1.0F, 0.0F, 0.0F);
                GL11.glTranslated(-child.pos.xCoord, -child.pos.yCoord, -child.pos.zCoord);
                renderPart(child.model, info.model, child.modelName);
             } finally { GL11.glPopMatrix(); }

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -53,7 +53,11 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
                System.out.println("Texture not found : " + tank.getTextureName());
                this.bindTexture(new ResourceLocation("textures/blocks/planks_oak.png"));
             }
-            renderBodyWithSkinOverlay(tankInfo.model, "tanks", tank);
+            if(tank.turretPopStarted) {
+               renderTankBodyWithoutPoppedTurret(tankInfo.model, tank.getTurretPopRoot());
+            } else {
+               renderBodyWithSkinOverlay(tankInfo.model, "tanks", tank);
+            }
             this.renderPoppedTurret(tank, tankInfo, yaw, pitch, roll, tickTime);
          }
       }

--- a/src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java
@@ -81,6 +81,8 @@ public abstract class W_ModelCustom implements IModelCustom {
 
    public abstract void renderAllTransformed();
 
+   public abstract void renderAllExcept(String ... excludedGroupNames);
+
    public abstract void renderPartTransformed(String var1);
 
    public abstract void renderAll(int var1, int var2);


### PR DESCRIPTION
### Motivation

- The chassis pass could still draw the canonical `$turret` when a detachable turret popped because `renderBodyModel` falls back to `model.renderAll()`, which renders `$turret` independently of the weapon pass. 
- The intent is to remove the attached `$turret` assembly from the wreck and render it exactly once as a detached rigid assembly for configs with `EnableTurretPop = true` while preserving existing parser behavior and defaults.

### Description

- Added a tank-specific chassis render path that activates when `turretPopStarted` to draw the body while excluding the canonical `$turret` and the configured turret root and child groups via a new exclusion helper so the attached turret geometry is suppressed in both base and skin-overlay passes (`src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`).
- Render the detached turret assembly exactly once by rendering the canonical `$turret` group followed by the configured turret root and its children under the frozen turret yaw/pitch so the main gun and its children travel with the detached turret (`src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`).
- Hooked the new chassis path into the tank renderer so the normal body path remains unchanged unless `turretPopStarted` is true (`src/main/java/mcheli/tank/MCH_RenderTank.java`).
- Exposed `renderAllExcept` through the shared model abstraction so both Metasequoia (MQO) and Wavefront (OBJ) backends can perform the exclusion pass uniformly (`src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java`).
- Preserved the `EnableTurretPop` parser and its default `false`, and left `configreference/tanks/m1a2.txt` and `CHANGELOG.md` untouched per constraints.
- Files changed: `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/tank/MCH_RenderTank.java`, and `src/main/java/mcheli/wrapper/modelloader/W_ModelCustom.java`.

### Testing

- Verified the parser and default: asserted `EnableTurretPop` parsing and the default `false` remain unchanged via a local Python check, which succeeded.
- Ran repository static checks: `git diff --check` and repository status validations succeeded with no whitespace or syntax diffs reported.
- Audited enabled vehicle configs and models with ripgrep and custom scripts and selected the enabled vehicle used for inspection as `DisplayName = Sherman VC Firefly` from `configreference/tanks/m4firefly.txt` and model `src/main/resources/assets/mcheli/models/tanks/m4firefly.mqo` while confirming the checked-in assets contain no exact `$turret` group so a full in-game regression could not be exercised in this checkout.
- Confirmed that the duplicated attached turret root came from the base model fallback (`renderBodyModel` -> `model.renderAll()`), and that the change suppresses that path by using `renderAllExcept` for models without `$body` so the turret is removed from the chassis pass and drawn only once as detached.
- Did not run `./gradlew build` or any runtime Forge tests because the task and repository policies prohibit compiling/launching binaries in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e74c166748323bac3958ec0180c1b)