### PR TITLE
Fix AA missile target validation and server null target handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Fix AA missile target validation and server null target handling (PR pending)
+
+- Reject null, dead, self, cross-world, unloaded, stale, and vehicle-occupant targets through the shared client/server guidance validator.
+- Keep ordinary players and mobs in the Ground domain regardless of jumping or falling, while classifying aircraft separately by real collision contact.
+- Clear stale client entity options before lock acquisition and reject zero or invalid target IDs before server missile creation, sound, ammunition, or cooldown handling.
+- Audit all runtime and reference AA missile assets; no weapon configuration changes were required.
+
 # Forge 1.7.10 development asset live reload (PR pending)
 
 - Make `/mcheli reload` prefer external addons and the editable `src/main/resources/assets/mcheli` tree over generated classpath output and development JARs.

--- a/docs/missile-target-domain-audit.md
+++ b/docs/missile-target-domain-audit.md
@@ -13,9 +13,18 @@ This audit traces every repository weapon configured as `ATMissile`, `ASMissile`
 1. Planes and helicopters are **Ground** while `onGround` is true or a narrow block-collision probe immediately below their complete bounding box finds contact; otherwise they are **Air**. Speed and `LockMinHeight` are not part of aircraft contact detection.
 2. Tanks, static turrets, UAV stations, and compatible external ground vehicle/mecha/AA-gun roles are **Ground**, even while jumping or crossing rough terrain.
 3. Ships are **Surface**; a diving ship entity in water is **Underwater**. Surface/underwater permissions remain separate from ground permission and use the existing water permission for backward compatibility.
-4. Unknown living/non-vehicle targets fall back to physical state. The fallback honors `onGround`, and always probes immediately below the bounding box even when `LockMinHeight = 0`; positive `LockMinHeight` retains its extra look-down meaning.
+4. Ordinary players and mobs have a stable **Ground** role regardless of `onGround`, jumping, falling, or block proximity. Unknown non-living entities are **Unknown** and are not lockable. `LockMinHeight` remains seeker behavior and does not define aircraft contact.
 5. Unknown MCHeli base-vehicle roles are not guessed from block contact. External compatibility name checks remain in place and now map their established roles to a stable domain.
 6. Weapon class permissions remain final: AA enables Air; AT enables Ground; immersion still requires `canLockInWater`; missile locking still requires `canLockMissile`; custom checkers run after basic domain checks.
+7. Target category is evaluated separately from domain. Aircraft retain the Aircraft category after landing (and therefore become valid Ground targets for AT weapons), while their occupants are not exposed as separate targets. Ships, submarines, and their existing Surface/Underwater behavior are unchanged.
+
+## Invalid entity-id correction
+
+The client weapon option could retain the ID from an earlier completed lock. By the time the server handled the control packet, `World.getEntityByID` could return `null` because the target died or unloaded; the public lock validator then dereferenced that value. A reused ID could likewise resolve to a different role. Client acquisition now resets the option to zero before every ordinary seeker attempt and writes an ID only after the completed target passes the shared validator again.
+
+The server rejects option zero and repeats the shared null, liveness, identity, world membership, canonical entity-ID, occupant, category/domain, seeker, countermeasure, range, angle, stealth, custom-checker, water, missile ownership, and line-of-sight checks. A rejected `shot` returns `false` before sound or entity creation, so `MCH_WeaponSet.use` does not apply ammunition, heat, reload, cooldown, or weapon-index state. No exception is logged for a stale ID.
+
+`PassiveRadar` and `ActiveRadar` remain the explicit configuration switches for targetless launch: those weapons deliberately launch into their existing post-launch search or continuous-designation flow. Other AA and AT missiles require a completely validated selected entity both on the HUD/client and at server launch.
 
 ## Corrected end-to-end behavior
 
@@ -33,7 +42,7 @@ Active AA and AT scans and in-flight homing use the same role/domain and counter
 
 ## Weapon asset result
 
