### PR TITLE
Fix stationary turret free look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -489,3 +489,7 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Match client and server vehicles by their synchronized entity ID instead of comparing side-local entity UUIDs.
 - Close the development GUI as soon as a targeted request is sent, while a client-side pending request tracks the response, timeout, and world lifetime.
 - Reload and apply only the selected definition and its models, preserving runtime vehicle state and rejecting seat-count changes before publication.
+# Stationary Turret Free Look (PR pending)
+
+- Enabled the existing free-look control for stationary turrets.
+- Kept turret weapon aim fixed while the rider looks around and smoothly recenters the camera before normal aiming resumes.

--- a/docs/stationary-turret-free-look.md
+++ b/docs/stationary-turret-free-look.md
@@ -1,0 +1,9 @@
+# Stationary turret free look
+
+Stationary turrets are custom `MCH_EntityTurret` vehicles: the pilot rides the entity directly, while extra occupants use the shared aircraft seat entities. Their client tick handler, renderer, camera dummy, and player-control packet are turret-specific, but mouse processing and free-look status come from the shared base-vehicle implementation.
+
+Previously, the turret disabled `canSwitchFreeLook`, omitted the free-look key from its polled key list, and ignored the packet field on the server. Consequently the shared mouse path always coupled player yaw and pitch to entity yaw and pitch. Unrestricted weapons also temporarily used the rider's rotation as their firing rotation.
+
+The turret now opts into the existing base-vehicle free-look status and handles that status through its existing control packet. While active, shared mouse processing changes the player's view but zeros turret rotation input, so the entity and synchronized rider-aim angles remain at their last aim. Weapon use temporarily applies those held aim angles instead of the free-look camera angles. On exit, the client camera recenters toward that held aim before asking the server to disable free look; this avoids snapping either the camera or turret. The temporary recenter state belongs only to the turret client handler and is cleared whenever the ridden turret changes or disappears.
+
+The same camera object and dummy render-view entity are used in first- and third-person views, so both modes follow the separated camera rotation. No aircraft, tank, ship, UAV, drone, or ordinary gunner-seat controls are changed.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -2772,7 +2772,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       }
 
       e = this.getRiddenByEntity();
