### PR TITLE
Fix stationary turret rider aiming

### DIFF
--- a/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
@@ -36,7 +36,7 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyExtra = new MCH_Key(MCH_Config.KeyExtra.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyGUI};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyFreeLook, super.KeyGUI};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTurret vehicle, MCH_TurretInfo info) {
@@ -110,6 +110,13 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       MCH_PacketTurretPlayerControl pc = new MCH_PacketTurretPlayerControl();
       boolean send = false;
       send = this.commonPlayerControl(player, vehicle, isPilot, pc);
+      if(vehicle.getAcInfo().defaultFreelook && pc.switchFreeLook > 0) {
+         pc.switchFreeLook = 0;
+      }
+      if(pc.useWeapon) {
+         pc.weaponAimYaw = player.rotationYaw;
+         pc.weaponAimPitch = player.rotationPitch;
+      }
       if(this.KeyExtra.isKeyDown()) {
          if(vehicle.getTowChainEntity() != null) {
             playSoundOK();

--- a/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_EntityTurret.java
@@ -84,6 +84,7 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
       } else {
          this.setAcInfo(this.turretInfo);
          this.newSeats(this.getAcInfo().getNumSeatAndRack());
+         this.switchFreeLookModeClient(this.getAcInfo().defaultFreelook);
          super.weapons = this.createWeapon(1 + this.getSeatNum());
          this.initPartRotation(super.rotationYaw, super.rotationPitch);
       }
@@ -181,14 +182,16 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
          }
       }
 
-      float breforeUseWeaponPitch1 = super.rotationPitch;
-      float breforeUseWeaponYaw1 = super.rotationYaw;
-      super.rotationPitch = prm.user.rotationPitch;
-      super.rotationYaw = prm.user.rotationYaw;
-      boolean result = super.useCurrentWeapon(prm);
-      super.rotationPitch = breforeUseWeaponPitch1;
-      super.rotationYaw = breforeUseWeaponYaw1;
-      return result;
+      float beforeUseWeaponPitch = super.rotationPitch;
+      float beforeUseWeaponYaw = super.rotationYaw;
+      try {
+         super.rotationPitch = prm.user.rotationPitch;
+         super.rotationYaw = prm.user.rotationYaw;
+         return super.useCurrentWeapon(prm);
+      } finally {
+         super.rotationPitch = beforeUseWeaponPitch;
+         super.rotationYaw = beforeUseWeaponYaw;
+      }
    }
 
    public void onUpdateAircraft() {
@@ -472,6 +475,6 @@ public class MCH_EntityTurret extends MCH_EntityBaseVehicle {
    }
 
    public boolean canSwitchFreeLook() {
-      return false;
+      return true;
    }
 }

