### PR TITLE
Fix tank stepping triggered by long physical hulls

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -102,6 +102,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private final PhysicalHullPath physicalHullNormalPath = new PhysicalHullPath();
    private boolean physicalHullPathCommitted;
    private boolean physicalHullPathIsStep;
+   private boolean physicalHullStepTriggeredByHull;
    private boolean rootMovementCandidateCalculation;
    private boolean acceptAuthoritativeHullTransform;
    private boolean hasBlockedHorizontalNormal;
@@ -522,6 +523,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
+      this.physicalHullStepTriggeredByHull = false;
    }
 
    /**
@@ -562,8 +564,66 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    protected final void commitPhysicalHullPath(boolean step) {
+      this.commitPhysicalHullPath(step, false);
+   }
+
+   protected final void commitPhysicalHullPath(boolean step, boolean triggeredByHull) {
       this.physicalHullPathCommitted = this.physicalHullPath.count > 0;
       this.physicalHullPathIsStep = step;
+      this.physicalHullStepTriggeredByHull = step && triggeredByHull;
+   }
+
+   /**
+    * Probes translated scratch hulls for a new, low horizontal block contact.  This deliberately
+    * does not resolve movement: it only lets the root route builder consider its ordinary raised
+    * route before a long hull is clipped by the final transform resolver.
+    */
+   protected final boolean hasClimbablePhysicalHullLedge(double moveX, double moveZ, float stepHeight) {
+      if(stepHeight <= 0.0F || moveX * moveX + moveZ * moveZ <= CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON
+              || this.worldObj == null) return false;
+      List hulls = this.getPhysicalHullBoxesForYaw();
+      if(hulls.isEmpty()) return false;
+      TransformSnapshot start = new TransformSnapshot();
+      start.set(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(), this.getRotRoll(), super.boundingBox);
+      TransformSnapshot end = new TransformSnapshot();
+      end.set(super.posX + moveX, super.posY, super.posZ + moveZ, start.yaw, start.pitch, start.roll, super.boundingBox);
+      this.collectSweptBlocks(start, end, hulls);
+      ArrayList startContacts = new ArrayList();
+      ArrayList candidateContacts = new ArrayList();
+      this.collectContacts(start, hulls, startContacts);
+      double distance = Math.sqrt(moveX * moveX + moveZ * moveZ);
+      int steps = Math.max(1, Math.min(64, (int)Math.ceil(distance / 0.05D)));
+      for(int step = 1; step <= steps; ++step) {
+         float fraction = (float)step / (float)steps;
+         TransformSnapshot candidate = interpolate(start, end, fraction, 0.0F);
+         this.collectContacts(candidate, hulls, candidateContacts);
+         for(int i = 0; i < candidateContacts.size(); ++i) {
+            HullBlockContact contact = (HullBlockContact)candidateContacts.get(i);
+            if(contact.floor || Math.abs(contact.normalY) > 0.75D) continue;
+            boolean existed = false;
+            for(int j = 0; j < startContacts.size(); ++j) {
+               if(contact.sameObstacleSide((HullBlockContact)startContacts.get(j))) { existed = true; break; }
+            }
+            if(existed) continue;
+            double horizontalNormal = Math.sqrt(contact.normalX * contact.normalX + contact.normalZ * contact.normalZ);
+            if(horizontalNormal < 0.75D) continue;
+            double toward = moveX * contact.normalX + moveZ * contact.normalZ;
+            if(toward >= -CONTROL_YAW_EPSILON) continue;
+            double requiredRise = contact.blockMaxY - super.boundingBox.minY;
+            if(isClimbablePhysicalStepContact(requiredRise, stepHeight)) return true;
+         }
+      }
+      return false;
+   }
+
+   static boolean isClimbablePhysicalStepContact(double requiredRise, float stepHeight) {
+      return requiredRise > CONTROL_YAW_EPSILON && requiredRise <= (double)stepHeight + 0.05D;
+   }
+
+   protected static boolean shouldTryTankStep(boolean rootBlocked, boolean physicalLedge,
+                                              double requestedX, double requestedZ) {
+      return requestedX * requestedX + requestedZ * requestedZ > CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON
+              && (rootBlocked || physicalLedge);
    }
 
    /** Remote interpolation is an already server-approved transform, not a new physical route. */
@@ -586,6 +646,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
+      this.physicalHullStepTriggeredByHull = false;
       this.acceptAuthoritativeHullTransform = false;
    }
 
