### PR TITLE
Enable global range scaling for land artillery weapons

### DIFF
--- a/configreference/weapons/2981mm_mortar.txt
+++ b/configreference/weapons/2981mm_mortar.txt
@@ -1,4 +1,5 @@
 DisplayName = 81mm M252 Mortar [M374A2 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 35
 Explosion = 2
@@ -19,11 +20,11 @@ DamageFactor = plane, 3.0
 DamageFactor = vehicle 2.0
 DamageFactor = heli, 3.0
 
-; ’…’e‹——£‚Ì•\¦
+; ç€å¼¾è·é›¢ã®è¡¨ç¤º
 DisplayMortarDistance = true
-; ƒJƒƒ‰‚Ì‚’¼•ûŒü‚ğ0‚ÉŒÅ’è‚·‚é
+; ã‚«ãƒ¡ãƒ©ã®å‚ç›´æ–¹å‘ã‚’0ã«å›ºå®šã™ã‚‹
 FixCameraPitch = true
-; ƒJƒƒ‰‚Ì‰ñ“]‘¬“x‚Ì”{—¦(¬‚³‚­‚·‚é‚Æ‚æ‚è×‚©‚­’…’e’n“_‚ª’²®‚ª‚Å‚«‚é)
+; ã‚«ãƒ¡ãƒ©ã®å›è»¢é€Ÿåº¦ã®å€ç‡(å°ã•ãã™ã‚‹ã¨ã‚ˆã‚Šç´°ã‹ãç€å¼¾åœ°ç‚¹ãŒèª¿æ•´ãŒã§ãã‚‹)
 CameraRotationSpeedPitch = 0.3
 
 DisableSmoke = true
@@ -37,10 +38,10 @@ HeatCount = 100
 MaxHeatCount = 250
 
 
-; AddMuzzleFlash = ”­ËŒ³‚©‚ç‚Ì‹——£, ƒTƒCƒY, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlash = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, ã‚µã‚¤ã‚º, è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlash      =           2.1,   1.05,        2,  220,254,219,104
 AddMuzzleFlash      =           2.0,   1.00,        1,  220,254,219,184
-; AddMuzzleFlashSmoke = ”­ËŒ³‚©‚ç‚Ì‹——£, •\¦”, ƒTƒCƒY, ”ÍˆÍ, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlashSmoke = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, è¡¨ç¤ºæ•°, ã‚µã‚¤ã‚º, ç¯„å›², è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlashSmoke   =             3.2,     10,    6.0,  3.0,       25,  220,160,140,120
 AddMuzzleFlashSmoke   =             2.2,      5,    6.0,  4.0,       35,  200,190,170,150
 

--- a/configreference/weapons/2s2a31.txt
+++ b/configreference/weapons/2s2a31.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [3OF56 - FRAG-HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 100
 ModelBullet = bullet

--- a/configreference/weapons/2s2a31_1.txt
+++ b/configreference/weapons/2s2a31_1.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [3BK13M - HEAT-FS-T]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/2s2a31_2.txt
+++ b/configreference/weapons/2s2a31_2.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [SH-1 AP - Flechete]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 ModelBullet = bullet

--- a/configreference/weapons/406mm_ap.txt
+++ b/configreference/weapons/406mm_ap.txt
@@ -1,4 +1,5 @@
 DisplayName = 406mm Artillery Grenade [AP]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/406mm_he.txt
+++ b/configreference/weapons/406mm_he.txt
@@ -1,4 +1,5 @@
 DisplayName = 406mm Artillery Grenade [HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/81mm_mortar252.txt
+++ b/configreference/weapons/81mm_mortar252.txt
@@ -1,4 +1,5 @@
 DisplayName = 81mm M252 Mortar [M374A2 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 35
 Explosion = 3
@@ -19,11 +20,11 @@ DamageFactor = plane, 3.0
 DamageFactor = vehicle 2.0
 DamageFactor = heli, 3.0
 
-; ’…’e‹——£‚Ì•\¦
+; ç€å¼¾è·é›¢ã®è¡¨ç¤º
 DisplayMortarDistance = true
-; ƒJƒƒ‰‚Ì‚’¼•ûŒü‚ğ0‚ÉŒÅ’è‚·‚é
+; ã‚«ãƒ¡ãƒ©ã®å‚ç›´æ–¹å‘ã‚’0ã«å›ºå®šã™ã‚‹
 FixCameraPitch = true
-; ƒJƒƒ‰‚Ì‰ñ“]‘¬“x‚Ì”{—¦(¬‚³‚­‚·‚é‚Æ‚æ‚è×‚©‚­’…’e’n“_‚ª’²®‚ª‚Å‚«‚é)
+; ã‚«ãƒ¡ãƒ©ã®å›è»¢é€Ÿåº¦ã®å€ç‡(å°ã•ãã™ã‚‹ã¨ã‚ˆã‚Šç´°ã‹ãç€å¼¾åœ°ç‚¹ãŒèª¿æ•´ãŒã§ãã‚‹)
 CameraRotationSpeedPitch = 0.3
 
 DisableSmoke = true
@@ -37,10 +38,10 @@ HeatCount = 100
 MaxHeatCount = 250
 
 
-; AddMuzzleFlash = ”­ËŒ³‚©‚ç‚Ì‹——£, ƒTƒCƒY, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlash = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, ã‚µã‚¤ã‚º, è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlash      =           2.1,   1.05,        2,  220,254,219,104
 AddMuzzleFlash      =           2.0,   1.00,        1,  220,254,219,184
-; AddMuzzleFlashSmoke = ”­ËŒ³‚©‚ç‚Ì‹——£, •\¦”, ƒTƒCƒY, ”ÍˆÍ, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlashSmoke = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, è¡¨ç¤ºæ•°, ã‚µã‚¤ã‚º, ç¯„å›², è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlashSmoke   =             3.2,     10,    6.0,  3.0,       25,  220,160,140,120
 AddMuzzleFlashSmoke   =             2.2,      5,    6.0,  4.0,       35,  200,190,170,150
 

--- a/configreference/weapons/akacia.txt
+++ b/configreference/weapons/akacia.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3OF25 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 62
 Explosion = 4

--- a/configreference/weapons/akacia2.txt
+++ b/configreference/weapons/akacia2.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [BR-540B - APHEBC]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 171
 Explosion = 2

--- a/configreference/weapons/akacia3.txt
+++ b/configreference/weapons/akacia3.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3BV3 Nuclear Artillery Shell - ~2KT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 171
 Explosion = 1

--- a/configreference/weapons/akacia4.txt
+++ b/configreference/weapons/akacia4.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3OF25 (PF) - HE-VT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 62
 Explosion = 8

--- a/configreference/weapons/dana152eof.txt
+++ b/configreference/weapons/dana152eof.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EOF - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/dana152eofd.txt
+++ b/configreference/weapons/dana152eofd.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EOFd - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/dana152eprsv.txt
+++ b/configreference/weapons/dana152eprsv.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EPrSv - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/fhm77.txt
+++ b/configreference/weapons/fhm77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [M107 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/gr34.txt
+++ b/configreference/weapons/gr34.txt
@@ -1,4 +1,5 @@
 DisplayName = 8cm Wurfgranate 34 Mortar [Mortar grenade 34 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 1.70F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m1how.txt
+++ b/configreference/weapons/m1how.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M1 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m1m327.txt
+++ b/configreference/weapons/m1m327.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M327 Shell - HEP-T (HESH)]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m1m413.txt
+++ b/configreference/weapons/m1m413.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M413 - Cluster Grenades]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 20
 Acceleration = 7

--- a/configreference/weapons/m1m444.txt
+++ b/configreference/weapons/m1m444.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M444 APICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 25
 Acceleration = 7

--- a/configreference/weapons/m1m546.txt
+++ b/configreference/weapons/m1m546.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M546 - APERS-T]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 15
 Acceleration = 7

--- a/configreference/weapons/m1m548.txt
+++ b/configreference/weapons/m1m548.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M548 Shell - HE-RA]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 152
 ModelBullet = bullet105mm

--- a/configreference/weapons/m1m916.txt
+++ b/configreference/weapons/m1m916.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M916 DPICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 Acceleration = 7

--- a/configreference/weapons/m40gas.txt
+++ b/configreference/weapons/m40gas.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [Chemical - H M104 Shell]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 0.60F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m40m107.txt
+++ b/configreference/weapons/m40m107.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [APBC/HE - AP M112 Shell]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m40m107vt.txt
+++ b/configreference/weapons/m40m107vt.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [HE - M107]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m549a1_fh77.txt
+++ b/configreference/weapons/m549a1_fh77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [ERFB-BB - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m77m107.txt
+++ b/configreference/weapons/m77m107.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M107 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m77m549a1.txt
+++ b/configreference/weapons/m77m549a1.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M549A1 Shell - HE-RA]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 ModelBullet = 155mm

--- a/configreference/weapons/m77m795.txt
+++ b/configreference/weapons/m77m795.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M795 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m77m864.txt
+++ b/configreference/weapons/m77m864.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M864 DPICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 80
 ModelBullet = 155mm

--- a/configreference/weapons/m7m1.txt
+++ b/configreference/weapons/m7m1.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [M1 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m7m60chem.txt
+++ b/configreference/weapons/m7m60chem.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [H M60 Shell - Chemical]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 0.50F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m7m67.txt
+++ b/configreference/weapons/m7m67.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [M67 Shell - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/m864_fh77.txt
+++ b/configreference/weapons/m864_fh77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [Nexter BONUS]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 ModelBullet = 155mm

--- a/configreference/weapons/mfom227mm.txt
+++ b/configreference/weapons/mfom227mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 227mm Rocket [M26 - DPICM M77 Cluster Munition]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 200
 DamageFactor = tank, 1.0

--- a/configreference/weapons/mfom227mm2.txt
+++ b/configreference/weapons/mfom227mm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 227mm Rocket [M26 - AT2 Mine]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 Power = 80
 DamageFactor = tank, 1.0

--- a/configreference/weapons/mstahe.txt
+++ b/configreference/weapons/mstahe.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-45 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/mstaheat.txt
+++ b/configreference/weapons/mstaheat.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-23 - HEAT Bomblet]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 ModelBullet = bullet105mm

--- a/configreference/weapons/mstalrcharge.txt
+++ b/configreference/weapons/mstalrcharge.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-45 with OF72 Long Range Charge - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/mstanuclear.txt
+++ b/configreference/weapons/mstanuclear.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [3BV3 Nuclear Artillery Shell - ~1KT]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/configreference/weapons/mstatv.txt
+++ b/configreference/weapons/mstatv.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [3V0F64 - GUIDED]
+UseGlobalArtilleryRangeModifier = true
 Type = TVMissile
 IsHeatSeekerMissile = true
 IsRadarMissile = false

--- a/configreference/weapons/nona120mm.txt
+++ b/configreference/weapons/nona120mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-49 - HE-FRAG]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 75
 Explosion = 3

--- a/configreference/weapons/nona120mm2.txt
+++ b/configreference/weapons/nona120mm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-50 - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 650
 Explosion = 3

--- a/configreference/weapons/nona120mm3.txt
+++ b/configreference/weapons/nona120mm3.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-843B - 3Z2 Incendiary]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 30
 Explosion = 2

--- a/configreference/weapons/pion203mm.txt
+++ b/configreference/weapons/pion203mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [OF-43 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 8

--- a/configreference/weapons/pion203mmNC.txt
+++ b/configreference/weapons/pion203mmNC.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [3BV2 Nuclear Artillery Shell - 5KT SURFACE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 6

--- a/configreference/weapons/pion203mmRA.txt
+++ b/configreference/weapons/pion203mmRA.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [OF-43R - HE RAP]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 6

--- a/configreference/weapons/tos220mm.txt
+++ b/configreference/weapons/tos220mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm TOS-1A Launcher [MO-1.01.04 - Rocket]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 Explosion = 9

--- a/configreference/weapons/toyotab-8v20a.txt
+++ b/configreference/weapons/toyotab-8v20a.txt
@@ -1,4 +1,5 @@
 DisplayName = B-8V20A [S-8KO Rocket - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 400
 ModelBullet = hydra70

--- a/configreference/weapons/toyotaub-32.txt
+++ b/configreference/weapons/toyotaub-32.txt
@@ -1,4 +1,5 @@
 DisplayName = 57mm UB-32M [S-5K Rocket]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 130
 ModelBullet = hydra70

--- a/configreference/weapons/type63rocket.txt
+++ b/configreference/weapons/type63rocket.txt
@@ -1,4 +1,5 @@
 DisplayName = 107mm Type-63 Rocket Launcher [HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 42
 ModelBullet = hydra70

--- a/configreference/weapons/uragan220mm.txt
+++ b/configreference/weapons/uragan220mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27F - HE-Frag]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 Explosion = 18

--- a/configreference/weapons/uragan220mmatm.txt
+++ b/configreference/weapons/uragan220mmatm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K2 - Anti Tank Mines]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 ;Power = 80
 Acceleration = 7.0

--- a/configreference/weapons/uragan220mmatm2.txt
+++ b/configreference/weapons/uragan220mmatm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K2 - Anti-Personnel Mines]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 Power = 80
 Acceleration = 7.0

--- a/configreference/weapons/uragan220mmfrag.txt
+++ b/configreference/weapons/uragan220mmfrag.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K1 - Cluster Munition]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 100
 Explosion = 3

--- a/src/main/resources/assets/mcheli/weapons/2981mm_mortar.txt
+++ b/src/main/resources/assets/mcheli/weapons/2981mm_mortar.txt
@@ -1,4 +1,5 @@
 DisplayName = 81mm M252 Mortar [M374A2 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 35
 Explosion = 2
@@ -19,11 +20,11 @@ DamageFactor = plane, 3.0
 DamageFactor = vehicle 2.0
 DamageFactor = heli, 3.0
 
-; ’…’e‹——£‚Ì•\¦
+; ç€å¼¾è·é›¢ã®è¡¨ç¤º
 DisplayMortarDistance = true
-; ƒJƒƒ‰‚Ì‚’¼•ûŒü‚ğ0‚ÉŒÅ’è‚·‚é
+; ã‚«ãƒ¡ãƒ©ã®å‚ç›´æ–¹å‘ã‚’0ã«å›ºå®šã™ã‚‹
 FixCameraPitch = true
-; ƒJƒƒ‰‚Ì‰ñ“]‘¬“x‚Ì”{—¦(¬‚³‚­‚·‚é‚Æ‚æ‚è×‚©‚­’…’e’n“_‚ª’²®‚ª‚Å‚«‚é)
+; ã‚«ãƒ¡ãƒ©ã®å›è»¢é€Ÿåº¦ã®å€ç‡(å°ã•ãã™ã‚‹ã¨ã‚ˆã‚Šç´°ã‹ãç€å¼¾åœ°ç‚¹ãŒèª¿æ•´ãŒã§ãã‚‹)
 CameraRotationSpeedPitch = 0.3
 
 DisableSmoke = true
@@ -37,10 +38,10 @@ HeatCount = 100
 MaxHeatCount = 250
 
 
-; AddMuzzleFlash = ”­ËŒ³‚©‚ç‚Ì‹——£, ƒTƒCƒY, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlash = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, ã‚µã‚¤ã‚º, è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlash      =           2.1,   1.05,        2,  220,254,219,104
 AddMuzzleFlash      =           2.0,   1.00,        1,  220,254,219,184
-; AddMuzzleFlashSmoke = ”­ËŒ³‚©‚ç‚Ì‹——£, •\¦”, ƒTƒCƒY, ”ÍˆÍ, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlashSmoke = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, è¡¨ç¤ºæ•°, ã‚µã‚¤ã‚º, ç¯„å›², è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlashSmoke   =             3.2,     10,    6.0,  3.0,       25,  220,160,140,120
 AddMuzzleFlashSmoke   =             2.2,      5,    6.0,  4.0,       35,  200,190,170,150
 

--- a/src/main/resources/assets/mcheli/weapons/2s2a31.txt
+++ b/src/main/resources/assets/mcheli/weapons/2s2a31.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [3OF56 - FRAG-HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 100
 ModelBullet = bullet

--- a/src/main/resources/assets/mcheli/weapons/2s2a31_1.txt
+++ b/src/main/resources/assets/mcheli/weapons/2s2a31_1.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [3BK13M - HEAT-FS-T]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/2s2a31_2.txt
+++ b/src/main/resources/assets/mcheli/weapons/2s2a31_2.txt
@@ -1,4 +1,5 @@
 DisplayName = 122mm 2A31 Howitzer [SH-1 AP - Flechete]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 ModelBullet = bullet

--- a/src/main/resources/assets/mcheli/weapons/406mm_ap.txt
+++ b/src/main/resources/assets/mcheli/weapons/406mm_ap.txt
@@ -1,4 +1,5 @@
 DisplayName = 406mm Artillery Grenade [AP]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/406mm_he.txt
+++ b/src/main/resources/assets/mcheli/weapons/406mm_he.txt
@@ -1,4 +1,5 @@
 DisplayName = 406mm Artillery Grenade [HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/81mm_mortar252.txt
+++ b/src/main/resources/assets/mcheli/weapons/81mm_mortar252.txt
@@ -1,4 +1,5 @@
 DisplayName = 81mm M252 Mortar [M374A2 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 35
 Explosion = 3
@@ -19,11 +20,11 @@ DamageFactor = plane, 3.0
 DamageFactor = vehicle 2.0
 DamageFactor = heli, 3.0
 
-; ’…’e‹——£‚Ì•\¦
+; ç€å¼¾è·é›¢ã®è¡¨ç¤º
 DisplayMortarDistance = true
-; ƒJƒƒ‰‚Ì‚’¼•ûŒü‚ğ0‚ÉŒÅ’è‚·‚é
+; ã‚«ãƒ¡ãƒ©ã®å‚ç›´æ–¹å‘ã‚’0ã«å›ºå®šã™ã‚‹
 FixCameraPitch = true
-; ƒJƒƒ‰‚Ì‰ñ“]‘¬“x‚Ì”{—¦(¬‚³‚­‚·‚é‚Æ‚æ‚è×‚©‚­’…’e’n“_‚ª’²®‚ª‚Å‚«‚é)
+; ã‚«ãƒ¡ãƒ©ã®å›è»¢é€Ÿåº¦ã®å€ç‡(å°ã•ãã™ã‚‹ã¨ã‚ˆã‚Šç´°ã‹ãç€å¼¾åœ°ç‚¹ãŒèª¿æ•´ãŒã§ãã‚‹)
 CameraRotationSpeedPitch = 0.3
 
 DisableSmoke = true
@@ -37,10 +38,10 @@ HeatCount = 100
 MaxHeatCount = 250
 
 
-; AddMuzzleFlash = ”­ËŒ³‚©‚ç‚Ì‹——£, ƒTƒCƒY, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlash = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, ã‚µã‚¤ã‚º, è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlash      =           2.1,   1.05,        2,  220,254,219,104
 AddMuzzleFlash      =           2.0,   1.00,        1,  220,254,219,184
-; AddMuzzleFlashSmoke = ”­ËŒ³‚©‚ç‚Ì‹——£, •\¦”, ƒTƒCƒY, ”ÍˆÍ, •\¦ŠÔ,  A,  R,  G,  B
+; AddMuzzleFlashSmoke = ç™ºå°„å…ƒã‹ã‚‰ã®è·é›¢, è¡¨ç¤ºæ•°, ã‚µã‚¤ã‚º, ç¯„å›², è¡¨ç¤ºæ™‚é–“,  A,  R,  G,  B
 AddMuzzleFlashSmoke   =             3.2,     10,    6.0,  3.0,       25,  220,160,140,120
 AddMuzzleFlashSmoke   =             2.2,      5,    6.0,  4.0,       35,  200,190,170,150
 

--- a/src/main/resources/assets/mcheli/weapons/akacia.txt
+++ b/src/main/resources/assets/mcheli/weapons/akacia.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3OF25 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 62
 Explosion = 4

--- a/src/main/resources/assets/mcheli/weapons/akacia2.txt
+++ b/src/main/resources/assets/mcheli/weapons/akacia2.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [BR-540B - APHEBC]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 171
 Explosion = 2

--- a/src/main/resources/assets/mcheli/weapons/akacia3.txt
+++ b/src/main/resources/assets/mcheli/weapons/akacia3.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3BV3 Nuclear Artillery Shell - ~2KT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 171
 Explosion = 1

--- a/src/main/resources/assets/mcheli/weapons/akacia4.txt
+++ b/src/main/resources/assets/mcheli/weapons/akacia4.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A33 Cannon [3OF25 (PF) - HE-VT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 62
 Explosion = 8

--- a/src/main/resources/assets/mcheli/weapons/dana152eof.txt
+++ b/src/main/resources/assets/mcheli/weapons/dana152eof.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EOF - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/dana152eofd.txt
+++ b/src/main/resources/assets/mcheli/weapons/dana152eofd.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EOFd - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/dana152eprsv.txt
+++ b/src/main/resources/assets/mcheli/weapons/dana152eprsv.txt
@@ -1,4 +1,5 @@
 DisplayName = 152.4mm Howitzer [152EPrSv - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/fhm77.txt
+++ b/src/main/resources/assets/mcheli/weapons/fhm77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [M107 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/gr34.txt
+++ b/src/main/resources/assets/mcheli/weapons/gr34.txt
@@ -1,4 +1,5 @@
 DisplayName = 8cm Wurfgranate 34 Mortar [Mortar grenade 34 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 1.70F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m1how.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1how.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M1 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m1m327.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m327.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M327 Shell - HEP-T (HESH)]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m1m413.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m413.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M413 - Cluster Grenades]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 20
 Acceleration = 7

--- a/src/main/resources/assets/mcheli/weapons/m1m444.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m444.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M444 APICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 25
 Acceleration = 7

--- a/src/main/resources/assets/mcheli/weapons/m1m546.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m546.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M546 - APERS-T]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 15
 Acceleration = 7

--- a/src/main/resources/assets/mcheli/weapons/m1m548.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m548.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M548 Shell - HE-RA]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 152
 ModelBullet = bullet105mm

--- a/src/main/resources/assets/mcheli/weapons/m1m916.txt
+++ b/src/main/resources/assets/mcheli/weapons/m1m916.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm Howitzer [M916 DPICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 Acceleration = 7

--- a/src/main/resources/assets/mcheli/weapons/m40gas.txt
+++ b/src/main/resources/assets/mcheli/weapons/m40gas.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [Chemical - H M104 Shell]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 0.60F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m40m107.txt
+++ b/src/main/resources/assets/mcheli/weapons/m40m107.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [APBC/HE - AP M112 Shell]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m40m107vt.txt
+++ b/src/main/resources/assets/mcheli/weapons/m40m107vt.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M1 Long Tom Cannon [HE - M107]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m549a1_fh77.txt
+++ b/src/main/resources/assets/mcheli/weapons/m549a1_fh77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [ERFB-BB - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m77m107.txt
+++ b/src/main/resources/assets/mcheli/weapons/m77m107.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M107 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m77m549a1.txt
+++ b/src/main/resources/assets/mcheli/weapons/m77m549a1.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M549A1 Shell - HE-RA]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 ModelBullet = 155mm

--- a/src/main/resources/assets/mcheli/weapons/m77m795.txt
+++ b/src/main/resources/assets/mcheli/weapons/m77m795.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M795 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m77m864.txt
+++ b/src/main/resources/assets/mcheli/weapons/m77m864.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm M777 Howitzer [M864 DPICM - Cluster]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 80
 ModelBullet = 155mm

--- a/src/main/resources/assets/mcheli/weapons/m7m1.txt
+++ b/src/main/resources/assets/mcheli/weapons/m7m1.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [M1 Shell - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m7m60chem.txt
+++ b/src/main/resources/assets/mcheli/weapons/m7m60chem.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [H M60 Shell - Chemical]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 0.50F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m7m67.txt
+++ b/src/main/resources/assets/mcheli/weapons/m7m67.txt
@@ -1,4 +1,5 @@
 DisplayName = 105mm M2 Howitzer [M67 Shell - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun2
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/m864_fh77.txt
+++ b/src/main/resources/assets/mcheli/weapons/m864_fh77.txt
@@ -1,4 +1,5 @@
 DisplayName = 155mm Haubits BW L/52 FH-77 [Nexter BONUS]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 ModelBullet = 155mm

--- a/src/main/resources/assets/mcheli/weapons/mfom227mm.txt
+++ b/src/main/resources/assets/mcheli/weapons/mfom227mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 227mm Rocket [M26 - DPICM M77 Cluster Munition]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 200
 DamageFactor = tank, 1.0

--- a/src/main/resources/assets/mcheli/weapons/mfom227mm2.txt
+++ b/src/main/resources/assets/mcheli/weapons/mfom227mm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 227mm Rocket [M26 - AT2 Mine]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 Power = 80
 DamageFactor = tank, 1.0

--- a/src/main/resources/assets/mcheli/weapons/mstahe.txt
+++ b/src/main/resources/assets/mcheli/weapons/mstahe.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-45 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/mstaheat.txt
+++ b/src/main/resources/assets/mcheli/weapons/mstaheat.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-23 - HEAT Bomblet]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 50
 ModelBullet = bullet105mm

--- a/src/main/resources/assets/mcheli/weapons/mstalrcharge.txt
+++ b/src/main/resources/assets/mcheli/weapons/mstalrcharge.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [OF-45 with OF72 Long Range Charge - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/mstanuclear.txt
+++ b/src/main/resources/assets/mcheli/weapons/mstanuclear.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [3BV3 Nuclear Artillery Shell - ~1KT]
+UseGlobalArtilleryRangeModifier = true
 Type = MachineGun1
 RecoilPitch = 3.00F
 RecoilYaw = 0.0F

--- a/src/main/resources/assets/mcheli/weapons/mstatv.txt
+++ b/src/main/resources/assets/mcheli/weapons/mstatv.txt
@@ -1,4 +1,5 @@
 DisplayName = 152mm 2A65 Howitzer [3V0F64 - GUIDED]
+UseGlobalArtilleryRangeModifier = true
 Type = TVMissile
 IsHeatSeekerMissile = true
 IsRadarMissile = false

--- a/src/main/resources/assets/mcheli/weapons/nona120mm.txt
+++ b/src/main/resources/assets/mcheli/weapons/nona120mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-49 - HE-FRAG]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 75
 Explosion = 3

--- a/src/main/resources/assets/mcheli/weapons/nona120mm2.txt
+++ b/src/main/resources/assets/mcheli/weapons/nona120mm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-50 - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 650
 Explosion = 3

--- a/src/main/resources/assets/mcheli/weapons/nona120mm3.txt
+++ b/src/main/resources/assets/mcheli/weapons/nona120mm3.txt
@@ -1,4 +1,5 @@
 DisplayName = 120mm 2A60 Mortar [OF-843B - 3Z2 Incendiary]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 30
 Explosion = 2

--- a/src/main/resources/assets/mcheli/weapons/pion203mm.txt
+++ b/src/main/resources/assets/mcheli/weapons/pion203mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [OF-43 - HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 8

--- a/src/main/resources/assets/mcheli/weapons/pion203mmNC.txt
+++ b/src/main/resources/assets/mcheli/weapons/pion203mmNC.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [3BV2 Nuclear Artillery Shell - 5KT SURFACE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 6

--- a/src/main/resources/assets/mcheli/weapons/pion203mmRA.txt
+++ b/src/main/resources/assets/mcheli/weapons/pion203mmRA.txt
@@ -1,4 +1,5 @@
 DisplayName = 203mm 2A44 Cannon L/56.2 [OF-43R - HE RAP]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 800
 Explosion = 6

--- a/src/main/resources/assets/mcheli/weapons/tos220mm.txt
+++ b/src/main/resources/assets/mcheli/weapons/tos220mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm TOS-1A Launcher [MO-1.01.04 - Rocket]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 Explosion = 9

--- a/src/main/resources/assets/mcheli/weapons/toyotab-8v20a.txt
+++ b/src/main/resources/assets/mcheli/weapons/toyotab-8v20a.txt
@@ -1,4 +1,5 @@
 DisplayName = B-8V20A [S-8KO Rocket - HEAT]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 400
 ModelBullet = hydra70

--- a/src/main/resources/assets/mcheli/weapons/toyotaub-32.txt
+++ b/src/main/resources/assets/mcheli/weapons/toyotaub-32.txt
@@ -1,4 +1,5 @@
 DisplayName = 57mm UB-32M [S-5K Rocket]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 130
 ModelBullet = hydra70

--- a/src/main/resources/assets/mcheli/weapons/type63rocket.txt
+++ b/src/main/resources/assets/mcheli/weapons/type63rocket.txt
@@ -1,4 +1,5 @@
 DisplayName = 107mm Type-63 Rocket Launcher [HE]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 42
 ModelBullet = hydra70

--- a/src/main/resources/assets/mcheli/weapons/uragan220mm.txt
+++ b/src/main/resources/assets/mcheli/weapons/uragan220mm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27F - HE-Frag]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 500
 Explosion = 18

--- a/src/main/resources/assets/mcheli/weapons/uragan220mmatm.txt
+++ b/src/main/resources/assets/mcheli/weapons/uragan220mmatm.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K2 - Anti Tank Mines]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 ;Power = 80
 Acceleration = 7.0

--- a/src/main/resources/assets/mcheli/weapons/uragan220mmatm2.txt
+++ b/src/main/resources/assets/mcheli/weapons/uragan220mmatm2.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K2 - Anti-Personnel Mines]
+UseGlobalArtilleryRangeModifier = true
 Type = Dispenser
 Power = 80
 Acceleration = 7.0

--- a/src/main/resources/assets/mcheli/weapons/uragan220mmfrag.txt
+++ b/src/main/resources/assets/mcheli/weapons/uragan220mmfrag.txt
@@ -1,4 +1,5 @@
 DisplayName = 220mm Rocket [9M27K1 - Cluster Munition]
+UseGlobalArtilleryRangeModifier = true
 Type = Rocket
 Power = 100
 Explosion = 3


### PR DESCRIPTION
### Motivation
- Opt individual artillery armament files into the global `ArtilleryRangeModifier` so land-based artillery (SPG/SPH/mortars/MLRS/towed/static) can opt into a global launch-speed multiplier without changing ballistic or weapon behavior.
- Use the active `DisplayName` as the sole classifier to identify qualifying artillery platforms and their artillery weapon variants.

### Description
- Inserted the exact active line `UseGlobalArtilleryRangeModifier = true` into 56 canonical weapon files under `src/main/resources/assets/mcheli/weapons` and identically into their 56 matching copies under `configreference/weapons`, for a total of 112 files changed and 112 insertions.
- Target selection covered artillery main guns, shells, rocket/mortar/MLRS variants and bomblet/warhead variants while explicitly excluding secondary machine guns, horns/placeholders, and other non-artillery references; no artillery-specific copies were created because no targeted canonical weapon file was shared with a non-artillery vehicle.
- Made only the requested per-weapon opt-in addition and synchronized reference copies; no Java source or ballistic/damage/ammo/sound/model/effect values were modified.

### Testing
- Ran `python3 tools/validate_config_weights.py` which passed for the changed files.
- Ran a custom audit script that: scanned vehicles for `DisplayName`, mapped referenced weapons, confirmed each targeted canonical file contains exactly one active `UseGlobalArtilleryRangeModifier = true`, ensured no active `false` values were left, and byte-compared each canonical file with its `configreference` counterpart; the audit passed (validated 56 canonical files and 56 synchronized references).
- Ran `git diff --check` (no whitespace or diff problems) and executed `./gradlew --no-daemon help` for wrapper/gradle health (no builds or binaries produced); both checks completed successfully, though `python3 tools/validate_plane_config_surface.py` reported a pre-existing issue in an unrelated `configreference/planes/b-21.txt` file that was not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ec019f7b48323b5d5cf84a15ef6a5)