### PR TITLE
Prevent control-driven vehicle yaw from phasing through blocks

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -82,6 +82,11 @@ import org.lwjgl.Sys;
 public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements MCH_IEntityLockChecker, MCH_IEntityCanRideBaseVehicle, IEntityAdditionalSpawnData {
    private static final Map<UUID, NewUavSafeReturn> NEW_UAV_SAFE_RETURNS = new HashMap<UUID, NewUavSafeReturn>();
    private final MCH_VehicleBoxCache vehicleBoxCache = new MCH_VehicleBoxCache();
+   private MCH_BoundingBox[] blockCollisionProbeBoxes = new MCH_BoundingBox[0];
+   private final ArrayList blockCollisionProbeResults = new ArrayList();
+   private static final double HULL_COLLISION_TOLERANCE = 1.0E-4D;
+   private static final int CONTROL_YAW_SEARCH_STEPS = 8;
+   private boolean latestHorizontalMoveClipped;
    private static final int NEW_UAV_SAFE_RETURN_MIN_TICKS = 20;
    private static MCH_EntityBaseVehicle aircraft;
     private ForgeChunkManager.Ticket chunkTicket;
@@ -454,6 +459,105 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void setRotYaw(float f) {
       super.rotationYaw = f;
+   }
+
+   /** Applies a driver/autopilot chassis yaw without allowing the configured hull to enter blocks. */
+   protected void setCollisionSafeControlYaw(float requestedYaw) {
+      this.setRotYaw(this.resolveCollisionSafeControlYaw(this.getRotYaw(), requestedYaw));
+   }
+
+   /**
+    * Resolves only control-driven yaw. Synchronization, loading and forced transforms continue
+    * to use setRotYaw directly so an authoritative correction can never be rejected locally.
+    */
+   protected float resolveCollisionSafeControlYaw(float currentYaw, float requestedYaw) {
+      float delta = MathHelper.wrapAngleTo180_float(requestedYaw - currentYaw);
+      if(MathHelper.abs(delta) < 1.0E-5F || this.worldObj == null || this.getAcInfo() == null) {
+         return requestedYaw;
+      }
+
+      double requestedPenetration = this.getBlockHullPenetrationAtTransform(super.posX, super.posY, super.posZ,
+              currentYaw + delta, this.getRotPitch(), this.getRotRoll());
+      if(requestedPenetration <= 0.0D) {
+         return currentYaw + delta;
+      }
+      double currentPenetration = this.getBlockHullPenetrationAtTransform(super.posX, super.posY, super.posZ,
+              currentYaw, this.getRotPitch(), this.getRotRoll());
+      if(requestedPenetration + HULL_COLLISION_TOLERANCE < currentPenetration) {
+         return currentYaw + delta;
+      }
+      if(currentPenetration > 0.0D) {
+         return currentYaw;
+      }
+
+      float safeFraction = 0.0F;
+      float blockedFraction = 1.0F;
+      for(int i = 0; i < CONTROL_YAW_SEARCH_STEPS; ++i) {
+         float candidateFraction = (safeFraction + blockedFraction) * 0.5F;
+         float candidateYaw = currentYaw + delta * candidateFraction;
+         if(!this.collidesWithBlocksAtTransform(super.posX, super.posY, super.posZ,
+                 candidateYaw, this.getRotPitch(), this.getRotRoll())) {
+            safeFraction = candidateFraction;
+         } else {
+            blockedFraction = candidateFraction;
+         }
+      }
+      return currentYaw + delta * safeFraction;
+   }
+
+   /** Current at the next control update because moveEntity records clipping after offset resolution. */
+   protected boolean wasLatestHorizontalMoveClipped() {
+      return this.latestHorizontalMoveClipped;
+   }
+
+   protected boolean collidesWithBlocksAtTransform(double x, double y, double z, float yaw, float pitch, float roll) {
+      return this.getBlockHullPenetrationAtTransform(x, y, z, yaw, pitch, roll) > 0.0D;
+   }
+
+   /** Uses disposable probe OBBs; live hit-box positions and the vehicle box cache are untouched. */
+   private double getBlockHullPenetrationAtTransform(double x, double y, double z, float yaw, float pitch, float roll) {
+      double penetration = 0.0D;
+      double offsetX = x - super.posX;
+      double offsetY = y - super.posY;
+      double offsetZ = z - super.posZ;
+      AxisAlignedBB root = super.boundingBox.getOffsetBoundingBox(offsetX, offsetY, offsetZ)
+              .contract(HULL_COLLISION_TOLERANCE, HULL_COLLISION_TOLERANCE, HULL_COLLISION_TOLERANCE);
+      penetration += this.getBlockPenetration(root, null);
+
+      MCH_BoundingBox[] source = this.extraBoundingBox != null ? this.extraBoundingBox : new MCH_BoundingBox[0];
+      if(this.blockCollisionProbeBoxes.length != source.length) {
+         this.blockCollisionProbeBoxes = new MCH_BoundingBox[source.length];
+      }
+      for(int i = 0; i < source.length; ++i) {
+         MCH_BoundingBox configured = source[i];
+         MCH_BoundingBox probe = this.blockCollisionProbeBoxes[i];
+         if(probe == null || probe.width != configured.width || probe.height != configured.height
+                 || probe.depth != configured.depth || probe.offsetX != configured.offsetX
+                 || probe.offsetY != configured.offsetY || probe.offsetZ != configured.offsetZ) {
+            probe = configured.copy();
+            this.blockCollisionProbeBoxes[i] = probe;
+         }
+         probe.updatePosition(x, y, z, yaw, pitch, roll);
+         penetration += this.getBlockPenetration(probe.boundingBox, probe);
+      }
+      return penetration;
+   }
+
+   private double getBlockPenetration(AxisAlignedBB broadPhase, MCH_BoundingBox narrowPhase) {
+      this.blockCollisionProbeResults.clear();
+      this.addBlockCollisionsToList(broadPhase, this.blockCollisionProbeResults);
+      double penetration = 0.0D;
+      for(int i = 0; i < this.blockCollisionProbeResults.size(); ++i) {
+         AxisAlignedBB blockBox = ((AxisAlignedBB)this.blockCollisionProbeResults.get(i)).contract(
+                 HULL_COLLISION_TOLERANCE, HULL_COLLISION_TOLERANCE, HULL_COLLISION_TOLERANCE);
+         if(narrowPhase == null ? broadPhase.intersectsWith(blockBox) : narrowPhase.intersectsWith(blockBox)) {
+            double overlapX = Math.min(broadPhase.maxX, blockBox.maxX) - Math.max(broadPhase.minX, blockBox.minX);
+            double overlapY = Math.min(broadPhase.maxY, blockBox.maxY) - Math.max(broadPhase.minY, blockBox.minY);
+            double overlapZ = Math.min(broadPhase.maxZ, blockBox.maxZ) - Math.max(broadPhase.minZ, blockBox.minZ);
+            penetration += Math.max(overlapX, 0.0D) * Math.max(overlapY, 0.0D) * Math.max(overlapZ, 0.0D);
+         }
+      }
+      return penetration;
    }
 
    public void setRotPitch(float f) {
@@ -4577,6 +4681,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          super.posY = super.boundingBox.minY + (double)super.yOffset - (double)super.ySize;
          super.posZ = (super.boundingBox.minZ + super.boundingBox.maxZ) / 2.0D;
          super.isCollidedHorizontally = d6 != par1 || d8 != par5;
+         this.latestHorizontalMoveClipped = super.isCollidedHorizontally;
          super.isCollidedVertically = d7 != par3;
          super.onGround = d7 != par3 && d7 < 0.0D;
          super.isCollided = super.isCollidedHorizontally || super.isCollidedVertically;

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -907,11 +907,11 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
 
             if(!this.newHeliFlightModelEnabled && this.heliInfo.isEnableFoldBlade && this.rotors.length > 0 && this.getFoldBladeStat() == 0 && !this.isDestroyed()) {
                if(super.moveLeft && !super.moveRight) {
-                  this.setRotYaw(this.getRotYaw() - 0.5F * partialTicks);
+                  this.setCollisionSafeControlYaw(this.getRotYaw() - 0.5F * partialTicks);
                }
 
                if(super.moveRight && !super.moveLeft) {
-                  this.setRotYaw(this.getRotYaw() + 0.5F * partialTicks);
+                  this.setCollisionSafeControlYaw(this.getRotYaw() + 0.5F * partialTicks);
                }
             }
          }
@@ -957,7 +957,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          this.yawDampingApplied = 0.0F;
          this.debugFinalYawRate = this.heliYawAngularVelocity;
          this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
-         this.setRotYaw(this.finalRotYaw);
+         this.setCollisionSafeControlYaw(this.finalRotYaw);
          this.logNewHelicopterControlDebug();
          return;
       }
