### PR TITLE
Default stationary turrets to free look

### DIFF
--- a/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
@@ -31,6 +31,7 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
 
    public MCH_TurretInfo(String name) {
       super(name);
+      this.defaultFreelook = true;
    }
 
    public boolean isValidData() throws Exception {
@@ -112,6 +113,7 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
 
    public void preReload() {
       super.preReload();
+      this.defaultFreelook = true;
       this.partList.clear();
    }
 


### PR DESCRIPTION
### Motivation
- Stationary turrets should default to free look when their definition omits `DefaultFreelook`, but the shared base default was `false` so omitted turret definitions remained disabled despite the turret free-look support added earlier.

### Description
- Set the inherited `defaultFreelook` to `true` for turret info objects by initializing `defaultFreelook` in `MCH_TurretInfo(String)` and resetting it in `preReload()` so the turret-specific default is applied before parsing; changed file: `src/main/java/mcheli/vehicle/MCH_TurretInfo.java`.

### Testing
- Ran `git diff --check` and repository-level source assertions (Python snippet) that verified omitted, explicit `true`, and explicit `false` parsing semantics, mount/toggle codepaths, and fresh-object reload behavior, and verified the working tree is clean; Gradle build and in-game runtime checks were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb08cf34883238cc1c62866b0599d)