### PR TITLE
Prevent vehicle hull yaw through walls

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -82,6 +82,12 @@ import org.lwjgl.Sys;
 public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements MCH_IEntityLockChecker, MCH_IEntityCanRideBaseVehicle, IEntityAdditionalSpawnData {
    private static final Map<UUID, NewUavSafeReturn> NEW_UAV_SAFE_RETURNS = new HashMap<UUID, NewUavSafeReturn>();
    private final MCH_VehicleBoxCache vehicleBoxCache = new MCH_VehicleBoxCache();
+   private MCH_BoundingBox[] controlYawProbeBoxes = new MCH_BoundingBox[0];
+   private final ArrayList controlYawBlockBoxes = new ArrayList();
+   private final ArrayList controlYawCurrentContacts = new ArrayList();
+   private final ArrayList controlYawCandidateContacts = new ArrayList();
+   private static final double CONTROL_YAW_EPSILON = 1.0E-4D;
+   private static final int CONTROL_YAW_SEARCH_STEPS = 9;
    private static final int NEW_UAV_SAFE_RETURN_MIN_TICKS = 20;
    private static MCH_EntityBaseVehicle aircraft;
     private ForgeChunkManager.Ticket chunkTicket;
@@ -454,6 +460,137 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void setRotYaw(float f) {
       super.rotationYaw = f;
+   }
+
+   /**
+    * Validates the result of a completed control calculation.  Callers deliberately run their
+    * normal steering first; this method changes only the final chassis yaw when that rotation
+    * would increase horizontal hull penetration.
+    */
+   protected void validateControlYaw(float originalYaw) {
+      float requestedYaw = this.getRotYaw();
+      float delta = MathHelper.wrapAngleTo180_float(requestedYaw - originalYaw);
+      if(MathHelper.abs(delta) < 1.0E-5F || this.worldObj == null || this.getAcInfo() == null) {
+         return;
+      }
+
+      this.collectControlYawContacts(originalYaw, this.controlYawCurrentContacts);
+      if(this.isControlYawSafe(originalYaw + delta, this.controlYawCurrentContacts)) {
+         return;
+      }
+
+      float safe = 0.0F;
+      float blocked = 1.0F;
+      for(int i = 0; i < CONTROL_YAW_SEARCH_STEPS; ++i) {
+         float fraction = (safe + blocked) * 0.5F;
+         if(this.isControlYawSafe(originalYaw + delta * fraction, this.controlYawCurrentContacts)) {
+            safe = fraction;
+         } else {
+            blocked = fraction;
+         }
+      }
+      this.setRotYaw(originalYaw + delta * safe);
+   }
+
+   private boolean isControlYawSafe(float yaw, List baseline) {
+      this.collectControlYawContacts(yaw, this.controlYawCandidateContacts);
+      for(int i = 0; i < this.controlYawCandidateContacts.size(); ++i) {
+         HullBlockContact candidate = (HullBlockContact)this.controlYawCandidateContacts.get(i);
+         double previousDepth = 0.0D;
+         for(int j = 0; j < baseline.size(); ++j) {
+            HullBlockContact current = (HullBlockContact)baseline.get(j);
+            if(candidate.sameObstacle(current)) {
+               previousDepth = current.depth;
+               break;
+            }
+         }
+         if(candidate.depth > previousDepth + CONTROL_YAW_EPSILON) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   /** Uses disposable OBBs and never updates the live hit boxes or their cache. */
+   private void collectControlYawContacts(float yaw, List contacts) {
+      contacts.clear();
+      MCH_BoundingBox[] source = this.extraBoundingBox != null ? this.extraBoundingBox : new MCH_BoundingBox[0];
+      if(this.controlYawProbeBoxes.length != source.length) {
+         this.controlYawProbeBoxes = new MCH_BoundingBox[source.length];
+      }
+      for(int i = 0; i < source.length; ++i) {
+         MCH_BoundingBox configured = source[i];
+         // Tracks, engines and turrets are damage/interaction regions, not solid hull volume.
+         if(configured.boundingBoxType != EnumBoundingBoxType.DEFAULT) {
+            continue;
+         }
+         MCH_BoundingBox probe = this.controlYawProbeBoxes[i];
+         if(probe == null || probe.width != configured.width || probe.height != configured.height
+                 || probe.depth != configured.depth || probe.offsetX != configured.offsetX
+                 || probe.offsetY != configured.offsetY || probe.offsetZ != configured.offsetZ) {
+            probe = configured.copy();
+            this.controlYawProbeBoxes[i] = probe;
+         }
+         // Yaw-only geometry intentionally decouples this side probe from suspension pitch/roll.
+         probe.updatePosition(super.posX, super.posY, super.posZ, yaw, 0.0F, 0.0F);
+         this.controlYawBlockBoxes.clear();
+         this.addBlockCollisionsToList(probe.boundingBox, this.controlYawBlockBoxes);
+         for(int blockIndex = 0; blockIndex < this.controlYawBlockBoxes.size(); ++blockIndex) {
+            AxisAlignedBB blockBox = (AxisAlignedBB)this.controlYawBlockBoxes.get(blockIndex);
+            double horizontalDepth = getHorizontalObbPenetration(probe, blockBox, yaw);
+            double verticalDepth = Math.min(probe.boundingBox.maxY, blockBox.maxY)
+                    - Math.max(probe.boundingBox.minY, blockBox.minY);
+            // The shallowest separating direction is vertical for ordinary floor/support contact.
+            if(horizontalDepth > CONTROL_YAW_EPSILON
+                    && verticalDepth > horizontalDepth + CONTROL_YAW_EPSILON) {
+               contacts.add(new HullBlockContact(i, blockBox, horizontalDepth));
+            }
+         }
+      }
+   }
+
+   /** Exact XZ SAT minimum translation depth for a yaw-oriented rectangle and block AABB. */
+   private static double getHorizontalObbPenetration(MCH_BoundingBox hull, AxisAlignedBB block, float yaw) {
+      double radians = Math.toRadians(-yaw);
+      double ux = Math.cos(radians), uz = Math.sin(radians);
+      double vx = -uz, vz = ux;
+      double cx = (block.minX + block.maxX) * 0.5D;
+      double cz = (block.minZ + block.maxZ) * 0.5D;
+      double dx = cx - hull.nowPos.xCoord;
+      double dz = cz - hull.nowPos.zCoord;
+      double blockHalfX = (block.maxX - block.minX) * 0.5D;
+      double blockHalfZ = (block.maxZ - block.minZ) * 0.5D;
+      double min = Double.MAX_VALUE;
+      for(int i = 0; i < 4; ++i) {
+         double axisX = i == 0 ? ux : i == 1 ? vx : i == 2 ? 1.0D : 0.0D;
+         double axisZ = i == 0 ? uz : i == 1 ? vz : i == 2 ? 0.0D : 1.0D;
+         double hullRadius = hull.width * 0.5D * Math.abs(axisX * ux + axisZ * uz)
+                 + hull.depth * 0.5D * Math.abs(axisX * vx + axisZ * vz);
+         double blockRadius = blockHalfX * Math.abs(axisX) + blockHalfZ * Math.abs(axisZ);
+         double overlap = hullRadius + blockRadius - Math.abs(dx * axisX + dz * axisZ);
+         if(overlap <= CONTROL_YAW_EPSILON) return 0.0D;
+         min = Math.min(min, overlap);
+      }
+      return min;
+   }
+
+   private static final class HullBlockContact {
+      private final int hullIndex;
+      private final AxisAlignedBB block;
+      private final double depth;
+
+      private HullBlockContact(int hullIndex, AxisAlignedBB block, double depth) {
+         this.hullIndex = hullIndex;
+         this.block = block;
+         this.depth = depth;
+      }
+
+      private boolean sameObstacle(HullBlockContact other) {
+         return this.hullIndex == other.hullIndex && this.block.minX == other.block.minX
+                 && this.block.minY == other.block.minY && this.block.minZ == other.block.minZ
+                 && this.block.maxX == other.block.maxX && this.block.maxY == other.block.maxY
+                 && this.block.maxZ == other.block.maxZ;
+      }
    }
 
    public void setRotPitch(float f) {
@@ -2155,7 +2292,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.setRotYaw(v.y);
       this.setRotPitch(v.x);
       this.setRotRoll(v.z);
+      float controlYaw = this.getRotYaw();
       this.onUpdateAngles(partialTicks);
+      this.validateControlYaw(controlYaw);
       if(this.getAcInfo().limitRotation) {
          v.x = MCH_Lib.RNG(this.getRotPitch(), this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
          v.z = MCH_Lib.RNG(this.getRotRoll(), this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);
@@ -2317,7 +2456,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.setRotYaw(v.y);
       this.setRotPitch(v.x);
       this.setRotRoll(v.z);
+      float controlYaw = this.getRotYaw();
       this.onUpdateAngles(partialTicks);
+      this.validateControlYaw(controlYaw);
       if(this.getAcInfo().limitRotation) {
          v.x = MCH_Lib.RNG(this.getRotPitch(), this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
          v.z = MCH_Lib.RNG(this.getRotRoll(), this.getAcInfo().minRotationRoll, this.getAcInfo().maxRotationRoll);

--- a/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
+++ b/src/main/java/mcheli/helicopter/MCH_EntityHeli.java
@@ -787,7 +787,9 @@ public class MCH_EntityHeli extends MCH_EntityBaseVehicle {
          }
          this.updateWeapons();
          this.onUpdate_Seats();
+         float controlYaw = this.getRotYaw();
          this.onUpdate_Control();
+         this.validateControlYaw(controlYaw);
          this.onUpdate_Rotor();
          super.prevPosX = super.posX;
          super.prevPosY = super.posY;

--- a/src/main/java/mcheli/plane/MCP_EntityPlane.java
+++ b/src/main/java/mcheli/plane/MCP_EntityPlane.java
@@ -501,7 +501,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
 
          this.updateWeapons();
          this.onUpdate_Seats();
+         float controlYaw = this.getRotYaw();
          this.onUpdate_Control();
+         this.validateControlYaw(controlYaw);
          this.prevRotationRotor = this.rotationRotor;
          this.rotationRotor = (float)((double)this.rotationRotor + this.getCurrentThrottle() * (double)this.getAcInfo().rotorSpeed);
          if(this.rotationRotor > 360.0F) {
@@ -1714,7 +1716,9 @@ public class MCP_EntityPlane extends MCH_EntityBaseVehicle {
       this.setRotYaw(v.y);
       this.setRotPitch(v.x);
       this.setRotRoll(v.z);
+      float controlYaw = this.getRotYaw();
       this.onUpdateAngles(partialTicks);
+      this.validateControlYaw(controlYaw);
       if(this.shouldUseLegacyRotationClamp()) {
          v.x = MCH_Lib.RNG(this.getRotPitch(), this.getAcInfo().minRotationPitch, this.getAcInfo().maxRotationPitch);
          v.x = this.clampIdleUnsupportedNoseUpPitch(v.x, stallSpeed);

--- a/src/main/java/mcheli/ship/MCH_EntityShip.java
+++ b/src/main/java/mcheli/ship/MCH_EntityShip.java
@@ -267,7 +267,9 @@ public class MCH_EntityShip extends MCH_EntityBaseVehicle {
 
             this.updateWeapons();
             this.onUpdate_Seats();
+            float controlYaw = this.getRotYaw();
             this.onUpdate_Control();
+            this.validateControlYaw(controlYaw);
             this.prevRotationRotor = this.rotationRotor;
             this.rotationRotor = (float)((double)this.rotationRotor + this.getCurrentThrottle() * (double)this.getAcInfo().rotorSpeed);
             if(this.rotationRotor > 360.0F) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -249,7 +249,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
 
          this.updateWeapons();
          this.onUpdate_Seats();
+         float controlYaw = this.getRotYaw();
          this.onUpdate_Control(partialTicks);
+         this.validateControlYaw(controlYaw);
          this.prevRotationRotor = this.rotationRotor;
          this.rotationRotor = (float)((double)this.rotationRotor + this.getCurrentThrottle() * (double)this.getAcInfo().rotorSpeed);
          if(this.rotationRotor > 360.0F) {
@@ -1478,7 +1480,9 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       this.setRotYaw(v.y);
       this.setRotPitch(v.x);
       this.setRotRoll(v.z);
+      float controlYaw = this.getRotYaw();
       this.onUpdateAngles(partialTicks);
+      this.validateControlYaw(controlYaw);
       if(this.getAcInfo().limitRotation) {
          v.x = MCH_Lib.RNG(this.getRotPitch(), -90.0F, 90.0F);
          v.z = MCH_Lib.RNG(this.getRotRoll(), -90.0F, 90.0F);


### PR DESCRIPTION
### Motivation

- Vehicles were able to rotate their hulls into solid blocks during player control, while previous fixes that routed many `setRotYaw` calls through a collision resolver blocked normal steering when ground support produced nonzero overlap.
- The goal is to stop only control-driven chassis yaw that would increase horizontal side penetration while preserving all existing steering behavior and airborne/step steering logic.

### Description

- Added a post-steering chassis-yaw validator `validateControlYaw` in `MCH_EntityBaseVehicle` that runs after existing control/steering calculations and only clamps the final requested yaw when it would increase horizontal hull penetration. It performs a bounded binary search to preserve the largest safe fraction of the requested rotation and keeps the requested rotation direction and angle wrapping correct.
- Implemented non-mutating yaw-only hull probes that copy `DEFAULT` hull boxes into scratch `MCH_BoundingBox` probes and query real block collision boxes via the existing `addBlockCollisionsToList`, avoiding updates to live `boundingBox`, `backupBoundingBox`, `nowPos`, `prevPos`, `axisX/Y/Z`, and not dirtying `MCH_VehicleBoxCache` for rejected candidates. Only boxes flagged as physical hull (`EnumBoundingBoxType.DEFAULT`) are used for block collision checks; track/engine/turret boxes are ignored.
- Replaced total enclosing-AABB volume checks with a conservative horizontal XZ separating-axis style penetration test between yaw-oriented hull probes and block AABBs, and separated horizontal side penetration from vertical support by requiring horizontal penetration to be measurably larger than the vertical overlap before treating the contact as a blocking wall. Matching current and candidate contacts are compared so rotations that reduce or do not increase penetration are allowed (allows turning away from walls and recovers from existing overlaps).
- Integrated `validateControlYaw` at shared update points for tanks, helicopters, planes, and ships (after `onUpdate_Control` and after angle calculations) without changing steering equations, `applyMovingAirborneSteering`, `onUpdate_ControlSub`, motion fallbacks, or other control code paths; position, motion, throttle, pitch, roll, and synchronization paths were left unchanged.
- Files changed: `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/tank/MCH_EntityTank.java`, `src/main/java/mcheli/helicopter/MCH_EntityHeli.java`, `src/main/java/mcheli/plane/MCP_EntityPlane.java`, `src/main/java/mcheli/ship/MCH_EntityShip.java`.

### Testing

- Ran the project Java compile: `./gradlew compileJava` (succeeded).
- Verified repository formatting checks: `git diff --check` (no whitespace errors) and inspected diffs to confirm only the intended five Java files were modified (OK).
- Performed static review to ensure the change does not route intermediate `setRotYaw` calls through the collision guard and that airborne/diagonal/partial-contact steering code paths are not altered (review pass).
- Runtime in-game tests (Toyota Hilux wall scenarios, full baseline steering, airborne/step, terrain, multi-vehicle and multiplayer observations) were not executed because they require launching a Forge 1.7.10 client/server; these remain to be validated in the interactive game environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc653d6d083238c00808ba3c26557)