@@ -978,7 +978,7 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
       this.logNewHelicopterControlDebug();
 
       this.finalRotYaw = this.getRotYaw() + this.heliYawAngularVelocity * tickDelta;
-      this.setRotYaw(this.finalRotYaw);
+      this.setCollisionSafeControlYaw(this.finalRotYaw);
    }
 
    private boolean isNewHelicopterGroundedForYaw() {

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -2686,7 +2686,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       if(!this.isDestroyed()) {
          if(super.isGunnerMode) {
             this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
-            this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
+            this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
             if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
                this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
             }
@@ -2718,11 +2718,11 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
             }
 
             if(super.moveLeft && !super.moveRight) {
-               this.setRotYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
+               this.setCollisionSafeControlYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
             }
 
             if(super.moveRight && !super.moveLeft) {
-               this.setRotYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
+               this.setCollisionSafeControlYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
             }
          }
 
@@ -3234,7 +3234,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                if (throttle == null || W_Block.isEqual(throttle, Blocks.air)) {
 
                   // Adjusts heading based on autopilot rotation amount (Yaw)
-                  this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 2.0F);
+                  this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 2.0F);
 
                   // If pitch is greater than -20 degrees, gradually decreases pitch
                   if (this.getRotPitch() > -20.0F) {
@@ -3243,7 +3243,7 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
                }
             } else {
                // If no obstacle is encountered, adjusts heading by autopilot rotation amount (Yaw)
-               this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
+               this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
 
                // Automatically adjusts pitch so it gradually decreases
                this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -391,7 +391,7 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
         if(!this.isDestroyed()) {
             if(super.isGunnerMode) {
                 this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
-                this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
+                this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
                 if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
                     this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
                 }
@@ -421,12 +421,12 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
 
                 if(super.moveLeft && !super.moveRight) {
-                    this.setRotYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
+                    this.setCollisionSafeControlYaw(this.getRotYaw() - 0.6F * rot * partialTicks);
                     this.currentSpeed = currentSpeed - rot;
                 }
 
                 if(super.moveRight && !super.moveLeft) {
-                    this.setRotYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
+                    this.setCollisionSafeControlYaw(this.getRotYaw() + 0.6F * rot * partialTicks);
                     this.currentSpeed = currentSpeed - rot;
                 }
             }
@@ -815,13 +815,13 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
                 if(throttle != null && !W_Block.isEqual(throttle, Blocks.air)) {
                     throttle = MCH_Lib.getBlockY(this, 3, -5, true);
                     if(throttle == null || W_Block.isEqual(throttle, Blocks.air)) {
-                        this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 2.0F);
+                        this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 2.0F);
                         if(this.getRotPitch() > -20.0F) {
                             this.setRotPitch(this.getRotPitch() - 0.5F);
                         }
                     }
                 } else {
-                    this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
+                    this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 1.0F);
                     this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, 1.0F));
                     if(this.canFoldLandingGear()) {
                         this.foldLandingGear();

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -440,7 +440,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       if(!this.isDestroyed()) {
          if(super.isGunnerMode) {
             this.setRotPitch(this.decayMobilityValue(this.getRotPitch(), 0.95F, partialTicks));
-            this.setRotYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
+            this.setCollisionSafeControlYaw(this.getRotYaw() + this.getAcInfo().autoPilotRot * 0.2F * partialTicks);
             if(MathHelper.abs(this.getRotRoll()) > 20.0F) {
                this.setRotRoll(this.decayMobilityValue(this.getRotRoll(), 0.95F, partialTicks));
             }
@@ -478,11 +478,11 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
                float flag = !super.throttleUp && super.throttleDown && this.getCurrentThrottle() < (double)pivotTurnThrottle1 + 0.05D?-1.0F:1.0F;
                if(super.moveLeft && !super.moveRight) {
-                  this.setRotYaw(this.getRotYaw() - 0.6F * rotonground * partialTicks * flag * sf);
+                  this.setCollisionSafeControlYaw(this.getRotYaw() - 0.6F * rotonground * partialTicks * flag * sf);
                }
 
                if(super.moveRight && !super.moveLeft) {
-                  this.setRotYaw(this.getRotYaw() + 0.6F * rotonground * partialTicks * flag * sf);
+                  this.setCollisionSafeControlYaw(this.getRotYaw() + 0.6F * rotonground * partialTicks * flag * sf);
                }
 
             }
@@ -510,7 +510,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       double dx = super.posX - super.prevPosX;
       double dz = super.posZ - super.prevPosZ;
       double dist = dx * dx + dz * dz;
-      if(dist <= 1.0E-6D) {
+      if(dist <= 1.0E-6D && !this.wasLatestHorizontalMoveClipped()) {
          dist = super.motionX * super.motionX + super.motionZ * super.motionZ;
       }
 
@@ -526,11 +526,11 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
          float flag = !super.throttleUp && super.throttleDown && this.getCurrentThrottle() < (double)pivotTurnThrottle1 + 0.05D?-1.0F:1.0F;
          if(super.moveLeft && !super.moveRight) {
-            this.setRotYaw(this.getRotYaw() - 0.6F * partialTicks * flag * sf);
+            this.setCollisionSafeControlYaw(this.getRotYaw() - 0.6F * partialTicks * flag * sf);
          }
 
          if(super.moveRight && !super.moveLeft) {
-            this.setRotYaw(this.getRotYaw() + 0.6F * partialTicks * flag * sf);
+            this.setCollisionSafeControlYaw(this.getRotYaw() + 0.6F * partialTicks * flag * sf);
          }
       }
    }
@@ -701,11 +701,11 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
                         float flag = !super.throttleUp && super.throttleDown && this.getCurrentThrottle() < (double)pivotTurnThrottle1 + 0.05D ? -1.0F : 1.0F;
                         if(super.moveLeft && !super.moveRight) {
-                           this.setRotYaw(this.getRotYaw() + 0.6F * rotonground * partialTicks * flag * sf);
+                           this.setCollisionSafeControlYaw(this.getRotYaw() + 0.6F * rotonground * partialTicks * flag * sf);
                         }
 
                         if(super.moveRight && !super.moveLeft) {
-                           this.setRotYaw(this.getRotYaw() - 0.6F * rotonground * partialTicks * flag * sf);
+                           this.setCollisionSafeControlYaw(this.getRotYaw() - 0.6F * rotonground * partialTicks * flag * sf);
                         }
                      }
                   }


