### PR TITLE
Automatic runtime model texture and UV repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Automatic runtime model texture and UV repair (PR pending)
+
+- Discover model/texture pairs at vehicle and 3D vehicle-item binding time, rasterize in-range MQO/OBJ UV faces, and conservatively repair small enclosed alpha damage in cached dynamic textures without changing source assets.
+- Preserve wrapping UVs, large and smooth transparency, and original UV data; move only repaired, in-range UV samples to nearby opaque texel centers when confidence permits.
+- Delete repaired GL textures on resource reload, expose conservative client configuration and optional development previews, and clarify that the Python manifest workflow is diagnostic only.
+
 # Complete deterministic texture/UV repair validation (PR pending)
 
 - Replaced unsupported per-channel `putchannel` mutation with split/dilate/merge RGB bleeding that preserves alpha byte-for-byte across every pass.

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -765,6 +765,7 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
 
    public void init() {
       MCH_ParticleTexture.register();
+      mcheli.texture.MCH_ModelTextureRepairManager.register();
       MinecraftForge.EVENT_BUS.register(new MCH_ParticlesUtil());
       MinecraftForge.EVENT_BUS.register(new MCH_ClientEventHook());
       MinecraftForge.EVENT_BUS.register(new MCH_RenderBVRLockBox());

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -146,6 +146,10 @@ public class MCH_Config {
    public static MCH_ConfigPrm AircraftLODThermalContrastExponent;
    public static MCH_ConfigPrm AircraftLODOpticalMinPixels;
    public static MCH_ConfigPrm AircraftLODThermalMinPixels;
+   public static MCH_ConfigPrm EnableModelTextureRepair, EnableModelUVCorrection;
+   public static MCH_ConfigPrm ModelTextureMaxHoleArea, ModelTextureMaxHoleThickness;
+   public static MCH_ConfigPrm ModelTextureRGBBleedRadius, ModelTextureAlphaExpansionRadius, ModelTextureUVCorrectionRadius;
+   public static MCH_ConfigPrm ModelTextureRepairDebugLogging, ModelTextureRepairDebugPreviews;
    public static MCH_ConfigPrm MobRenderDistanceWeight;
    public static MCH_ConfigPrm CreativeTabIcon;
    public static MCH_ConfigPrm CreativeTabIconHeli;
@@ -493,6 +497,15 @@ public class MCH_Config {
       AircraftLODThermalContrastExponent = new MCH_ConfigPrm("AircraftLODThermalContrastExponent", 0.35D);
       AircraftLODOpticalMinPixels = new MCH_ConfigPrm("AircraftLODOpticalMinPixels", 0.75D);
       AircraftLODThermalMinPixels = new MCH_ConfigPrm("AircraftLODThermalMinPixels", 0.35D);
+      EnableModelTextureRepair = new MCH_ConfigPrm("EnableModelTextureRepair", true);
+      EnableModelUVCorrection = new MCH_ConfigPrm("EnableModelUVCorrection", true);
+      ModelTextureMaxHoleArea = new MCH_ConfigPrm("ModelTextureMaxHoleArea", 16);
+      ModelTextureMaxHoleThickness = new MCH_ConfigPrm("ModelTextureMaxHoleThickness", 2);
+      ModelTextureRGBBleedRadius = new MCH_ConfigPrm("ModelTextureRGBBleedRadius", 2);
+      ModelTextureAlphaExpansionRadius = new MCH_ConfigPrm("ModelTextureAlphaExpansionRadius", 1);
+      ModelTextureUVCorrectionRadius = new MCH_ConfigPrm("ModelTextureUVCorrectionRadius", 2);
+      ModelTextureRepairDebugLogging = new MCH_ConfigPrm("ModelTextureRepairDebugLogging", false);
+      ModelTextureRepairDebugPreviews = new MCH_ConfigPrm("ModelTextureRepairDebugPreviews", false);
       MobRenderDistanceWeight = new MCH_ConfigPrm("MobRenderDistanceWeight", 10.0D);
       CreativeTabIcon = new MCH_ConfigPrm("CreativeTabIconItem", "fuel");
       CreativeTabIconHeli = new MCH_ConfigPrm("CreativeTabIconHeli", "ah-64");
@@ -732,6 +745,11 @@ public class MCH_Config {
               EnableMCHLibDebugLog,
               TestMode,
               EnableCommand,
+              EnableModelTextureRepair, EnableModelUVCorrection,
+              ModelTextureMaxHoleArea, ModelTextureMaxHoleThickness,
+              ModelTextureRGBBleedRadius, ModelTextureAlphaExpansionRadius,
+              ModelTextureUVCorrectionRadius, ModelTextureRepairDebugLogging,
+              ModelTextureRepairDebugPreviews,
               null,
               PlaceableOnSpongeOnly,
               ItemDamage,

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -331,6 +331,9 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
       }else {
          try {
             activeBaseTexture = new ResourceLocation(W_MOD.DOMAIN, getBaseTexturePath(path));
+            activeBaseTexture = mcheli.texture.MCH_ModelTextureRepairManager.resolve(activeBaseTexture,
+                  ac.getAcInfo() != null ? ac.getAcInfo().model : null,
+                  ac.getAcInfo() != null ? ac.getAcInfo().getDirectoryName() + "/" + ac.getAcInfo().name : "unknown");
             super.bindTexture(activeBaseTexture);
          } catch (Exception var4) {
             System.out.println("Error loading texture: " + path + " (" + var4.getMessage() + ")"); //why the fuck is this happening

--- a/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
+++ b/src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java
@@ -109,13 +109,8 @@ public class MCH_VehicleItemModelRender implements IItemRenderer {
 
       transform(type, info);
 
-      W_McClient.MOD_bindTexture(
-              "textures/"
-                      + info.getDirectoryName()
-                      + "/"
-                      + MCH_RenderBaseVehicle.getBaseTextureName(info.name)
-                      + ".png"
-      );
+      net.minecraft.util.ResourceLocation original = new net.minecraft.util.ResourceLocation("mcheli", "textures/" + info.getDirectoryName() + "/" + MCH_RenderBaseVehicle.getBaseTextureName(info.name) + ".png");
+      Minecraft.getMinecraft().getTextureManager().bindTexture(mcheli.texture.MCH_ModelTextureRepairManager.resolve(original, info.model, info.getDirectoryName() + "/" + info.name));
 
       MCH_RenderBaseVehicle.beginSkinOverlayRender(
               info.getDirectoryName(),

--- a/src/main/java/mcheli/texture/MCH_ModelTextureRepairManager.java
+++ b/src/main/java/mcheli/texture/MCH_ModelTextureRepairManager.java
@@ -1,0 +1,61 @@
+package mcheli.texture;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import javax.imageio.ImageIO;
+import mcheli.MCH_Config;
+import mcheli.MCH_Lib;
+import mcheli.wrapper.modelloader.W_Face;
+import mcheli.wrapper.modelloader.W_GroupObject;
+import mcheli.wrapper.modelloader.W_MetasequoiaObject;
+import mcheli.wrapper.modelloader.W_WavefrontObject;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.client.renderer.texture.TextureManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.model.IModelCustom;
+
+/** Client-only, lazy cache joining each rendered model instance to its vehicle texture. */
+@SideOnly(Side.CLIENT)
+public final class MCH_ModelTextureRepairManager implements IResourceManagerReloadListener {
+   private static final MCH_ModelTextureRepairManager INSTANCE=new MCH_ModelTextureRepairManager();
+   private final Map cache=new HashMap(); private int generation;
+   private MCH_ModelTextureRepairManager(){}
+   public static void register(){IResourceManager r=Minecraft.getMinecraft().getResourceManager();if(r instanceof IReloadableResourceManager)((IReloadableResourceManager)r).registerReloadListener(INSTANCE);}
+   public static ResourceLocation resolve(ResourceLocation original,IModelCustom model,String modelPath){return INSTANCE.resolve0(original,model,modelPath);}
+   private ResourceLocation resolve0(ResourceLocation original,IModelCustom model,String modelPath){
+      if(MCH_Config.EnableModelTextureRepair==null||!MCH_Config.EnableModelTextureRepair.prmBool||model==null)return original;
+      Key key=new Key(original,model);Entry hit=(Entry)cache.get(key);if(hit!=null)return hit.location;
+      Entry made=build(original,model,modelPath);cache.put(key,made);return made.location;
+   }
+   private Entry build(ResourceLocation source,IModelCustom model,String modelPath){InputStream in=null;try{
+      IResource resource=Minecraft.getMinecraft().getResourceManager().getResource(source);in=resource.getInputStream();BufferedImage original=ImageIO.read(in);if(original==null)return new Entry(source,null);
+      boolean[] coverage=new boolean[original.getWidth()*original.getHeight()];if(!coverage(model,coverage,original.getWidth(),original.getHeight()))return new Entry(source,null);
+      MCH_ModelTextureRepairProcessor.Result result=MCH_ModelTextureRepairProcessor.repair(original,coverage,positive(MCH_Config.ModelTextureMaxHoleArea,16),positive(MCH_Config.ModelTextureMaxHoleThickness,2),positive(MCH_Config.ModelTextureRGBBleedRadius,2),positive(MCH_Config.ModelTextureAlphaExpansionRadius,1));
+      if(result.repairedPixels==0)return new Entry(source,null); // RGB-only changes are deliberately not enough confidence for replacement.
+      if(MCH_Config.EnableModelUVCorrection!=null&&MCH_Config.EnableModelUVCorrection.prmBool)correct(model,result.image,positive(MCH_Config.ModelTextureUVCorrectionRadius,2));
+      DynamicTexture dynamic=new DynamicTexture(result.image);ResourceLocation location=Minecraft.getMinecraft().getTextureManager().getDynamicTextureLocation("mcheli_model_repair_"+(generation++),dynamic);
+      if(MCH_Config.ModelTextureRepairDebugPreviews!=null&&MCH_Config.ModelTextureRepairDebugPreviews.prmBool)preview(modelPath,source,original,coverage,result);
+      if(MCH_Config.ModelTextureRepairDebugLogging!=null&&MCH_Config.ModelTextureRepairDebugLogging.prmBool)MCH_Lib.Log("Texture repair: model=%s texture=%s pixels=%d",modelPath,source,Integer.valueOf(result.repairedPixels));
+      return new Entry(location,dynamic);
+   }catch(Exception e){if(MCH_Config.ModelTextureRepairDebugLogging!=null&&MCH_Config.ModelTextureRepairDebugLogging.prmBool)MCH_Lib.Log("Texture repair skipped: model=%s texture=%s (%s)",modelPath,source,e.getMessage());return new Entry(source,null);}finally{if(in!=null)try{in.close();}catch(Exception ignored){}}}
+   private static int positive(mcheli.MCH_ConfigPrm p,int d){return p==null?d:Math.max(0,p.prmInt);}
+   private static boolean coverage(IModelCustom model,boolean[] mask,int w,int h){Iterator groups=null;if(model instanceof W_MetasequoiaObject)groups=((W_MetasequoiaObject)model).groupObjects.iterator();else if(model instanceof W_WavefrontObject)groups=((W_WavefrontObject)model).groupObjects.iterator();if(groups==null)return false;boolean any=false;while(groups.hasNext()){W_GroupObject g=(W_GroupObject)groups.next();for(Object o:g.faces){W_Face f=(W_Face)o;int n=f.getTextureCoordinateCount();if(n!=3&&n!=4)continue;float[] uv=new float[n*2];for(int i=0;i<n;i++){uv[i*2]=f.getTextureU(i);uv[i*2+1]=f.getTextureV(i);}MCH_ModelTextureRepairProcessor.rasterizeFace(mask,w,h,uv);any=true;}}return any;}
+   private static void correct(IModelCustom model,BufferedImage image,int radius){Iterator groups=model instanceof W_MetasequoiaObject?((W_MetasequoiaObject)model).groupObjects.iterator():model instanceof W_WavefrontObject?((W_WavefrontObject)model).groupObjects.iterator():null;if(groups==null)return;while(groups.hasNext())for(Object o:((W_GroupObject)groups.next()).faces){W_Face f=(W_Face)o;int n=f.getTextureCoordinateCount();float[] uv=new float[n*2];boolean changed=false;for(int i=0;i<n;i++){float u=f.getTextureU(i),v=f.getTextureV(i);float[] c=MCH_ModelTextureRepairProcessor.correctUV(u,v,image,radius);uv[i*2]=c[0];uv[i*2+1]=c[1];changed|=u!=c[0]||v!=c[1];}if(changed)f.setRepairedTextureCoordinates(uv);}}
+   private static void preview(String model,ResourceLocation texture,BufferedImage original,boolean[] mask,MCH_ModelTextureRepairProcessor.Result result)throws Exception{File dir=new File(Minecraft.getMinecraft().mcDataDir,"mcheli-texture-repair/"+safe(model+"__"+texture));dir.mkdirs();ImageIO.write(original,"png",new File(dir,"original.png"));BufferedImage m=new BufferedImage(original.getWidth(),original.getHeight(),BufferedImage.TYPE_INT_ARGB),components=new BufferedImage(original.getWidth(),original.getHeight(),BufferedImage.TYPE_INT_ARGB),overlay=new BufferedImage(original.getWidth(),original.getHeight(),BufferedImage.TYPE_INT_ARGB);for(int p=0;p<mask.length;p++){int x=p%original.getWidth(),y=p/original.getWidth();if(mask[p])m.setRGB(x,y,Color.WHITE.getRGB());if(result.components[p])components.setRGB(x,y,0xFFFF0000);overlay.setRGB(x,y,result.components[p]?0xFFFF00FF:original.getRGB(x,y));}ImageIO.write(m,"png",new File(dir,"uv-coverage.png"));ImageIO.write(components,"png",new File(dir,"transparent-components.png"));ImageIO.write(result.image,"png",new File(dir,"repaired.png"));ImageIO.write(overlay,"png",new File(dir,"uv-correction-overlay.png"));java.io.PrintWriter report=new java.io.PrintWriter(new File(dir,"report.txt"),"UTF-8");report.println("model="+model);report.println("texture="+texture);report.close();}
+   private static String safe(String s){return s.replaceAll("[^A-Za-z0-9._-]","_");}
+   public void onResourceManagerReload(IResourceManager ignored){TextureManager tm=Minecraft.getMinecraft().getTextureManager();for(Object o:cache.values()){Entry e=(Entry)o;if(e.dynamic!=null)tm.deleteTexture(e.location);}cache.clear();generation=0;}
+   static final class Key{final ResourceLocation texture;final IModelCustom model;Key(ResourceLocation t,IModelCustom m){texture=t;model=m;}public int hashCode(){return texture.hashCode()*31+System.identityHashCode(model);}public boolean equals(Object o){return o instanceof Key&&((Key)o).texture.equals(texture)&&((Key)o).model==model;}}
+   static final class Entry{final ResourceLocation location;final DynamicTexture dynamic;Entry(ResourceLocation l,DynamicTexture d){location=l;dynamic=d;}}
+}

--- a/src/main/java/mcheli/texture/MCH_ModelTextureRepairProcessor.java
+++ b/src/main/java/mcheli/texture/MCH_ModelTextureRepairProcessor.java
@@ -1,0 +1,65 @@
+package mcheli.texture;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayDeque;
+
+/** Deterministic, OpenGL-free image/UV algorithms used by the client repair cache. */
+public final class MCH_ModelTextureRepairProcessor {
+   private MCH_ModelTextureRepairProcessor() {}
+
+   public static void rasterizeTriangle(boolean[] mask, int width, int height, float[] uv) {
+      for(float value : uv) if(value < 0.0F || value > 1.0F) return; // wrapping must remain wrapping
+      float ax=uv[0]*(width-1), ay=(1.0F-uv[1])*(height-1);
+      float bx=uv[2]*(width-1), by=(1.0F-uv[3])*(height-1);
+      float cx=uv[4]*(width-1), cy=(1.0F-uv[5])*(height-1);
+      int minX=Math.max(0,(int)Math.floor(Math.min(ax,Math.min(bx,cx))));
+      int maxX=Math.min(width-1,(int)Math.ceil(Math.max(ax,Math.max(bx,cx))));
+      int minY=Math.max(0,(int)Math.floor(Math.min(ay,Math.min(by,cy))));
+      int maxY=Math.min(height-1,(int)Math.ceil(Math.max(ay,Math.max(by,cy))));
+      float area=edge(ax,ay,bx,by,cx,cy); if(area==0.0F) return;
+      for(int y=minY;y<=maxY;y++) for(int x=minX;x<=maxX;x++) {
+         float px=x+0.5F, py=y+0.5F;
+         float a=edge(bx,by,cx,cy,px,py), b=edge(cx,cy,ax,ay,px,py), c=edge(ax,ay,bx,by,px,py);
+         if((a>=0&&b>=0&&c>=0)||(a<=0&&b<=0&&c<=0)) mask[y*width+x]=true;
+      }
+   }
+   private static float edge(float ax,float ay,float bx,float by,float x,float y){return (x-ax)*(by-ay)-(y-ay)*(bx-ax);}
+
+   /** MQO quads use the same fan split as GL_QUADS: (0,1,2) and (0,2,3). */
+   public static void rasterizeFace(boolean[] mask,int w,int h,float[] uv) {
+      if(uv.length==6) rasterizeTriangle(mask,w,h,uv);
+      else if(uv.length==8) {
+         rasterizeTriangle(mask,w,h,new float[]{uv[0],uv[1],uv[2],uv[3],uv[4],uv[5]});
+         rasterizeTriangle(mask,w,h,new float[]{uv[0],uv[1],uv[4],uv[5],uv[6],uv[7]});
+      }
+   }
+
+   public static Result repair(BufferedImage source, boolean[] coverage, int maxArea, int maxThickness, int bleedRadius, int expandRadius) {
+      int w=source.getWidth(),h=source.getHeight(); BufferedImage out=new BufferedImage(w,h,BufferedImage.TYPE_INT_ARGB);
+      out.setRGB(0,0,w,h,source.getRGB(0,0,w,h,null,0,w),0,w);
+      boolean[] visited=new boolean[w*h], components=new boolean[w*h]; int repaired=0;
+      for(int start=0;start<w*h;start++) if(coverage[start]&&!visited[start]&&alpha(out,start,w)==0) {
+         ArrayDeque<Integer> q=new ArrayDeque<Integer>(); ArrayDeque<Integer> pixels=new ArrayDeque<Integer>(); q.add(start);visited[start]=true;
+         int minX=w,maxX=-1,minY=h,maxY=-1; boolean enclosed=true;
+         while(!q.isEmpty()){int p=q.remove(),x=p%w,y=p/w;pixels.add(p);minX=Math.min(minX,x);maxX=Math.max(maxX,x);minY=Math.min(minY,y);maxY=Math.max(maxY,y);
+            int[] ns={p-1,p+1,p-w,p+w}; for(int n:ns){int nx=n%w,ny=n/w;if(n<0||n>=w*h||Math.abs(nx-x)+Math.abs(ny-y)!=1||!coverage[n]){enclosed=false;continue;}if(!visited[n]&&alpha(out,n,w)==0){visited[n]=true;q.add(n);}}
+         }
+         int thickness=Math.min(maxX-minX+1,maxY-minY+1);
+         if(enclosed&&pixels.size()<=maxArea&&thickness<=maxThickness){while(!pixels.isEmpty()){int p=pixels.remove();components[p]=true;int color=nearestOpaque(out,p,w,h,Math.max(1,expandRadius));if(color!=0){out.setRGB(p%w,p/w,color|0xFF000000);repaired++;}}}
+      }
+      // Bleed color only; alpha remains byte-for-byte unchanged in this pass.
+      for(int pass=0;pass<bleedRadius;pass++){int[] before=out.getRGB(0,0,w,h,null,0,w);for(int p=0;p<w*h;p++)if(coverage[p]&&((before[p]>>>24)&255)==0){int c=nearestOpaque(before,p,w,h);if(c!=0)out.setRGB(p%w,p/w,c&0x00FFFFFF);}}
+      return new Result(out,components,repaired);
+   }
+   private static int alpha(BufferedImage i,int p,int w){return (i.getRGB(p%w,p/w)>>>24)&255;}
+   private static int nearestOpaque(BufferedImage i,int p,int w,int h,int r){int[] a=i.getRGB(0,0,w,h,null,0,w);return nearestOpaque(a,p,w,h);}
+   private static int nearestOpaque(int[] a,int p,int w,int h){int x=p%w,y=p/w;for(int r=1;r<=2;r++)for(int dy=-r;dy<=r;dy++)for(int dx=-r;dx<=r;dx++){int nx=x+dx,ny=y+dy;if(nx>=0&&ny>=0&&nx<w&&ny<h&&((a[ny*w+nx]>>>24)&255)>=250)return a[ny*w+nx];}return 0;}
+
+   public static float[] correctUV(float u,float v,BufferedImage image,int radius){
+      if(u<0||u>1||v<0||v>1)return new float[]{u,v};int w=image.getWidth(),h=image.getHeight(),x=Math.min(w-1,Math.max(0,(int)(u*w))),y=Math.min(h-1,Math.max(0,(int)((1-v)*h)));
+      if(((image.getRGB(x,y)>>>24)&255)>0)return new float[]{u,v};
+      for(int r=1;r<=radius;r++)for(int dy=-r;dy<=r;dy++)for(int dx=-r;dx<=r;dx++)if(dx*dx+dy*dy<=r*r){int nx=x+dx,ny=y+dy;if(nx>=0&&ny>=0&&nx<w&&ny<h&&((image.getRGB(nx,ny)>>>24)&255)>=250)return new float[]{(nx+0.5F)/w,1.0F-(ny+0.5F)/h};}
+      return new float[]{u,v};
+   }
+   public static final class Result { public final BufferedImage image; public final boolean[] components; public final int repairedPixels; Result(BufferedImage i,boolean[] c,int n){image=i;components=c;repairedPixels=n;} }
+}

--- a/src/main/java/mcheli/wrapper/modelloader/W_Face.java
+++ b/src/main/java/mcheli/wrapper/modelloader/W_Face.java
@@ -23,6 +23,7 @@ public class W_Face {
    private float faceNormalY;
    private float faceNormalZ;
    private boolean hasPackedFaceNormal;
+   private float[] repairedTextureCoordinates;
 
    public W_Face copy() {
       W_Face f = new W_Face();
@@ -199,7 +200,7 @@ public class W_Face {
       return new W_Vertex(normalX, normalY, normalZ);
    }
 
-   private int getTextureCoordinateCount() {
+   public int getTextureCoordinateCount() {
       if(this.packedData != null) {
          return this.packedTextureOffset >= 0 ? this.packedVertexCount : 0;
       }
@@ -207,12 +208,18 @@ public class W_Face {
       return this.textureCoordinates != null ? this.textureCoordinates.length : 0;
    }
 
-   private float getTextureU(int index) {
-      return this.packedData != null ? this.packedData[index * this.packedStride + this.packedTextureOffset] : this.textureCoordinates[index].u;
+   public float getTextureU(int index) {
+      return this.repairedTextureCoordinates != null ? this.repairedTextureCoordinates[index * 2]
+         : this.packedData != null ? this.packedData[index * this.packedStride + this.packedTextureOffset] : this.textureCoordinates[index].u;
    }
 
-   private float getTextureV(int index) {
-      return this.packedData != null ? this.packedData[index * this.packedStride + this.packedTextureOffset + 1] : this.textureCoordinates[index].v;
+   public float getTextureV(int index) {
+      return this.repairedTextureCoordinates != null ? this.repairedTextureCoordinates[index * 2 + 1]
+         : this.packedData != null ? this.packedData[index * this.packedStride + this.packedTextureOffset + 1] : this.textureCoordinates[index].v;
+   }
+
+   public void setRepairedTextureCoordinates(float[] coordinates) {
+      this.repairedTextureCoordinates = coordinates;
    }
 
    private boolean hasVertexNormal(int index) {

--- a/src/test/java/mcheli/texture/MCH_ModelTextureRepairProcessorTest.java
+++ b/src/test/java/mcheli/texture/MCH_ModelTextureRepairProcessorTest.java
@@ -1,0 +1,13 @@
+package mcheli.texture;
+import java.awt.image.BufferedImage;
+import org.junit.Test;
+import static org.junit.Assert.*;
+public class MCH_ModelTextureRepairProcessorTest {
+ @Test public void triangleAndQuadCoverage(){boolean[] t=new boolean[64];MCH_ModelTextureRepairProcessor.rasterizeTriangle(t,8,8,new float[]{0,0,1,0,0,1});assertTrue(count(t)>20);boolean[] q=new boolean[64];MCH_ModelTextureRepairProcessor.rasterizeFace(q,8,8,new float[]{0,0,1,0,1,1,0,1});assertTrue(count(q)>50);}
+ @Test public void wrappingUvsRemainUntouched(){boolean[] m=new boolean[16];MCH_ModelTextureRepairProcessor.rasterizeTriangle(m,4,4,new float[]{-0.1F,0,1,0,0,1});assertEquals(0,count(m));assertEquals(-.2F,MCH_ModelTextureRepairProcessor.correctUV(-.2F,.5F,opaque(4,4),2)[0],0);assertEquals(1.2F,MCH_ModelTextureRepairProcessor.correctUV(1.2F,.5F,opaque(4,4),2)[0],0);}
+ @Test public void onlySmallEnclosedBinaryHolesFill(){BufferedImage i=opaque(9,9);i.setRGB(4,4,0);assertEquals(1,MCH_ModelTextureRepairProcessor.repair(i,full(81),4,2,0,1).repairedPixels);BufferedImage large=opaque(9,9);for(int y=2;y<7;y++)for(int x=2;x<7;x++)large.setRGB(x,y,0);assertEquals(0,MCH_ModelTextureRepairProcessor.repair(large,full(81),4,2,0,1).repairedPixels);BufferedImage smooth=opaque(9,9);smooth.setRGB(4,4,0x80606060);assertEquals(0,MCH_ModelTextureRepairProcessor.repair(smooth,full(81),4,2,0,1).repairedPixels);}
+ @Test public void bleedPreservesAlphaAndCoverage(){BufferedImage i=new BufferedImage(5,5,BufferedImage.TYPE_INT_ARGB);i.setRGB(2,2,0xFFFF0000);boolean[] c=new boolean[25];c[12]=c[13]=true;BufferedImage r=MCH_ModelTextureRepairProcessor.repair(i,c,0,0,1,0).image;assertEquals(0,r.getRGB(3,2)>>>24);assertEquals(0xFF0000,r.getRGB(3,2)&0xFFFFFF);assertEquals(0,r.getRGB(1,2));}
+ @Test public void nearestUvObeysRadius(){BufferedImage i=new BufferedImage(8,8,BufferedImage.TYPE_INT_ARGB);i.setRGB(5,4,0xFFFFFFFF);assertNotEquals(.5F,MCH_ModelTextureRepairProcessor.correctUV(.5F,.5F,i,1)[0],0);assertArrayEquals(new float[]{.5F,.5F},MCH_ModelTextureRepairProcessor.correctUV(.5F,.5F,i,0),0);}
+ @Test public void validHalfTexelTinyIslandDoesNotCollapse(){assertArrayEquals(new float[]{.25F,.75F},MCH_ModelTextureRepairProcessor.correctUV(.25F,.75F,opaque(2,2),1),0);}
+ private static int count(boolean[] a){int n=0;for(boolean b:a)if(b)n++;return n;}private static boolean[] full(int n){boolean[] a=new boolean[n];java.util.Arrays.fill(a,true);return a;}private static BufferedImage opaque(int w,int h){BufferedImage i=new BufferedImage(w,h,BufferedImage.TYPE_INT_ARGB);for(int y=0;y<h;y++)for(int x=0;x<w;x++)i.setRGB(x,y,0xFF336699);return i;}
+}

--- a/tools/texture_uv_repair.md
+++ b/tools/texture_uv_repair.md
@@ -1,5 +1,7 @@
 # Texture and UV audit
 
+This optional Python utility is diagnostic only. It is not required by the automatic Java runtime repair system, and its tests do not change a PNG, MQO, or rendered model.
+
 Run from the repository root (Pillow is a development-only requirement):
 
 ```sh


### PR DESCRIPTION
### Motivation

- Vehicle textures downscaled to 512px caused unexpected transparent holes and see-through areas at render time, and the existing manifest-based Python workflow did not alter runtime PNG/MQO assets.  
- The goal is to repair textures and apply conservative UV corrections automatically at runtime without modifying source files or requiring manual per-vehicle approvals.  
- Maintain client-only behavior and Forge 1.7.10 / Java 8 compatibility while keeping the offline Python tooling available for diagnostics.  

### Description

- Add a client-only repair cache and resolver `MCH_ModelTextureRepairManager` that discovers model/texture pairs, rasterizes loaded MQO/OBJ UV faces, builds coverage masks, runs deterministic repairs, uploads accepted results via `DynamicTexture`, and caches the repaired `ResourceLocation` for binding (new file: `src/main/java/mcheli/texture/MCH_ModelTextureRepairManager.java`).  
- Implement deterministic image/UV algorithms in `MCH_ModelTextureRepairProcessor` for triangle/quad rasterization, connected-component transparent-hole detection, conservative hole fill, RGB bleeding that preserves alpha, and nearest-opaque UV correction (new file: `src/main/java/mcheli/texture/MCH_ModelTextureRepairProcessor.java`).  
- Integrate the repair resolver into normal vehicle rendering and 3D vehicle item rendering by binding repaired textures when available, preserve original packed UV data while adding a render-only corrected UV array in `W_Face`, and add conservative client options in `MCH_Config` with safe defaults (modified files: `src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java`, `src/main/java/mcheli/aircraft/MCH_VehicleItemModelRender.java`, `src/main/java/mcheli/wrapper/modelloader/W_Face.java`, `src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/MCH_ClientProxy.java`).  
- Add deterministic Java unit tests for the image/UV processor and update documentation and `CHANGELOG.md` to clarify runtime behavior and that the Python manifest tool remains an optional diagnostic (added: `src/test/java/mcheli/texture/MCH_ModelTextureRepairProcessorTest.java`; updated: `tools/texture_uv_repair.md`, `CHANGELOG.md`).  

### Testing

- Ran the repository Python unit test suite for the audit tooling with `python -m unittest discover -s tools -p 'test_repair_texture_uvs.py'`, which completed successfully (16 tests run, 7 skipped).  
- Performed repository checks including `git diff --check` to ensure no whitespace/patch problems prior to commit.  
- Gradle build and Forge client startup were intentionally not executed because compiling binary artifacts was prohibited by project constraints, so graphical verification in a running Forge 1.7.10 client remains pending.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ecdc050348323b11cf71cc0dbf00c)