### PR TITLE
Fix Abrams tank root step candidate collision

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -101,6 +101,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private final PhysicalHullPath physicalHullNormalPath = new PhysicalHullPath();
    private boolean physicalHullPathCommitted;
    private boolean physicalHullPathIsStep;
+   private boolean rootMovementCandidateCalculation;
    private boolean acceptAuthoritativeHullTransform;
    private final TransformSnapshot lastSafePhysicalTransform = new TransformSnapshot();
    private boolean hasLastSafePhysicalTransform;
@@ -518,6 +519,18 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
+   }
+
+   /**
+    * Root movement candidates must be resolved from the root box only.  The
+    * selected route is subsequently checked against every physical hull OBB.
+    */
+   protected final void beginRootMovementCandidateCalculation() {
+      this.rootMovementCandidateCalculation = true;
+   }
+
+   protected final void endRootMovementCandidateCalculation() {
+      this.rootMovementCandidateCalculation = false;
    }
 
    protected final void recordPhysicalHullWaypoint(AxisAlignedBB root, int segmentType) {
@@ -5280,7 +5293,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       if(par1Entity instanceof MCH_EntityBaseVehicle) {
          MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)par1Entity;
-         vehicle.addExtraBoundingBoxBlockCollisions(par2AxisAlignedBB, collidingBoundingBoxes);
+         if(!vehicle.rootMovementCandidateCalculation) {
+            vehicle.addExtraBoundingBoxBlockCollisions(par2AxisAlignedBB, collidingBoundingBoxes);
+         }
       }
 
       double var15 = 0.25D;

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -353,57 +353,63 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
       double my = parY;
       double mz = parZ;
       AxisAlignedBB backUpAxisalignedBB = super.boundingBox.copy();
-      List list = getCollidingBoundingBoxes(this, super.boundingBox.addCoord(parX, parY, parZ));
-      parY = this.calculateYOffset(list, super.boundingBox, parY);
-      this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_Y);
-      boolean flag1 = super.onGround || my != parY && my < 0.0D;
-      MCH_BoundingBox[] prevPX = super.extraBoundingBox;
-      int len$ = prevPX.length;
-
-      for(int prevPZ = 0; prevPZ < len$; ++prevPZ) {
-         MCH_BoundingBox ebb = prevPX[prevPZ];
-         ebb.updatePosition(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(), this.getRotRoll());
-      }
-
-      parX = this.calculateXOffset(list, super.boundingBox, parX);
-      this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_X);
-      parZ = this.calculateZOffset(list, super.boundingBox, parZ);
-      this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_Z);
-      this.saveNormalPhysicalHullPath();
-      boolean selectedStepRoute = false;
+      List list;
       double minX;
       double var38;
       double var39;
-      if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F && (mx != parX || mz != parZ)) {
-         var38 = parX;
-         var39 = parY;
-         minX = parZ;
-         parY = (double)super.stepHeight;
-         AxisAlignedBB minZ = super.boundingBox.copy();
-         super.boundingBox.setBB(backUpAxisalignedBB);
-         this.clearRecordedPhysicalHullPath();
-         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_ROTATION);
-         list = getCollidingBoundingBoxes(this, super.boundingBox.addCoord(mx, parY, mz));
-         this.calculateYOffset(list, super.boundingBox, parY);
-         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_UP);
-         parX = this.calculateXOffset(list, super.boundingBox, mx);
-         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_X);
-         parZ = this.calculateZOffset(list, super.boundingBox, mz);
-         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_Z);
-         parY = this.calculateYOffset(list, super.boundingBox, (double)(-super.stepHeight));
-         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_DOWN);
-         if(var38 * var38 + minX * minX >= parX * parX + parZ * parZ) {
-            parX = var38;
-            parY = var39;
-            parZ = minX;
-            super.boundingBox.setBB(minZ);
-            this.restoreNormalPhysicalHullPathForRecording();
-         } else {
-            selectedStepRoute = true;
-         }
-      }
+      this.beginRootMovementCandidateCalculation();
+      try {
+         list = getCollidingBoundingBoxes(this, super.boundingBox.addCoord(parX, parY, parZ));
+         parY = this.calculateYOffset(list, super.boundingBox, parY);
+         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_Y);
+         boolean flag1 = super.onGround || my != parY && my < 0.0D;
+         MCH_BoundingBox[] prevPX = super.extraBoundingBox;
+         int len$ = prevPX.length;
 
