### PR TITLE
Fix missile target classification and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Missile target classification and locking correction (PR pending)
+
+- Classify planes and helicopters by deterministic full-footprint ground contact while retaining stable domains for tanks, turrets, UAV stations, ships, and compatible external vehicles.
+- Share domain and countermeasure eligibility across acquisition, server launch validation, active scanning, and in-flight guidance; reject forged or stale wrong-domain target IDs.
+- Select the nearest eligible lock target, expose the last completed lock correctly, and correct AA/AT proximity-fuze squared-distance comparisons.
+- Audit all missile weapon assets without changing their configuration or loadouts.
+
 # Catastrophic tank turret-pop correction (PR pending)
 
 - Detach the exact `$turret` model group with its configured weapon children, preserving the destruction-time turret yaw and gun elevation in synchronized/NBT state.

--- a/docs/missile-target-domain-audit.md
+++ b/docs/missile-target-domain-audit.md
@@ -4,18 +4,36 @@ This audit traces every repository weapon configured as `ATMissile`, `ASMissile`
 
 ## Confirmed classification and launch paths
 
-* **Stinger:** `fim92`, `aim92`, `aim92_2`, `aim92_l`, `mqaim92_l`, `gepstinger`, and `imshoradstinger` select through `MCH_WeaponAAMissile` → `MCH_WeaponGuidanceSystem`. The client sends `lastLockEntity` as `optionParameter1`; the server resolves that same entity ID and assigns it to `MCH_EntityAAMissile`. Air permission is enabled by weapon class, not by name. Previously a ground vehicle with false `onGround` and `LockMinHeight = 0` appeared airborne.
-* **Hellfire:** `agm114` (mounted by the AH-64, AH-1W, and AH-1Z) and `mqagm114` (MQ-9) select through `MCH_WeaponATMissile` → the same guidance system. The selected client entity ID follows the same `optionParameter1` server path and is assigned to `MCH_EntityATMissile`; top-attack mode remains in `optionParameter2`. Ground permission is enabled by weapon class. Previously the same false airborne classification rejected the vehicle. TV Hellfire variants retain manual/camera guidance.
+* **Stinger:** `fim92`, `aim92`, `aim92_2`, `aim92_l`, `mqaim92_l`, `gepstinger`, and `imshoradstinger` select through `MCH_WeaponAAMissile` → `MCH_WeaponGuidanceSystem`. The client sends `lastLockEntity` as `optionParameter1`; the server resolves that same entity ID and assigns it to `MCH_EntityAAMissile`. Air permission is enabled by weapon class, not by name. Aircraft now follow physical ground contact, while stable ground-vehicle roles remain Ground despite transient `onGround` values.
+* **Hellfire:** `agm114` (mounted by the AH-64, AH-1W, and AH-1Z) and `mqagm114` (MQ-9) select through `MCH_WeaponATMissile` → the same guidance system. The selected client entity ID follows the same `optionParameter1` server path and is assigned to `MCH_EntityATMissile`; top-attack mode remains in `optionParameter2`. Ground permission is enabled by weapon class. The shared contact-aware domain rule now accepts landed planes and helicopters without permitting airborne aircraft. TV Hellfire variants retain manual/camera guidance.
 * **Continued locks and active seekers:** continued player locks now call the same classification used for acquisition without repeating physical ground/air decisions. Active AA and AT missile scans and AA terminal homing also use the shared role classifier. Countermeasure eligibility remains an earlier, separate heat/radar decision.
 
 ## Final target-domain rules
 
-1. Planes and helicopters are **Air**, even while landed.
+1. Planes and helicopters are **Ground** while `onGround` is true or a narrow block-collision probe immediately below their complete bounding box finds contact; otherwise they are **Air**. Speed and `LockMinHeight` are not part of aircraft contact detection.
 2. Tanks, static turrets, UAV stations, and compatible external ground vehicle/mecha/AA-gun roles are **Ground**, even while jumping or crossing rough terrain.
 3. Ships are **Surface**; a diving ship entity in water is **Underwater**. Surface/underwater permissions remain separate from ground permission and use the existing water permission for backward compatibility.
 4. Unknown living/non-vehicle targets fall back to physical state. The fallback honors `onGround`, and always probes immediately below the bounding box even when `LockMinHeight = 0`; positive `LockMinHeight` retains its extra look-down meaning.
 5. Unknown MCHeli base-vehicle roles are not guessed from block contact. External compatibility name checks remain in place and now map their established roles to a stable domain.
 6. Weapon class permissions remain final: AA enables Air; AT enables Ground; immersion still requires `canLockInWater`; missile locking still requires `canLockMissile`; custom checkers run after basic domain checks.