### PR DESCRIPTION
### Motivation

- Fix chassis yaw input that rotated full vehicle hulls through solid blocks by using only the small root AABB and raw motion as evidence of travel, which allowed wall-clipped throttle to enable uncontrolled yaw (regression from earlier steering changes).\
- Preserve existing airborne and diagonal-step steering behavior while preventing hull penetration for all controllable vehicles.\

### Description

- Add a collision-safe control-yaw resolver and public `setCollisionSafeControlYaw` in `MCH_EntityBaseVehicle` that tests candidate chassis yaw against the full configured hull (root AABB plus every `extraBoundingBox`) and returns the largest safe partial yaw when a requested turn would penetrate blocks.\
- Implement pure probe logic that uses reusable `MCH_BoundingBox` copies and the existing OBB-to-AABB narrow-phase intersection path plus a broad-phase block query, with a small tolerance to allow valid contact without measurable penetration.\
- Route all control/autopilot yaw updates for tank, helicopter, plane and ship yaw code through the new resolver while leaving `setRotYaw` unchanged for synchronization, loading and authoritative corrections.\
- Prevent the airborne steering fallback from treating wall-clipped throttle as genuine horizontal motion by recording whether the last horizontal translation was clipped (`latestHorizontalMoveClipped`) and only using `motionX/motionZ` fallback when the move was not clipped; keep `applyMovingAirborneSteering` behavior but route its yaw through the resolver.\
- Reuse existing translation collision handling and step behavior; avoid rewriting movement resolution and avoid per-tick allocations for probes.\

Changed files:
- `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`\
- `src/main/java/mcheli/tank/MCH_EntityTank.java`\
- `src/main/java/mcheli/helicopter/MCH_EntityHeli.java`\
- `src/main/java/mcheli/plane/MCP_EntityPlane.java`\
- `src/main/java/mcheli/ship/MCH_EntityShip.java`

### Testing

- Ran `./gradlew compileJava` which completed successfully (build success, standard deprecation/unchecked warnings remain).\
- Ran repository checks: `git diff --check` and `git status --short` after the change; both succeeded and the working tree is updated on branch `MCHRgithub`.\
- Notes on manual/runtime tests: interactive in-game reproduction (Toyota Hilux wall/pillar scenarios, full steering regression matrix, block-shape matrix, and multiplayer observation) could not be executed in this non-interactive environment and remain to be validated in a live Forge/Minecraft runtime.

Automated build and static checks: PASS. Manual gameplay and multiplayer verification: PENDING.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc12bf3908323be1464d46c1437f9)