@@ -616,6 +677,24 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
               && Math.abs(end.roll - this.controlTransformStart.roll) < 1.0E-5F) return;
 
       if(this.physicalHullPathCommitted) {
+         if(this.physicalHullStepTriggeredByHull && this.physicalHullNormalPath.count > 0) {
+            TransformSnapshot normalEnd = this.physicalHullNormalPath.points[this.physicalHullNormalPath.count - 1];
+            if(this.isPhysicalHullPathSafe(this.physicalHullNormalPath, hulls)) {
+               this.applySnapshot(normalEnd);
+               this.lastSafePhysicalTransform.copyFrom(normalEnd);
+               this.hasLastSafePhysicalTransform = true;
+               this.updatePhysicalHullPositions();
+               this.vehicleBoxCache.markDirty("physical hull normal route selected");
+               return;
+            }
+            if(this.isPhysicalHullPathSafe(this.physicalHullPath, hulls)) {
+               this.lastSafePhysicalTransform.copyFrom(end);
+               this.hasLastSafePhysicalTransform = true;
+               return;
+            }
+            this.applySnapshot(normalEnd);
+            end = normalEnd;
+         } else
          if(this.isPhysicalHullPathSafe(this.physicalHullPath, hulls)) {
             this.lastSafePhysicalTransform.copyFrom(end);
             this.hasLastSafePhysicalTransform = true;

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -377,7 +377,11 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          this.recordPhysicalHullWaypoint(super.boundingBox, HULL_PATH_NORMAL_Z);
          this.saveNormalPhysicalHullPath();
          boolean selectedStepRoute = false;
-         if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F && (mx != parX || mz != parZ)) {
+         boolean rootHorizontallyBlocked = mx != parX || mz != parZ;
+         boolean physicalHullLedge = !rootHorizontallyBlocked && flag1 && super.ySize < 0.05F
+                 && this.hasClimbablePhysicalHullLedge(mx, mz, super.stepHeight);
+         if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F
+                 && shouldTryTankStep(rootHorizontallyBlocked, physicalHullLedge, mx, mz)) {
             float stepYaw = this.getRotYaw();
             float startPitch = this.getPhysicalHullStartPitch();
             float startRoll = this.getPhysicalHullStartRoll();
@@ -406,7 +410,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
             parY = this.calculateYOffset(list, super.boundingBox, (double)(-super.stepHeight));
             this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, suspensionPitch, suspensionRoll,
                     HULL_PATH_STEP_DOWN);
-            if(var38 * var38 + minX * minX >= parX * parX + parZ * parZ) {
+            if(!physicalHullLedge && var38 * var38 + minX * minX >= parX * parX + parZ * parZ) {
                parX = var38;
                parY = var39;
                parZ = minX;
@@ -417,7 +421,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
             }
          }
 
-         this.commitPhysicalHullPath(selectedStepRoute);
+         this.commitPhysicalHullPath(selectedStepRoute, physicalHullLedge);
       } finally {
          this.endRootMovementCandidateCalculation();
       }

--- a/src/test/java/mcheli/aircraft/MCH_ObbCollisionTest.java
+++ b/src/test/java/mcheli/aircraft/MCH_ObbCollisionTest.java
@@ -85,6 +85,18 @@ public class MCH_ObbCollisionTest {
               shortHull, new double[]{0.0D, 0.5D, 3.75D}, new double[]{0.5D, 0.5D, 0.5D}));
    }
 
+   @Test
+   public void physicalLedgeTriggerUsesSupportPlaneRise() {
+      assertFalse(MCH_EntityBaseVehicle.shouldTryTankStep(false, false, 0.2D, 0.0D));
+      assertTrue(MCH_EntityBaseVehicle.shouldTryTankStep(false, true, 0.2D, 0.0D));
+      assertTrue(MCH_EntityBaseVehicle.shouldTryTankStep(true, false, 0.2D, 0.0D));
+      assertFalse(MCH_EntityBaseVehicle.shouldTryTankStep(false, true, 0.0D, 0.0D));
+      assertTrue(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(1.0D, 1.8F));
+      assertTrue(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(1.0D, 1.5F));
+      assertFalse(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(0.0D, 1.8F));
+      assertFalse(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(2.0D, 1.8F));
+   }
+
    private static boolean sweepHits(double[] start, double[] end, double[] hullHalf,
                                     double[] blockCenter, double[] blockHalf) {
       for(int i = 1; i <= 40; ++i) {


### PR DESCRIPTION
### Motivation
- Long physical hull boxes (e.g. Abrams) could contact a block before the small root bounding box was clipped, preventing the existing root-only step trigger from ever running.
- Prior fixes adjusted step validation but did not change the root-only activation condition, so tanks with long hulls remained permanently stopped at one-block ledges.
- Introduce a non-mutating early probe of the physical hulls so a climbable ledge can generate the raised route before final hull clipping prevents it.

### Description
- Add a non-mutating physical-hull ledge probe `hasClimbablePhysicalHullLedge(...)` to `MCH_EntityBaseVehicle` that sweeps the existing physical hull OBBs through the requested X/Z translation, queries real block collision shapes, ignores floors/pre-existing contacts/mostly-vertical normals/rotation-only movement, and computes the required rise against the root support plane to determine climbability.
- Extend the physical-hull path lifecycle with a `physicalHullStepTriggeredByHull` flag and overload `commitPhysicalHullPath(...)` so a step candidate can be marked as originating from the hull probe.
- Change tank step activation in `MCH_EntityTank.moveEntity` to attempt a raised route when either the root box is horizontally blocked or the physical-hull probe reports a climbable ledge, while preserving the existing root-only candidate generation logic and gating conditions (`stepHeight`, grounded state, `ySize`, and nonzero requested motion).
- Update route selection in the transform resolver to preserve both normal and raised candidates, validate the full-hull normal route first, and only if the normal route is unsafe validate and accept the full raised route (fall back to safely clipped normal route otherwise); add small helper predicates (`isClimbablePhysicalStepContact` and `shouldTryTankStep`) and unit-coverage for the trigger logic.
- Added focused tests in `MCH_ObbCollisionTest` to assert the new trigger and support-plane-rise behavior without changing vehicle configuration files or physical bounding-box definitions.

### Testing
- Ran `./gradlew compileJava --no-configuration-cache`, which completed successfully for the main source set.
- Attempted `./gradlew compileJava test`, but the test task could not run because configured Maven repositories returned HTTP 403 while resolving `junit:junit:4.13.2`, so JVM tests were not executed in this environment.
- Ran `git diff --check` and repository checks against the produced diff; no style/merge-check issues were reported.
- No interactive Minecraft client/server runtime tests were performed in this environment; the patch is designed to preserve wall-phasing, rotation-only collision behavior, wheel and suspension logic, and two-block-wall rejection, but the runtime scenarios listed in the task should be exercised manually or on CI with resolving test dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a701004703c8323bc00cb5e47b88e51)