-Every file under both weapon directories was inspected for the requested type, seeker, radar, laser, height, range, angle, fuze, rider, and missile-interception fields. **No weapon asset change was required.** In particular, `agm114.txt` and `mqagm114.txt` remain `ATMissile` weapons with `LockMinHeight = 0`; landed-aircraft support is supplied by the shared domain rule, not an air-lock permission or weapon-name exception. Existing multi-mode seeker flags were retained because the runtime countermeasure behavior is explicitly driven by those configured capabilities. Runtime and `configreference` assets therefore remain synchronized.
+Every file under both weapon directories was inspected for the requested type, seeker, radar, laser, height, range, angle, fuze, rider, and missile-interception fields, including all 178 AA missile definitions in each tree. **No weapon asset change was required.** In particular, `agm114.txt` and `mqagm114.txt` remain `ATMissile` weapons with `LockMinHeight = 0`; landed-aircraft support is supplied by the shared domain rule, not an air-lock permission or weapon-name exception. Existing multi-mode seeker flags and explicit passive/active radar launch modes were retained because runtime countermeasure and targetless-launch behavior is driven by those configured capabilities. Runtime and `configreference` assets therefore remain synchronized.
 
 ## Per-weapon audit
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java
@@ -34,6 +34,9 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
    public boolean shot(MCH_WeaponParam prm) {
       boolean result = false;
       if(!super.worldObj.isRemote) {
+         if(prm == null || prm.user == null || prm.entity == null) {
+            return false;
+         }
          if(getInfo().passiveRadar || getInfo().activeRadar) {
             this.playSound(prm.entity);
 
@@ -49,7 +52,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
             double tZ = MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tY = -MathHelper.sin(pitch / 180.0F * 3.1415927F);
             MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
-            if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
+            if (yaw > 180.0F) {
                yaw -= 360.0F;
             } else if (yaw < -180.0F) {
                yaw += 360.0F;
@@ -59,6 +62,9 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
             super.worldObj.spawnEntityInWorld(e);
             result = true;
          } else {
+            if(prm.option1 == 0) {
+               return false;
+            }
             Entity tgtEnt = prm.user.worldObj.getEntityByID(prm.option1);
             if (super.guidanceSystem.canLaunchAt(prm.user, tgtEnt)) {
                this.playSound(prm.entity);
@@ -74,7 +80,7 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
                double tZ = (double) (MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tY = (double) (-MathHelper.sin(pitch / 180.0F * 3.1415927F));
                MCH_EntityAAMissile e = new MCH_EntityAAMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
-               if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
+               if (yaw > 180.0F) {
                   yaw -= 360.0F;
                } else if (yaw < -180.0F) {
                   yaw += 360.0F;
@@ -89,9 +95,13 @@ public class MCH_WeaponAAMissile extends MCH_WeaponEntitySeeker {
       } else {
          if(getInfo().passiveRadar || getInfo().activeRadar) {
             result = true;
-         } else if (super.guidanceSystem.lock(prm.user) && super.guidanceSystem.lastLockEntity != null) {
-            result = true;
-            super.optionParameter1 = W_Entity.getEntityId(super.guidanceSystem.lastLockEntity);
+         } else {
+            super.optionParameter1 = 0;
+            if(super.guidanceSystem.lock(prm.user) && super.guidanceSystem.lastLockEntity != null
+                    && super.guidanceSystem.canLockEntity(prm.user, super.guidanceSystem.lastLockEntity)) {
+               result = true;
+               super.optionParameter1 = W_Entity.getEntityId(super.guidanceSystem.lastLockEntity);
+            }
          }
       }
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponATMissile.java
@@ -48,6 +48,9 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
    public boolean shot(MCH_WeaponParam prm) {
       boolean result = false;
       if(!super.worldObj.isRemote) {
+         if(prm == null || prm.user == null || prm.entity == null) {
+            return false;
+         }
          if(getInfo().passiveRadar || getInfo().activeRadar) {
             this.playSound(prm.entity);
 
@@ -63,7 +66,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
             double tZ = MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F);
             double tY = -MathHelper.sin(pitch / 180.0F * 3.1415927F);
             MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
-            if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
+            if (yaw > 180.0F) {
                yaw -= 360.0F;
             } else if (yaw < -180.0F) {
                yaw += 360.0F;
@@ -74,6 +77,9 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
             super.worldObj.spawnEntityInWorld(e);
             result = true;
          } else {
+            if(prm.option1 == 0) {
+               return false;
+            }
             Entity tgtEnt = prm.user.worldObj.getEntityByID(prm.option1);
             if (super.guidanceSystem.canLaunchAt(prm.user, tgtEnt)) {
                this.playSound(prm.entity);
@@ -89,7 +95,7 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
                double tZ = (double) (MathHelper.cos(yaw / 180.0F * 3.1415927F) * MathHelper.cos(pitch / 180.0F * 3.1415927F));
                double tY = (double) (-MathHelper.sin(pitch / 180.0F * 3.1415927F));
                MCH_EntityATMissile e = new MCH_EntityATMissile(super.worldObj, prm.posX, prm.posY, prm.posZ, tX, tY, tZ, yaw, pitch, super.getEffectiveLaunchAcceleration());
-               if (yaw > 180.0F) {//so we are just basically defining yaw to like not go 360 mlg mode right hopefully pray to god it works okay
+               if (yaw > 180.0F) {
                   yaw -= 360.0F;
                } else if (yaw < -180.0F) {
                   yaw += 360.0F;
@@ -105,10 +111,14 @@ public class MCH_WeaponATMissile extends MCH_WeaponEntitySeeker {
       } else {
          if(getInfo().passiveRadar || getInfo().activeRadar) {
             result = true;
-         } else if (super.guidanceSystem.lock(prm.user) && super.guidanceSystem.lastLockEntity != null) {
-            result = true;
-            super.optionParameter1 = W_Entity.getEntityId(super.guidanceSystem.lastLockEntity);
-            super.optionParameter2 = this.getCurrentMode();
+         } else {
+            super.optionParameter1 = 0;
+            if(super.guidanceSystem.lock(prm.user) && super.guidanceSystem.lastLockEntity != null
+                    && super.guidanceSystem.canLockEntity(prm.user, super.guidanceSystem.lastLockEntity)) {
+               result = true;
+               super.optionParameter1 = W_Entity.getEntityId(super.guidanceSystem.lastLockEntity);
+               super.optionParameter2 = this.getCurrentMode();
+            }
          }
       }
 

--- a/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
+++ b/src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java
@@ -35,6 +35,16 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       UNKNOWN
    }
 
+   public enum TargetCategory {
+      AIRCRAFT,
+      GROUND_VEHICLE,
+      SHIP,
+      LIVING,
+      MISSILE,
+      COUNTERMEASURE,
+      UNKNOWN
+   }
+
    public World worldObj;
    protected Entity user;
    public Entity lastLockEntity;
@@ -181,7 +191,47 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       if(entity instanceof MCH_EntityBaseVehicle) {
          return TargetDomain.UNKNOWN;
       }
-      return isEntityOnGround(entity, groundProbeHeight) ? TargetDomain.GROUND : TargetDomain.AIR;
+      // A transient movement state does not change an ordinary entity's physical role.
+      // In particular, jumping players and falling mobs are not aircraft.
+      if(W_Lib.isEntityLivingBase(entity)) {
+         return TargetDomain.GROUND;
+      }
+      return TargetDomain.UNKNOWN;
+   }
+
+   /** Returns the stable role independently of the target's current physical domain. */
+   public static TargetCategory getTargetCategory(Entity entity) {
+      if(entity == null || entity.isDead) {
+         return TargetCategory.UNKNOWN;
+      }
+      if(entity instanceof MCH_EntityFlare || entity instanceof MCH_EntityChaff) {
+         return TargetCategory.COUNTERMEASURE;
+      }
+      if(entity instanceof MCH_EntityBaseBullet) {
+         return TargetCategory.MISSILE;
+      }
+      if(entity instanceof MCP_EntityPlane || entity instanceof MCH_EntityHeli) {
+         return TargetCategory.AIRCRAFT;
+      }
+      if(entity instanceof MCH_EntityShip) {
+         return TargetCategory.SHIP;
+      }
+      if(entity instanceof MCH_EntityTank || entity instanceof MCH_EntityTurret
+              || entity instanceof MCH_EntityUavStation) {
+         return TargetCategory.GROUND_VEHICLE;
+      }
+      String className = entity.getClass().getName();
+      if(className.indexOf("EntityPlane") >= 0) {
+         return TargetCategory.AIRCRAFT;
+      }
+      if(className.indexOf("EntityVehicle") >= 0 || className.indexOf("EntityMecha") >= 0
+              || className.indexOf("EntityAAGun") >= 0) {
+         return TargetCategory.GROUND_VEHICLE;
+      }
+      if(W_Lib.isEntityLivingBase(entity)) {
+         return TargetCategory.LIVING;
+      }
+      return TargetCategory.UNKNOWN;
    }
 
    private boolean isDomainAllowed(Entity entity) {
@@ -211,7 +261,10 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
    }
 
    public boolean lock(Entity user, boolean isLockContinue) {
-
+      if(user == null || user.isDead || this.worldObj == null || user.worldObj != this.worldObj) {
+         this.clearLock();
+         return false;
+      }
       // If server side, returns immediately
       if(!this.worldObj.isRemote) {
          return false;
@@ -230,11 +283,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
             for(int i = 0; i < canLock.size(); ++i) {
                Entity currentEntity = (Entity)canLock.get(i);
                // Checks whether entity can be locked
-               if(this.canLockEntity(currentEntity) ) { //please fucking work
-                  //&& !this.aircraft.isFreeLookMode()
-                  //do not fucking do this here god hates this
-                  //&& !this.aircraft.isFreeLookMode()
-                  //todo here I CANT FUCKING ACCESS THIS SHIT FROM HERE AAAAA //this.aircraft.isFreeLookMode()
+               if(this.canLockEntity(currentEntity)) {
                   dz = currentEntity.posX - user.posX;
                   double dy = currentEntity.posY - user.posY;
                   double dz1 = currentEntity.posZ - user.posZ;
@@ -274,23 +323,12 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
                }
             }
 
-            //todo here
-            //if (this.aircraft.isFreeLookMode()) {
-            //   canLockTarget = false;
-            //}
-            //should work please I pray actually I should probably use the bullshit below this for that because
-            // I assigned aircraft earlier and java just fucking hates actual working logic because fuck you also
-            // fucking goddamn it has no constructor or some bullshit idk fuck this goddamn mod
-
-            //no god hates ts
-
             MCH_EntityBaseVehicle ac = null; //Entity ridden by the player
             if(user.ridingEntity instanceof MCH_EntityBaseVehicle) {
                ac = (MCH_EntityBaseVehicle)user.ridingEntity;
 
                if (ac.isFreeLookMode() && this.canLockInAir && (ac instanceof MCP_EntityPlane)) {
                   canLockTarget = false;
-                  //NO MORE BITCH SHIT
                }
 
             } else if(user.ridingEntity instanceof MCH_EntitySeat) {
@@ -408,12 +446,17 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
       this.lockCount = 0;
       this.continueLockCount = 0;
       this.lockSoundCount = 0;
-      if(this.lastLockEntity != null && this.lastLockEntity.isDead) {
+      if(this.lastLockEntity != null && (this.lastLockEntity.isDead
+              || this.lastLockEntity.worldObj == null
+              || this.lastLockEntity.worldObj.getEntityByID(this.lastLockEntity.getEntityId()) != this.lastLockEntity)) {
          this.lastLockEntity = null;
       }
    }
 
    public Entity getLockEntity(Entity entity) {
+      if(entity == null) {
+         return null;
+      }
       if(entity.ridingEntity instanceof MCH_EntityUavStation) {
          MCH_EntityUavStation us = (MCH_EntityUavStation)entity.ridingEntity;
          if(us.getControlAircract() != null) {
@@ -425,6 +468,12 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
    }
 
    public boolean canLockEntity(Entity entity) {
+      if(!isBasicTargetValid(this.user, entity)) {
+         return false;
+      }
+      if(isVehicleOccupant(entity)) {
+         return false;
+      }
       // If locking players is not allowed and entity is a player, returns false
       if(this.ridableOnly && entity instanceof EntityPlayer && entity.ridingEntity == null) {
          return false;
@@ -475,16 +524,41 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
    }
 
    public boolean canLockEntity(Entity shooter, Entity entity) {
+      if(!isBasicTargetValid(shooter, entity)) {
+         return false;
+      }
       this.user = shooter;
       return canLockEntity(entity);
    }
 
+   private static boolean isBasicTargetValid(Entity shooter, Entity target) {
+      return shooter != null && target != null && !shooter.isDead && !target.isDead
+              && !W_Entity.isEqual(shooter, target) && shooter.worldObj != null
+              && shooter.worldObj == target.worldObj
+              && target.worldObj.getEntityByID(target.getEntityId()) == target;
+   }
+
+   private static boolean isVehicleOccupant(Entity entity) {
+      if(entity == null || entity.ridingEntity == null) {
+         return false;
+      }
+      Entity mount = entity.ridingEntity;
+      if(mount instanceof MCH_EntitySeat) {
+         return ((MCH_EntitySeat)mount).getParent() != null;
+      }
+      return mount instanceof MCH_EntityBaseVehicle || mount instanceof MCH_EntityUavStation;
+   }
+
    /** Server-side validation for the entity id supplied by the client. */
    public boolean canLaunchAt(Entity shooter, Entity entity) {
-      if(shooter == null || !canLockEntity(shooter, entity)) {
+      if(!isBasicTargetValid(shooter, entity) || this.worldObj == null
+              || shooter.worldObj != this.worldObj || !canLockEntity(shooter, entity)) {
          return false;
       }
       Entity locker = getLockEntity(shooter);
+      if(locker == null || locker.worldObj != this.worldObj) {
+         return false;
+      }
       double dx = entity.posX - shooter.posX;
       double dy = entity.posY - shooter.posY;
       double dz = entity.posZ - shooter.posZ;
@@ -502,7 +576,7 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
    public static boolean isEligibleMissileTarget(Entity target, Entity shooter, MCH_WeaponInfo info,
            boolean allowGround, boolean allowAir, boolean allowWater) {
-      if(target == null || info == null || target.isDead || W_Entity.isEqual(target, shooter)) {
+      if(info == null || !isBasicTargetValid(shooter, target) || isVehicleOccupant(target)) {
          return false;
       }
       if(target instanceof MCH_EntityFlare || target instanceof MCH_EntityChaff) {
@@ -547,6 +621,10 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
 
    public static boolean inLockAngle(Entity entity, float rotationYaw, float rotationPitch, Entity target, float lockAng) {
+      if(entity == null || target == null || entity.isDead || target.isDead
+              || entity.worldObj == null || entity.worldObj != target.worldObj) {
+         return false;
+      }
       double dx = target.posX - entity.posX;
       double dy = target.posY + (double)(target.height / 2.0F) - entity.posY;
       double dz = target.posZ - entity.posZ;
@@ -566,16 +644,16 @@ public class MCH_WeaponGuidanceSystem extends MCH_EntityGuidanceSystem {
 
    @Override
    public double getLockPosX() {
-      return targetEntity.posX;
+      return targetEntity != null ? targetEntity.posX : 0.0D;
    }
 
    @Override
    public double getLockPosY() {
-      return targetEntity.posY;
+      return targetEntity != null ? targetEntity.posY : 0.0D;
    }
 
    @Override
    public double getLockPosZ() {
-      return targetEntity.posZ;
+      return targetEntity != null ? targetEntity.posZ : 0.0D;
    }
 }


### PR DESCRIPTION
### Motivation

- Prevent server `NullPointerException` and incorrect AA locks by making all public target-validation paths null-safe and consistent between client acquisition and server launch validation. 
- Ensure missiles cannot lock or spawn against invalid, stale, unloaded, same-world-mismatch, dead, self, or occupant targets while preserving intended seeker and passive/active-radar behaviors. 
- Keep target-category/domain rules stable so living entities are not classified as airborne merely from transient motion and landed aircraft are treated as grounded aircraft for AT weapons.

### Description

- Centralized and hardened validation in `MCH_WeaponGuidanceSystem`: added stable `TargetCategory`, tightened `getTargetDomain` behavior for living vs. aircraft, added `getTargetCategory`, and introduced `isBasicTargetValid` and `isVehicleOccupant` helpers to reject null, dead, self, cross-world, stale/unloaded-ID, and occupant cases. (modified `src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java`).
- Made lock and angle helper methods null-safe and defensive, protected `getLockEntity` and lock-position accessors against null, and cleared stale `lastLockEntity` when it is dead or no longer canonical in the world. (modified `src/main/java/mcheli/weapon/MCH_WeaponGuidanceSystem.java`).
- Prevented invalid launches in entity-guided seekers by validating parameters and resolved entity IDs before playing sound, spawning missiles, or changing weapon option/cooldown/ammo state; reject `option1 == 0` and missing `prm` fields. (modified `src/main/java/mcheli/weapon/MCH_WeaponAAMissile.java` and `src/main/java/mcheli/weapon/MCH_WeaponATMissile.java`).
- Kept explicit `PassiveRadar`/`ActiveRadar` behavior unchanged (they still allow targetless launch/search) while requiring a fully validated target for ordinary AA/AT launches and ensuring the server repeats the full eligibility checks prior to spawn. (docs and code). 
- Documentation and changelog updates: added a changelog entry and expanded `docs/missile-target-domain-audit.md` describing the final classification, client/server validation flow, and the invalid entity-id correction.

### Testing

- Ran repository static and asset checks: `git diff --check` and a brace-balance check for modified Java files, both succeeded. 
- Performed an AA asset parser audit using Python that compared runtime and `configreference` definitions and confirmed 178 runtime and 178 reference AA missile entries with no missing counterparts and no relevant setting differences. 
- Ran targeted source checks (profanity grep and other quick safety scans) which passed and ensured edited files contain balanced braces and no leftover profane comments. 
- Did not run `./gradlew build` or any Minecraft/Forge integration because compilation and live server tests are disallowed in this environment; integrated and dedicated-server gameplay verification remain manual and are documented in `docs/missile-target-domain-audit.md` for follow-up testing (lock/firing cases, stale/unloaded ID handling, ammo/cooldown preservation, countermeasure behavior, and passive/active radar launch rules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eaf8e36808323bdaae758d348c78c)