### PR TITLE
Fix targeted vehicle reload identity and GUI workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -468,3 +468,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 
 * Replaced watcher-only respawn success with bounded server-to-client probes and detailed client-to-server resolution evidence.
 * Targetedly resend only missing normal parents and then their dependents, with two-attempt and 60-tick limits; UAV paths remain unchanged.
+# Fix targeted vehicle configuration reload
+
+- Match client and server vehicles by their synchronized entity ID instead of comparing side-local entity UUIDs.
+- Close the development GUI as soon as a targeted request is sent, while a client-side pending request tracks the response, timeout, and world lifetime.
+- Reload and apply only the selected definition and its models, preserving runtime vehicle state and rejecting seat-count changes before publication.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -96,8 +96,11 @@ The Development GUI deliberately provides four separate scopes:
 - **Reload vehicle configuration settings** targets only the definition selected by the
   MCHeli vehicle the player currently rides or controls. The server validates that entity,
   replaces one manager entry, applies it only to that entity, and the client reloads only
-  that definition's main/part models and item/LOD caches. The button stays disabled while
-  the request is pending; seat-count changes are rejected as restart-required.
+  that definition's main/part models and item/LOD caches. Pressing the button immediately
+  closes the GUI and unpauses an integrated game; completion is reported in chat. A pending
+  request is owned by the client proxy rather than the closed screen and is cleared by a
+  response, a ten-second timeout, disconnect, or world replacement. The button stays
+  disabled while a request is pending; seat-count changes are rejected as restart-required.
 - **Reload All Weapons** reloads weapon definitions. It does not reload vehicle definitions.
 - **Reload All HUD** reloads HUD definitions. It does not trigger the vehicle button.
 - **`/mcheli reload`** remains the expensive complete development reload for all information
@@ -105,6 +108,10 @@ The Development GUI deliberately provides four separate scopes:
 
 The targeted vehicle button never scans loaded worlds or other vehicles with the same name,
 and does not recreate seats or reset the selected vehicle's riders and runtime state.
+Most definition values are read through the newly installed information snapshot. Runtime
+dimensions, step height, extra collision boxes, camera bounds, force-spawn policy, and APS
+timings/range/capacity are refreshed explicitly. Changing the combined seat/rack count still
+requires a restart, as does adding content that requires registration of a new Minecraft item.
 
 In a repository development run, `/mcheli reload` reads the editable
 `src/main/resources/assets/mcheli` tree directly. Running `processResources`, relogging, and
@@ -121,6 +128,17 @@ throttle, and weapon state while definition-derived objects are refreshed. Defin
 which require a newly registered Minecraft item still print the existing restart warning.
 
 ### Manual verification
