### PR TITLE
Fix configured tank turret detachment

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -628,7 +628,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    public static void renderTankBodyWithoutPoppedTurret(final IModelCustom model,
          MCH_BaseVehicleInfo.PartWeapon turretRoot) {
       if(model == null) return;
-      final String[] excluded = getDetachedTankTurretGroups(turretRoot);
+      final String[] excluded = getDetachedTankTurretGroups(model, turretRoot);
       renderTankBodyModelWithoutPoppedTurret(model, excluded);
       renderSkinOverlayPass(new RenderRunnable() {
          public void render() {
@@ -651,15 +651,19 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       }
    }
 
-   private static String[] getDetachedTankTurretGroups(MCH_BaseVehicleInfo.PartWeapon root) {
+   private static String[] getDetachedTankTurretGroups(IModelCustom model,
+         MCH_BaseVehicleInfo.PartWeapon root) {
       java.util.List groups = new java.util.ArrayList();
-      groups.add("$turret");
-      if(root != null) {
-         groups.add("$" + root.modelName);
+      if(root != null && model instanceof W_ModelCustom) {
+         W_ModelCustom custom = (W_ModelCustom)model;
+         String rootName = "$" + root.modelName;
+         if(custom.containsPart(rootName)) groups.add(rootName);
          for(Object object : root.child) {
-            MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
-            groups.add("$" + child.modelName);
+            String childName = "$" + ((MCH_BaseVehicleInfo.PartWeaponChild)object).modelName;
+            if(custom.containsPart(childName)) groups.add(childName);
          }
+         // Some packs provide a separate shell around the configured main gun.
+         if(custom.containsPart("$turret")) groups.add("$turret");
       }
       return (String[])groups.toArray(new String[groups.size()]);
    }
@@ -924,31 +928,40 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       renderWeapon(ac, info, tickTime, true);
    }
 
-   /** Draws the canonical tank group and the configured children with a frozen pose. */
+   /** Draws the resolved configured tank groups with their frozen destruction pose. */
    public static void renderDetachedTankTurret(mcheli.tank.MCH_EntityTank tank, MCH_BaseVehicleInfo info) {
       MCH_BaseVehicleInfo.PartWeapon root = tank.getTurretPopRoot();
-      if(root == null) return;
+      if(root == null || !(info.model instanceof W_ModelCustom)) return;
+      W_ModelCustom model = (W_ModelCustom)info.model;
       GL11.glPushMatrix();
       try {
          GL11.glTranslated(info.turretPosition.xCoord, info.turretPosition.yCoord, info.turretPosition.zCoord);
          GL11.glRotatef(tank.turretPopFrozenYaw, 0.0F, -1.0F, 0.0F);
          GL11.glTranslated(-info.turretPosition.xCoord, -info.turretPosition.yCoord, -info.turretPosition.zCoord);
-         // The exact named model group is the detachable source of truth.
-         renderPart(null, info.model, "turret");
-         GL11.glTranslated(root.pos.xCoord, root.pos.yCoord, root.pos.zCoord);
-         if(root.pitch) GL11.glRotatef(tank.turretPopFrozenPitch, 1.0F, 0.0F, 0.0F);
-         GL11.glTranslated(-root.pos.xCoord, -root.pos.yCoord, -root.pos.zCoord);
-         renderPart(root.model, info.model, root.modelName);
-         for(Object object : root.child) {
-            MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
-            GL11.glPushMatrix();
-            try {
-               GL11.glTranslated(child.pos.xCoord, child.pos.yCoord, child.pos.zCoord);
-               GL11.glTranslated(-child.pos.xCoord, -child.pos.yCoord, -child.pos.zCoord);
-               renderPart(child.model, info.model, child.modelName);
-            } finally { GL11.glPopMatrix(); }
-         }
+         if(model.containsPart("$turret")) model.renderPart("$turret");
+         GL11.glPushMatrix();
+         try {
+            applyFrozenTurretPitch(root.pos, root.pitch, tank.turretPopFrozenPitch);
+            if(model.containsPart("$" + root.modelName)) model.renderPart("$" + root.modelName);
+            // Children inherit the root transform, matching renderWeaponChild.
+            for(Object object : root.child) {
+               MCH_BaseVehicleInfo.PartWeaponChild child = (MCH_BaseVehicleInfo.PartWeaponChild)object;
+               if(!model.containsPart("$" + child.modelName)) continue;
+               GL11.glPushMatrix();
+               try {
+                  applyFrozenTurretPitch(child.pos, child.pitch, tank.turretPopFrozenPitch);
+                  model.renderPart("$" + child.modelName);
+               } finally { GL11.glPopMatrix(); }
+            }
+         } finally { GL11.glPopMatrix(); }
       } finally { GL11.glPopMatrix(); }
+   }
+
+   private static void applyFrozenTurretPitch(Vec3 pivot, boolean pitches, float frozenPitch) {
+      if(!pitches) return;
+      GL11.glTranslated(pivot.xCoord, pivot.yCoord, pivot.zCoord);
+      GL11.glRotatef(frozenPitch, 1.0F, 0.0F, 0.0F);
+      GL11.glTranslated(-pivot.xCoord, -pivot.yCoord, -pivot.zCoord);
    }
 
    private static void renderWeapon(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime, boolean detachedOnly) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -67,6 +67,8 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    public float turretPopFrozenYaw, turretPopFrozenPitch;
    public int turretPopAge;
    private boolean turretPopMissingPartWarned;
+   /** Persisted destruction edge latch; prevents old wrecks from starting after reload. */
+   private boolean turretPopDestructionObserved;
 
    //TODO
    private int currentGear = 1;  // Starting gear
@@ -93,6 +95,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.trackDamageTaken = 0;
       this.turretPopStarted = false;
       this.turretPopLanded = false;
+      this.turretPopDestructionObserved = false;
    }
 
    //tracks are very broken
@@ -160,6 +163,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       super.writeEntityToNBT(par1NBTTagCompound);
       par1NBTTagCompound.setInteger("TrackDamage", this.trackDamageTaken);
       par1NBTTagCompound.setBoolean("TurretPopStarted", this.turretPopStarted);
+      par1NBTTagCompound.setBoolean("TurretPopDestructionObserved", this.turretPopDestructionObserved || this.isDestroyed());
       if(this.turretPopStarted) {
          par1NBTTagCompound.setBoolean("TurretPopLanded", this.turretPopLanded);
          par1NBTTagCompound.setDouble("TurretPopX", this.turretPopX); par1NBTTagCompound.setDouble("TurretPopY", this.turretPopY); par1NBTTagCompound.setDouble("TurretPopZ", this.turretPopZ);
@@ -175,6 +179,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       super.readEntityFromNBT(par1NBTTagCompound);
       this.trackDamageTaken = Math.max(0, par1NBTTagCompound.getInteger("TrackDamage"));
       this.turretPopStarted = par1NBTTagCompound.getBoolean("TurretPopStarted");
+      // Old saves have no latch: an already destroyed entity must be treated as observed.
+      this.turretPopDestructionObserved = par1NBTTagCompound.hasKey("TurretPopDestructionObserved")
+            ? par1NBTTagCompound.getBoolean("TurretPopDestructionObserved") : this.isDestroyed();
       if(this.turretPopStarted) {
          this.turretPopLanded = par1NBTTagCompound.getBoolean("TurretPopLanded");
          this.turretPopX = this.prevTurretPopX = par1NBTTagCompound.getDouble("TurretPopX"); this.turretPopY = this.prevTurretPopY = par1NBTTagCompound.getDouble("TurretPopY"); this.turretPopZ = this.prevTurretPopZ = par1NBTTagCompound.getDouble("TurretPopZ");
@@ -221,7 +228,10 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          super.prevPosY = super.posY;
          super.prevPosZ = super.posZ;
       } else {
-         if(!super.worldObj.isRemote) this.updateTurretPop();
+         if(!super.worldObj.isRemote) {
+            this.updateTurretPopDestructionTransition();
+            this.updateTurretPop();
+         }
          else this.updateTurretPopSmoke();
          if(!super.isRequestedSyncStatus) {
             super.isRequestedSyncStatus = true;
@@ -840,36 +850,61 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
    }
 
    public void destroyAircraft() {
+      boolean wasDestroyed = this.isDestroyed();
       super.destroyAircraft();
       super.rotDestroyedPitch = 0.0F;
       super.rotDestroyedRoll = 0.0F;
       super.rotDestroyedYaw = 0.0F;
-      if(!super.worldObj.isRemote && !this.turretPopStarted && this.tankInfo != null && this.tankInfo.enableTurretPop) {
-         if(this.getTurretPopRoot() != null) this.startTurretPop();
-         else this.warnMissingTurretPart();
+      if(!super.worldObj.isRemote && !wasDestroyed && this.isDestroyed()) {
+         this.onTurretPopDestructionTransition();
       }
    }
 
+   /** Detects every server-side alive-to-destroyed edge, including max-HP setters. */
+   private void updateTurretPopDestructionTransition() {
+      boolean destroyed = this.isDestroyed();
+      if(destroyed && !this.turretPopDestructionObserved) this.onTurretPopDestructionTransition();
+      else if(!destroyed) this.turretPopDestructionObserved = false;
+   }
+
+   private void onTurretPopDestructionTransition() {
+      this.turretPopDestructionObserved = true;
+      if(this.turretPopStarted || this.tankInfo == null || !this.tankInfo.enableTurretPop) return;
+      MCH_BaseVehicleInfo.PartWeapon root = this.getTurretPopRoot();
+      if(root != null) this.startTurretPop();
+      else this.warnMissingTurretPart();
+   }
+
+   /**
+    * Resolves the configured main-cannon assembly. Part order is configuration order,
+    * so the first top-level weapon part with a loaded group is the primary gun; coax,
+    * cupola and remote stations configured later cannot displace it.
+    */
    public MCH_BaseVehicleInfo.PartWeapon getTurretPopRoot() {
-      boolean canonicalModel = this.tankInfo != null && (!super.worldObj.isRemote
-            || this.tankInfo.model instanceof mcheli.wrapper.modelloader.W_ModelCustom
-            && ((mcheli.wrapper.modelloader.W_ModelCustom)this.tankInfo.model).containsPart("$turret"));
-      if(canonicalModel) {
-         /* weapon0 is the repository convention for the main gun/turret assembly;
-          * the model group, rather than the 'turret' aiming flag, is authoritative. */
-         for(Object o : this.tankInfo.partWeapon) {
-            MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)o;
-            if("weapon0".equalsIgnoreCase(part.modelName)) return part;
-         }
+      if(this.tankInfo == null || !this.tankInfo.enableTurretPop) return null;
+      mcheli.wrapper.modelloader.W_ModelCustom model = this.tankInfo.model instanceof mcheli.wrapper.modelloader.W_ModelCustom
+            ? (mcheli.wrapper.modelloader.W_ModelCustom)this.tankInfo.model : null;
+      for(Object object : this.tankInfo.partWeapon) {
+         MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)object;
+         // Dedicated servers intentionally do not load render models. They select the
+         // same configured root; clients additionally reject a missing loaded group.
+         if(model == null || model.containsPart("$" + part.modelName)) return part;
       }
       return null;
    }
 
    private void warnMissingTurretPart() {
-      if(!this.turretPopMissingPartWarned) {
-         this.turretPopMissingPartWarned = true;
-         MCH_Lib.Log((Entity)this, "Turret pop disabled for tank '%s': loaded model has no canonical $turret part", new Object[]{this.getTypeName()});
+      if(this.turretPopMissingPartWarned) return;
+      this.turretPopMissingPartWarned = true;
+      java.util.List attempted = new java.util.ArrayList();
+      if(this.tankInfo != null) for(Object object : this.tankInfo.partWeapon) {
+         MCH_BaseVehicleInfo.PartWeapon part = (MCH_BaseVehicleInfo.PartWeapon)object;
+         attempted.add("$" + part.modelName);
+         for(Object childObject : part.child) attempted.add("$" + ((MCH_BaseVehicleInfo.PartWeaponChild)childObject).modelName);
       }
+      MCH_Lib.Log((Entity)this,
+            "Turret pop disabled: display='%s', type='%s', no configured model group found; attempted=%s",
+            new Object[]{this.tankInfo != null ? this.tankInfo.displayName : "?", this.getTypeName(), attempted.toString()});
    }
 
    private void startTurretPop() {

--- a/src/main/java/mcheli/tank/MCH_RenderTank.java
+++ b/src/main/java/mcheli/tank/MCH_RenderTank.java
@@ -68,9 +68,9 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
       double x = tank.prevTurretPopX + (tank.turretPopX - tank.prevTurretPopX) * tickTime;
       double y = tank.prevTurretPopY + (tank.turretPopY - tank.prevTurretPopY) * tickTime;
       double z = tank.prevTurretPopZ + (tank.turretPopZ - tank.prevTurretPopZ) * tickTime;
-      float popYaw = tank.prevTurretPopYaw + (tank.turretPopYaw - tank.prevTurretPopYaw) * tickTime;
-      float popPitch = tank.prevTurretPopPitch + (tank.turretPopPitch - tank.prevTurretPopPitch) * tickTime;
-      float popRoll = tank.prevTurretPopRoll + (tank.turretPopRoll - tank.prevTurretPopRoll) * tickTime;
+      float popYaw = interpolateAngle(tank.prevTurretPopYaw, tank.turretPopYaw, tickTime);
+      float popPitch = interpolateAngle(tank.prevTurretPopPitch, tank.turretPopPitch, tickTime);
+      float popRoll = interpolateAngle(tank.prevTurretPopRoll, tank.turretPopRoll, tickTime);
       GL11.glPushMatrix();
       GL11.glRotatef(-hullRoll, 0.0F, 0.0F, 1.0F);
       GL11.glRotatef(-hullPitch, 1.0F, 0.0F, 0.0F);
@@ -84,6 +84,10 @@ public class MCH_RenderTank extends MCH_RenderBaseVehicle {
       GL11.glRotatef(popRoll, 0.0F, 0.0F, 1.0F);
       renderDetachedTankTurret(tank, info);
       GL11.glPopMatrix();
+   }
+
+   private static float interpolateAngle(float previous, float current, float tickTime) {
+      return previous + net.minecraft.util.MathHelper.wrapAngleTo180_float(current - previous) * tickTime;
    }
 
    public void renderWheel(MCH_EntityTank tank, double posX, double posY, double posZ) {


### PR DESCRIPTION
### Motivation

- The turret-pop renderer required a literal `$turret` group and/or a hard-coded `weapon0` root, causing enabled tanks (for example T-90 MBT) with configured groups like `$weapon0`, `$weapon0_0`, `$weapon0_1` but no `$turret` to never show a detached turret after destruction.
- The server already simulated turret-pop physics and sent snapshots, but clients returned early in `renderPoppedTurret()` because `getTurretPopRoot()` failed; the change makes client and server agree on the resolved configured turret root and ensures the detached assembly is rendered.

### Description

- Replace the old `$turret` / `weapon0`-centric root lookup with config-driven resolution that returns the first configured top-level `PartWeapon` whose loaded model group exists, while allowing dedicated servers (which do not load render models) to select the same configured root. (file: `src/main/java/mcheli/tank/MCH_EntityTank.java`)
- Add a persisted destruction-edge latch and centralized alive->destroyed transition detection so turret pop starts exactly once for every authoritative destruction path (including direct isDestroyed toggles), and old wrecks / reloads cannot restart the effect. (file: `src/main/java/mcheli/tank/MCH_EntityTank.java`)
- Only exclude actual, loaded model groups from the chassis render: the resolved root, its configured child groups (only when present in the model), and an optional `$turret` shell if present. This prevents suppressing/hiding nonexistent groups. (file: `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`)
- Rewrite detached turret rendering to draw the resolved root and its configured children (applying the frozen turret yaw and frozen pitch in the same hierarchy as normal weapon rendering) and to render `$turret` only when present. This removes the early-return when `$turret` is absent. (file: `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`)
- Use wrap-safe interpolation for detached rigid-body angles so rotated values cross the 180/-180 boundary smoothly. (file: `src/main/java/mcheli/tank/MCH_RenderTank.java`)
- Preserve existing server-authored physics, packet serialization (`MCH_PacketTurretPop`), spawn-data and NBT state; only the root resolution, suppression, rendering and destruction activation paths were modified. (files changed: `MCH_EntityTank.java`, `MCH_RenderTank.java`, `MCH_RenderBaseVehicle.java`)
- Diagnostic/warning behavior: when no configured model groups are present, a single informative warning is logged (display name, internal type and attempted model groups) instead of noisy per-tick messages.
- Note on changelog/documentation: this PR did not modify `CHANGELOG.md` or repository docs in this patch; please add an entry to your changelog (recommended title = this PR title) and update docs if desired.

### Testing

- Automated source-level assertions: ran repository checks and custom Python assertions that verified the T-90 config remains enabled (`DisplayName = T-90 MBT`, `EnableTurretPop = true`), the T-90 model lacks `$turret` but contains `$weapon0`, `$weapon0_0`, `$weapon0_1`, and the modified code no longer hard-codes `$turret`/`weapon0`; these assertions passed.
- Git validations: executed `git diff --check`, `git diff --stat`, and `git log` to confirm the intended three-file change set and that the commit `Fix configured tank turret detachment` was created; checks passed.
- Packet/serialization unchanged: inspected `MCH_PacketTurretPop` and `MCH_TankPacketHandler` to confirm networking and handler IDs are preserved and used by the new activation flow; no functional changes to packet format were made.
- Not run: Gradle build and runtime tests were not executed in this PR because building/running the game environment was not performed; therefore in-engine verification (singleplayer, dedicated server, multi-client, smoke, collision, LOD-crossing, late-join synchronization) remains to be validated by running the mod in Minecraft.

Suggested changelog entry (please add to your changelog.md using this PR title as the tracker):

- Fix configured tank turret detachment: resolve popped turret from configured weapon parts (don't require `$turret`), suppress/detach only loaded root/child groups, ensure authoritative once-only activation on destruction, and render detached assembly with frozen pose and wrap-safe interpolation.

Files changed: `src/main/java/mcheli/tank/MCH_EntityTank.java`, `src/main/java/mcheli/tank/MCH_RenderTank.java`, `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e78066e2c8323ac1f16128e33b173)