### PR TITLE
Fix tank steering while airborne and on diagonal steps

### DIFF
--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -487,8 +487,51 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
             }
          }
+         else if(!super.onGround || this.WheelMng.hasWheelContact()) {
+            this.applyMovingAirborneSteering(partialTicks);
+         }
 
          this.addkeyRotValue = this.decayMobilityValue(this.addkeyRotValue, 0.9F, partialTicks);
+      }
+   }
+
+   /**
+    * Retains directional yaw while a moving tank is briefly unsupported or has
+    * only partial track contact. Grounded and floating steering remain handled
+    * by the existing path above.
+    */
+   private void applyMovingAirborneSteering(float partialTicks) {
+      float pivotTurnThrottle1 = this.getAcInfo().pivotTurnThrottle;
+      if(pivotTurnThrottle1 > 0.0F && this.getAcInfo().enableBack && super.throttleDown && this.getCurrentThrottle() <= 0.0D && super.throttleBack > 0.0F) {
+         // onUpdate_ControlSub already applies the established reverse yaw here.
+         return;
+      }
+
+      double dx = super.posX - super.prevPosX;
+      double dz = super.posZ - super.prevPosZ;
+      double dist = dx * dx + dz * dz;
+      if(dist <= 1.0E-6D) {
+         dist = super.motionX * super.motionX + super.motionZ * super.motionZ;
+      }
+
+      if(dist <= 1.0E-6D) {
+         return;
+      }
+
+      if(pivotTurnThrottle1 <= 0.0F || this.getCurrentThrottle() >= (double)pivotTurnThrottle1 || super.throttleBack >= pivotTurnThrottle1 / 10.0F || dist > (double)super.throttleBack * 0.01D) {
+         float sf = (float)Math.sqrt(dist <= 1.0D?dist:1.0D);
+         if(pivotTurnThrottle1 <= 0.0F) {
+            sf = 1.0F;
+         }
+
+         float flag = !super.throttleUp && super.throttleDown && this.getCurrentThrottle() < (double)pivotTurnThrottle1 + 0.05D?-1.0F:1.0F;
+         if(super.moveLeft && !super.moveRight) {
+            this.setRotYaw(this.getRotYaw() - 0.6F * partialTicks * flag * sf);
+         }
+
+         if(super.moveRight && !super.moveLeft) {
+            this.setRotYaw(this.getRotYaw() + 0.6F * partialTicks * flag * sf);
+         }
       }
    }
 

--- a/src/main/java/mcheli/tank/MCH_WheelManager.java
+++ b/src/main/java/mcheli/tank/MCH_WheelManager.java
@@ -52,6 +52,16 @@ public class MCH_WheelManager {
       this.weightedCenter = Vec3.createVectorHelper(0.0D, 0.0D, 0.0D);
    }
 
+   /** Returns whether any wheel currently has collision-derived ground contact. */
+   public boolean hasWheelContact() {
+      for(int i = 0; i < this.wheels.length; ++i) {
+         if(this.wheels[i] != null && this.wheels[i].onGround) {
+            return true;
+         }
+      }
+      return false;
+   }
+
    // fast top-surface query (returns top solid/liquid block Y)
    private double getGroundYAt(double wx, double wz) {
       int ix = MathHelper.floor_double(wx + 0.5D);


### PR DESCRIPTION
### Motivation
- Restore left/right steering input while a tank is actually falling, briefly airborne, or climbing a diagonal one-block step without changing any existing grounded turning behavior. 
- Avoid the regression introduced by the prior refactor that caused grounded turns to use airborne yaw factors or motion-derived scaling incorrectly.

### Description
- Added a yaw-only fallback method `applyMovingAirborneSteering(float)` in `MCH_EntityTank` that runs only when the original center-based grounded check reports air and the tank is unsupported or has at least one wheel collision contact. 
- Added `hasWheelContact()` to `MCH_WheelManager` to provide a small read-only way to detect partial track support without replacing the existing block-based grounded checks. 
- The fallback uses position delta (`posX - prevPosX`, `posZ - prevPosZ`) first, falls back to `motionX`/`motionZ` when that delta is nearly zero, and rejects movement below the squared-epsilon `1.0E-6D` so stationary unsupported tanks cannot pivot freely. 
- Preserved all original grounded behavior and parameters (`mobilityYawOnGround`, `canRotOnGround`, `pivotTurnThrottle`, `throttleBack`, forward/reverse signs, `pivotTurnThrottle` gating, and speed-based yaw scaling), and avoided duplicating the reverse steering logic handled by `onUpdate_ControlSub`. 
- Analysis of the referenced commit `b7b718ec...` found it funneled all steering through a shared support helper and substituted motion for near-zero position deltas even on grounded ticks, which allowed the airborne `1.0F` yaw factor (and different pivot scaling) to apply when the tank was actually considered grounded; this PR confines the airborne behavior to the new isolated fallback so grounded turning remains byte-for-byte unchanged.

### Testing
- Ran `git diff --check` to validate no whitespace or obvious diff-errors and confirmed changes are limited to `MCH_EntityTank.java` and `MCH_WheelManager.java`. 
- Executed source assertions via a Python script that verified the original grounded/floating steering branch was not modified, that the fallback uses position delta first with `motion` as fallback and an epsilon guard, that reverse yaw logic was not duplicated, and that the wheel contact accessor is read-only. 
- Verified a commit was recorded on branch `MCHRgithub` with message `Fix tank steering while briefly airborne` and generated PR metadata titled `Fix tank steering while airborne and on diagonal steps`. 
- Did not run `./gradlew` or any in-game integration tests in this environment because compiling binaries and running a Forge/Minecraft runtime were not available or were prohibited by the task constraints, so the runtime integration tests (driving, step climbs, falls, multiplayer checks, and landing/jitter verification) remain to be validated in the target runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fbb6a4608832382850fd1092a7491)