-      this.commitPhysicalHullPath(selectedStepRoute);
+         for(int prevPZ = 0; prevPZ < len$; ++prevPZ) {
+            MCH_BoundingBox ebb = prevPX[prevPZ];
+            ebb.updatePosition(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(), this.getRotRoll());
+         }
+
+         parX = this.calculateXOffset(list, super.boundingBox, parX);
+         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_X);
+         parZ = this.calculateZOffset(list, super.boundingBox, parZ);
+         this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_Z);
+         this.saveNormalPhysicalHullPath();
+         boolean selectedStepRoute = false;
+         if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F && (mx != parX || mz != parZ)) {
+            var38 = parX;
+            var39 = parY;
+            minX = parZ;
+            parY = (double)super.stepHeight;
+            AxisAlignedBB minZ = super.boundingBox.copy();
+            super.boundingBox.setBB(backUpAxisalignedBB);
+            this.clearRecordedPhysicalHullPath();
+            this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_ROTATION);
+            list = getCollidingBoundingBoxes(this, super.boundingBox.addCoord(mx, parY, mz));
+            this.calculateYOffset(list, super.boundingBox, parY);
+            this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_UP);
+            parX = this.calculateXOffset(list, super.boundingBox, mx);
+            this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_X);
+            parZ = this.calculateZOffset(list, super.boundingBox, mz);
+            this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_Z);
+            parY = this.calculateYOffset(list, super.boundingBox, (double)(-super.stepHeight));
+            this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_STEP_DOWN);
+            if(var38 * var38 + minX * minX >= parX * parX + parZ * parZ) {
+               parX = var38;
+               parY = var39;
+               parZ = minX;
+               super.boundingBox.setBB(minZ);
+               this.restoreNormalPhysicalHullPathForRecording();
+            } else {
+               selectedStepRoute = true;
+            }
+         }
+
+         this.commitPhysicalHullPath(selectedStepRoute);
+      } finally {
+         this.endRootMovementCandidateCalculation();
+      }
 
       var38 = super.posX;
       var39 = super.posZ;


### PR DESCRIPTION
### Motivation

- Abrams-family tanks were failing to climb valid one-block obstacles because approximate extra-hull block collisions from many large overlapping hull boxes were injected into root-box collision queries and clipped raised step candidates before the full OBB path-aware validator ran.
- The intent is to keep the path-aware physical hull validation and post-dismount collision lifecycle while ensuring the vanilla root-box candidate selection is not prematurely clipped by approximate extra-hull collisions.

### Description

- Add a narrow scoped state with `beginRootMovementCandidateCalculation()` / `endRootMovementCandidateCalculation()` to avoid injecting approximate extra-hull collisions while the root movement candidates are computed, and apply that scope around root candidate selection in `MCH_EntityTank.moveEntity`.
- Skip calling `addExtraBoundingBoxBlockCollisions` from `getCollidingBoundingBoxes` when the scoped root-candidate flag is active so the normal root-box offsets and raised-step candidate are computed from vanilla root-box collisions only.
- Preserve recording of rotation and step waypoints and continue committing the selected route to the existing full path-aware OBB validator (`isPhysicalHullPathSafe`) so final per-OBB validation, wall-phasing protection, and normal-route fallback remain unchanged.
- Files changed: `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java` and `src/main/java/mcheli/tank/MCH_EntityTank.java`.

### Testing

- Ran `git diff --check` and repository status checks to ensure no trailing whitespace or forbidden files were modified, and performed a static inspection of the Abrams and Toyota vehicle definitions to confirm differing `StepHeight` and hull box counts.
- Verified via code inspection that root candidate selection now excludes approximate extra-hull collisions and that the committed route still flows into the path-aware validator; no unit or integration test runs were executed in this environment.
- Not run: `./gradlew compileJava`, `./gradlew test`, and in-game/manual verification on Forge 1.7.10 (occupied/unoccupied vehicle, slab/stair, wall and multiplayer scenarios) because compiling/running the game runtime is outside the allowed actions in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7001181d488323b14a420326119594)