+
+## Corrected end-to-end behavior
+
+Acquisition and continued locks use `canLockEntity`; deterministic acquisition retains the nearest visible eligible candidate. The server resolves the client entity id but now repeats eligibility, domain, range, angle, stealth, custom-checker, water, rider, missile-interception, and line-of-sight checks before spawning an entity-guided AA or AT missile. Passive-radar lock updates retain the last completed live lock, while ordinary resets cannot expose a completed stale lock.
+
+Active AA and AT scans and in-flight homing use the same role/domain and countermeasure helper. Thus an already-launched AAM drops an aircraft after ground contact and an AT missile drops it after takeoff; an active seeker cannot reacquire the now-wrong-domain aircraft. Countermeasures use each weapon's actual heat/radar flags: heat-only accepts active flares, radar accepts active chaff, and neither accepts the other countermeasure.
+
+## Additional confirmed corrections
+
+* The acquisition loop now updates its best squared distance instead of allowing entity-list order to choose the final target.
+* `getLastLockEntity()` returns the completed-lock field; `clearLock()` also removes a dead completed target while preserving a live completed target needed by passive-radar updates.
+* AA and AT proximity fuzes compare squared target distance with the square of the configured linear distance.
+* Bomb proximity queries, ordinary bullet fuzes, and AS missile coordinate fuzes were inspected and left unchanged: they already use a linear AABB range, a correct squared comparison, and a true linear distance respectively.
+* TV/camera, coordinate, and manual guidance were inspected and left unchanged because they do not use the entity-domain lock path.
+
+## Weapon asset result
+
+Every file under both weapon directories was inspected for the requested type, seeker, radar, laser, height, range, angle, fuze, rider, and missile-interception fields. **No weapon asset change was required.** In particular, `agm114.txt` and `mqagm114.txt` remain `ATMissile` weapons with `LockMinHeight = 0`; landed-aircraft support is supplied by the shared domain rule, not an air-lock permission or weapon-name exception. Existing multi-mode seeker flags were retained because the runtime countermeasure behavior is explicitly driven by those configured capabilities. Runtime and `configreference` assets therefore remain synchronized.
 
 ## Per-weapon audit
 

--- a/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityAAMissile.java
@@ -44,11 +44,12 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
             double x = super.posX - super.targetEntity.posX;
             double y = super.posY - super.targetEntity.posY;
             double z = super.posZ - super.targetEntity.posZ;
