### PR TITLE
Fix texture UV repair validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Complete deterministic texture/UV repair validation (PR pending)
+
+- Replaced unsupported per-channel `putchannel` mutation with split/dilate/merge RGB bleeding that preserves alpha byte-for-byte across every pass.
+- Corrected premultiplied-alpha resizing, removed deprecated Pillow pixel access, and expanded command and image edge-case coverage.
+- Made empty, unresolved, missing-source, and hash-failure repair states explicit and fail-safe, and added ranked suspicious-asset CSV output.
+
 # Texture downscale and MQO UV audit tooling (PR pending)
 
 - Added a deterministic, manifest-driven Python audit/repair/verification tool for runtime-selected vehicle model and texture pairs.

--- a/tools/repair_texture_uvs.py
+++ b/tools/repair_texture_uvs.py
@@ -18,6 +18,11 @@ CONFIG_DIRS = {"helicopters", "planes", "tanks", "vehicles", "ships"}
 ALPHA_THRESHOLD = 1  # W_Render uses GL_GREATER, 0.001: byte alpha >= 1 passes.
 _MODEL_CACHE = {}
 
+def flattened_data(image):
+    """Return flattened pixels without triggering Pillow 12's getdata warning."""
+    method = getattr(image, "get_flattened_data", None)
+    return method() if method is not None else image.getdata()
+
 @dataclass(frozen=True)
 class Face:
     vertex_count: int
@@ -77,28 +82,29 @@ def rewrite_mqo(data: bytes, transform) -> bytes:
         return match.group(0).replace(match.group(2), body)
     return FACE_RE.sub(replace, text).encode("utf-8", "surrogateescape")
 
-def bleed_transparent_rgb(image):
-    rgba=image.convert("RGBA"); alpha=rgba.getchannel("A"); rgb=rgba.convert("RGB")
+def bleed_transparent_rgb(image, passes=4):
+    rgba=image.convert("RGBA"); alpha=rgba.getchannel("A"); channels=list(rgba.convert("RGB").split())
     # Repeated max-filter dilation supplies colour only; original alpha is restored exactly.
     opaque=alpha.point(lambda x: 255 if x else 0)
-    for _ in range(4):
+    for _ in range(passes):
         grown=opaque.filter(ImageFilter.MaxFilter(3)); ring=ImageChops.subtract(grown, opaque)
-        for channel in range(3):
-            c=rgb.getchannel(channel); dilated=c.filter(ImageFilter.MaxFilter(3)); c.paste(dilated, mask=ring); rgb.putchannel(channel,c)
+        updated=[]
+        for channel in channels:
+            dilated=channel.filter(ImageFilter.MaxFilter(3))
+            channel.paste(dilated, mask=ring)
+            updated.append(channel)
+        # The next dilation starts with the channels produced by this pass.
+        channels=list(Image.merge("RGB", updated).split())
         opaque=grown
-    return Image.merge("RGBA", (*rgb.split(), alpha))
+    return Image.merge("RGBA", (*channels, alpha))
 
 def premultiplied_resize(image, size):
     rgba=image.convert("RGBA"); bands=list(rgba.split()); alpha=bands[3]
     premul=[ImageChops.multiply(b, alpha) for b in bands[:3]]
     premul=[b.resize(size, Image.Resampling.LANCZOS) for b in premul]
     out_a=alpha.resize(size, Image.Resampling.LANCZOS)
-    out=[]
-    for b in premul:
-        # premul is divided by alpha in byte space.
-        out.append(Image.eval(Image.merge("LA",(b,out_a)), lambda x:x) if False else b)
     pixels=[]
