### PR TITLE
Fix tank steering over uneven terrain and falls

### DIFF
--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -449,27 +449,16 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          this.updateRecoil(partialTicks);
          this.setRotPitch(this.getRotPitch() + (this.WheelMng.targetPitch - this.getRotPitch()) * partialTicks);
          this.setRotRoll(this.getRotRoll() + (this.WheelMng.targetRoll - this.getRotRoll()) * partialTicks);
-         boolean isFly = MCH_Lib.getBlockIdY(this, 3, -3) == 0;
-         //System.out.println("isfly" + isFly);
+         double dx = super.posX - super.prevPosX;
+         double dz = super.posZ - super.prevPosZ;
+         double dist = dx * dx + dz * dz;
+         if(dist <= 1.0E-6D) {
+            dist = super.motionX * super.motionX + super.motionZ * super.motionZ;
+         }
+         float rotonground = this.getTankSteeringYawFactor(dist);
 
-         //logic for like rotation
-         if(!isFly || this.getAcInfo().isFloat && this.getWaterDepth() > 0.0D) {
-            float rotonground = 1.0F;
-            if(!isFly) {
-               rotonground = this.getAcInfo().mobilityYawOnGround;
-               if(!this.getAcInfo().canRotOnGround) {
-                  Block pivotTurnThrottle = MCH_Lib.getBlockY(this, 3, -2, false);
-                  if(!W_Block.isEqual(pivotTurnThrottle, W_Block.getWater()) && !W_Block.isEqual(pivotTurnThrottle, Blocks.air)) {
-                     rotonground = 0.0F;
-                  }
-               }
-            }
-
+         if(rotonground > 0.0F) {
             float pivotTurnThrottle1 = this.getAcInfo().pivotTurnThrottle;
-            double dx = super.posX - super.prevPosX;
-            double dz = super.posZ - super.prevPosZ;
-            double dist = dx * dx + dz * dz;
-
             if(pivotTurnThrottle1 <= 0.0F || this.getCurrentThrottle() >= (double)pivotTurnThrottle1 || super.throttleBack >= pivotTurnThrottle1 / 10.0F || dist > (double)super.throttleBack * 0.01D) {
                float sf = (float)Math.sqrt(dist <= 1.0D?dist:1.0D);
                if(pivotTurnThrottle1 <= 0.0F) {
@@ -484,12 +473,38 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
                if(super.moveRight && !super.moveLeft) {
                   this.setRotYaw(this.getRotYaw() + 0.6F * rotonground * partialTicks * flag * sf);
                }
-
             }
          }
 
          this.addkeyRotValue = this.decayMobilityValue(this.addkeyRotValue, 0.9F, partialTicks);
       }
+   }
+
+   /**
+    * Determines whether tank yaw input can be applied. A block check beneath the
+    * tank center is unreliable when only one track reaches a diagonal step, so
+    * collision and actual wheel contact are the authoritative support signals.
+    */
+   private float getTankSteeringYawFactor(double horizontalMovementSq) {
+      boolean floating = this.getAcInfo().isFloat && this.getWaterDepth() > 0.0D;
+      boolean supported = super.onGround || this.WheelMng.hasWheelSupport();
+      if(!supported && !floating) {
+         // Moving tanks retain directional control in a fall, but cannot pivot in midair.
+         return horizontalMovementSq > 1.0E-6D ? 1.0F : 0.0F;
+      }
+
+      if(floating && !supported) {
+         return 1.0F;
+      }
+
+      float yawFactor = this.getAcInfo().mobilityYawOnGround;
+      if(!this.getAcInfo().canRotOnGround) {
+         Block block = MCH_Lib.getBlockY(this, 3, -2, false);
+         if(!W_Block.isEqual(block, W_Block.getWater()) && !W_Block.isEqual(block, Blocks.air)) {
+            yawFactor = 0.0F;
+         }
+      }
+      return yawFactor;
    }
 
    protected void onUpdate_Control(float partialTicks) {
@@ -638,23 +653,15 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
                         double dx = super.posX - super.prevPosX;
                         double dz = super.posZ - super.prevPosZ;
                         double dist = dx * dx + dz * dz;
+                        if(dist <= 1.0E-6D) {
+                           dist = super.motionX * super.motionX + super.motionZ * super.motionZ;
+                        }
                         float sf = (float)Math.sqrt(dist <= 1.0D ? dist : 1.0D);
                         if (pivotTurnThrottle1 <= 0.0F) {
                            sf = 1.0F;
                         }
 
-                        float rotonground = 1.0F;
-                        boolean isFly = MCH_Lib.getBlockIdY(this, 3, -3) == 0;
-
-                        if (!isFly) {
-                           rotonground = this.getAcInfo().mobilityYawOnGround;
-                           if (!this.getAcInfo().canRotOnGround) {
-                              Block pivotTurnThrottle = MCH_Lib.getBlockY(this, 3, -2, false);
-                              if (!W_Block.isEqual(pivotTurnThrottle, W_Block.getWater()) && !W_Block.isEqual(pivotTurnThrottle, Blocks.air)) {
-                                 rotonground = 0.0F;
-                              }
-                           }
-                        }
+                        float rotonground = this.getTankSteeringYawFactor(dist);
 
                         float flag = !super.throttleUp && super.throttleDown && this.getCurrentThrottle() < (double)pivotTurnThrottle1 + 0.05D ? -1.0F : 1.0F;
                         if(super.moveLeft && !super.moveRight) {

--- a/src/main/java/mcheli/tank/MCH_WheelManager.java
+++ b/src/main/java/mcheli/tank/MCH_WheelManager.java
@@ -33,6 +33,8 @@ public class MCH_WheelManager {
    public float targetRoll;
    public float prevYaw;
    private static Random rand = new Random();
+   private int wheelSupportGraceTicks;
+   private static final int WHEEL_SUPPORT_GRACE_TICKS = 2;
 
    // per-wheel state (persist during runtime)
    //*unused helper
@@ -60,6 +62,31 @@ public class MCH_WheelManager {
       return (double)top;
    }
 
+
+   /**
+    * Returns collision-derived wheel support, retaining it briefly because angle
+    * updates can run before wheel movement refreshes contact for the current tick.
+    */
+   public boolean hasWheelSupport() {
+      return this.hasCurrentWheelContact() || this.wheelSupportGraceTicks > 0;
+   }
+
+   private boolean hasCurrentWheelContact() {
+      for(int i = 0; i < this.wheels.length; ++i) {
+         if(this.wheels[i] != null && this.wheels[i].onGround) {
+            return true;
+         }
+      }
+      return false;
+   }
+
+   private void updateWheelSupport() {
+      if(this.hasCurrentWheelContact()) {
+         this.wheelSupportGraceTicks = WHEEL_SUPPORT_GRACE_TICKS;
+      } else if(this.wheelSupportGraceTicks > 0) {
+         --this.wheelSupportGraceTicks;
+      }
+   }
 
    public void createWheels(World w, List list, Vec3 weightedCenter) {
       this.wheels = new MCH_EntityWheel[list.size() * 2];
@@ -153,6 +180,8 @@ public class MCH_WheelManager {
             b.onGround = true;
          }
       }
+
+      this.updateWheelSupport();
 
       // horizontal speed and small-stop guard (prevent jitter when stopped)
       double horizSpeed = Math.sqrt(ac.motionX * ac.motionX + ac.motionZ * ac.motionZ);


### PR DESCRIPTION
### Motivation
- A center-based airborne check (`MCH_Lib.getBlockIdY` under the vehicle) could misclassify the tank as airborne during diagonal one-block climbs, corner crossings, step transitions, and short falls, which suppressed yaw input and caused steering to stop responding. 

### Description
- Centralized steering eligibility into `getTankSteeringYawFactor` in `MCH_EntityTank` and replaced the broad center `isFly` gate with a rule set that uses `super.onGround`, wheel contact, floating state, and horizontal motion as authoritative signals. 
- Added a deterministic two-tick wheel-support grace period and `hasWheelSupport`/`updateWheelSupport` helpers to `MCH_WheelManager` so brief tick-order contact gaps do not disable steering, and used actual per-wheel `onGround` contact rather than scanning terrain under the center. 
- Added a small movement fallback (use `motionX/motionZ` when position delta is effectively zero) to allow directional yaw while moving through the air and prevented unsupported stationary pivoting in midair, while preserving `mobilityYawOnGround`, `canRotOnGround`, `pivotTurnThrottle`, water/floating behavior, and destroyed-track disabling. 
- Changed files: `src/main/java/mcheli/tank/MCH_EntityTank.java`, `src/main/java/mcheli/tank/MCH_WheelManager.java`.

### Testing
- Ran `./gradlew compileJava` which completed successfully (build succeeded). 
- Ran `git diff --check` which reported no whitespace errors. 
- Verified the repository diff and committed the two-file change (local commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fb84ec4048323adaa49c57f868d2a)