--- a/src/main/java/mcheli/vehicle/MCH_PacketTurretPlayerControl.java
+++ b/src/main/java/mcheli/vehicle/MCH_PacketTurretPlayerControl.java
@@ -9,6 +9,8 @@ public class MCH_PacketTurretPlayerControl extends MCH_PacketPlayerControlBase {
 
    public byte switchFold = -1;
    public int unhitchChainId = -1;
+   public float weaponAimYaw;
+   public float weaponAimPitch;
 
 
    public int getMessageID() {
@@ -21,6 +23,10 @@ public class MCH_PacketTurretPlayerControl extends MCH_PacketPlayerControlBase {
       try {
          this.switchFold = data.readByte();
          this.unhitchChainId = data.readInt();
+         if(this.useWeapon) {
+            this.weaponAimYaw = data.readFloat();
+            this.weaponAimPitch = data.readFloat();
+         }
       } catch (Exception var3) {
          var3.printStackTrace();
       }
@@ -33,6 +39,10 @@ public class MCH_PacketTurretPlayerControl extends MCH_PacketPlayerControlBase {
       try {
          dos.writeByte(this.switchFold);
          dos.writeInt(this.unhitchChainId);
+         if(this.useWeapon) {
+            dos.writeFloat(this.weaponAimYaw);
+            dos.writeFloat(this.weaponAimPitch);
+         }
       } catch (IOException var3) {
          var3.printStackTrace();
       }

--- a/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_RenderTurret.java
@@ -30,15 +30,6 @@ public class MCH_RenderTurret extends MCH_RenderBaseVehicle {
          MCH_EntityTurret vehicle = (MCH_EntityTurret)entity;
          turretInfo = vehicle.getTurretInfo();
          if(turretInfo != null) {
-            if(vehicle.riddenByEntity != null && !vehicle.isDestroyed()) {
-               vehicle.isUsedPlayer = true;
-               vehicle.lastRiderYaw = vehicle.riddenByEntity.rotationYaw;
-               vehicle.lastRiderPitch = vehicle.riddenByEntity.rotationPitch;
-            } else if(!vehicle.isUsedPlayer && !vehicle.worldObj.isRemote) {
-               vehicle.lastRiderYaw = vehicle.rotationYaw;
-               vehicle.lastRiderPitch = vehicle.rotationPitch;
-            }
-
             this.renderDebugHitBox(vehicle, posX, posY, posZ, yaw, pitch, roll);
             this.renderDebugPilotSeat(vehicle, posX, posY, posZ, yaw, pitch, roll);
             GL11.glTranslated(posX, posY, posZ);

--- a/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretInfo.java
@@ -31,6 +31,7 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
 
    public MCH_TurretInfo(String name) {
       super(name);
+      this.defaultFreelook = true;
    }
 
    public boolean isValidData() throws Exception {
@@ -112,6 +113,7 @@ public class MCH_TurretInfo extends MCH_BaseVehicleInfo {
 
    public void preReload() {
       super.preReload();
+      this.defaultFreelook = true;
       this.partList.clear();
    }
 

--- a/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
@@ -30,11 +30,20 @@ public class MCH_TurretPacketHandler {
                   vehicle.switchCameraMode(player, pc.switchCameraMode - 1);
                }
 
+               if(pc.switchFreeLook > 0 && vehicle.isPilot(player)
+                     && vehicle.canSwitchFreeLook() && !vehicle.getAcInfo().defaultFreelook) {
+                  vehicle.switchFreeLookMode(pc.switchFreeLook == 1);
+               }
+
                if(pc.switchWeapon >= 0) {
                   vehicle.switchWeapon(player, pc.switchWeapon);
                }
 
                if(pc.useWeapon) {
+                  player.rotationYaw = pc.weaponAimYaw;
+                  player.rotationPitch = pc.weaponAimPitch;
+                  vehicle.lastRiderYaw = pc.weaponAimYaw;
+                  vehicle.lastRiderPitch = pc.weaponAimPitch;
                   MCH_WeaponParam e = new MCH_WeaponParam();
                   e.entity = vehicle;
                   e.user = player;


### PR DESCRIPTION
### Motivation
- Correct stationary turret aiming/firing so rider aim (rendered turret and weapon direction) matches actual projectile launch direction and to eliminate Sea RAM one-direction launches. 
- Make turret definitions default to free-look and initialize entity state consistently with the tank code path so default behavior and `/mcheli reload` behave identically to tanks. 
- Preserve stationary base orientation while allowing the rider to aim freely, and ensure server-side authoritative fire uses the same live aim as the client render.

### Description
- Set `defaultFreelook = true` for turret definitions on construction and during `preReload` so a missing `DefaultFreelook` field defaults to true while explicit `DefaultFreelook false` still overrides the default (files: `MCH_TurretInfo.java`).
- Initialize the turret free-look state in `MCH_EntityTurret.changeType` immediately after seat creation and before weapon creation to match `MCH_EntityTank.changeType` ordering (`MCH_EntityTurret.java`).
- Add `KeyFreeLook` to the turret client key list and make the client handler respect the tank-style rule that a definition-level default free-look cannot be turned off by the hold-key path (`MCH_ClientTurretTickHandler.java`).
- Add `weaponAimYaw`/`weaponAimPitch` to `MCH_PacketTurretPlayerControl` and send the rider’s current aim with weapon-use packets so the server receives the visible aim at fire time (`MCH_PacketTurretPlayerControl.java`, `MCH_ClientTurretTickHandler.java`).
- Apply the transmitted aim on the server before calling `useCurrentWeapon` so missiles/projectiles are launched along the visible turret orientation and update `lastRiderYaw`/`lastRiderPitch` accordingly (`MCH_TurretPacketHandler.java`).
- Protect temporary rotation changes used for firing with a `try`/`finally` block so rotations are always restored and cannot leak after weapon use (`MCH_EntityTurret.java`).
- Declare stationary turrets as able to switch free-look (`canSwitchFreeLook()`), and only handle `switchFreeLook` packets when the turret permits manual switching and the definition does not treat free-look as a permanent default (`MCH_EntityTurret.java`, `MCH_TurretPacketHandler.java`).
- Stop mutating or relying on client-only render fields during rendering; turret parts now use the synchronized live aim state rather than letting render-time updates be the sole source of weapon direction (`MCH_RenderTurret.java`).
- Files changed: `MCH_TurretInfo.java`, `MCH_EntityTurret.java`, `MCH_ClientTurretTickHandler.java`, `MCH_TurretPacketHandler.java`, `MCH_PacketTurretPlayerControl.java`, `MCH_RenderTurret.java`.

### Testing
- Ran automated source invariant checks (`python3` script) that assert the important edits (constructor/reload defaults, parser override, tank-style initialization order, packet serialization fields, server application of aim, and rotation restoration) — checks passed. 
- Ran `git diff --check` to ensure no whitespace/patch problems — passed. 
- Did not run `./gradlew compileJava` or any build tasks because compiling binaries was intentionally skipped per the request. 
- Note: full runtime verification (Sea RAM four-direction/multi-angle firing, chunk unload/reload, mounting/dismounting, `/mcheli reload` end-to-end, first/third-person and dedicated-server observer checks) requires a Forge 1.7.10 client/server runtime and was not executed in this non-interactive source-only environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb3ef9a3c83239b92298507a2bd5f)