### PR TITLE
Forge 1.7.10 development asset live reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Forge 1.7.10 development asset live reload (PR pending)
+
+- Make `/mcheli reload` prefer external addons and the editable `src/main/resources/assets/mcheli` tree over generated classpath output and development JARs.
+- Refresh configuration, HUD, model, texture, and sound resources on the client thread while preserving loaded vehicle seats and persistent state.
+- Add deterministic source-selection coverage and document the development verification workflow.
+
 # Missile target classification and locking correction (PR pending)
 
 - Classify planes and helicopters by deterministic full-footprint ground contact while retaining stable domains for tanks, turrets, UAV stations, ships, and compatible external vehicles.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,6 +34,7 @@ Permissions are per subcommand. Granting `status` does not grant `fill` or `kill
 | --- | --- | --- |
 | `list` | `/mcheli list` | Prints the available MCHeli subcommands. |
 | `reconfig` | `/mcheli reconfig` | Reloads `mcheli.cfg`; on servers, broadcasts updated server settings to clients. |
+| `reload` | `/mcheli reload` | Re-scans configuration and client assets, then notifies connected clients. |
 | `sendss` | `/mcheli sendss <playerName>` | Sends a client packet requesting/triggering screenshot-related client handling for the named player. |
 | `modlist` | `/mcheli modlist <playerName>` | Requests mod-list information from the named player. |
 | `title` | `/mcheli title <timeSeconds> <position> <jsonMessage>` | Sends a JSON chat title/message packet to clients. Time is clamped to 1-180 seconds; position is clamped by code to 0-5. |
@@ -87,6 +88,32 @@ Enable debug bounding boxes for connected clients:
 ```text
 /mcheli showboundingbox true
 ```
+
+## Development live reload
+
+In a repository development run, `/mcheli reload` reads the editable
+`src/main/resources/assets/mcheli` tree directly. Running `processResources`, relogging, and
+restarting the world are not required. Resolution is deterministic: an external
+`mcheli_addons` override wins first, followed by the editable source tree, an ordinary
+classpath resource directory, and finally a packaged/development JAR. When the editable
+tree is present it is authoritative, so deleting a source asset cannot reveal an old copy
+from `build/resources/main` or a development JAR.
+
+The client-thread reload covers vehicle, weapon, item, throwable, and HUD definitions;
+MQO, OBJ, and TCN models; textures; `sounds.json`; and referenced OGG files. Existing
+vehicles retain seats, riders, ownership, locks, ammunition, fuel, health, damage,
+throttle, and weapon state while definition-derived objects are refreshed. Definitions
+which require a newly registered Minecraft item still print the existing restart warning.
+
+### Manual verification
+
+1. Start `runClient`, enter a world, and use an existing MCHeli vehicle.
+2. Edit its source `.txt`, run `/mcheli reload`, and confirm the value changes in place.
+3. Repeat after editing its MQO or OBJ model and then a texture.
+4. Repeat after editing a HUD file, `sounds.json`, or an OGG asset.
+5. Add a configuration, reload, and confirm discovery or the explicit item-registration restart warning.
+6. Delete a configuration, reload, and confirm no generated copy restores it.
+7. Reload several times and check for crashes, duplicate seats, leaked display lists, or overlapping model jobs.
 
 ## Safety notes
 

--- a/src/main/java/mcheli/MCH_AddonResourcePack.java
+++ b/src/main/java/mcheli/MCH_AddonResourcePack.java
@@ -25,12 +25,22 @@ public class MCH_AddonResourcePack implements IResourcePack {
     private static final String DOMAIN = "mcheli";
     private final File[] addonRoots;
 
+    /** Dynamic pack used by reload; it follows MCH_ResourceHelper's live precedence. */
+    public MCH_AddonResourcePack() {
+        this.addonRoots = null;
+    }
+
     public MCH_AddonResourcePack(File[] addonRoots) {
         this.addonRoots = addonRoots;
     }
 
     @Override
     public InputStream getInputStream(ResourceLocation location) throws IOException {
+        if (addonRoots == null) {
+            InputStream stream = MCH_ResourceHelper.openResourceStream(toAssetPath(location));
+            if (stream != null) return stream;
+            throw new IOException("Resource not found: " + location);
+        }
         File file = findFile(location);
         if (file == null) {
             throw new IOException("Resource not found: " + location);
@@ -40,6 +50,7 @@ public class MCH_AddonResourcePack implements IResourcePack {
 
     @Override
     public boolean resourceExists(ResourceLocation location) {
+        if (addonRoots == null) return MCH_ResourceHelper.resourceExists(toAssetPath(location));
         return findFile(location) != null;
     }
 
@@ -62,7 +73,7 @@ public class MCH_AddonResourcePack implements IResourcePack {
 
     @Override
     public String getPackName() {
-        return "MCHeli Addon Pack";
+        return addonRoots == null ? "MCHeli Live Development Resources" : "MCHeli Addon Pack";
     }
 
     private File findFile(ResourceLocation location) {
@@ -76,5 +87,9 @@ public class MCH_AddonResourcePack implements IResourcePack {
             }
         }
         return null;
+    }
+
+    private String toAssetPath(ResourceLocation location) {
+        return "assets/" + location.getResourceDomain() + "/" + location.getResourcePath();
     }
 }

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -161,18 +161,25 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
    public void scheduleClientInfoReload() {
       Minecraft.getMinecraft().func_152344_a(new Runnable() {
          public void run() {
-            MCH_HeliInfoManager.getInstance().reload();
-            MCP_PlaneInfoManager.getInstance().reload();
-            MCH_ShipInfoManager.getInstance().reload();
-            MCH_TankInfoManager.getInstance().reload();
-            MCH_TurretInfoManager.getInstance().reload();
-            MCH_WeaponInfoManager.reload();
-            MCH_ItemInfoManager.reload();
-            MCH_ThrowableInfoManager.reload();
+            MCH_ResourceHelper.refreshResourceSources();
+            // 1.7.10 rebuilds textures and the sound registry on this client-thread call.
+            Minecraft.getMinecraft().refreshResources();
+            int succeeded = 0;
+            if(MCH_HeliInfoManager.getInstance().reload()) ++succeeded;
+            if(MCP_PlaneInfoManager.getInstance().reload()) ++succeeded;
+            if(MCH_ShipInfoManager.getInstance().reload()) ++succeeded;
+            if(MCH_TankInfoManager.getInstance().reload()) ++succeeded;
+            if(MCH_TurretInfoManager.getInstance().reload()) ++succeeded;
+            if(MCH_WeaponInfoManager.reload()) ++succeeded;
+            if(MCH_ItemInfoManager.reload()) ++succeeded;
+            if(MCH_ThrowableInfoManager.reload()) ++succeeded;
             MCH_VehicleItemModelRender.resetForReload();
+            MCH_ModelManager.clearForReload();
             registerModels();
-            reloadHUD();
-            MCH_SoundsJson.update("assets/mcheli/");
+            boolean hud = false;
+            try { reloadHUD(); hud = true; } catch(RuntimeException e) { MCH_Lib.Log("HUD reload failed: %s", e.getMessage()); }
+            MCH_Lib.Log("Client live reload: info=%d/8, models=complete, HUD=%s, textures/sounds=refreshed",
+                    Integer.valueOf(succeeded), hud ? "complete" : "failed");
          }
       });
    }

--- a/src/main/java/mcheli/MCH_InfoManagerBase.java
+++ b/src/main/java/mcheli/MCH_InfoManagerBase.java
@@ -29,7 +29,14 @@ public abstract class MCH_InfoManagerBase {
       LinkedHashMap newMap = new LinkedHashMap();
       path = path.replace('\\', '/');
       List<String> entries = MCH_ResourceHelper.listResources(path + type, ".txt");
-      if(entries == null || entries.isEmpty()) return false;
+      if(entries == null || entries.isEmpty()) {
+         if(reload) {
+            setMap(newMap);
+            MCH_Lib.Log("Read 0 %s (all definitions removed)", new Object[]{type});
+            return true;
+         }
+         return false;
+      }
 
       for(int i = 0; i < entries.size(); ++i) {
          String resourcePath = entries.get(i);

--- a/src/main/java/mcheli/MCH_MOD.java
+++ b/src/main/java/mcheli/MCH_MOD.java
@@ -205,6 +205,7 @@ public class MCH_MOD {
           // Set the JAR file for classpath resource enumeration
           File sourceFile = Loader.instance().activeModContainer().getSource();
           MCH_ResourceHelper.setSourceJar(sourceFile);
+          MCH_ResourceHelper.discoverDevClasspath();
           MCH_Lib.DbgLog(false, "Mods Directory: %s", sourcePath);
        }
 
@@ -225,10 +226,8 @@ public class MCH_MOD {
        // approach was wiped by clearResources() on each reload.
        if (isDev || true) {
           try {
-             java.util.List<File> roots = MCH_ResourceHelper.getAddonAssetRoots();
-             if (roots != null && !roots.isEmpty()) {
-                File[] rootArray = roots.toArray(new File[0]);
-                net.minecraft.client.resources.IResourcePack addonPack = new MCH_AddonResourcePack(rootArray);
+             {
+                net.minecraft.client.resources.IResourcePack addonPack = new MCH_AddonResourcePack();
                 // Access Minecraft.defaultResourcePacks (private List<IResourcePack>)
                 java.lang.reflect.Field field = net.minecraft.client.Minecraft.class.getDeclaredField("defaultResourcePacks");
                 field.setAccessible(true);
@@ -236,7 +235,7 @@ public class MCH_MOD {
                 java.util.List<net.minecraft.client.resources.IResourcePack> defaultPacks =
                     (java.util.List<net.minecraft.client.resources.IResourcePack>) field.get(net.minecraft.client.Minecraft.getMinecraft());
                 defaultPacks.add(addonPack);
-                MCH_Lib.Log("Registered addon resource pack in defaultResourcePacks with %d roots", rootArray.length);
+                MCH_Lib.Log("Registered live MCHeli resource pack");
              }
           } catch (Exception e) {
              MCH_Lib.Log("Failed to register addon resource pack: %s", e.getMessage());

--- a/src/main/java/mcheli/MCH_ModelManager.java
+++ b/src/main/java/mcheli/MCH_ModelManager.java
@@ -35,6 +35,13 @@ public class MCH_ModelManager extends W_ModelBase {
       forceReloadMode = b;
    }
 
+   /** Drops all model objects before a complete client-thread registration pass. */
+   public static void clearForReload() {
+      MAP.clear();
+      mcheli.tank.MCH_TurretPopModelCache.clear();
+      forceReloadMode = true;
+   }
+
    public static IModelCustom load(String path, String name) {
       return (name != null && !name.isEmpty()) ? load(path + "/" + name) : null;
    }

--- a/src/main/java/mcheli/MCH_ResourceHelper.java
+++ b/src/main/java/mcheli/MCH_ResourceHelper.java
@@ -6,335 +6,252 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 
+/** Resolves MCHeli resources with a stable overlay order. */
 public class MCH_ResourceHelper {
 
-    private static File sourceJar = null;
-    private static List<File> devClasspathDirs = null;
-    private static File addonDir = null;
-    private static List<File> addonAssetRoots = null;
-
     private static final String ASSET_PREFIX = "assets/mcheli/";
+    private static File sourceJar;
+    private static File addonDir;
+    private static List<File> addonAssetRoots = Collections.emptyList();
+    private static List<File> devSourceDirs = Collections.emptyList();
+    private static List<File> classpathDirs = Collections.emptyList();
+    private static List<File> jarSources = Collections.emptyList();
 
-    public static void setSourceJar(File jar) {
+    public static synchronized void setSourceJar(File jar) {
         sourceJar = jar;
     }
 
-    /**
-     * Sets the addon directory and discovers addon asset roots.
-     * Supports two layouts:
-     *   Flat:      mcheli_addons/helicopters/ah-60.txt
-     *   Nested:    mcheli_addons/atom4a/assets/mcheli/helicopters/ah-60.txt
-     */
-    public static void setAddonDir(File dir) {
+    public static synchronized void setAddonDir(File dir) {
         addonDir = dir;
-        addonAssetRoots = new ArrayList<>();
-        if (addonDir != null) {
-            if (!addonDir.exists()) {
-                addonDir.mkdirs();
-                MCH_Lib.Log("MCH_ResourceHelper: Created addon directory: %s", addonDir.getAbsolutePath());
-            }
-            discoverAddonRoots();
-        }
+        if (dir != null && !dir.exists()) dir.mkdirs();
+        discoverAddonRoots();
         MCH_Lib.Log("MCH_ResourceHelper: Addon directory: %s (%d asset roots)",
-                addonDir != null ? addonDir.getAbsolutePath() : "null", addonAssetRoots.size());
+                dir != null ? dir.getAbsolutePath() : "null", addonAssetRoots.size());
     }
 
-    public static File getAddonDir() {
-        return addonDir;
-    }
+    public static File getAddonDir() { return addonDir; }
+    public static List<File> getAddonAssetRoots() { return new ArrayList<File>(addonAssetRoots); }
+    public static List<File> getDevelopmentSourceDirs() { return new ArrayList<File>(devSourceDirs); }
 
-    public static List<File> getAddonAssetRoots() {
-        return addonAssetRoots;
+    /** Re-scans both the classpath/project layout and addon packs for /mcheli reload. */
+    public static synchronized void refreshResourceSources() {
+        discoverDevClasspath();
+        discoverAddonRoots();
     }
 
     private static void discoverAddonRoots() {
-        addonAssetRoots = new ArrayList<>();
-
-        // Check if the addon root itself is an asset root (flat layout)
-        if (new File(addonDir, ASSET_PREFIX).isDirectory()) {
-            addonAssetRoots.add(addonDir);
-            MCH_Lib.Log("  Flat addon root: %s", addonDir.getAbsolutePath());
-        }
-
-        // Scan subdirectories for nested addon packs (e.g. atom4a/assets/mcheli/)
-        File[] children = addonDir.listFiles();
-        if (children != null) {
-            for (File child : children) {
-                if (child.isDirectory() && new File(child, ASSET_PREFIX).isDirectory()) {
-                    addonAssetRoots.add(child);
-                    MCH_Lib.Log("  Nested addon root: %s", child.getName());
+        ArrayList<File> roots = new ArrayList<File>();
+        if (addonDir != null) {
+            File[] children = addonDir.listFiles();
+            if (children != null) {
+                List<File> sorted = new ArrayList<File>();
+                Collections.addAll(sorted, children);
+                Collections.sort(sorted);
+                for (File child : sorted) {
+                    if (child.isDirectory() && new File(child, ASSET_PREFIX).isDirectory()) roots.add(canonical(child));
                 }
             }
+            if (new File(addonDir, ASSET_PREFIX).isDirectory() || isFlatAddon(addonDir)) roots.add(canonical(addonDir));
         }
+        addonAssetRoots = roots;
     }
 
-    public static void discoverDevClasspath() {
-        devClasspathDirs = new ArrayList<>();
+    private static boolean isFlatAddon(File root) {
+        String[] assetDirs = {"helicopters", "planes", "ships", "tanks", "vehicles", "weapons", "items", "throwable", "hud", "models", "textures", "sounds"};
+        for (String dir : assetDirs) if (new File(root, dir).isDirectory()) return true;
+        return false;
+    }
+
+    /** Discovers all source types; finding a jar never terminates directory discovery. */
+    public static synchronized void discoverDevClasspath() {
+        LinkedHashSet<File> sources = new LinkedHashSet<File>();
+        LinkedHashSet<File> dirs = new LinkedHashSet<File>();
+        LinkedHashSet<File> jars = new LinkedHashSet<File>();
+        if (sourceJar != null && sourceJar.isFile()) jars.add(canonical(sourceJar));
+
+        File root = findProjectRoot(new File(System.getProperty("user.dir", ".")));
+        if (root != null) addIfAssetRoot(sources, new File(root, "src/main/resources"));
 
         String cp = System.getProperty("java.class.path", "");
-
-        // Method 1: Find JARs on classpath that contain assets/mcheli/ (RFG dev mode)
-        for (String entry : cp.split(File.pathSeparator)) {
-            File f = new File(entry);
-            if (f.isFile() && entry.endsWith(".jar")) {
-                try (JarFile jar = new JarFile(f)) {
-                    Enumeration<JarEntry> entries = jar.entries();
-                    while (entries.hasMoreElements()) {
-                        JarEntry e = entries.nextElement();
-                        if (e.getName().startsWith("assets/mcheli/") && !e.isDirectory()) {
-                            sourceJar = f;
-                            MCH_Lib.Log("MCH_ResourceHelper: Found dev JAR with assets: %s", f.getName());
-                            return;
-                        }
-                    }
-                } catch (Exception ignored) {}
-            }
-        }
-
-        // Method 2: Find directories on classpath with assets/mcheli
-        for (String entry : cp.split(File.pathSeparator)) {
-            File f = new File(entry);
-            if (f.isDirectory() && new File(f, "assets/mcheli").isDirectory()) {
-                devClasspathDirs.add(f);
-            }
-        }
-
-        // Method 3: Search classloader hierarchy for URLClassLoaders
-        if (devClasspathDirs.isEmpty()) {
-            ClassLoader cl = MCH_ResourceHelper.class.getClassLoader();
-            while (cl != null) {
-                if (cl instanceof java.net.URLClassLoader) {
-                    try {
-                        for (java.net.URL url : ((java.net.URLClassLoader) cl).getURLs()) {
-                            if ("file".equals(url.getProtocol())) {
-                                File dir = new File(url.getPath());
-                                if (dir.isDirectory() && new File(dir, "assets/mcheli").isDirectory()) {
-                                    devClasspathDirs.add(dir);
-                                }
-                            }
-                        }
-                    } catch (Exception ignored) {}
-                }
-                cl = cl.getParent();
-            }
-        }
-
-        // Method 4: Walk upward from working directory to find build/resources/main or src/main/resources
-        if (devClasspathDirs.isEmpty()) {
-            File cwd = new File(System.getProperty("user.dir"));
-            File projectRoot = cwd;
-            // If user.dir is a run/ subdirectory, walk up to project root
-            while (projectRoot != null && !new File(projectRoot, "src").isDirectory()) {
-                projectRoot = projectRoot.getParentFile();
-            }
-            if (projectRoot != null) {
-                for (String rel : new String[]{"build/resources/main", "src/main/resources"}) {
-                    File candidate = new File(projectRoot, rel);
-                    if (candidate.isDirectory() && new File(candidate, "assets/mcheli").isDirectory()) {
-                        devClasspathDirs.add(candidate);
-                    }
+        for (String entry : cp.split(java.util.regex.Pattern.quote(File.pathSeparator))) classify(new File(entry), sources, dirs, jars);
+        ClassLoader loader = MCH_ResourceHelper.class.getClassLoader();
+        while (loader != null) {
+            if (loader instanceof URLClassLoader) {
+                for (URL url : ((URLClassLoader)loader).getURLs()) if ("file".equals(url.getProtocol())) {
+                    try { classify(new File(url.toURI()), sources, dirs, jars); } catch (Exception ignored) {}
                 }
             }
+            loader = loader.getParent();
         }
+        devSourceDirs = new ArrayList<File>(sources);
+        classpathDirs = new ArrayList<File>(dirs);
+        jarSources = new ArrayList<File>(jars);
+        MCH_Lib.DbgLog(false, "Resource roots refreshed: editable=%s classpath=%s jars=%s",
+                devSourceDirs, classpathDirs, jarSources);
+    }
 
-        MCH_Lib.Log("MCH_ResourceHelper: dev classpath found %d dirs", devClasspathDirs.size());
-        for (File dir : devClasspathDirs) {
-            MCH_Lib.Log("  -> %s", dir.getAbsolutePath());
-        }
-
-        if (devClasspathDirs.isEmpty() && sourceJar == null) {
-            MCH_Lib.Log("WARNING: No assets found on classpath. java.class.path entries: %d", cp.split(File.pathSeparator).length);
+    private static void classify(File file, Set<File> sources, Set<File> dirs, Set<File> jars) {
+        if (file.isDirectory() && new File(file, ASSET_PREFIX).isDirectory()) {
+            File c = canonical(file);
+            String p = c.getPath().replace('\\', '/');
+            if (p.endsWith("/src/main/resources")) sources.add(c); else dirs.add(c);
+        } else if (file.isFile() && file.getName().toLowerCase().endsWith(".jar") && containsAssets(file)) {
+            jars.add(canonical(file));
         }
     }
 
-    public static List<String> listResources(String dirPrefix, String suffix) {
-        List<String> result = new ArrayList<>();
-
-        if (!dirPrefix.endsWith("/")) dirPrefix = dirPrefix + "/";
-
-        final String jarPrefix = dirPrefix.startsWith("/") ? dirPrefix.substring(1) : dirPrefix;
-
-        if (sourceJar != null && sourceJar.exists() && sourceJar.isFile()) {
-            try (JarFile jar = new JarFile(sourceJar)) {
-                Enumeration<JarEntry> entries = jar.entries();
-                while (entries.hasMoreElements()) {
-                    JarEntry entry = entries.nextElement();
-                    String name = entry.getName();
-                    if (name.startsWith(jarPrefix) && name.endsWith(suffix) && !entry.isDirectory()) {
-                        result.add(name);
-                    }
-                }
-            } catch (Exception e) {
-                MCH_Lib.Log("MCH_ResourceHelper: Failed to enumerate JAR: %s", e.getMessage());
-            }
-        }
-
-        if (result.isEmpty() && devClasspathDirs != null) {
-            for (File cpDir : devClasspathDirs) {
-                File targetDir = new File(cpDir, jarPrefix);
-                if (targetDir.isDirectory()) {
-                    try {
-                        Path dirPath = targetDir.toPath();
-                        Files.walk(dirPath)
-                            .filter(p -> p.toString().endsWith(suffix) && !Files.isDirectory(p))
-                            .forEach(p -> {
-                                String rel = dirPath.relativize(p).toString().replace('\\', '/');
-                                result.add(jarPrefix + rel);
-                            });
-                    } catch (Exception e) {
-                        MCH_Lib.Log("MCH_ResourceHelper: Failed to walk %s: %s", targetDir, e.getMessage());
-                    }
-                }
-            }
-        }
-
-        // Scan addon directory for additional files (additive, never removes JAR entries)
-        if (addonAssetRoots != null && jarPrefix.startsWith(ASSET_PREFIX)) {
-            String relSubdir = jarPrefix.substring(ASSET_PREFIX.length());
-            for (File root : addonAssetRoots) {
-                File addonSubdir = new File(root, ASSET_PREFIX + relSubdir);
-                if (addonSubdir.isDirectory()) {
-                    try {
-                        Path dirPath = addonSubdir.toPath();
-                        Files.walk(dirPath)
-                            .filter(p -> p.toString().endsWith(suffix) && !Files.isDirectory(p))
-                            .forEach(p -> {
-                                String rel = dirPath.relativize(p).toString().replace('\\', '/');
-                                String resourcePath = ASSET_PREFIX + relSubdir + rel;
-                                if (!result.contains(resourcePath)) {
-                                    result.add(resourcePath);
-                                }
-                            });
-                    } catch (Exception e) {
-                        MCH_Lib.Log("MCH_ResourceHelper: Failed to walk addon dir %s: %s", addonSubdir, e.getMessage());
-                    }
-                }
-            }
-        }
-
-        return result;
+    private static boolean containsAssets(File file) {
+        try (JarFile jar = new JarFile(file)) {
+            Enumeration<JarEntry> e = jar.entries();
+            while (e.hasMoreElements()) if (e.nextElement().getName().startsWith(ASSET_PREFIX)) return true;
+        } catch (Exception ignored) {}
+        return false;
     }
 
-    public static boolean resourceExists(String resourcePath) {
-        resourcePath = normalizeAssetPath(resourcePath);
-
-        // Check addon asset roots first (additive overlay)
-        if (addonAssetRoots != null && !addonAssetRoots.isEmpty()) {
-            File addonFile = findAddonResourceFile(resourcePath);
-            if (addonFile != null && addonFile.isFile()) return true;
-        }
-
-        if (sourceJar != null && sourceJar.exists() && sourceJar.isFile()) {
-            try (JarFile jar = new JarFile(sourceJar)) {
-                return jar.getEntry(resourcePath) != null;
-            } catch (Exception e) {
-                return false;
-            }
-        }
-
-        String relPath = resourcePath;
-        if (devClasspathDirs != null) {
-            for (File cpDir : devClasspathDirs) {
-                if (new File(cpDir, relPath).isFile()) return true;
-            }
-        }
-        return MCH_ResourceHelper.class.getResourceAsStream("/" + resourcePath) != null;
-    }
-
-    public static BufferedReader openResource(String resourcePath) {
-        if (!resourcePath.startsWith("/")) resourcePath = "/" + resourcePath;
-
-        // Check addon asset roots first (user overrides take priority)
-        if (addonAssetRoots != null && !addonAssetRoots.isEmpty()) {
-            File addonFile = findAddonResourceFile(resourcePath);
-            if (addonFile != null && addonFile.isFile()) {
-                try {
-                    return new BufferedReader(new InputStreamReader(new FileInputStream(addonFile), StandardCharsets.UTF_8));
-                } catch (FileNotFoundException e) {
-                    // fall through to classpath
-                }
-            }
-        }
-
-        InputStream is = MCH_ResourceHelper.class.getResourceAsStream(resourcePath);
-        if (is == null) return null;
-        return new BufferedReader(new InputStreamReader(is));
-    }
-
-    /**
-     * Opens a resource as an InputStream (for binary resources like .mqo, .obj models).
-     * Checks addon dirs first, then classpath.
-     * Caller is responsible for closing the stream.
-     */
-    public static InputStream openResourceStream(String resourcePath) {
-        if (!resourcePath.startsWith("/")) resourcePath = "/" + resourcePath;
-
-        // Check addon asset roots first
-        if (addonAssetRoots != null && !addonAssetRoots.isEmpty()) {
-            File addonFile = findAddonResourceFile(resourcePath);
-            if (addonFile != null && addonFile.isFile()) {
-                try {
-                    return new FileInputStream(addonFile);
-                } catch (FileNotFoundException e) {
-                    // fall through
-                }
-            }
-        }
-
-        return MCH_ResourceHelper.class.getResourceAsStream(resourcePath);
-    }
-
-    /**
-     * Searches all addon asset roots for a resource file.
-     * Checks nested packs first (higher priority), then flat layout.
-     * Returns the first match found.
-     */
-    private static File findAddonResourceFile(String resourcePath) {
-        String path = normalizeAssetPath(resourcePath);
-        if (!path.startsWith(ASSET_PREFIX)) return null;
-        String relPath = path.substring(ASSET_PREFIX.length());
-
-        // Check nested addon packs first (they can override flat)
-        for (File root : addonAssetRoots) {
-            if (root != addonDir) {
-                File candidate = new File(root, ASSET_PREFIX + relPath);
-                if (candidate.isFile()) return candidate;
-            }
-        }
-        // Check flat layout last
-        if (addonDir != null && addonAssetRoots.contains(addonDir)) {
-            File candidate = new File(addonDir, ASSET_PREFIX + relPath);
-            if (candidate.isFile()) return candidate;
+    private static File findProjectRoot(File from) {
+        for (File f = canonical(from); f != null; f = f.getParentFile()) {
+            if ((new File(f, "build.gradle.kts").isFile() || new File(f, "build.gradle").isFile())
+                    && new File(f, "src/main/resources/" + ASSET_PREFIX).isDirectory()) return f;
         }
         return null;
     }
 
-    /** Classpath and filesystem probes always use an assets/mcheli path. */
-    public static String normalizeAssetPath(String resourcePath) {
-        String path = resourcePath == null ? "" : resourcePath.replace('\\', '/');
+    private static void addIfAssetRoot(Set<File> result, File root) {
+        if (new File(root, ASSET_PREFIX).isDirectory()) result.add(canonical(root));
+    }
+
+    public static synchronized List<String> listResources(String dirPrefix, String suffix) {
+        String prefix = normalizeAssetPath(dirPrefix);
+        if (!prefix.endsWith("/")) prefix += "/";
+        LinkedHashSet<String> result = new LinkedHashSet<String>();
+        // Highest-precedence files are enumerated first, matching openResource.
+        addDirectoryResources(result, addonAssetRoots, prefix, suffix);
+        addDirectoryResources(result, devSourceDirs, prefix, suffix);
+        // An editable tree is authoritative: absent source files are deletions, not jar fallbacks.
+        if (devSourceDirs.isEmpty()) {
+            addDirectoryResources(result, classpathDirs, prefix, suffix);
+            addJarResources(result, jarSources, prefix, suffix);
+        }
+        return new ArrayList<String>(result);
+    }
+
+    private static void addDirectoryResources(Set<String> result, List<File> roots, String prefix, String suffix) {
+        for (File root : roots) {
+            File target = resourceFile(root, prefix);
+            if (!target.isDirectory()) continue;
+            ArrayList<String> found = new ArrayList<String>();
+            try (Stream<Path> paths = Files.walk(target.toPath())) {
+                for (java.util.Iterator<Path> it = paths.iterator(); it.hasNext();) {
+                    Path p = it.next();
+                    if (!Files.isDirectory(p) && p.toString().endsWith(suffix))
+                        found.add(prefix + target.toPath().relativize(p).toString().replace('\\', '/'));
+                }
+            } catch (Exception e) { MCH_Lib.Log("Failed to walk resource root %s: %s", target, e.getMessage()); }
+            Collections.sort(found);
+            result.addAll(found);
+        }
+    }
+
+    private static void addJarResources(Set<String> result, List<File> jars, String prefix, String suffix) {
+        for (File file : jars) try (JarFile jar = new JarFile(file)) {
+            ArrayList<String> found = new ArrayList<String>();
+            Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry e = entries.nextElement();
+                if (!e.isDirectory() && e.getName().startsWith(prefix) && e.getName().endsWith(suffix)) found.add(e.getName());
+            }
+            Collections.sort(found); result.addAll(found);
+        } catch (Exception e) { MCH_Lib.Log("Failed to enumerate resource jar %s: %s", file, e.getMessage()); }
+    }
+
+    public static synchronized boolean resourceExists(String path) {
+        ResolvedResource r = resolve(path);
+        if (r.file != null) return true;
+        if (r.jar != null) { try (JarFile j = new JarFile(r.jar)) { return j.getEntry(r.path) != null; } catch (Exception ignored) {} }
+        return r.classpath && MCH_ResourceHelper.class.getResource("/" + r.path) != null;
+    }
+
+    public static BufferedReader openResource(String path) {
+        InputStream in = openResourceStream(path);
+        return in == null ? null : new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+    }
+
+    public static synchronized InputStream openResourceStream(String path) {
+        ResolvedResource r = resolve(path);
+        try {
+            if (r.file != null) { debugSource(r.path, r.file); return new FileInputStream(r.file); }
+            if (r.jar != null) {
+                // JarFile must remain open until its entry stream is closed.
+                final JarFile jar = new JarFile(r.jar);
+                JarEntry entry = jar.getJarEntry(r.path);
+                if (entry != null) { debugSource(r.path, r.jar); return new java.io.FilterInputStream(jar.getInputStream(entry)) {
+                    public void close() throws java.io.IOException { try { super.close(); } finally { jar.close(); } }
+                }; }
+                jar.close();
+            }
+        } catch (Exception e) { MCH_Lib.Log("Failed to open resource %s: %s", r.path, e.getMessage()); return null; }
+        if (r.classpath) {
+            URL url = MCH_ResourceHelper.class.getResource("/" + r.path);
+            if (url != null) MCH_Lib.DbgLog(false, "Resource %s <- %s", r.path, url);
+            return MCH_ResourceHelper.class.getResourceAsStream("/" + r.path);
+        }
+        return null;
+    }
+
+    private static ResolvedResource resolve(String raw) {
+        String path = normalizeAssetPath(raw);
+        File f = findFile(addonAssetRoots, path);
+        if (f != null) return new ResolvedResource(path, f, null, false);
+        f = findFile(devSourceDirs, path);
+        if (f != null) return new ResolvedResource(path, f, null, false);
+        if (!devSourceDirs.isEmpty()) return new ResolvedResource(path, null, null, false);
+        f = findFile(classpathDirs, path);
+        if (f != null) return new ResolvedResource(path, f, null, false);
+        for (File jar : jarSources) if (jarHas(jar, path)) return new ResolvedResource(path, null, jar, false);
+        return new ResolvedResource(path, null, null, true);
+    }
+
+    private static File findFile(List<File> roots, String path) {
+        for (File root : roots) { File f = resourceFile(root, path); if (f.isFile()) return f; }
+        return null;
+    }
+    private static File resourceFile(File root, String path) {
+        if (root.equals(addonDir) && !new File(root, ASSET_PREFIX).isDirectory() && path.startsWith(ASSET_PREFIX))
+            return new File(root, path.substring(ASSET_PREFIX.length()));
+        return new File(root, path);
+    }
+    private static boolean jarHas(File file, String path) {
+        try (JarFile jar = new JarFile(file)) { return jar.getJarEntry(path) != null; } catch (Exception ignored) { return false; }
+    }
+    private static void debugSource(String path, File source) { MCH_Lib.DbgLog(false, "Resource %s <- %s", path, source); }
+    private static File canonical(File f) { try { return f.getCanonicalFile(); } catch (Exception e) { return f.getAbsoluteFile(); } }
+
+    public static String normalizeAssetPath(String path) {
+        path = path == null ? "" : path.replace('\\', '/');
         while (path.startsWith("/")) path = path.substring(1);
         while (path.contains("//")) path = path.replace("//", "/");
         return path;
     }
+    public static String getFileName(String path) { int i = path.lastIndexOf('/'); return i < 0 ? path : path.substring(i + 1); }
+    public static String getEntryName(String path) { String n = getFileName(path); int i = n.lastIndexOf('.'); return (i > 0 ? n.substring(0, i) : n).toLowerCase(); }
 
-    public static String getFileName(String resourcePath) {
-        int lastSlash = resourcePath.lastIndexOf('/');
-        return lastSlash >= 0 ? resourcePath.substring(lastSlash + 1) : resourcePath;
-    }
-
-    public static String getEntryName(String resourcePath) {
-        String fileName = getFileName(resourcePath);
-        int dot = fileName.lastIndexOf('.');
-        if (dot > 0) fileName = fileName.substring(0, dot);
-        return fileName.toLowerCase();
+    private static final class ResolvedResource {
+        final String path; final File file; final File jar; final boolean classpath;
+        ResolvedResource(String p, File f, File j, boolean c) { path = p; file = f; jar = j; classpath = c; }
     }
 }

--- a/src/main/java/mcheli/command/MCH_Command.java
+++ b/src/main/java/mcheli/command/MCH_Command.java
@@ -14,7 +14,7 @@ import mcheli.MCH_MOD;
 import mcheli.MCH_HBMUtil;
 import mcheli.MCH_Lib;
 import mcheli.MCH_PacketNotifyServerSettings;
-import mcheli.MCH_SoundsJson;
+import mcheli.MCH_ResourceHelper;
 import mcheli.command.MCH_PacketTitle;
 import mcheli.multiplay.MCH_MultiplayPacketHandler;
 import mcheli.multiplay.MCH_PacketIndClient;
@@ -49,6 +49,17 @@ import net.minecraftforge.event.CommandEvent;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class MCH_Command extends CommandBase {
+
+   /** Updates only definition-derived runtime objects; seats and persistent state stay intact. */
+   private static void applyReloadedInfo(mcheli.aircraft.MCH_EntityBaseVehicle vehicle, String name) {
+      mcheli.aircraft.MCH_BaseVehicleInfo info = null;
+      if(vehicle instanceof mcheli.helicopter.MCH_EntityHeli) info = mcheli.helicopter.MCH_HeliInfoManager.get(name);
+      else if(vehicle instanceof mcheli.plane.MCP_EntityPlane) info = mcheli.plane.MCP_PlaneInfoManager.get(name);
+      else if(vehicle instanceof mcheli.ship.MCH_EntityShip) info = mcheli.ship.MCH_ShipInfoManager.get(name);
+      else if(vehicle instanceof mcheli.tank.MCH_EntityTank) info = mcheli.tank.MCH_TankInfoManager.get(name);
+      else if(vehicle instanceof mcheli.vehicle.MCH_EntityTurret) info = mcheli.vehicle.MCH_TurretInfoManager.get(name);
+      if(info != null) vehicle.setAcInfo(info);
+   }
 
    public static final String CMD_GET_SS = "sendss";
    public static final String CMD_MOD_LIST = "modlist";
@@ -183,6 +194,7 @@ public class MCH_Command extends CommandBase {
                    throw new CommandException("Parameter error! : /mcheli reload", new Object[0]);
                 }
 
+                MCH_ResourceHelper.refreshResourceSources();
                 int count = 0;
                 StringBuilder sb = new StringBuilder();
 
@@ -219,18 +231,22 @@ public class MCH_Command extends CommandBase {
                       if(list.get(i) instanceof mcheli.aircraft.MCH_EntityBaseVehicle) {
                          mcheli.aircraft.MCH_EntityBaseVehicle ac =
                             (mcheli.aircraft.MCH_EntityBaseVehicle)list.get(i);
-                         if(ac.getAcInfo() != null) {
-                            ac.changeType(ac.getAcInfo().name);
-                            ac.createSeats(java.util.UUID.randomUUID().toString());
-                         }
+                         if(ac.getAcInfo() != null) applyReloadedInfo(ac, ac.getAcInfo().name);
                       }
                    }
                 }
 
                 // Notify clients to also reload (matters on dedicated servers)
-                mcheli.aircraft.MCH_PacketNotifyInfoReloaded.sendToAllClients(2);
+                boolean notified = false;
+                try {
+                   mcheli.aircraft.MCH_PacketNotifyInfoReloaded.sendToAllClients(2);
+                   notified = true;
+                } catch(Exception notifyError) {
+                   MCH_Lib.Log("Client reload notification failed: %s", notifyError.getMessage());
+                }
 
-                String reloadMsg = "Reloaded " + count + " info types: " + sb.toString();
+                String reloadMsg = "Server info reload: " + count + " types (" + sb.toString()
+                   + "); client notification: " + (notified ? "sent" : "failed");
                 MCH_Lib.Log(reloadMsg);
                 sender.addChatMessage(new ChatComponentText(reloadMsg));
             } else {

--- a/src/main/java/mcheli/multithread/MultiThreadModelManager.java
+++ b/src/main/java/mcheli/multithread/MultiThreadModelManager.java
@@ -16,10 +16,9 @@ import java.util.concurrent.*;
 public class MultiThreadModelManager {
 
     private static final int THREADS = Runtime.getRuntime().availableProcessors();
-    private static final ExecutorService EXECUTOR =
-            Executors.newFixedThreadPool(THREADS);
+    public static synchronized void start(MCH_ClientProxy proxy) {
 
-    public static void start(MCH_ClientProxy proxy) {
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
 
         waitForData("helicopter", MCH_HeliInfoManager.map);
         waitForData("plane", MCP_PlaneInfoManager.map);
@@ -34,7 +33,7 @@ public class MultiThreadModelManager {
         // Helicopters
         for (Object key : MCH_HeliInfoManager.map.keySet()) {
             String name = (String) key;
-            futures.add(EXECUTOR.submit(() ->
+            futures.add(executor.submit(() ->
                     proxy.registerModelsHeli(name, false)
             ));
         }
@@ -42,7 +41,7 @@ public class MultiThreadModelManager {
         // Planes
         for (Object key : MCP_PlaneInfoManager.map.keySet()) {
             String name = (String) key;
-            futures.add(EXECUTOR.submit(() ->
+            futures.add(executor.submit(() ->
                     proxy.registerModelsPlane(name, false)
             ));
         }
@@ -50,7 +49,7 @@ public class MultiThreadModelManager {
         // Ships
         for (Object key : MCH_ShipInfoManager.map.keySet()) {
             String name = (String) key;
-            futures.add(EXECUTOR.submit(() ->
+            futures.add(executor.submit(() ->
                     proxy.registerModelsShip(name, false)
             ));
         }
@@ -58,7 +57,7 @@ public class MultiThreadModelManager {
         // Tanks
         for (Object key : MCH_TankInfoManager.map.keySet()) {
             String name = (String) key;
-            futures.add(EXECUTOR.submit(() ->
+            futures.add(executor.submit(() ->
                     proxy.registerModelsTank(name, false)
             ));
         }
@@ -66,7 +65,7 @@ public class MultiThreadModelManager {
         // Vehicles
         for (Object key : MCH_TurretInfoManager.map.keySet()) {
             String name = (String) key;
-            futures.add(EXECUTOR.submit(() -> {
+            futures.add(executor.submit(() -> {
                 try {
                     proxy.registerModelsVehicle(name, false);
                 } catch (Exception e) {
@@ -88,7 +87,7 @@ public class MultiThreadModelManager {
 
 
 
-        EXECUTOR.shutdown();
+        executor.shutdown();
 
         // Bullets (register once only)
         proxy.registerModels_Bullet();

--- a/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java
@@ -107,16 +107,7 @@ public class W_MetasequoiaObject extends W_ModelCustom {
    public W_MetasequoiaObject(ResourceLocation resource) throws ModelFormatException {
       this.fileName = resource.toString();
 
-      // Try Minecraft's resource manager first (works for JAR-bundled resources)
-      try {
-         IResource e = Minecraft.getMinecraft().getResourceManager().getResource(resource);
-         this.loadObjModel(e.getInputStream());
-         return;
-      } catch (IOException ignored) {
-         // Fall through to MCH_ResourceHelper for addon filesystem resources
-      }
-
-      // Try MCH_ResourceHelper for addon directory files
+      // Use the shared resolver first so editable files beat stale resource packs.
       String assetPath = "assets/" + resource.getResourceDomain() + "/" + resource.getResourcePath();
       InputStream is = mcheli.MCH_ResourceHelper.openResourceStream(assetPath);
       if (is != null) {
@@ -126,6 +117,14 @@ public class W_MetasequoiaObject extends W_ModelCustom {
          } catch (Exception var3) {
             throw new ModelFormatException("IO Exception reading model format:" + this.fileName, var3);
          }
+      }
+
+      try {
+         IResource e = Minecraft.getMinecraft().getResourceManager().getResource(resource);
+         this.loadObjModel(e.getInputStream());
+         return;
+      } catch (IOException ignored) {
+         // Fall through to MCH_ResourceHelper for addon filesystem resources
       }
 
       throw new ModelFormatException("IO Exception reading model format:" + this.fileName);

--- a/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java
@@ -56,16 +56,7 @@ public class W_WavefrontObject extends W_ModelCustom {
    public W_WavefrontObject(ResourceLocation resource) throws ModelFormatException {
       this.fileName = resource.toString();
 
-      // Try Minecraft's resource manager first
-      try {
-         IResource e = Minecraft.getMinecraft().getResourceManager().getResource(resource);
-         this.loadObjModel(e.getInputStream());
-         return;
-      } catch (IOException ignored) {
-         // Fall through to MCH_ResourceHelper for addon directory files
-      }
-
-      // Try MCH_ResourceHelper for addon directory files
+      // Use the shared resolver first so editable files beat stale resource packs.
       String assetPath = "assets/" + resource.getResourceDomain() + "/" + resource.getResourcePath();
       InputStream is = mcheli.MCH_ResourceHelper.openResourceStream(assetPath);
       if (is != null) {
@@ -75,6 +66,14 @@ public class W_WavefrontObject extends W_ModelCustom {
          } catch (Exception var3) {
             throw new ModelFormatException("IO Exception reading model format", var3);
          }
+      }
+
+      try {
+         IResource e = Minecraft.getMinecraft().getResourceManager().getResource(resource);
+         this.loadObjModel(e.getInputStream());
+         return;
+      } catch (IOException ignored) {
+         // Fall through to MCH_ResourceHelper for addon directory files
       }
 
       throw new ModelFormatException("IO Exception reading model format:" + this.fileName);

--- a/src/test/java/mcheli/MCH_ResourceHelperTest.java
+++ b/src/test/java/mcheli/MCH_ResourceHelperTest.java
@@ -1,0 +1,102 @@
+package mcheli;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MCH_ResourceHelperTest {
+    private String oldUserDir;
+    private String oldClasspath;
+    private File project;
+
+    @Before public void setUp() throws Exception {
+        oldUserDir = System.getProperty("user.dir");
+        oldClasspath = System.getProperty("java.class.path");
+        project = Files.createTempDirectory("mch-live-resources").toFile();
+        new File(project, "build.gradle.kts").createNewFile();
+        new File(project, "src/main/resources/assets/mcheli/test").mkdirs();
+        System.setProperty("user.dir", new File(project, "run").getPath());
+        new File(project, "run").mkdirs();
+        MCH_ResourceHelper.setSourceJar(null);
+        MCH_ResourceHelper.setAddonDir(new File(project, "run/mcheli_addons"));
+    }
+
+    @After public void tearDown() {
+        System.setProperty("user.dir", oldUserDir);
+        System.setProperty("java.class.path", oldClasspath);
+        MCH_ResourceHelper.setAddonDir(null);
+        MCH_ResourceHelper.discoverDevClasspath();
+    }
+
+    @Test public void liveSourceIsAuthoritativeAndAllApisAgree() throws Exception {
+        File source = write("src/main/resources/assets/mcheli/test/shared.txt", "source");
+        File generated = write("build/resources/main/assets/mcheli/test/shared.txt", "generated");
+        write("build/resources/main/assets/mcheli/test/deleted.txt", "stale");
+        File jar = new File(project, "dev.jar");
+        makeJar(jar, "assets/mcheli/test/shared.txt", "jar");
+        System.setProperty("java.class.path", new File(project, "build/resources/main").getPath()
+                + File.pathSeparator + jar.getPath());
+
+        MCH_ResourceHelper.refreshResourceSources();
+        assertTrue(MCH_ResourceHelper.resourceExists("\\assets\\mcheli\\test\\shared.txt"));
+        assertEquals("source", read(MCH_ResourceHelper.openResource("/assets/mcheli/test/shared.txt")));
+        assertEquals("source", read(MCH_ResourceHelper.openResourceStream("//assets//mcheli//test//shared.txt")));
+        assertFalse("a deleted source asset must not fall back to generated output",
+                MCH_ResourceHelper.resourceExists("assets/mcheli/test/deleted.txt"));
+        assertEquals(1, MCH_ResourceHelper.listResources("/assets/mcheli/test", ".txt").size());
+
+        File added = write("src/main/resources/assets/mcheli/test/added.txt", "new");
+        MCH_ResourceHelper.refreshResourceSources();
+        assertTrue(MCH_ResourceHelper.listResources("assets/mcheli/test", ".txt").contains(
+                "assets/mcheli/test/added.txt"));
+        assertTrue(added.delete());
+        assertTrue(source.isFile());
+    }
+
+    @Test public void addonOverridesSourceAndRefreshFindsNewPackWithoutDuplicates() throws Exception {
+        write("src/main/resources/assets/mcheli/test/shared.txt", "source");
+        MCH_ResourceHelper.refreshResourceSources();
+        File addon = write("run/mcheli_addons/pack/assets/mcheli/test/shared.txt", "addon");
+        MCH_ResourceHelper.refreshResourceSources();
+        assertEquals("addon", read(MCH_ResourceHelper.openResourceStream("assets/mcheli/test/shared.txt")));
+        for (int i = 0; i < 20; ++i) {
+            MCH_ResourceHelper.refreshResourceSources();
+            List<String> paths = MCH_ResourceHelper.listResources("assets/mcheli/test", ".txt");
+            assertEquals(1, paths.size());
+            assertEquals("addon", read(MCH_ResourceHelper.openResource(paths.get(0))));
+        }
+        assertTrue("streams must not keep addon files open", addon.delete());
+    }
+
+    @Test public void normalizesSeparatorsAndLeadingSlashes() {
+        assertEquals("assets/mcheli/a.txt", MCH_ResourceHelper.normalizeAssetPath("//assets\\mcheli//a.txt"));
+    }
+
+    private File write(String relative, String value) throws Exception {
+        File f = new File(project, relative); f.getParentFile().mkdirs();
+        Files.write(f.toPath(), value.getBytes(StandardCharsets.UTF_8)); return f;
+    }
+    private static String read(BufferedReader reader) throws Exception {
+        assertNotNull(reader); try { return reader.readLine(); } finally { reader.close(); }
+    }
+    private static String read(InputStream stream) throws Exception {
+        assertNotNull(stream); try { byte[] b = new byte[64]; int n = stream.read(b); return new String(b, 0, n, StandardCharsets.UTF_8); }
+        finally { stream.close(); }
+    }
+    private static void makeJar(File file, String path, String value) throws Exception {
+        JarOutputStream out = new JarOutputStream(new FileOutputStream(file));
+        try { out.putNextEntry(new JarEntry(path)); out.write(value.getBytes(StandardCharsets.UTF_8)); out.closeEntry(); }
+        finally { out.close(); }
+    }
+}


### PR DESCRIPTION
### Motivation

- Fix /mcheli reload so development runs read live editable assets (src/main/resources/assets/mcheli) instead of stale generated or JAR copies.
- Make resource discovery deterministic and consistent across listing, existence checks, and open/stream APIs so clients and servers see the same authoritative files. 
- Refresh client-side models, textures, HUDs and sounds on the Minecraft client thread while preserving loaded vehicle runtime state. 
- Provide developer-visible behavior and documentation so manual verification is possible without forcing Gradle resource tasks or a full restart.

### Description

- Rewrote `MCH_ResourceHelper` to separately track addon roots, editable development source dirs, ordinary classpath dirs, and JAR sources, to deterministically enumerate and open resources with the precedence: external addon > editable source > classpath dir > JAR; and to open live files with `FileInputStream` and close JAR/Files.walk streams correctly. (src/main/java/mcheli/MCH_ResourceHelper.java)
- Made addon discovery refreshable and supported both nested and flat `mcheli_addons` layouts; added debug-only logging that shows the physical source for a reloaded resource. (src/main/java/mcheli/MCH_ResourceHelper.java, src/main/java/mcheli/MCH_AddonResourcePack.java)
- Ensure discovery is refreshed before server-side info reloads by calling `MCH_ResourceHelper.refreshResourceSources()` from the `/mcheli reload` flow and updated the server message to report server reload and client-notify results separately; re-apply new info to loaded vehicles without deleting or recreating seats. (src/main/java/mcheli/command/MCH_Command.java)
- Update client reload path so `scheduleClientInfoReload()` refreshes development sources, calls `Minecraft.refreshResources()` on the client thread, reloads info maps, clears model/display-list caches, forces model map replacement, registers models (serialized), reloads HUD, and regenerates/refreshes sounds where applicable. (src/main/java/mcheli/MCH_ClientProxy.java, src/main/java/mcheli/MCH_ModelManager.java)
- Make model loaders consult the shared resolver first so editable MQO/OBJ/TCN files win over stale resource-pack classpath entries. (src/main/java/mcheli/wrapper/modelloader/W_MetasequoiaObject.java, src/main/java/mcheli/wrapper/modelloader/W_WavefrontObject.java)
- Serialize multithreaded model registration executor usage and avoid overlapping global executor reuse; make multithread manager create a new executor per run. (src/main/java/mcheli/multithread/MultiThreadModelManager.java)
- Preserve atomic information-map replacement and publish an empty map when an authoritative editable asset root becomes empty so deletions are applied during reload. (src/main/java/mcheli/MCH_InfoManagerBase.java)
- Add focused unit tests that exercise resource-source selection, precedence, refresh, deletion masking, path normalization, duplicate prevention, and stream closure; and update docs and CHANGELOG describing live-reload behavior and the manual verification steps. (src/test/java/mcheli/MCH_ResourceHelperTest.java, docs/commands.md, CHANGELOG.md)

### Testing

- Ran repository static and structural checks: `git diff --check`, textual Java delimiter checks and lightweight structural assertions, and a binary-patch absence check; all passed. 
- Added focused JUnit tests for resource precedence and refresh semantics (`MCH_ResourceHelperTest`), but per repository constraints the Gradle test/compile tasks and `runClient` were not executed. 
- Performed repository-level validation (status/diff checks) to ensure no binary files were added and changes were committed; no automated compile/runtime verification was performed. 
- Manual run instructions and a developer verification checklist were added to `docs/commands.md` to exercise live reload behavior in a Forge 1.7.10 development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eaa03fa0c8323b8987a30e0d33dfc)