-            double d = x * x + y * y + z * z;
-            if(d > 3422500.0D) {
+            double distanceSq = x * x + y * y + z * z;
+            if(distanceSq > 3422500.0D) {
                this.setDead();
             } else if(this.getCountOnUpdate() > this.getInfo().rigidityTime) {
-               if(this.getInfo().proximityFuseDist >= 0.1F && d * d < (double)this.getInfo().proximityFuseDist) {
+               double fuseDistanceSq = (double)this.getInfo().proximityFuseDist * (double)this.getInfo().proximityFuseDist;
+               if(this.getInfo().proximityFuseDist >= 0.1F && distanceSq < fuseDistanceSq) {
                   MovingObjectPosition mop = new MovingObjectPosition(super.targetEntity);
                   super.posX = (super.targetEntity.posX + super.posX) / 2.0D;
                   super.posY = (super.targetEntity.posY + super.posY) / 2.0D;
@@ -83,15 +84,10 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
          Entity closestTarget = null;
 
          for (Entity entity : list) {
-            if (entity instanceof MCH_EntityBaseVehicle
-                    || MCH_WeaponGuidanceSystem.isValidCountermeasureTarget(entity, false, true)) {
+            if (MCH_WeaponGuidanceSystem.isEligibleMissileTarget(entity, shootingAircraft,
+                    getInfo(), false, true, false)) {
 
                if (W_Entity.isEqual(entity, shootingAircraft)) {
-                  continue;
-               }
-
-               if (MCH_WeaponGuidanceSystem.getTargetDomain(entity, getInfo().lockMinHeight)
-                       != MCH_WeaponGuidanceSystem.TargetDomain.AIR) {
                   continue;
                }
 
@@ -120,13 +116,8 @@ public class MCH_EntityAAMissile extends MCH_EntityBaseBullet implements MCH_IEn
    }
 
    private boolean isValidExistingTarget(Entity entity) {
-      if(entity == null || entity.isDead) {
-         return false;
-      }
-      if(entity instanceof MCH_EntityFlare || entity instanceof MCH_EntityChaff) {
-         return MCH_WeaponGuidanceSystem.isValidCountermeasureTarget(entity, false, true);
-      }
-      return true;
+      return MCH_WeaponGuidanceSystem.isEligibleMissileTarget(entity, shootingAircraft,
+              getInfo(), false, true, false);
    }
 
 

--- a/src/main/java/mcheli/weapon/MCH_EntityATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityATMissile.java
@@ -94,12 +94,13 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
         }
 
         if (!super.worldObj.isRemote && this.getInfo() != null) {
-            if (super.shootingEntity != null && super.targetEntity != null && !super.targetEntity.isDead) {
+            if (super.shootingEntity != null && MCH_WeaponGuidanceSystem.isEligibleMissileTarget(
+                    super.targetEntity, shootingAircraft, getInfo(), true, false, false)) {
                 double x = super.posX - super.targetEntity.posX;
                 double y = super.posY - super.targetEntity.posY;
                 double z = super.posZ - super.targetEntity.posZ;
-                double d = x * x + y * y + z * z;
-                if (d > 3422500.0D) {
+                double distanceSq = x * x + y * y + z * z;
+                if (distanceSq > 3422500.0D) {
                     this.setDead();
                 } else if (this.getCountOnUpdate() > this.getInfo().rigidityTime) {
 
@@ -126,7 +127,8 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
 
                     //Non-top-attack
                     else {
-                        if (this.getInfo().proximityFuseDist >= 0.1F && d < (double) this.getInfo().proximityFuseDist) {
+                        double fuseDistanceSq = (double)this.getInfo().proximityFuseDist * (double)this.getInfo().proximityFuseDist;
+                        if (this.getInfo().proximityFuseDist >= 0.1F && distanceSq < fuseDistanceSq) {
                             MovingObjectPosition mop = new MovingObjectPosition(super.targetEntity);
                             super.posX = (super.targetEntity.posX + super.posX) / 2.0D;
                             super.posY = (super.targetEntity.posY + super.posY) / 2.0D;
@@ -159,14 +161,10 @@ public class MCH_EntityATMissile extends MCH_EntityBaseBullet {
             Entity closestTarget = null;
 
             for (Entity entity : list) {
-                if (entity instanceof MCH_EntityBaseVehicle) {
+                if (MCH_WeaponGuidanceSystem.isEligibleMissileTarget(entity, shootingAircraft,
+                        getInfo(), true, false, false)) {
 
                     if (W_Entity.isEqual(entity, shootingAircraft)) {
-                        continue;
-                    }
-
-                    if (MCH_WeaponGuidanceSystem.getTargetDomain(entity, getInfo().lockMinHeight)
-                            != MCH_WeaponGuidanceSystem.TargetDomain.GROUND) {
                         continue;
                     }
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
@@ -60,7 +60,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
             result = true;
          } else {
             Entity tgtEnt = prm.user.worldObj.getEntityByID(prm.option1);
-            if (tgtEnt != null && !tgtEnt.isDead) {
+            if (super.guidanceSystem.canLaunchAt(prm.user, tgtEnt)) {
                this.playSound(prm.entity);
                float yaw, pitch;
                if(getInfo().enableOffAxis) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
@@ -75,7 +75,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
             result = true;
          } else {
             Entity tgtEnt = prm.user.worldObj.getEntityByID(prm.option1);
-            if (tgtEnt != null && !tgtEnt.isDead) {
+            if (super.guidanceSystem.canLaunchAt(prm.user, tgtEnt)) {
                this.playSound(prm.entity);
                float yaw, pitch;
                if(getInfo().enableOffAxis) {

--- a/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
@@ -19,6 +19,7 @@ import mcheli.wrapper.W_WorldFunc;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
@@ -133,13 +134,30 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       return false;
    }
 
+   /**
+    * Uses the physics flag plus a narrow, full-footprint block probe.  Unlike
+    * LockMinHeight, this is contact detection and cannot classify low flight as ground.
+    */
+   public static boolean hasAircraftGroundContact(Entity entity) {
+      if(entity == null || entity.isDead || entity.worldObj == null || entity.boundingBox == null) {
+         return false;
+      }
+      if(entity.onGround) {
+         return true;
+      }
+      AxisAlignedBB contactBox = entity.boundingBox.copy();
+      contactBox.minY -= 0.0625D;
+      contactBox.maxY = entity.boundingBox.minY + 0.001D;
+      return entity.worldObj.checkBlockCollision(contactBox);
+   }
+
    /** Classifies stable vehicle roles before using transient physical contact. */
    public static TargetDomain getTargetDomain(Entity entity, int groundProbeHeight) {
       if(entity == null || entity.isDead) {
          return TargetDomain.UNKNOWN;
       }
       if(entity instanceof MCP_EntityPlane || entity instanceof MCH_EntityHeli) {
-         return TargetDomain.AIR;
+         return hasAircraftGroundContact(entity) ? TargetDomain.GROUND : TargetDomain.AIR;
       }
       if(entity instanceof MCH_EntityShip) {
          MCH_EntityShip ship = (MCH_EntityShip)entity;
@@ -154,7 +172,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       // Preserve the legacy external-mod compatibility contract, but give its known
       // roles stable domains instead of treating all vehicles as airborne off blocks.
       if(className.indexOf("EntityPlane") >= 0) {
-         return TargetDomain.AIR;
+         return hasAircraftGroundContact(entity) ? TargetDomain.GROUND : TargetDomain.AIR;
       }
       if(className.indexOf("EntityVehicle") >= 0 || className.indexOf("EntityMecha") >= 0
               || className.indexOf("EntityAAGun") >= 0) {
@@ -234,6 +252,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                      MovingObjectPosition m = W_WorldFunc.clip(this.worldObj, v1, v2, false, true, false);
                      if(m == null || W_MovingObjectPosition.isHitTypeEntity(m)) {
                         potentialTarget = currentEntity;  // Sets lock target
+                        dist = distance;
                      }
                   }
                }
@@ -389,6 +408,9 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       this.lockCount = 0;
       this.continueLockCount = 0;
       this.lockSoundCount = 0;
+      if(this.lastLockEntity != null && this.lastLockEntity.isDead) {
+         this.lastLockEntity = null;
+      }
    }
 
    public Entity getLockEntity(Entity entity) {
@@ -452,6 +474,67 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       }
    }
 
+   public boolean canLockEntity(Entity shooter, Entity entity) {
+      this.user = shooter;
+      return canLockEntity(entity);
+   }
+
+   /** Server-side validation for the entity id supplied by the client. */
+   public boolean canLaunchAt(Entity shooter, Entity entity) {
+      if(shooter == null || !canLockEntity(shooter, entity)) {
+         return false;
+      }
+      Entity locker = getLockEntity(shooter);
+      double dx = entity.posX - shooter.posX;
+      double dy = entity.posY - shooter.posY;
+      double dz = entity.posZ - shooter.posZ;
+      double range = this.lockRange * (double)(1.0F - getEntityStealth(entity));
+      if(dx * dx + dy * dy + dz * dz >= range * range
+              || !inLockAngle(locker, shooter.rotationYaw, shooter.rotationPitch, entity, (float)this.lockAngle)) {
+         return false;
+      }
+      Vec3 from = W_WorldFunc.getWorldVec3(this.worldObj, locker.posX, locker.posY, locker.posZ);
+      Vec3 to = W_WorldFunc.getWorldVec3(this.worldObj, entity.posX,
+              entity.posY + (double)(entity.height / 2.0F), entity.posZ);
+      MovingObjectPosition hit = W_WorldFunc.clip(this.worldObj, from, to, false, true, false);
+      return hit == null || W_MovingObjectPosition.isHitTypeEntity(hit);
+   }
+
+   public static boolean isEligibleMissileTarget(Entity target, Entity shooter, MCH_WeaponInfo info,
+           boolean allowGround, boolean allowAir, boolean allowWater) {
+      if(target == null || info == null || target.isDead || W_Entity.isEqual(target, shooter)) {
+         return false;
+      }
+      if(target instanceof MCH_EntityFlare || target instanceof MCH_EntityChaff) {
+         return isValidCountermeasureTarget(target, info.isHeatSeekerMissile, info.isRadarMissile);
+      }
+      if(info.ridableOnly && target instanceof EntityPlayer && target.ridingEntity == null) {
+         return false;
+      }
+      if(target instanceof MCH_EntityBaseBullet) {
+         return info.canLockMissile
+                 && !W_Entity.isEqual(shooter, ((MCH_EntityBaseBullet)target).shootingEntity);
+      }
+      String className = target.getClass().getName();
+      if(className.indexOf("EntityCamera") >= 0
+              || !W_Lib.isEntityLivingBase(target)
+              && !(target instanceof MCH_EntityBaseVehicle)
+              && !(target instanceof MCH_EntityUavStation)
+              && className.indexOf("EntityVehicle") < 0
+              && className.indexOf("EntityPlane") < 0
+              && className.indexOf("EntityMecha") < 0
+              && className.indexOf("EntityAAGun") < 0) {
+         return false;
+      }
+      if(!allowWater && target.isInWater()) {
+         return false;
+      }
+      TargetDomain domain = getTargetDomain(target, info.lockMinHeight);
+      return domain == TargetDomain.GROUND ? allowGround
+              : domain == TargetDomain.AIR ? allowAir
+              : (domain == TargetDomain.SURFACE || domain == TargetDomain.UNDERWATER) && allowWater;
+   }
+
    public static boolean isValidCountermeasureTarget(Entity entity, boolean heatSeeking, boolean radarGuided) {
       if(entity instanceof MCH_EntityFlare) {
          return !radarGuided && heatSeeking && ((MCH_EntityFlare)entity).isActiveCountermeasure();
@@ -478,8 +561,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
    @Override
    protected Entity getLastLockEntity() {
-      // TODO Auto-generated method stub
-      return null;
+      return this.lastLockEntity;
    }
 
    @Override


### PR DESCRIPTION
### Motivation

- Repair the incorrect target-domain behavior introduced earlier so aircraft are classified by real ground contact rather than class-name or speed heuristics. 
- Ensure all lock paths (client acquisition, continued locks, passive updates, active scans, server launch validation, and in-flight homing) enforce the same deterministic eligibility rules. 
- Correct proximity-fuze unit errors and make countermeasure handling respect each weapon's configured seeker flags.

### Description

- Add a deterministic aircraft ground-contact probe `hasAircraftGroundContact` and use it from `getTargetDomain` so planes/helicopters are Ground only when truly contacting terrain; preserved stable Ground/SURFACE roles for tanks, turrets, ships and UAV stations. (edited `MCH_WeaponGuidanceSystem.java`)
- Centralize and share eligibility checks by adding `isEligibleMissileTarget` and server-side `canLaunchAt` to validate client-supplied entity IDs (range, angle, LOS, stealth, domain, rider, water, custom checkers, and missile-interception). (edited `MCH_WeaponGuidanceSystem.java`)
- Make acquisition deterministic by updating the stored best squared distance during `lock` and return the actual `lastLockEntity` from `getLastLockEntity`, and avoid keeping dead completed locks in `clearLock`. (edited `MCH_WeaponGuidanceSystem.java`)
- Replace ad-hoc type checks in active seeker scans and in-flight validation with the shared eligibility helper so AAM/AT seekers reject or accept targets by current domain and seeker flags, and use the weapon info for countermeasure acceptance. (edited `MCH_EntityAAMissile.java`, `MCH_EntityATMissile.java`)
- Fix proximity fuzes to compare squared distances against `ProximityFuseDist * ProximityFuseDist` and use clear variable names such as `distanceSq` and `fuseDistanceSq`. (edited `MCH_EntityAAMissile.java`, `MCH_EntityATMissile.java`)
- Gate server launch paths to re-validate the entity id before spawning an entity-guided missile (AA and AT launch paths now call `canLaunchAt`). (edited `MCH_WeaponAAMissile.java`, `MCH_WeaponATMissile.java`)
- Audit weapon assets under `src/main/resources/assets/mcheli/weapons` and `configreference/weapons` for requested fields and confirmed no configuration changes were required; updated `docs/missile-target-domain-audit.md` and appended an entry to `CHANGELOG.md` documenting the change. (edited `docs/missile-target-domain-audit.md`, `CHANGELOG.md`)

### Testing

- Ran a focused Python assertion/audit script that verified nearest-target selection, ground-contact probe usage, `lastLockEntity` return, squared-fuze math, and that `agm114`/`mqagm114` runtime and `configreference` assets remain byte-for-byte synchronized (passed). 
- Ran `git diff --check` and repository hygiene checks to ensure no build outputs, IDE files, or binaries were included (passed). 
- Did not run Gradle `build`/`test` because the request explicitly prohibited compiling binary files; these tasks were intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ea7d6e8b883239cf1aa9356de2ebe)