+
+For the targeted vehicle button:
+
+1. Start `runClient`, enter an existing MCHeli vehicle, and open the Development GUI.
+2. Change a visible value in that vehicle's source `.txt` and press **Reload vehicle configuration settings**.
+3. Confirm the GUI closes immediately, gameplay resumes without **Save & Close**, chat reports success, and the edited value is active.
+4. Confirm no controlled-vehicle-change error appears, then edit the selected MQO/OBJ model and repeat.
+5. Confirm only the selected entity/model changes and that seats, riders, fuel, health, ammunition, ownership, locks, and throttle remain unchanged.
+6. Repeat several times and check for crashes, stale requests, duplicate seats, or display-list growth.
+
+For the complete reload command:
 
 1. Start `runClient`, enter a world, and use an existing MCHeli vehicle.
 2. Edit its source `.txt`, run `/mcheli reload`, and confirm the value changes in place.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -246,6 +246,7 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    }
 
    public void onTickPre() {
+      MCH_MOD.proxy.tickTargetedVehicleReload();
       boolean replayActive = MCH_ReplayModCompat.updatePlaybackState();
       if(replayActive != this.replayPlaybackActive) {
          this.replayPlaybackActive = replayActive;

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.relauncher.Side;
 import java.util.Iterator;
+import java.util.UUID;
 
 import mcheli.aircraft.MCH_BaseVehicleInfo;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
@@ -86,6 +87,13 @@ import mcheli.mob.MCH_RenderGunner;
 public class MCH_ClientProxy extends MCH_CommonProxy {
 
    public String lastLoadHUDPath = "";
+   private long nextTargetedReloadId;
+   private long pendingTargetedReloadId;
+   private int pendingTargetedEntityId = -1;
+   private UUID pendingTargetedEntityUuid;
+   private String pendingTargetedDefinition;
+   private Object pendingTargetedWorld;
+   private long pendingTargetedDeadline;
 
 
    public String getDataDir() {
@@ -184,20 +192,72 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       });
    }
 
-   public void scheduleTargetedVehicleReload(final int entityId, final String uuid,
+   public boolean requestTargetedVehicleReload(MCH_EntityBaseVehicle vehicle) {
+      Minecraft mc = Minecraft.getMinecraft();
+      if(this.pendingTargetedReloadId != 0L) {
+         chatTargetedReload(false, "A vehicle reload request is already pending");
+         return false;
+      }
+      if(vehicle == null || vehicle.getAcInfo() == null) return false;
+      long id = ++this.nextTargetedReloadId;
+      if(id == 0L) id = ++this.nextTargetedReloadId;
+      this.pendingTargetedReloadId = id;
+      this.pendingTargetedEntityId = vehicle.getEntityId();
+      this.pendingTargetedEntityUuid = vehicle.getUniqueID();
+      this.pendingTargetedDefinition = vehicle.getAcInfo().name;
+      this.pendingTargetedWorld = mc.theWorld;
+      this.pendingTargetedDeadline = System.currentTimeMillis() + 10000L;
+      mcheli.aircraft.MCH_PacketNotifyInfoReloaded.sendTargetedRequest(id, vehicle.getEntityId());
+      return true;
+   }
+
+   public boolean isTargetedVehicleReloadPending() { return this.pendingTargetedReloadId != 0L; }
+
+   public void tickTargetedVehicleReload() {
+      if(this.pendingTargetedReloadId == 0L) return;
+      Minecraft mc = Minecraft.getMinecraft();
+      if(mc.theWorld == null || mc.theWorld != this.pendingTargetedWorld) {
+         clearTargetedReload();
+      } else if(System.currentTimeMillis() >= this.pendingTargetedDeadline) {
+         clearTargetedReload();
+         chatTargetedReload(false, "Request timed out");
+      }
+   }
+
+   private void clearTargetedReload() {
+      this.pendingTargetedReloadId = 0L;
+      this.pendingTargetedEntityId = -1;
+      this.pendingTargetedEntityUuid = null;
+      this.pendingTargetedDefinition = null;
+      this.pendingTargetedWorld = null;
+      this.pendingTargetedDeadline = 0L;
+   }
+
+   private void chatTargetedReload(boolean success, String text) {
+      if(Minecraft.getMinecraft().thePlayer != null)
+         Minecraft.getMinecraft().thePlayer.addChatMessage(new net.minecraft.util.ChatComponentText(
+               success ? "Vehicle configuration reloaded: " + text : "Vehicle reload failed: " + text));
+   }
+
+   public void scheduleTargetedVehicleReload(final long requestId, final int entityId,
          final String definition, final boolean serverSuccess, final String serverReason) {
       Minecraft.getMinecraft().func_152344_a(new Runnable() {
          public void run() {
+            if(requestId == 0L || requestId != pendingTargetedReloadId) return;
             boolean success = serverSuccess;
             String reason = serverReason;
             Entity entity = Minecraft.getMinecraft().theWorld == null ? null
                   : Minecraft.getMinecraft().theWorld.getEntityByID(entityId);
             MCH_EntityBaseVehicle vehicle = entity instanceof MCH_EntityBaseVehicle
                   ? (MCH_EntityBaseVehicle)entity : null;
-            if(success && (vehicle == null || !vehicle.getUniqueID().toString().equals(uuid)
-                  || vehicle.getAcInfo() == null || !vehicle.getAcInfo().name.equals(definition))) {
+            if(success && vehicle == null) {
                success = false;
-               reason = "Target vehicle changed before the reload result arrived";
+               reason = "Client entity unloaded";
+            } else if(success && (entityId != pendingTargetedEntityId
+                  || !vehicle.getUniqueID().equals(pendingTargetedEntityUuid)
+                  || !definition.equals(pendingTargetedDefinition))) {
+               success = false;
+               reason = "Client entity changed before the reload result arrived";
             }
             if(success) {
                mcheli.MCH_InfoManagerBase manager = mcheli.aircraft.MCH_VehicleInfoReload.managerFor(vehicle);
@@ -207,21 +267,26 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
                   MCH_BaseVehicleInfo info = (MCH_BaseVehicleInfo)manager.getMap().get(definition);
                   success = vehicle.applyTargetedInfo(info);
                   if(success) {
-                     MCH_VehicleItemModelRender.invalidate(oldInfo);
-                     mcheli.tank.MCH_TurretPopModelCache.invalidate(oldInfo);
-                     if(vehicle instanceof MCH_EntityHeli) registerModelsHeli(definition, true);
-                     else if(vehicle instanceof MCP_EntityPlane) registerModelsPlane(definition, true);
-                     else if(vehicle instanceof MCH_EntityShip) registerModelsShip(definition, true);
-                     else if(vehicle instanceof MCH_EntityTank) registerModelsTank(definition, true);
-                     else if(vehicle instanceof MCH_EntityTurret) registerModelsVehicle(definition, true);
-                     MCH_VehicleLODManager.INSTANCE.invalidate(vehicle.getUniqueID());
+                     try {
+                        MCH_VehicleItemModelRender.invalidate(oldInfo);
+                        mcheli.tank.MCH_TurretPopModelCache.invalidate(oldInfo);
+                        if(vehicle instanceof MCH_EntityHeli) registerModelsHeli(definition, true);
+                        else if(vehicle instanceof MCP_EntityPlane) registerModelsPlane(definition, true);
+                        else if(vehicle instanceof MCH_EntityShip) registerModelsShip(definition, true);
+                        else if(vehicle instanceof MCH_EntityTank) registerModelsTank(definition, true);
+                        else if(vehicle instanceof MCH_EntityTurret) registerModelsVehicle(definition, true);
+                        else throw new IllegalStateException("Unsupported vehicle type");
+                        MCH_VehicleLODManager.INSTANCE.invalidate(vehicle.getUniqueID());
+                     } catch(RuntimeException e) {
+                        success = false;
+                        reason = "Client model reload failed: " + e.getMessage();
+                     }
                   } else reason = "Seat count changed; restart is required";
-               } else if(manager != null) reason = manager.getLastReloadError();
+               } else reason = manager == null ? "Unsupported vehicle type"
+                     : "Client definition reload failed: " + manager.getLastReloadError();
             }
-            mcheli.gui.MCH_ConfigGui.onTargetedReloadResult(success, reason);
-            if(Minecraft.getMinecraft().thePlayer != null)
-               Minecraft.getMinecraft().thePlayer.addChatMessage(new net.minecraft.util.ChatComponentText(
-                     (success ? "Vehicle reload complete: " : "Vehicle reload failed: ") + reason));
+            clearTargetedReload();
+            chatTargetedReload(success, success ? definition : reason);
          }
       });
    }

--- a/src/main/java/mcheli/MCH_CommonProxy.java
+++ b/src/main/java/mcheli/MCH_CommonProxy.java
@@ -78,7 +78,10 @@ public class MCH_CommonProxy {
    public void reloadHUD() {}
 
    public void scheduleClientInfoReload() {}
-   public void scheduleTargetedVehicleReload(int entityId, String uuid, String definition,
+   public boolean requestTargetedVehicleReload(mcheli.aircraft.MCH_EntityBaseVehicle vehicle) { return false; }
+   public boolean isTargetedVehicleReloadPending() { return false; }
+   public void tickTargetedVehicleReload() {}
+   public void scheduleTargetedVehicleReload(long requestId, int entityId, String definition,
          boolean success, String reason) {}
 
    public Entity getClientPlayer() {

--- a/src/main/java/mcheli/MCH_InfoManagerBase.java
+++ b/src/main/java/mcheli/MCH_InfoManagerBase.java
@@ -123,6 +123,13 @@ public abstract class MCH_InfoManagerBase {
             MCH_Lib.Log("### %s", new Object[]{lastReloadError});
             return false;
          }
+         if(oldInfo instanceof mcheli.aircraft.MCH_BaseVehicleInfo
+               && newInfo instanceof mcheli.aircraft.MCH_BaseVehicleInfo
+               && ((mcheli.aircraft.MCH_BaseVehicleInfo)oldInfo).getNumSeatAndRack()
+               != ((mcheli.aircraft.MCH_BaseVehicleInfo)newInfo).getNumSeatAndRack()) {
+            lastReloadError = "Seat count changed; restart is required";
+            return false;
+         }
          preserveRuntimeState(oldInfo, newInfo);
          LinkedHashMap newMap = new LinkedHashMap(oldMap);
          newMap.put(name, newInfo);

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -500,7 +500,7 @@ public class MCH_BaseVehiclePacketHandler {
       }
 
       if(player.worldObj.isRemote && pc.type == 4) {
-         MCH_MOD.proxy.scheduleTargetedVehicleReload(pc.entityId, pc.entityUuid,
+         MCH_MOD.proxy.scheduleTargetedVehicleReload(pc.requestId, pc.entityId,
                pc.definition, pc.success, pc.reason);
          return;
       }
@@ -544,20 +544,19 @@ public class MCH_BaseVehiclePacketHandler {
          MCH_PacketNotifyInfoReloaded request, boolean validateIdentity) {
       MCH_EntityBaseVehicle vehicle = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
       if(vehicle == null || vehicle.getAcInfo() == null) {
-         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, null, "", false,
-               "No controlled MCHeli vehicle exists");
+         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, request.requestId,
+               request.entityId, "", false, "No controlled vehicle");
          return;
       }
-      if(validateIdentity && (request.entityId != vehicle.getEntityId()
-            || !vehicle.getUniqueID().toString().equals(request.entityUuid))) {
-         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, vehicle,
-               vehicle.getAcInfo().name, false, "The controlled vehicle changed before reload");
+      if(validateIdentity && request.entityId != vehicle.getEntityId()) {
+         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, request.requestId,
+               request.entityId, vehicle.getAcInfo().name, false, "Entity ID changed");
          return;
       }
       String name = vehicle.getAcInfo().name;
       MCH_InfoManagerBase manager = MCH_VehicleInfoReload.managerFor(vehicle);
       if(manager == null) {
-         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, vehicle, name, false,
+         MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, request.requestId, request.entityId, name, false,
                "Unsupported MCHeli vehicle type");
          return;
       }
@@ -568,7 +567,7 @@ public class MCH_BaseVehiclePacketHandler {
          success = vehicle.applyTargetedInfo(info);
          if(!success) reason = "Seat count changed; restart is required";
       }
-      MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, vehicle, name, success,
+      MCH_PacketNotifyInfoReloaded.sendTargetedResult(player, request.requestId, request.entityId, name, success,
             success ? "Reloaded vehicle definition and model" : reason);
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -8397,6 +8397,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.markVehicleBoxCacheDirty("targeted vehicle config reload");
       super.stepHeight = info.stepHeight;
       this.setSize(info.bodyWidth, info.bodyHeight);
+      this.aps.configure(info.apsUseTime, info.apsWaitTime, info.apsRange, info.apsAmmo);
       return true;
    }
 

--- a/src/main/java/mcheli/aircraft/MCH_PacketNotifyInfoReloaded.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketNotifyInfoReloaded.java
@@ -11,7 +11,7 @@ public class MCH_PacketNotifyInfoReloaded extends MCH_Packet {
 
    public int type = -1;
    public int entityId = -1;
-   public String entityUuid = "";
+   public long requestId;
    public String definition = "";
    public boolean success;
    public String reason = "";
@@ -25,8 +25,8 @@ public class MCH_PacketNotifyInfoReloaded extends MCH_Packet {
       try {
          this.type = data.readInt();
          if(this.type == 3 || this.type == 4) {
+            this.requestId = data.readLong();
             this.entityId = data.readInt();
-            this.entityUuid = data.readUTF();
             if(this.type == 4) {
                this.definition = data.readUTF();
                this.success = data.readBoolean();
@@ -43,8 +43,8 @@ public class MCH_PacketNotifyInfoReloaded extends MCH_Packet {
       try {
          dos.writeInt(this.type);
          if(this.type == 3 || this.type == 4) {
+            dos.writeLong(this.requestId);
             dos.writeInt(this.entityId);
-            dos.writeUTF(this.entityUuid);
             if(this.type == 4) {
                dos.writeUTF(this.definition);
                dos.writeBoolean(this.success);
@@ -63,17 +63,16 @@ public class MCH_PacketNotifyInfoReloaded extends MCH_Packet {
       W_Network.sendToServer(s);
    }
 
-   public static void sendTargetedRequest(MCH_EntityBaseVehicle vehicle) {
+   public static void sendTargetedRequest(long requestId, int entityId) {
       MCH_PacketNotifyInfoReloaded p = new MCH_PacketNotifyInfoReloaded();
-      p.type = 3; p.entityId = vehicle.getEntityId(); p.entityUuid = vehicle.getUniqueID().toString();
+      p.type = 3; p.requestId = requestId; p.entityId = entityId;
       W_Network.sendToServer(p);
    }
 
-   public static void sendTargetedResult(EntityPlayer player, MCH_EntityBaseVehicle vehicle,
+   public static void sendTargetedResult(EntityPlayer player, long requestId, int entityId,
          String definition, boolean success, String reason) {
       MCH_PacketNotifyInfoReloaded p = new MCH_PacketNotifyInfoReloaded();
-      p.type = 4; p.entityId = vehicle == null ? -1 : vehicle.getEntityId();
-      p.entityUuid = vehicle == null ? "" : vehicle.getUniqueID().toString();
+      p.type = 4; p.requestId = requestId; p.entityId = entityId;
       p.definition = definition == null ? "" : definition; p.success = success;
       p.reason = reason == null ? "" : reason;
       W_Network.sendToPlayer(p, player);

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -106,8 +106,6 @@ public class MCH_ConfigGui extends W_GuiContainer {
    public static final int SCREEN_DEVELOP = 3;
    public static final int SCREEN_PLANE_CAMERA = 4;
    private int ignoreButtonCounter = 0;
-   private boolean targetedReloadPending;
-   private int targetedReloadTimeout;
 
 
    public MCH_ConfigGui(EntityPlayer player) {
@@ -718,14 +716,9 @@ public class MCH_ConfigGui extends W_GuiContainer {
             this.applySwitchScreen();
          }
       }
-      if(this.targetedReloadPending && --this.targetedReloadTimeout <= 0) {
-         this.targetedReloadPending = false;
-         if(super.mc.thePlayer != null) super.mc.thePlayer.addChatMessage(
-               new net.minecraft.util.ChatComponentText("Vehicle reload failed: request timed out"));
-      }
       if(this.buttonReloadAircraftInfo != null) {
          MCH_EntityBaseVehicle target = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(this.thePlayer);
-         this.buttonReloadAircraftInfo.enabled = !this.targetedReloadPending
+         this.buttonReloadAircraftInfo.enabled = !MCH_MOD.proxy.isTargetedVehicleReloadPending()
                && target != null && target.getAcInfo() != null
                && mcheli.aircraft.MCH_VehicleInfoReload.managerFor(target) != null;
       }
@@ -814,10 +807,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
          case 400:
             ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(this.thePlayer);
             if(ac != null && ac.getAcInfo() != null) {
-               this.targetedReloadPending = true;
-               this.targetedReloadTimeout = 200;
-               this.buttonReloadAircraftInfo.enabled = false;
-               MCH_PacketNotifyInfoReloaded.sendTargetedRequest(ac);
+               if(MCH_MOD.proxy.requestTargetedVehicleReload(ac)) super.mc.thePlayer.closeScreen();
             }
             break;
          }
@@ -825,14 +815,6 @@ public class MCH_ConfigGui extends W_GuiContainer {
          var7.printStackTrace();
       }
 
-   }
-
-   public static void onTargetedReloadResult(boolean success, String reason) {
-      if(Minecraft.getMinecraft().currentScreen instanceof MCH_ConfigGui) {
-         MCH_ConfigGui gui = (MCH_ConfigGui)Minecraft.getMinecraft().currentScreen;
-         gui.targetedReloadPending = false;
-         gui.targetedReloadTimeout = 0;
-      }
    }
 
    public boolean doesGuiPauseGame() {


### PR DESCRIPTION
### Motivation

- Targeted vehicle reload requests were being rejected because the client-local `Entity.getUniqueID()` was compared across client and server, but in Forge 1.7.10 the client-side entity UUID can differ from the server-side UUID.
- The development workflow required the GUI to remain open while waiting for a server response; the goal is to restore the original immediate-close workflow and allow reload completion without a relog or restart.

### Description

- Replace cross-side UUIDs in the targeted-request packet with a monotonic `requestId` and the synchronized `entityId`, and echo `requestId` in the server response (`MCH_PacketNotifyInfoReloaded`).
- Use server-authoritative validation by comparing only the server `entityId` when handling requests and rejecting only true entity-ID mismatches (`MCH_BaseVehiclePacketHandler`).
- Move pending request state out of the GUI into the client proxy (`MCH_ClientProxy`) where the client stores `requestId`, `entityId`, client-local UUID, definition, originating world, and a deadline, and added a tick-driven timeout/cleanup path; the GUI now closes immediately after sending the request and does not call `saveAndApplyConfig()` (button `400` behavior in `MCH_ConfigGui`).
- Apply targeted reloads safely: `MCH_InfoManagerBase.reloadEntry(name)` reloads a single published definition atomically and rejects seat-count changes before publishing, and `applyTargetedInfo()` refreshes body dimensions, step height, extra bounding boxes, camera bounds, force-spawn policy, and APS timings/capacity without recreating seats or changing runtime state (changes in `MCH_InfoManagerBase` and `MCH_EntityBaseVehicle`).
- Client-side model work remains on the client thread; the client matches responses by `requestId`, verifies the saved client-local UUID against the resolved client entity, reloads only the targeted definition/models, invalidates only the affected item/LOD/turret caches, and reports success/failure in chat; documentation and CHANGELOG were updated to describe the new flow.

### Testing

- Ran `git diff --check` and repository static assertions for the targeted-request workflow; these passed (immediate GUI close, no `saveAndApplyConfig()` call on button `400`, packet uses `requestId` and no cross-side `entityUuid`).
- Ran `python3 tools/validate_config_weights.py` which passed for repository weight data.
- Ran `python3 tools/validate_plane_config_surface.py` which reported an existing repository configuration problem unrelated to this change (`configreference/planes/b-21.txt` contains removed keys), and this PR did not modify those files.
- Did not run Java/Forge compile or `runClient` because binary/compile tasks were avoided per the task constraints; manual verification steps are documented in `docs/commands.md` and a changelog entry was added to `CHANGELOG.md`.

Changed files: `CHANGELOG.md`, `docs/commands.md`, `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`, `src/main/java/mcheli/MCH_ClientProxy.java`, `src/main/java/mcheli/MCH_CommonProxy.java`, `src/main/java/mcheli/MCH_InfoManagerBase.java`, `src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/aircraft/MCH_PacketNotifyInfoReloaded.java`, and `src/main/java/mcheli/gui/MCH_ConfigGui.java`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6eb77a55f08323ba93c71269d80925)