-      if(e != null && !e.isDead && !this.isDestroyed()) {
+      if(e != null && !e.isDead && !this.isDestroyed() && this.shouldUpdateLastRiderAngles()) {
          this.lastRiderYaw = e.rotationYaw;
          this.prevLastRiderYaw = e.prevRotationYaw;
          this.lastRiderPitch = e.rotationPitch;
@@ -2850,6 +2850,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.lastRiddenByEntity = this.getRiddenByEntity();
       this.lastRidingEntity = this.getRidingEntity();
       this.prevPosition.put(Vec3.createVectorHelper(super.posX, super.posY, super.posZ));
+   }
+
+   protected boolean shouldUpdateLastRiderAngles() {
+      return true;
    }
 
    private void updateSearchlightBlocks() {

--- a/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
@@ -15,6 +15,7 @@ import mcheli.wrapper.W_Reflection;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityClientPlayerMP;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MathHelper;
 
 public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandler {
 
@@ -23,6 +24,8 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
    public MCH_Key KeyZoom;
    public MCH_Key KeyExtra;
    public MCH_Key[] Keys;
+   private MCH_EntityTurret freeLookTurret;
+   private boolean recenteringFreeLook;
 
 
    public MCH_ClientTurretTickHandler(Minecraft minecraft, MCH_Config config) {
@@ -36,7 +39,7 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyExtra = new MCH_Key(MCH_Config.KeyExtra.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyGUI};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyFreeLook, super.KeyGUI};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTurret vehicle, MCH_TurretInfo info) {
@@ -74,6 +77,10 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       }
 
       if(var7 != null && var7.getAcInfo() != null) {
+         if(this.freeLookTurret != var7) {
+            this.freeLookTurret = var7;
+            this.recenteringFreeLook = false;
+         }
          MCH_Lib.disableFirstPersonItemRender(var6.getCurrentEquippedItem());
          this.update(var6, var7, var7.getTurretInfo());
          MCH_ViewEntityDummy var10 = MCH_ViewEntityDummy.getInstance(super.mc.theWorld);
@@ -90,6 +97,8 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
          super.isRiding = true;
       } else {
          super.isRiding = false;
+         this.freeLookTurret = null;
+         this.recenteringFreeLook = false;
       }
 
       if (!this.isBeforeRiding && this.isRiding) {
@@ -110,6 +119,25 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       MCH_PacketTurretPlayerControl pc = new MCH_PacketTurretPlayerControl();
       boolean send = false;
       send = this.commonPlayerControl(player, vehicle, isPilot, pc);
+      if(pc.switchFreeLook == 2) {
+         // Return the camera to the held aim before re-coupling it to the turret.
+         pc.switchFreeLook = 0;
+         this.recenteringFreeLook = true;
+      }
+      if(this.recenteringFreeLook) {
+         float yawDiff = MathHelper.wrapAngleTo180_float(vehicle.rotationYaw - player.rotationYaw);
+         float pitchDiff = vehicle.rotationPitch - player.rotationPitch;
+         player.rotationYaw += MathHelper.clamp_float(yawDiff, -10.0F, 10.0F);
+         player.rotationPitch += MathHelper.clamp_float(pitchDiff, -10.0F, 10.0F);
+         player.prevRotationYaw = player.rotationYaw;
+         player.prevRotationPitch = player.rotationPitch;
+         vehicle.updateCameraRotate(player.rotationYaw, player.rotationPitch);
+         if(Math.abs(yawDiff) <= 10.0F && Math.abs(pitchDiff) <= 10.0F) {
+            pc.switchFreeLook = 2;
+            this.recenteringFreeLook = false;
+            send = true;
+         }
+      }
       if(this.KeyExtra.isKeyDown()) {
          if(vehicle.getTowChainEntity() != null) {
             playSoundOK();

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -171,6 +171,17 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
    }
 
    public boolean useCurrentWeapon(MCH_WeaponParam prm) {
+      if(this.isFreeLookMode() && prm.user != null) {
+         float cameraPitch = prm.user.rotationPitch;
+         float cameraYaw = prm.user.rotationYaw;
+         prm.user.rotationPitch = this.getLastRiderPitch();
+         prm.user.rotationYaw = this.getLastRiderYaw();
+         boolean result = super.useCurrentWeapon(prm);
+         prm.user.rotationPitch = cameraPitch;
+         prm.user.rotationYaw = cameraYaw;
+         return result;
+      }
+
       if(prm.user != null) {
          MCH_WeaponSet breforeUseWeaponPitch = this.getCurrentWeapon(prm.user);
          if(breforeUseWeaponPitch != null) {
@@ -460,6 +471,10 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
 
    public void onUpdateAngles(float partialTicks) {}
 
+   protected boolean shouldUpdateLastRiderAngles() {
+      return !this.isFreeLookMode();
+   }
+
    //no usages
    public void _updateRiderPosition() {
       float yaw = super.rotationYaw;
@@ -472,6 +487,6 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
    }
 
    public boolean canSwitchFreeLook() {
-      return false;
+      return true;
    }
 }

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -30,7 +30,7 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
          MCH_EntityTurret vehicle = (MCH_EntityTurret)entity;
          turretInfo = vehicle.getTurretInfo();
          if(turretInfo != null) {
-            if(vehicle.riddenByEntity != null && !vehicle.isDestroyed()) {
+            if(vehicle.riddenByEntity != null && !vehicle.isDestroyed() && !vehicle.isFreeLookMode()) {
                vehicle.isUsedPlayer = true;
                vehicle.lastRiderYaw = vehicle.riddenByEntity.rotationYaw;
                vehicle.lastRiderPitch = vehicle.riddenByEntity.rotationPitch;

--- a/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
@@ -30,6 +30,10 @@ public class MCH_TurretPacketHandler {
                   vehicle.switchCameraMode(player, pc.switchCameraMode - 1);
                }
 
+               if(pc.switchFreeLook > 0 && vehicle.isPilot(player)) {
+                  vehicle.switchFreeLookMode(pc.switchFreeLook == 1);
+               }
+
                if(pc.switchWeapon >= 0) {
                   vehicle.switchWeapon(player, pc.switchWeapon);
                }


### PR DESCRIPTION
### Motivation

- Stationary turrets incorrectly forced the rider camera to drive turret aim, preventing the player from using the existing free-look while seated. 
- The goal is to reuse the existing MCHeli free-look system so players can look around while the turret aim remains authoritative and synchronized to other clients. 
- The change must avoid adding a second free-look system, preserve turret limits/weapon behavior, and avoid sudden snaps when free-look ends.

### Description

- Opted turrets into the shared free-look system by returning `true` from `MCH_EntityTurret.canSwitchFreeLook()` and adding the free-look key to the turret client key poll so clients can request free-look with the same control as other vehicles. 
- Added server handling for the existing free-look packet field in `MCH_TurretPacketHandler` so only the pilot can toggle free-look server-side, and kept authoritative aim synchronization unchanged. 
- Separated camera rotation and turret aim on the client by: (a) preventing the renderer from overwriting last-rider aim while free-look is active, (b) making `useCurrentWeapon` apply the held turret aim when firing during free-look, and (c) adding a client-only smooth recenter transition in `MCH_ClientTurretTickHandler` that returns the camera toward the held turret aim before re-coupling to normal aiming. 
- Added a small hook `shouldUpdateLastRiderAngles()` to `MCH_EntityBaseVehicle` and overriden it in `MCH_EntityTurret` so last-rider/turret angles are not updated while free-look is active, and updated changelog and a short documentation note. 
- Files changed: `CHANGELOG.md`, `docs/stationary-turret-free-look.md`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java`, `src/main/java/mcheli/vehicle/MCH_EntityTurret.java`, `src/main/java/mcheli/vehicle/MCH_RenderTurret.java`, `src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java`.

### Testing

- Ran repository assertions implemented as a short `python` check that verified the turret free-look opt-in, free-look key polling, server packet handling, held firing aim substitution, and renderer separation and the assertions passed. 
- Ran `git diff --check` and status checks which reported no whitespace or diff problems and confirmed the set of modified files. 
- Did not run a Forge 1.7.10 client or dedicated-server runtime test or project compilation because a live environment and binary build were not available and compilation was intentionally not executed; those runtime integration tests remain required to validate live multiplayer, mount/dismount, death, reconnect, chunk reload, and moving-vehicle regression scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fa600b8548323a37d71c88a82ebf4)