### PR TITLE
Add EnableNEIHandler startup config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Configurable NEI Vehicle Ammunition Handler (PR pending)
+
+- Added the `EnableNEIHandler` boolean startup option, defaulting to `true`, to allow clients to prevent the optional NEI vehicle ammunition recipe and usage handler from registering.
+
 # Complete deterministic texture/UV repair validation (PR pending)
 
 - Replaced unsupported per-channel `putchannel` mutation with split/dilate/merge RGB bleeding that preserves alpha byte-for-byte across every pass.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ Client keybinds and rendering settings are safest to change while the client is 
 | --- | --- | --- |
 | `TestMode` | `false` | Development/test toggle. |
 | `EnableCommand` | `true` | Enables `/mcheli` subcommands. |
+| `EnableNEIHandler` | `true` | `true` registers the MCHeli vehicle ammunition recipe and usage handler in NotEnoughItems; `false` prevents the handler from registering. Changing NEI registration requires a client restart and is not applied by `/mcheli reconfig`. |
 | `PlaceableOnSpongeOnly` | `false` | Restricts vehicle placement to sponge blocks. |
 | `ItemDamage` | `true` | Enables item damage behavior for applicable MCHeli items. |
 | `ItemFuel` | `true` | Enables fuel item behavior. |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -30,6 +30,7 @@ public class MCH_Config {
    public static String configFilePath;
    public static MCH_ConfigPrm EnableMCHLibLog;
    public static MCH_ConfigPrm EnableMCHLibDebugLog;
+   public static MCH_ConfigPrm EnableNEIHandler;
    public static String configVer;
    public static int hitMarkColorRGB;
    public static float hitMarkColorAlpha;
@@ -430,6 +431,8 @@ public class MCH_Config {
       EnableMCHLibLog.desc = ";Write normal MCH_Lib.Log messages to the Minecraft log.";
       EnableMCHLibDebugLog = new MCH_ConfigPrm("EnableMCHLibDebugLog", false);
       EnableMCHLibDebugLog.desc = ";Write verbose MCH_Lib.DbgLog messages to the Minecraft log.";
+      EnableNEIHandler = new MCH_ConfigPrm("EnableNEIHandler", true);
+      EnableNEIHandler.desc = ";Controls the MCHeli vehicle ammunition category in NotEnoughItems. Requires a client restart.";
       TestMode = new MCH_ConfigPrm("TestMode", false);
       EnableCommand = new MCH_ConfigPrm("EnableCommand", true);
       PlaceableOnSpongeOnly = new MCH_ConfigPrm("PlaceableOnSpongeOnly", false);
@@ -730,6 +733,7 @@ public class MCH_Config {
       General = new MCH_ConfigPrm[]{
               EnableMCHLibLog,
               EnableMCHLibDebugLog,
+              EnableNEIHandler,
               TestMode,
               EnableCommand,
               null,

--- a/src/main/java/mcheli/nei/NEIMCHeliConfig.java
+++ b/src/main/java/mcheli/nei/NEIMCHeliConfig.java
@@ -4,6 +4,7 @@ import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import mcheli.MCH_Config;
 import mcheli.MCH_MOD;
 
 /**
@@ -15,6 +16,9 @@ public class NEIMCHeliConfig implements IConfigureNEI {
 
     @Override
     public void loadConfig() {
+        if (!MCH_Config.EnableNEIHandler.prmBool) {
+            return;
+        }
         MCH_VehicleAmmoRecipeHandler handler = new MCH_VehicleAmmoRecipeHandler();
         API.registerRecipeHandler(handler);
         API.registerUsageHandler(handler);


### PR DESCRIPTION
### Motivation

- Provide a direct, boolean startup config to allow clients to opt out of registering the optional NEI vehicle-ammunition handler so NEI registration is controlled explicitly at startup. 

### Description

- Added `EnableNEIHandler` as a `MCH_ConfigPrm` boolean with default `true` and a clear description, and included it in the `General` collection so it is loaded, saved, and written to `config/mcheli.cfg` when missing. 
- Updated `NEIMCHeliConfig.loadConfig()` to read `MCH_Config.EnableNEIHandler.prmBool` and return early when `false`, preserving the current single `MCH_VehicleAmmoRecipeHandler` recipe and usage registration when `true`. 
- Kept all direct `codechicken.nei` references inside the existing optional `mcheli.nei` package to avoid required NEI dependencies on servers, and updated `docs/configuration.md` and `CHANGELOG.md` with the new option and behavior. 

### Testing

- `python3` static assertions verifying the boolean declaration/default, presence in `General`, early return check, and single recipe/usage registrations — passed. 
- Ripgrep-based check confirming all direct `codechicken.nei` references remain confined to `mcheli.nei` — passed. 
- `git diff --check` and repository status checks to validate the working tree and produced diff — passed. 
- `./gradlew build` and runtime client/server startup checks were not run due to the project's no-binary/explicit-build prohibition in the task instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ecffe21708323a3ca207ecfcd06f1)