-    for p0,p1,p2,a in zip(*(list(b.getdata()) for b in premul), list(out_a.getdata())):
+    for p0,p1,p2,a in zip(*(flattened_data(b) for b in premul), flattened_data(out_a)):
         pixels.append(tuple(0 if not a else min(255,(p*255+a//2)//a) for p in (p0,p1,p2))+(a,))
     result=Image.new("RGBA",size); result.putdata(pixels)
     return bleed_transparent_rgb(result)
@@ -129,6 +135,7 @@ def audit_entry(root, model, texture, config, previews=False):
     faces,errors=_MODEL_CACHE[key]
     uvs=[uv for face in faces for uv in face.uvs]; triangles=[t for f in faces for t in triangulate(f)]
     record={"model_path":str(model.relative_to(root)) if model.exists() else str(model),"texture_path":str(texture.relative_to(root)),"configuration_path":str(config.relative_to(root)),
+      "model_exists":model.exists(),"texture_exists":texture.exists(),
       "texture_width":None,"texture_height":None,"texture_color_mode":None,"minimum_alpha":None,"alpha_coverage":None,
       "uv_min_u":min((u for u,v in uvs),default=None),"uv_max_u":max((u for u,v in uvs),default=None),"uv_min_v":min((v for u,v in uvs),default=None),"uv_max_v":max((v for u,v in uvs),default=None),
       "uv_triangle_count":len(triangles),"small_uv_triangle_count":None,"out_of_range_uv_count":sum(not(0<=u<=1 and 0<=v<=1) for u,v in uvs),"malformed_uv_count":len(errors),
@@ -136,13 +143,14 @@ def audit_entry(root, model, texture, config, previews=False):
     if not texture.exists() or Image is None: return record
     with Image.open(texture) as source:
         image=source.convert("RGBA"); w,h=image.size; alpha=image.getchannel("A")
-        record.update(texture_width=w,texture_height=h,texture_color_mode=source.mode,minimum_alpha=min(alpha.getdata()),alpha_coverage=sum(a>=ALPHA_THRESHOLD for a in alpha.getdata())/(w*h),small_uv_triangle_count=sum(triangle_area(t,w,h)<1 for t in triangles))
+        alpha_values=list(flattened_data(alpha))
+        record.update(texture_width=w,texture_height=h,texture_color_mode=source.mode,minimum_alpha=min(alpha_values),alpha_coverage=sum(a>=ALPHA_THRESHOLD for a in alpha_values)/(w*h),small_uv_triangle_count=sum(triangle_area(t,w,h)<1 for t in triangles))
         if triangles and all(0<=u<=1 and 0<=v<=1 for u,v in uvs):
             mask=Image.new("1",(w,h)); draw=ImageDraw.Draw(mask)
             for tri in triangles: draw.polygon([(u*(w-1),v*(h-1)) for u,v in tri],fill=1)
-            covered=list(mask.getdata()); av=list(alpha.getdata()); record["transparent_covered_pixels"]=sum(m and a<ALPHA_THRESHOLD for m,a in zip(covered,av))
+            covered=list(flattened_data(mask)); av=alpha_values; record["transparent_covered_pixels"]=sum(m and a<ALPHA_THRESHOLD for m,a in zip(covered,av))
             expanded=mask.filter(ImageFilter.MaxFilter(3)); edge=ImageChops.subtract(expanded,mask)
-            record["sampling_edge_pixels"]=sum(m and a<ALPHA_THRESHOLD for m,a in zip(edge.getdata(),av))
+            record["sampling_edge_pixels"]=sum(m and a<ALPHA_THRESHOLD for m,a in zip(flattened_data(edge),av))
         if record["minimum_alpha"]==255: record.update(suspected_cause="none detected",recommended_repair="none")
         elif record["transparent_covered_pixels"]: record.update(suspected_cause="UV coverage intersects transparent texels",recommended_repair="restore source and premultiplied resize; validate intentional transparency")
         else: record.update(suspected_cause="intentional or unproven transparency",recommended_repair="manual review")
@@ -155,36 +163,85 @@ def write_reports(records, output):
     with (output/"audit.csv").open("w",newline="") as stream:
         writer=csv.DictWriter(stream,fields); writer.writeheader(); writer.writerows(records)
 
+def write_suspicious_report(records, output):
+    """Rank likely opaque-surface problems while retaining measurements for review."""
+    intentional=("glass","window","sight","rotor","propeller","exhaust","lamp","decal","hud")
+    priority=("body","turret","wheel","track","skin","hull","weapon")
+    ranked=[]
+    for record in records:
+        names=(record["model_path"]+" "+record["texture_path"]).lower()
+        missing=not record["model_exists"] or not record["texture_exists"]
+        transparent=record["transparent_covered_pixels"] or 0
+        edge=record["sampling_edge_pixels"] or 0
+        small=record["small_uv_triangle_count"] or 0
+        out=record["out_of_range_uv_count"] or 0
+        if not (missing or transparent or edge or small or out): continue
+        classification="intentional transparency review" if any(word in names for word in intentional) else "likely opaque vehicle surface"
+        score=(1000000 if missing else 0)+(transparent*10)+edge+(small*4)+(out*2)
+        if any(word in names for word in priority): score+=10000
+        if classification.startswith("intentional"): score-=10000
+        reason=("missing model or texture; " if missing else "")+("UV-covered transparent pixels; " if transparent else "")+("transparent sampling edge; " if edge else "")+("sub-texel UV triangles; " if small else "")+("out-of-range UVs (may wrap); " if out else "")
+        ranked.append({"rank":0,"score":score,"classification":classification,"reason":reason.rstrip("; "),**record})
+    ranked.sort(key=lambda row:(-row["score"],row["model_path"],row["texture_path"]))
+    for number,row in enumerate(ranked,1): row["rank"]=number
+    fields=list(ranked[0]) if ranked else ["rank","score","classification","reason"]
+    with (output/"suspicious_assets.csv").open("w",newline="") as stream:
+        writer=csv.DictWriter(stream,fields); writer.writeheader(); writer.writerows(ranked)
+
 def load_manifest(path): return json.loads(path.read_text())
 
 def repair(args, apply=False):
-    root=Path(args.assets); changes=[]
-    for item in load_manifest(Path(args.manifest)).get("repairs",[]):
+    root=Path(args.assets); changes=[]; failures=[]; manifest=load_manifest(Path(args.manifest)); entries=manifest.get("repairs",[])
+    if not entries:
+        print("No repair entries are defined in %s.\nNo files were changed." % args.manifest)
+        return 1 if apply else 0
+    if apply and manifest.get("unresolved"):
+        print("APPLY refused: %d unresolved manifest entries remain." % len(manifest["unresolved"]))
+        return 1
+    for item in entries:
         if Image is None: raise SystemExit("Pillow is required for repair")
         source=Path(item["source_texture_path"]); source=source if source.is_absolute() else root/source
         target=root/item["current_texture_path"]
-        if not source.exists(): print("UNRESOLVED %s: source %s missing"%(target,source)); continue
-        if sha256(source.read_bytes())!=item["source_sha256"]: raise SystemExit("source hash mismatch: "+str(source))
+        if not source.exists(): failures.append("UNRESOLVED %s: source %s missing"%(target,source)); continue
+        if sha256(source.read_bytes())!=item["source_sha256"]: failures.append("source hash mismatch: "+str(source)); continue
         with Image.open(source) as image: result=premultiplied_resize(image,(item["output_width"],item["output_height"]))
         import io; buf=io.BytesIO(); result.save(buf,"PNG",optimize=False,compress_level=9); data=buf.getvalue()
-        if sha256(data)!=item["output_sha256"]: raise SystemExit("output hash mismatch: "+str(target))
+        if sha256(data)!=item["output_sha256"]: failures.append("output hash mismatch: "+str(target)); continue
         changes.append(str(target));
         if apply: target.parent.mkdir(parents=True,exist_ok=True); target.write_bytes(data)
         transform=item.get("uv_transform")
         for model_name in item.get("models",[]):
             model=root/model_name; changed=rewrite_mqo(model.read_bytes(),transform) if transform else model.read_bytes()
             if changed!=model.read_bytes(): changes.append(str(model)); apply and model.write_bytes(changed)
-    print(("APPLY" if apply else "DRY-RUN")+"\n"+"\n".join(changes)); return 0
+    print(("APPLY" if apply else "DRY-RUN")+"\n"+"\n".join(changes+failures))
+    if not changes: print("No files were changed.")
+    return 1 if apply and failures else 0
+
+def verify_manifest(args):
+    root=Path(args.assets); manifest=load_manifest(Path(args.manifest)); failures=[]
+    for entry in manifest.get("unresolved",[]):
+        failures.append("UNRESOLVED: "+entry.get("required_source",entry.get("reason","manifest entry")))
+    for item in manifest.get("repairs",[]):
+        source=Path(item["source_texture_path"]); source=source if source.is_absolute() else root/source
+        target=root/item["current_texture_path"]
+        if not source.exists(): failures.append("MISSING SOURCE: "+str(source))
+        elif sha256(source.read_bytes()) != item["source_sha256"]: failures.append("SOURCE HASH MISMATCH: "+str(source))
+        if not target.exists(): failures.append("MISSING OUTPUT: "+str(target))
+        elif sha256(target.read_bytes()) != item["output_sha256"]: failures.append("OUTPUT HASH MISMATCH: "+str(target))
+    if failures:
+        print("Verification failed:\n"+"\n".join(failures)); return 1
+    print("Verification succeeded: %d repair entries are complete." % len(manifest.get("repairs",[]))); return 0
 
 def main(argv=None):
     parser=argparse.ArgumentParser(); parser.add_argument("--assets",default="src/main/resources/assets/mcheli"); parser.add_argument("--output",default="build/texture_uv_audit"); parser.add_argument("--manifest",default="tools/texture_downscale_manifest.json")
     subs=parser.add_subparsers(dest="command",required=True); subs.add_parser("audit"); rep=subs.add_parser("repair"); mode=rep.add_mutually_exclusive_group(required=True); mode.add_argument("--dry-run",action="store_true"); mode.add_argument("--apply",action="store_true"); subs.add_parser("verify")
     args=parser.parse_args(argv); root=Path(args.assets)
     if args.command=="repair": return repair(args,args.apply)
-    records=[audit_entry(root,*pair) for pair in sorted(config_pairs(root),key=lambda p:(str(p[0]),str(p[1]),str(p[2])))]; write_reports(records,Path(args.output))
+    if args.command=="verify": return verify_manifest(args)
+    records=[audit_entry(root,*pair) for pair in sorted(config_pairs(root),key=lambda p:(str(p[0]),str(p[1]),str(p[2])))]; write_reports(records,Path(args.output)); write_suspicious_report(records,Path(args.output))
     manifest=load_manifest(Path(args.manifest))
     unresolved=list(manifest.get("unresolved",[]))+[x for x in manifest.get("repairs",[]) if not (root/x["source_texture_path"]).exists()]
     print("audited %d runtime model/texture selections; %d manifest sources unresolved"%(len(records),len(unresolved)))
-    return 1 if args.command=="verify" and unresolved else 0
+    return 0
 
 if __name__=="__main__": sys.exit(main())

--- a/tools/test_repair_texture_uvs.py
+++ b/tools/test_repair_texture_uvs.py
@@ -1,4 +1,4 @@
-import hashlib, io, tempfile, unittest
+import contextlib, hashlib, io, json, tempfile, unittest
 from pathlib import Path
 import repair_texture_uvs as tool
 Image=tool.Image
@@ -44,14 +44,32 @@ class ImageTests(unittest.TestCase):
     def test_premultiplied_resize_and_alpha_coverage(self):
         result=tool.premultiplied_resize(self.make_image(),(8,8))
         self.assertEqual((8,8),result.size)
-        self.assertGreater(sum(a>=128 for *_,a in result.getdata()),8)
+        self.assertGreater(sum(a>=128 for *_,a in tool.flattened_data(result)),8)
         self.assertGreater(result.getpixel((4,4))[3],240)
 
     def test_bleed_does_not_expand_alpha(self):
-        image=self.make_image(); before=list(image.getchannel("A").getdata())
+        image=self.make_image(); before=list(tool.flattened_data(image.getchannel("A")))
         result=tool.bleed_transparent_rgb(image)
-        self.assertEqual(before,list(result.getchannel("A").getdata()))
+        self.assertEqual(before,list(tool.flattened_data(result.getchannel("A"))))
         self.assertNotEqual((0,0,0),result.getpixel((3,3))[:3])
+
+    def test_each_bleed_pass_propagates_farther(self):
+        image=Image.new("RGBA",(9,1),(0,0,0,0)); image.putpixel((0,0),(90,40,10,255))
+        one=tool.bleed_transparent_rgb(image,1); four=tool.bleed_transparent_rgb(image,4)
+        self.assertEqual((0,0,0),one.getpixel((4,0))[:3])
+        self.assertNotEqual((0,0,0),four.getpixel((4,0))[:3])
+
+    def test_opaque_and_transparent_extremes(self):
+        opaque=tool.premultiplied_resize(Image.new("RGBA",(4,4),(3,8,20,255)),(7,7))
+        transparent=tool.premultiplied_resize(Image.new("RGBA",(4,4),(3,8,20,0)),(7,7))
+        self.assertTrue(all(a==255 for *_,a in tool.flattened_data(opaque)))
+        self.assertTrue(all(a==0 for *_,a in tool.flattened_data(transparent)))
+
+    def test_semitransparent_and_border_rgb_are_valid(self):
+        result=tool.premultiplied_resize(self.make_image(),(8,8))
+        semi=[p for p in tool.flattened_data(result) if 0<p[3]<255]
+        self.assertTrue(semi); self.assertTrue(all(any(p[:3]) for p in semi))
+        self.assertNotEqual((0,0,0),result.getpixel((1,1))[:3])
 
     def test_deterministic_hash(self):
         hashes=[]
@@ -59,5 +77,43 @@ class ImageTests(unittest.TestCase):
             result=tool.premultiplied_resize(self.make_image(),(8,8)); out=io.BytesIO()
             result.save(out,"PNG",compress_level=9,optimize=False); hashes.append(hashlib.sha256(out.getvalue()).hexdigest())
         self.assertEqual(hashes[0],hashes[1])
+
+    def test_repair_dry_run_apply_and_complete_verification(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); (root/"sources").mkdir(); source=root/"sources/original.png"
+            Image.new("RGBA",(4,4),(20,40,60,255)).save(source)
+            result=tool.premultiplied_resize(Image.open(source),(2,2)); encoded=io.BytesIO()
+            result.save(encoded,"PNG",optimize=False,compress_level=9)
+            manifest=root/"manifest.json"; manifest.write_text(json.dumps({"repairs":[{
+                "current_texture_path":"textures/out.png","source_texture_path":"sources/original.png",
+                "source_sha256":tool.sha256(source.read_bytes()),"output_sha256":tool.sha256(encoded.getvalue()),
+                "output_width":2,"output_height":2,"models":[],"uv_transform":None}],"unresolved":[]}))
+            common=["--assets",str(root),"--manifest",str(manifest),"repair"]
+            output=io.StringIO()
+            with contextlib.redirect_stdout(output): self.assertEqual(0,tool.main(common+["--dry-run"]))
+            self.assertIn(str(root/"textures/out.png"),output.getvalue()); self.assertFalse((root/"textures/out.png").exists())
+            with contextlib.redirect_stdout(io.StringIO()): self.assertEqual(0,tool.main(common+["--apply"]))
+            self.assertTrue((root/"textures/out.png").exists())
+            with contextlib.redirect_stdout(io.StringIO()): self.assertEqual(0,tool.main(["--assets",str(root),"--manifest",str(manifest),"verify"]))
+
+class CommandTests(unittest.TestCase):
+    def manifest(self, root, content):
+        path=root/"manifest.json"; path.write_text(json.dumps(content)); return path
+
+    def test_empty_manifest_messages_and_apply_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory); manifest=self.manifest(root,{"repairs":[],"unresolved":[]})
+            for mode, expected in (("--dry-run",0),("--apply",1)):
+                output=io.StringIO()
+                with contextlib.redirect_stdout(output): result=tool.main(["--assets",str(root),"--manifest",str(manifest),"repair",mode])
+                self.assertEqual(expected,result); self.assertIn("No repair entries are defined",output.getvalue()); self.assertIn("No files were changed",output.getvalue())
+
+    def test_verify_rejects_unresolved_and_missing_source(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root=Path(directory)
+            unresolved=self.manifest(root,{"repairs":[],"unresolved":[{"required_source":"original.png"}]})
+            with contextlib.redirect_stdout(io.StringIO()): self.assertEqual(1,tool.main(["--assets",str(root),"--manifest",str(unresolved),"verify"]))
+            missing=self.manifest(root,{"repairs":[{"source_texture_path":"missing.png","current_texture_path":"out.png","source_sha256":"0","output_sha256":"0"}],"unresolved":[]})
+            with contextlib.redirect_stdout(io.StringIO()): self.assertEqual(1,tool.main(["--assets",str(root),"--manifest",str(missing),"verify"]))
 
 if __name__=="__main__": unittest.main()

--- a/tools/texture_uv_repair.md
+++ b/tools/texture_uv_repair.md
@@ -3,7 +3,7 @@
 Run from the repository root (Pillow is a development-only requirement):
 
 ```sh
-python -m pip install Pillow
+python -m pip install Pillow==12.3.0
 python tools/repair_texture_uvs.py audit
 python tools/repair_texture_uvs.py repair --dry-run
 python tools/repair_texture_uvs.py repair --apply
@@ -24,6 +24,8 @@ Static renderer inspection confirms ordinary vehicle textures resolve as `textur
 Only add an entry after locating a genuine source. Record its repository-relative source and destination, dimensions, SHA-256 values, `premultiplied_lanczos` resize, `transparent_rgb_edge_bleed` alpha repair, reason, and affected `models`. Use `uv_transform: null` for proportional resizing. For a proven canvas change, specify old/new dimensions, crop, padding, and independent scales; only the listed MQOs are rewritten.
 
 Run `audit`, inspect its transparent coverage and edge sampling counts, then run dry-run. After reviewing its exact file list, use `--apply` and `verify`. Hash checks make an asset update fail safely until the manifest is deliberately refreshed.
+
+An empty manifest is an explicit no-op in dry-run mode and an error in apply mode. Apply also refuses to run while unresolved entries remain; verification checks every source and output hash and reports each missing asset. `suspicious_assets.csv` ranks missing assets, transparent UV coverage, sampling edges, sub-texel triangles, and out-of-range coordinates. The ranking labels glass, windows, sights, rotor/propeller/exhaust effects, lamps, decals, and HUD assets for intentional-transparency review rather than automatically treating them as damage.
 
 ## Unresolved sources
 


### PR DESCRIPTION
### Motivation

- Fix an AttributeError caused by calling the unsupported Pillow `Image.putchannel()` API and complete the incomplete texture/UV repair implementation. 
- Ensure premultiplied-alpha resizes, RGB bleeding, manifest-driven repair, and verification are deterministic and fail-safe when sources or hashes are missing. 

### Description

- Replace per-channel `putchannel` usage with splitting the RGB image into channel images, applying dilation to each channel, pasting with a computed ring mask, merging with `Image.merge("RGB", ...)`, and restoring the original alpha exactly so alpha coverage is never changed. 
- Add `flattened_data()` compatibility helper to prefer `get_flattened_data()` and fall back to `getdata()` to avoid Pillow deprecation warnings and make pixel access consistent. 
- Correct `premultiplied_resize()` so it converts to RGBA, premultiplies RGB by alpha, resizes premultiplied RGB and alpha with the same Lanczos filter, unpremultiplies RGB using the resized alpha (zeroing RGB where alpha is zero), and then performs RGB-only edge bleeding. 
- Make repair behavior explicit and fail-safe by printing a clear `No repair entries...` message for empty manifests, refusing `--apply` when unresolved entries exist, reporting missing-source and hash mismatches, and returning nonzero exit codes on apply/verification failures; add `verify_manifest()` to check unresolved entries, source/output existence, and source/output hashes. 
- Add `write_suspicious_report()` to produce `suspicious_assets.csv` that ranks likely problematic assets (missing files, transparent-covered pixels, sampling edges, small UV triangles, out-of-range UVs) while classifying known intentional-transparent assets for review instead of treating them as errors. 
- Expand tests in `tools/test_repair_texture_uvs.py` to cover alpha-preservation, multi-pass RGB bleeding propagation, opaque/transparent extremes, semitransparent pixel validity, deterministic output, dry-run/apply behavior, empty-manifest messaging, and verification failure conditions. 
- Update documentation and changelog to pin Pillow to `12.3.0`, describe the new command behaviors, and record the implemented fixes. 

### Testing

- Ran unit tests with `python -m unittest discover -s tools -p 'test_repair_texture_uvs.py'`, which passed (16 tests ran) with 7 Pillow-dependent tests skipped because Pillow could not be installed in this environment. 
- Verified `repair --dry-run` exits 0 and prints `No repair entries are defined in tools/texture_downscale_manifest.json.` and `No files were changed.`. 
- Verified `repair --apply` returns nonzero when the manifest is empty and prints the same explanatory message. 
- Verified `verify` returns nonzero and reports unresolved sources when the manifest contains unresolved entries. 
- Attempted to install `Pillow==12.3.0` but package installation is blocked by the environment (HTTP 403 through proxy), so full Pillow-run image-audit validation and deprecation-warning suppression could not be executed here. 

Changed files: `tools/repair_texture_uvs.py`, `tools/test_repair_texture_uvs.py`, `tools/texture_uv_repair.md`, and `CHANGELOG.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ec80707688323891b2126e41cfb86)