### PR TITLE
Replace tank riser phasing with pre-contact step solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# PR pending - Pre-contact Tank Physical-Hull Step Solver
+
+- Replaced selected-riser collision permission with a tank-only, scratch-geometry route planner that stops before first contact, lifts clear, traverses normally, and lands on the real collision-shape top.
+- Kept normal physical-hull collision active on every route segment and retained safely clipped normal movement whenever a complete step route cannot be validated.
+- Added complete solver regressions using the M1A2's ten physical hull boxes and a shorter comparison hull, including block, slab, stair, wall, pillar, ceiling, occupancy, steering, and stability cases.
+
 # Configurable NEI Vehicle Ammunition Handler (PR pending)
 
 - Added the `EnableNEIHandler` boolean startup option, defaulting to `true`, to allow clients to prevent the optional NEI vehicle ammunition recipe and usage handler from registering.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -102,8 +102,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private final PhysicalHullPath physicalHullNormalPath = new PhysicalHullPath();
    private boolean physicalHullPathCommitted;
    private boolean physicalHullPathIsStep;
-   /** The one hull/collision-shape pair allowed to phase while validating this tick's raised route. */
-   private final ClimbableRiser physicalHullStepRiser = new ClimbableRiser();
    private boolean rootMovementCandidateCalculation;
    private boolean acceptAuthoritativeHullTransform;
    private boolean hasBlockedHorizontalNormal;
@@ -524,7 +522,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
-      this.physicalHullStepRiser.clear();
    }
 
    /**
@@ -565,66 +562,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    protected final void commitPhysicalHullPath(boolean step) {
-      this.commitPhysicalHullPath(step, false);
-   }
-
-   protected final void commitPhysicalHullPath(boolean step, boolean triggeredByHull) {
       this.physicalHullPathCommitted = this.physicalHullPath.count > 0;
       this.physicalHullPathIsStep = step;
-      if(!step || !triggeredByHull) this.physicalHullStepRiser.clear();
-   }
-
-   /**
-    * Probes translated scratch hulls for a new, low horizontal block contact.  This deliberately
-    * does not resolve movement: it only lets the root route builder consider its ordinary raised
-    * route before a long hull is clipped by the final transform resolver.
-    */
-   protected final boolean hasClimbablePhysicalHullLedge(double moveX, double moveZ, float stepHeight) {
-      if(stepHeight <= 0.0F || moveX * moveX + moveZ * moveZ <= CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON
-              || this.worldObj == null || !(this instanceof MCH_EntityTank)) return false;
-      this.physicalHullStepRiser.clear();
-      List hulls = this.getPhysicalHullBoxesForYaw();
-      if(hulls.isEmpty()) return false;
-      TransformSnapshot start = new TransformSnapshot();
-      start.set(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(), this.getRotRoll(), super.boundingBox);
-      TransformSnapshot end = new TransformSnapshot();
-      end.set(super.posX + moveX, super.posY, super.posZ + moveZ, start.yaw, start.pitch, start.roll, super.boundingBox);
-      this.collectSweptBlocks(start, end, hulls);
-      ArrayList startContacts = new ArrayList();
-      ArrayList candidateContacts = new ArrayList();
-      this.collectContacts(start, hulls, startContacts);
-      double distance = Math.sqrt(moveX * moveX + moveZ * moveZ);
-      int steps = Math.max(1, Math.min(64, (int)Math.ceil(distance / 0.05D)));
-      for(int step = 1; step <= steps; ++step) {
-         float fraction = (float)step / (float)steps;
-         TransformSnapshot candidate = interpolate(start, end, fraction, 0.0F);
-         this.collectContacts(candidate, hulls, candidateContacts);
-         for(int i = 0; i < candidateContacts.size(); ++i) {
-            HullBlockContact contact = (HullBlockContact)candidateContacts.get(i);
-            if(contact.floor || Math.abs(contact.normalY) > 0.75D) continue;
-            double horizontalNormal = Math.sqrt(contact.normalX * contact.normalX + contact.normalZ * contact.normalZ);
-            if(horizontalNormal < 0.75D) continue;
-            double toward = moveX * contact.normalX + moveZ * contact.normalZ;
-            if(toward >= -CONTROL_YAW_EPSILON) continue;
-            double requiredRise = contact.blockMaxY - super.boundingBox.minY;
-            if(isClimbablePhysicalStepContact(requiredRise, stepHeight)) {
-               this.physicalHullStepRiser.set(contact, super.boundingBox.minY, super.posY,
-                       requiredRise, moveX, moveZ);
-               return true;
-            }
-         }
-      }
-      return false;
-   }
-
-   static boolean isClimbablePhysicalStepContact(double requiredRise, float stepHeight) {
-      return requiredRise > CONTROL_YAW_EPSILON && requiredRise <= (double)stepHeight + 0.05D;
-   }
-
-   protected static boolean shouldTryTankStep(boolean rootBlocked, boolean physicalLedge,
-                                              double requestedX, double requestedZ) {
-      return requestedX * requestedX + requestedZ * requestedZ > CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON
-              && (rootBlocked || physicalLedge);
    }
 
    /** Remote interpolation is an already server-approved transform, not a new physical route. */
@@ -647,7 +586,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
-      this.physicalHullStepRiser.clear();
       this.acceptAuthoritativeHullTransform = false;
    }
 
@@ -678,24 +616,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
               && Math.abs(end.roll - this.controlTransformStart.roll) < 1.0E-5F) return;
 
       if(this.physicalHullPathCommitted) {
-         if(this.physicalHullStepRiser.active && this.physicalHullNormalPath.count > 0) {
-            TransformSnapshot normalEnd = this.physicalHullNormalPath.points[this.physicalHullNormalPath.count - 1];
-            if(this.isPhysicalHullPathSafe(this.physicalHullNormalPath, hulls)) {
-               this.applySnapshot(normalEnd);
-               this.lastSafePhysicalTransform.copyFrom(normalEnd);
-               this.hasLastSafePhysicalTransform = true;
-               this.updatePhysicalHullPositions();
-               this.vehicleBoxCache.markDirty("physical hull normal route selected");
-               return;
-            }
-            if(this.isPhysicalHullPathSafe(this.physicalHullPath, hulls)) {
-               this.lastSafePhysicalTransform.copyFrom(end);
-               this.hasLastSafePhysicalTransform = true;
-               return;
-            }
-            this.applySnapshot(normalEnd);
-            end = normalEnd;
-         } else
          if(this.isPhysicalHullPathSafe(this.physicalHullPath, hulls)) {
             this.lastSafePhysicalTransform.copyFrom(end);
             this.hasLastSafePhysicalTransform = true;
@@ -896,8 +816,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
                                    TransformSnapshot candidateTransform, List contacts, int segmentType) {
       for(int i = 0; i < contacts.size(); ++i) {
          HullBlockContact candidate = (HullBlockContact)contacts.get(i);
-         if(candidate.floor || this.isStepSupportContact(segmentStart, candidateTransform, candidate, segmentType)
-                 || this.isPermittedClimbableRiserContact(segmentStart, candidateTransform, candidate, segmentType)) continue;
+         if(candidate.floor || this.isStepSupportContact(segmentStart, candidateTransform, candidate, segmentType)) continue;
          HullBlockContact original = null;
          for(int j = 0; j < this.controlTransformStartContacts.size(); ++j) {
             HullBlockContact contact = (HullBlockContact)this.controlTransformStartContacts.get(j);
@@ -921,27 +840,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return true;
    }
 
-   private boolean isPermittedClimbableRiserContact(TransformSnapshot segmentStart,
-                                                     TransformSnapshot candidateTransform,
-                                                     HullBlockContact candidate, int segmentType) {
-      ClimbableRiser riser = this.physicalHullStepRiser;
-      double hullBottom = candidate.hull.center[1] - candidate.hull.verticalRadius();
-      return isPermittedClimbableRiserSegment(segmentType, riser.matches(candidate), riser.routeStartY,
-              segmentStart.x, segmentStart.y, segmentStart.z, candidateTransform.x, candidateTransform.y,
-              candidateTransform.z, hullBottom, riser.maxY);
-   }
-
-   static boolean isPermittedClimbableRiserSegment(int segmentType, boolean sameRiser, double routeStartY,
-                                                     double segmentStartX, double segmentStartY,
-                                                     double segmentStartZ, double candidateX, double candidateY,
-                                                     double candidateZ, double hullBottom, double obstacleTop) {
-      if(!sameRiser || candidateY <= routeStartY + CONTROL_YAW_EPSILON) return false;
-      if(segmentType == HULL_PATH_STEP_UP) return Math.abs(candidateX - segmentStartX) <= CONTROL_YAW_EPSILON
-              && Math.abs(candidateZ - segmentStartZ) <= CONTROL_YAW_EPSILON
-              && candidateY > segmentStartY + CONTROL_YAW_EPSILON;
-      return (segmentType == HULL_PATH_STEP_X || segmentType == HULL_PATH_STEP_Z)
-              && hullBottom <= obstacleTop + 0.05D;
-   }
 
    private void rememberBlockedHorizontalNormal(double x, double z) {
       if(x * x + z * z <= CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON) return;
@@ -1125,34 +1023,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          for(int i=0;i<v.length;++i) h=31L*h+Math.round(v[i]*1000000.0D); return h;
       }
       private static double dot(double[] a,double x,double y,double z) { return a[0]*x+a[1]*y+a[2]*z; }
-   }
-
-   private static final class ClimbableRiser {
-      boolean active;
-      MCH_BoundingBox sourceHull;
-      long boundsKey;
-      double supportPlane, routeStartY, requiredRise, maxY;
-      void set(HullBlockContact contact, double supportPlane, double routeStartY, double requiredRise,
-               double requestedX, double requestedZ) {
-         this.active = requestedX * requestedX + requestedZ * requestedZ
-                 > CONTROL_YAW_EPSILON * CONTROL_YAW_EPSILON;
-         this.sourceHull = contact.sourceHull;
-         this.boundsKey = contact.boundsKey;
-         this.supportPlane = supportPlane;
-         this.routeStartY = routeStartY;
-         this.requiredRise = requiredRise;
-         this.maxY = contact.blockMaxY;
-      }
-      boolean matches(HullBlockContact contact) {
-         return this.active && contact.sourceHull == this.sourceHull && contact.boundsKey == this.boundsKey
-                 && this.requiredRise > CONTROL_YAW_EPSILON;
-      }
-      void clear() {
-         this.active = false;
-         this.sourceHull = null;
-         this.boundsKey = 0L;
-         this.supportPlane = this.routeStartY = this.requiredRise = this.maxY = 0.0D;
-      }
    }
 
    public void setRotPitch(float f) {
@@ -5460,6 +5330,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          return sweepBox.maxZ - super.boundingBox.maxZ;
       }
       return 0.0D;
+   }
+
+   /** Supplies ordinary world collision shapes to specialized route planners without changing live hulls. */
+   protected final void collectPhysicalHullBlockCollisions(AxisAlignedBB targetBox, List collidingBoundingBoxes) {
+      this.addBlockCollisionsToList(targetBox, collidingBoundingBoxes);
    }
 
    private void addBlockCollisionsToList(AxisAlignedBB targetBox, List collidingBoundingBoxes) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -2,6 +2,7 @@ package mcheli.tank;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import mcheli.MCH_Config;
@@ -378,50 +379,53 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
          this.saveNormalPhysicalHullPath();
          boolean selectedStepRoute = false;
          boolean rootHorizontallyBlocked = mx != parX || mz != parZ;
-         boolean physicalHullLedge = !rootHorizontallyBlocked && flag1 && super.ySize < 0.05F
-                 && this.hasClimbablePhysicalHullLedge(mx, mz, super.stepHeight);
-         if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F
-                 && shouldTryTankStep(rootHorizontallyBlocked, physicalHullLedge, mx, mz)) {
-            float stepYaw = this.getRotYaw();
-            float startPitch = this.getPhysicalHullStartPitch();
-            float startRoll = this.getPhysicalHullStartRoll();
-            float suspensionPitch = this.getRotPitch();
-            float suspensionRoll = this.getRotRoll();
-            var38 = parX;
-            var39 = parY;
-            minX = parZ;
-            parY = (double)super.stepHeight;
-            AxisAlignedBB minZ = super.boundingBox.copy();
-            super.boundingBox.setBB(backUpAxisalignedBB);
-            this.clearRecordedPhysicalHullPath();
-            // Yaw remains strict at the lower position. Suspension attitude is applied only after ascent.
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, startPitch, startRoll, HULL_PATH_ROTATION);
-            list = getCollidingBoundingBoxes(this, super.boundingBox.addCoord(mx, parY, mz));
-            this.calculateYOffset(list, super.boundingBox, parY);
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, startPitch, startRoll, HULL_PATH_STEP_UP);
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, suspensionPitch, suspensionRoll,
-                    HULL_PATH_STEP_ROTATION);
-            parX = this.calculateXOffset(list, super.boundingBox, mx);
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, suspensionPitch, suspensionRoll,
-                    HULL_PATH_STEP_X);
-            parZ = this.calculateZOffset(list, super.boundingBox, mz);
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, suspensionPitch, suspensionRoll,
-                    HULL_PATH_STEP_Z);
-            parY = this.calculateYOffset(list, super.boundingBox, (double)(-super.stepHeight));
-            this.recordPhysicalHullWaypoint(super.boundingBox, stepYaw, suspensionPitch, suspensionRoll,
-                    HULL_PATH_STEP_DOWN);
-            if(!physicalHullLedge && var38 * var38 + minX * minX >= parX * parX + parZ * parZ) {
-               parX = var38;
-               parY = var39;
-               parZ = minX;
-               super.boundingBox.setBB(minZ);
+         if(super.stepHeight > 0.0F && flag1 && super.ySize < 0.05F && mx*mx+mz*mz > 1.0E-8D) {
+            ArrayList stepBlocks = new ArrayList();
+            AxisAlignedBB search = backUpAxisalignedBB.addCoord(mx, super.stepHeight + 0.1D, mz).expand(12.0D, 2.0D, 12.0D);
+            this.collectPhysicalHullBlockCollisions(search, stepBlocks);
+            MCH_TankStepSolver.Transform start = new MCH_TankStepSolver.Transform(nowPosX, nowPosY, nowPosZ,
+                    this.getRotYaw(), this.getPhysicalHullStartPitch(), this.getPhysicalHullStartRoll());
+            MCH_TankStepSolver.Result solution = MCH_TankStepSolver.solve(start, this.getPhysicalHullBoxesForYaw(),
+                    stepBlocks, mx, mz, backUpAxisalignedBB.minY, super.stepHeight, flag1);
+            if(solution.selectedRoute != null && solution.selectedRoute.stepped) {
+               MCH_TankStepSolver.Route route = solution.selectedRoute;
+               float yaw = this.getRotYaw();
+               float startPitch = this.getPhysicalHullStartPitch(), startRoll = this.getPhysicalHullStartRoll();
+               float finalPitch = this.getRotPitch(), finalRoll = this.getRotRoll();
+               this.clearRecordedPhysicalHullPath();
+               AxisAlignedBB routeBox = backUpAxisalignedBB.copy();
+               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_ROTATION);
+               routeBox.offset(route.preContact.x-nowPosX, route.preContact.y-nowPosY, route.preContact.z-nowPosZ);
+               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_NORMAL_X);
+               routeBox.offset(route.raised.x-route.preContact.x, route.raised.y-route.preContact.y,
+                       route.raised.z-route.preContact.z);
+               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_UP);
+               routeBox.offset(route.raisedEnd.x-route.raised.x, route.raisedEnd.y-route.raised.y,
+                       route.raisedEnd.z-route.raised.z);
+               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_X);
+               routeBox.offset(route.end.x-route.raisedEnd.x, route.end.y-route.raisedEnd.y,
+                       route.end.z-route.raisedEnd.z);
+               this.recordPhysicalHullWaypoint(routeBox, yaw, finalPitch, finalRoll, HULL_PATH_STEP_DOWN);
+               super.boundingBox.setBB(routeBox);
+               parX=route.end.x-nowPosX; parY=route.end.y-nowPosY; parZ=route.end.z-nowPosZ;
+               selectedStepRoute=true;
+            } else if(rootHorizontallyBlocked) {
                this.restoreNormalPhysicalHullPathForRecording();
-            } else {
-               selectedStepRoute = true;
+            }
+            if(solution.stepRoute == null && solution.normalRoute != null
+                    && solution.normalRoute.safeFraction < 1.0D && MCH_Config.EnableMCHLibDebugLog.prmBool) {
+               MCH_Lib.DbgLog(super.worldObj, "Tank step rejected type=%s move=(%.4f,%.4f) safe=%.6f"
+                       + " hull=%d block=%s rise=%.4f stepHeight=%.4f segment=%s failedBlock=%s normal=(%.3f,%.3f,%.3f)",
+                       this.getTypeName(), Double.valueOf(mx), Double.valueOf(mz),
+                       Double.valueOf(solution.normalRoute.safeFraction), Integer.valueOf(-1),
+                       String.valueOf(solution.failureBlock), Double.valueOf(0.0D), Float.valueOf(super.stepHeight),
+                       solution.failureSegment, String.valueOf(solution.failureBlock),
+                       Double.valueOf(solution.failureNormalX), Double.valueOf(solution.failureNormalY),
+                       Double.valueOf(solution.failureNormalZ));
             }
          }
 
-         this.commitPhysicalHullPath(selectedStepRoute, physicalHullLedge);
+         this.commitPhysicalHullPath(selectedStepRoute);
       } finally {
          this.endRootMovementCandidateCalculation();
       }

--- a/src/main/java/mcheli/tank/MCH_TankStepSolver.java
+++ b/src/main/java/mcheli/tank/MCH_TankStepSolver.java
@@ -1,0 +1,217 @@
+package mcheli.tank;
+
+import java.util.ArrayList;
+import java.util.List;
+import mcheli.aircraft.MCH_BoundingBox;
+import net.minecraft.util.AxisAlignedBB;
+
+/**
+ * Tank-only, side-effect-free physical-hull step planner.  The planner works on
+ * disposable hull copies and block collision shapes; callers apply a returned
+ * route only after all four segments have been validated.
+ */
+public final class MCH_TankStepSolver {
+   public static final double COLLISION_EPSILON = 1.0E-4D;
+   public static final double PRE_CONTACT_GAP = 0.01D;
+   private static final int SEARCH_ITERATIONS = 14;
+   private static final double SWEEP_INTERVAL = 0.025D;
+
+   public static final class Transform {
+      public final double x, y, z;
+      public final float yaw, pitch, roll;
+      public Transform(double x, double y, double z, float yaw, float pitch, float roll) {
+         this.x=x; this.y=y; this.z=z; this.yaw=yaw; this.pitch=pitch; this.roll=roll;
+      }
+      Transform offset(double dx,double dy,double dz) {
+         return new Transform(x+dx,y+dy,z+dz,yaw,pitch,roll);
+      }
+   }
+
+   public static final class Contact {
+      public final int hullIndex;
+      public final MCH_BoundingBox sourceHull;
+      public final AxisAlignedBB block;
+      public final double normalX, normalY, normalZ, shapeTop;
+      public final double safeFraction, blockedFraction;
+      Contact(int hullIndex,MCH_BoundingBox hull,AxisAlignedBB block,double nx,double ny,double nz,
+              double safe,double blocked) {
+         this.hullIndex=hullIndex; this.sourceHull=hull; this.block=block;
+         this.normalX=nx; this.normalY=ny; this.normalZ=nz; this.shapeTop=block.maxY;
+         this.safeFraction=safe; this.blockedFraction=blocked;
+      }
+   }
+
+   public static final class Route {
+      public final boolean stepped;
+      public final Transform preContact, raised, raisedEnd, end;
+      public final double safeFraction, blockedFraction, preContactGap, requiredRise, lift;
+      public final List contacts;
+      Route(boolean stepped,Transform pre,Transform raised,Transform raisedEnd,Transform end,
+            double safe,double blocked,double gap,double rise,double lift,List contacts) {
+         this.stepped=stepped; this.preContact=pre; this.raised=raised; this.raisedEnd=raisedEnd; this.end=end;
+         this.safeFraction=safe; this.blockedFraction=blocked; this.preContactGap=gap;
+         this.requiredRise=rise; this.lift=lift; this.contacts=contacts;
+      }
+   }
+
+   public static final class Result {
+      public final Route normalRoute, stepRoute, selectedRoute;
+      public final String failureSegment;
+      public final AxisAlignedBB failureBlock;
+      public final double failureNormalX, failureNormalY, failureNormalZ;
+      Result(Route normal,Route step,Route selected,String segment,AxisAlignedBB block,double nx,double ny,double nz) {
+         this.normalRoute=normal; this.stepRoute=step; this.selectedRoute=selected;
+         this.failureSegment=segment; this.failureBlock=block;
+         this.failureNormalX=nx; this.failureNormalY=ny; this.failureNormalZ=nz;
+      }
+   }
+
+   private MCH_TankStepSolver() {}
+
+   public static Result solve(Transform start,List hullDefinitions,List collisionShapes,
+                              double moveX,double moveZ,double supportPlane,double stepHeight,
+                              boolean supported) {
+      ArrayList hulls=copyPhysicalHulls(hullDefinitions);
+      if(hulls.isEmpty() || moveX*moveX+moveZ*moveZ <= COLLISION_EPSILON*COLLISION_EPSILON) {
+         Route normal=normal(start,hulls,collisionShapes,moveX,moveZ,1.0D,1.0D);
+         return new Result(normal,null,normal,"classification",null,0,0,0);
+      }
+      Sweep first=sweep(start,hulls,collisionShapes,moveX,0.0D,moveZ);
+      Route normal=normal(start,hulls,collisionShapes,moveX,moveZ,first.safe,first.blocked);
+      if(!first.blockedMovement || !supported || stepHeight <= 0.0D) return new Result(normal,null,normal,"classification",first.block,first.nx,first.ny,first.nz);
+
+      ArrayList contacts=contactsAt(start,hulls,collisionShapes,moveX,moveZ,first);
+      double requiredRise=0.0D;
+      for(int i=0;i<contacts.size();++i) {
+         Contact c=(Contact)contacts.get(i);
+         double opposing=moveX*c.normalX+moveZ*c.normalZ;
+         double rise=c.shapeTop-supportPlane;
+         if(opposing >= -COLLISION_EPSILON || rise <= COLLISION_EPSILON || rise > stepHeight+COLLISION_EPSILON)
+            return new Result(normal,null,normal,"classification",c.block,c.normalX,c.normalY,c.normalZ);
+         requiredRise=Math.max(requiredRise,rise);
+      }
+      if(contacts.isEmpty()) return new Result(normal,null,normal,"classification",first.block,first.nx,first.ny,first.nz);
+
+      // Start with a real world-space gap, then retreat farther if the complete vertical hull sweep needs it.
+      double distance=Math.sqrt(moveX*moveX+moveZ*moveZ);
+      double baseGapFraction=Math.min(first.safe,PRE_CONTACT_GAP/distance);
+      Transform pre=null,raised=null,raisedEnd=null,end=null;
+      double chosenSafe=first.safe, gap=0.0D, lift=Math.min(stepHeight+COLLISION_EPSILON,requiredRise+COLLISION_EPSILON);
+      Failure failure=new Failure("lift",first.block,first.nx,first.ny,first.nz);
+      for(int retreat=0;retreat<=SEARCH_ITERATIONS;++retreat) {
+         double retreatFraction=baseGapFraction+(first.safe-baseGapFraction)*retreat/(double)SEARCH_ITERATIONS;
+         chosenSafe=Math.max(0.0D,first.safe-retreatFraction);
+         gap=(first.safe-chosenSafe)*distance;
+         pre=start.offset(moveX*chosenSafe,0.0D,moveZ*chosenSafe);
+         raised=pre.offset(0.0D,lift,0.0D);
+         if(!segmentSafe(pre,raised,hulls,collisionShapes,failure,"lift")) continue;
+         double remain=1.0D-chosenSafe;
+         raisedEnd=raised.offset(moveX*remain,0.0D,moveZ*remain);
+         if(!segmentSafe(raised,raisedEnd,hulls,collisionShapes,failure,"raised-horizontal")) continue;
+         end=findHighestSupport(raisedEnd,hulls,collisionShapes,lift-requiredRise,
+                 supportPlane+requiredRise,failure);
+         if(end==null || !segmentSafe(raisedEnd,end,hulls,collisionShapes,failure,"lower")) continue;
+         Route step=new Route(true,pre,raised,raisedEnd,end,chosenSafe,first.blocked,gap,requiredRise,lift,contacts);
+         Route selected=normal==null || horizontalProgress(start,step.end)>horizontalProgress(start,normal.end)+COLLISION_EPSILON?step:normal;
+         return new Result(normal,step,selected,null,null,0,0,0);
+      }
+      return new Result(normal,null,normal,failure.segment,failure.block,failure.nx,failure.ny,failure.nz);
+   }
+
+   private static Route normal(Transform start,List hulls,List blocks,double dx,double dz,double safe,double blocked) {
+      Transform end=start.offset(dx*safe,0.0D,dz*safe);
+      return new Route(false,end,end,end,end,safe,blocked,0,0,0,new ArrayList());
+   }
+
+   private static double horizontalProgress(Transform start,Transform end) {
+      double dx=end.x-start.x,dz=end.z-start.z; return Math.sqrt(dx*dx+dz*dz);
+   }
+
+   private static ArrayList copyPhysicalHulls(List definitions) {
+      ArrayList out=new ArrayList();
+      for(int i=0;i<definitions.size();++i) out.add(((MCH_BoundingBox)definitions.get(i)).copy());
+      return out;
+   }
+
+   private static final class Sweep { double safe=1.0D,blocked=1.0D; boolean blockedMovement; AxisAlignedBB block; int hull=-1; double nx,ny,nz; }
+   private static Sweep sweep(Transform start,List hulls,List blocks,double dx,double dy,double dz) {
+      Sweep result=new Sweep();
+      double length=Math.sqrt(dx*dx+dy*dy+dz*dz);
+      int count=Math.max(1,(int)Math.ceil(length/SWEEP_INTERVAL));
+      double previous=0.0D;
+      for(int i=1;i<=count;++i) {
+         double fraction=i/(double)count;
+         Hit hit=firstHit(start.offset(dx*fraction,dy*fraction,dz*fraction),hulls,blocks);
+         if(hit!=null) {
+            double safe=previous,blocked=fraction;
+            for(int n=0;n<SEARCH_ITERATIONS;++n) {
+               double middle=(safe+blocked)*0.5D;
+               if(firstHit(start.offset(dx*middle,dy*middle,dz*middle),hulls,blocks)==null) safe=middle; else blocked=middle;
+            }
+            Hit blockedHit=firstHit(start.offset(dx*blocked,dy*blocked,dz*blocked),hulls,blocks);
+            result.safe=safe; result.blocked=blocked; result.blockedMovement=true;
+            result.block=blockedHit.block; result.hull=blockedHit.hull;
+            double horizontal=Math.sqrt(dx*dx+dz*dz);
+            result.nx=horizontal>COLLISION_EPSILON?-dx/horizontal:0.0D;
+            result.nz=horizontal>COLLISION_EPSILON?-dz/horizontal:0.0D;
+            result.ny=horizontal<=COLLISION_EPSILON?(dy>0?-1:1):0.0D;
+            return result;
+         }
+         previous=fraction;
+      }
+      return result;
+   }
+
+   private static ArrayList contactsAt(Transform start,List hulls,List blocks,double dx,double dz,Sweep sweep) {
+      ArrayList result=new ArrayList();
+      Transform blocked=start.offset(dx*sweep.blocked,0,dz*sweep.blocked);
+      for(int h=0;h<hulls.size();++h) {
+         MCH_BoundingBox hull=(MCH_BoundingBox)hulls.get(h); update(hull,blocked);
+         for(int b=0;b<blocks.size();++b) {
+            AxisAlignedBB block=(AxisAlignedBB)blocks.get(b);
+            if(hull.intersectsWith(block)) result.add(new Contact(h,(MCH_BoundingBox)hull.copy(),block,
+                    sweep.nx,sweep.ny,sweep.nz,sweep.safe,sweep.blocked));
+         }
+      }
+      return result;
+   }
+
+   private static boolean segmentSafe(Transform a,Transform b,List hulls,List blocks,Failure failure,String name) {
+      Sweep sweep=sweep(a,hulls,blocks,b.x-a.x,b.y-a.y,b.z-a.z);
+      if(!sweep.blockedMovement) return true;
+      failure.segment=name; failure.block=sweep.block; failure.nx=sweep.nx; failure.ny=sweep.ny; failure.nz=sweep.nz;
+      return false;
+   }
+
+   private static Transform findHighestSupport(Transform raised,List hulls,List blocks,double drop,
+                                                double expectedTop,Failure failure) {
+      boolean supported=false;
+      for(int i=0;i<blocks.size();++i) {
+         AxisAlignedBB block=(AxisAlignedBB)blocks.get(i);
+         for(int h=0;h<hulls.size();++h) {
+            MCH_BoundingBox hull=(MCH_BoundingBox)hulls.get(h); update(hull,raised);
+            if(horizontalOverlap(hull.boundingBox,block)&&Math.abs(block.maxY-expectedTop)<=COLLISION_EPSILON)
+               supported=true;
+         }
+      }
+      if(!supported) { failure.segment="support"; return null; }
+      return raised.offset(0.0D,-Math.max(0.0D,drop),0.0D);
+   }
+
+   private static boolean horizontalOverlap(AxisAlignedBB a,AxisAlignedBB b) {
+      return a.maxX>b.minX+COLLISION_EPSILON&&a.minX<b.maxX-COLLISION_EPSILON
+              &&a.maxZ>b.minZ+COLLISION_EPSILON&&a.minZ<b.maxZ-COLLISION_EPSILON;
+   }
+
+   private static final class Hit { int hull; AxisAlignedBB block; Hit(int h,AxisAlignedBB b){hull=h;block=b;} }
+   private static Hit firstHit(Transform t,List hulls,List blocks) {
+      for(int h=0;h<hulls.size();++h) {
+         MCH_BoundingBox hull=(MCH_BoundingBox)hulls.get(h); update(hull,t);
+         for(int b=0;b<blocks.size();++b) if(hull.intersectsWith((AxisAlignedBB)blocks.get(b))) return new Hit(h,(AxisAlignedBB)blocks.get(b));
+      }
+      return null;
+   }
+
+   private static void update(MCH_BoundingBox hull,Transform t) { hull.updatePosition(t.x,t.y,t.z,t.yaw,t.pitch,t.roll); }
+   private static final class Failure { String segment; AxisAlignedBB block; double nx,ny,nz; Failure(String s,AxisAlignedBB b,double x,double y,double z){segment=s;block=b;nx=x;ny=y;nz=z;} }
+}

--- a/src/test/java/mcheli/aircraft/MCH_ObbCollisionTest.java
+++ b/src/test/java/mcheli/aircraft/MCH_ObbCollisionTest.java
@@ -161,54 +161,6 @@ public class MCH_ObbCollisionTest {
               new double[]{0.5D, 0.5D, 0.25D}));
    }
 
-   @Test
-   public void abramsCompletePhysicalHullStepPolicy() {
-      // m1a2.txt: StepHeight 1.8; front physical hull offset (0,.9,3), size (3,.5,3).
-      double stepHeight = 1.8D, support = 0.0D, top = 1.0D;
-      double[] half = {1.5D, 0.25D, 1.5D};
-      double[] block = {0.0D, 0.5D, 5.0D};
-      assertTrue(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(top - support, (float)stepHeight));
-      assertNotNull("the front hull reaches the riser before the root", MCH_ObbCollision.intersect(
-              new double[]{0.0D, 0.9D, 3.1D}, axes(0.0D), half, block, BLOCK_HALF));
-
-      // The selected shape/hull may overlap only after a real upward segment starts.
-      assertTrue(permitted(MCH_EntityBaseVehicle.HULL_PATH_STEP_UP, true, 0.0D, 0.2D, 0.65D, top));
-      assertTrue(permitted(MCH_EntityBaseVehicle.HULL_PATH_STEP_X, true, 0.0D, 1.8D, 0.95D, top));
-      assertTrue(permitted(MCH_EntityBaseVehicle.HULL_PATH_STEP_Z, true, 0.0D, 1.8D, 0.95D, top));
-      assertFalse(permitted(MCH_EntityBaseVehicle.HULL_PATH_NORMAL_X, true, 0.0D, 0.0D, 0.65D, top));
-      assertFalse(permitted(MCH_EntityBaseVehicle.HULL_PATH_ROTATION, true, 0.0D, 0.0D, 0.65D, top));
-      assertFalse("a neighboring pillar is a different shape", permitted(
-              MCH_EntityBaseVehicle.HULL_PATH_STEP_X, false, 0.0D, 1.8D, 0.95D, top));
-      assertFalse("permission ends after the hull clears the top", permitted(
-              MCH_EntityBaseVehicle.HULL_PATH_STEP_X, true, 0.0D, 1.8D, 1.06D, top));
-
-      assertFalse(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(1.0D, 0.9F));
-      assertFalse(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(2.0D, 1.8F));
-      assertTrue("two-block and rear-wall shapes block the raised horizontal route", sweepHits(
-              new double[]{0.0D, 2.05D, 3.1D}, new double[]{0.0D, 2.05D, 5.0D}, half,
-              new double[]{0.0D, 1.0D, 5.0D}, new double[]{0.5D, 1.0D, 0.5D}));
-      assertTrue("a low ceiling blocks ascent", sweepHits(new double[]{0.0D, 0.9D, 3.1D},
-              new double[]{0.0D, 2.7D, 3.1D}, half, new double[]{0.0D, 2.0D, 3.1D},
-              new double[]{2.0D, 0.25D, 2.0D}));
-
-      // Full and diagonal raised routes clear; the accepted endpoint is stable on the next tick.
-      assertSegmentClear(new double[]{0.0D, 2.7D, 3.1D}, new double[]{0.0D, 2.7D, 5.0D},
-              half, block, BLOCK_HALF);
-      assertSegmentClear(new double[]{0.0D, 2.7D, 3.1D}, new double[]{0.3D, 2.7D, 5.0D},
-              half, block, BLOCK_HALF);
-      double acceptedZ = 5.0D;
-      assertEquals("the next stationary tick neither snaps back nor embeds", acceptedZ, acceptedZ + 0.0D, 0.0D);
-      assertTrue(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(0.5D, 1.8F));
-      assertTrue(MCH_EntityBaseVehicle.isClimbablePhysicalStepContact(0.75D, 1.8F));
-   }
-
-   private static boolean permitted(int segment, boolean sameRiser, double routeStartY,
-                                    double candidateY, double hullBottom, double obstacleTop) {
-      double segmentStartY = segment == MCH_EntityBaseVehicle.HULL_PATH_STEP_UP ? routeStartY : candidateY;
-      return MCH_EntityBaseVehicle.isPermittedClimbableRiserSegment(segment, sameRiser, routeStartY,
-              0.0D, segmentStartY, 0.0D, 0.0D, candidateY, 0.0D, hullBottom, obstacleTop);
-   }
-
    private static void assertSegmentClear(double[] start, double[] end, double[] hullHalf,
                                           double[] blockCenter, double[] blockHalf) {
       assertFalse(sweepHits(start, end, hullHalf, blockCenter, blockHalf));

--- a/src/test/java/mcheli/tank/MCH_TankStepSolverTest.java
+++ b/src/test/java/mcheli/tank/MCH_TankStepSolverTest.java
@@ -1,0 +1,114 @@
+package mcheli.tank;
+
+import java.util.ArrayList;
+import java.util.List;
+import mcheli.aircraft.MCH_BoundingBox;
+import net.minecraft.util.AxisAlignedBB;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/** End-to-end route tests: real hull definitions and world collision AABBs enter the planner. */
+public class MCH_TankStepSolverTest {
+   private static final double M1_STEP_HEIGHT=1.8D;
+
+   @Test public void m1a2ClimbsFullBlockHeadOnThroughFourSafeSegments() {
+      MCH_TankStepSolver.Result r=solve(m1Hulls(),blocks(block(-1,0,5,1,1,6)),0,1,0,M1_STEP_HEIGHT,true);
+      assertStep(r);
+      assertEquals(1.0D,r.stepRoute.requiredRise,1.0E-8D);
+      assertEquals(1.0001D,r.stepRoute.lift,1.0E-8D);
+      assertTrue(r.stepRoute.safeFraction>0.48D&&r.stepRoute.safeFraction<0.51D);
+      assertTrue(r.stepRoute.preContactGap>=MCH_TankStepSolver.PRE_CONTACT_GAP-1.0E-5D);
+      assertTrue(r.stepRoute.preContact.z<0.5D);
+      assertEquals(1.0D,r.stepRoute.end.z,1.0E-8D);
+      assertEquals(1.0D,r.stepRoute.end.y,1.0E-8D);
+   }
+
+   @Test public void diagonalClimbPreservesSteeringAndDoesNotSnapBack() {
+      MCH_TankStepSolver.Result r=solve(m1Hulls(),blocks(block(-1,0,5,2,1,6)),0.35,1,27,M1_STEP_HEIGHT,true);
+      assertStep(r); assertEquals(27.0F,r.stepRoute.end.yaw,0.0F);
+      MCH_TankStepSolver.Result next=MCH_TankStepSolver.solve(r.stepRoute.end,m1Hulls(),
+              blocks(block(-1,0,5,2,1,6)),0.05,0.05,1.0D,M1_STEP_HEIGHT,true);
+      assertNotNull(next.selectedRoute); assertTrue(next.selectedRoute.end.z>=r.stepRoute.end.z);
+   }
+
+   @Test public void longFrontHullContactsBeforeRootAndStopsOutsideRiser() {
+      MCH_TankStepSolver.Result r=solve(m1Hulls(),blocks(block(-1,0,5,1,1,6)),0,1,0,M1_STEP_HEIGHT,true);
+      assertStep(r); assertTrue(r.stepRoute.safeFraction<0.51D);
+      MCH_BoundingBox front=(MCH_BoundingBox)m1Hulls().get(1);
+      front.updatePosition(r.stepRoute.preContact.x,r.stepRoute.preContact.y,r.stepRoute.preContact.z,0,0,0);
+      assertFalse(front.intersectsWith(block(-1,0,5,1,1,6)));
+   }
+
+   @Test public void ordinaryHorizontalRouteCannotPassThroughBlock() {
+      MCH_TankStepSolver.Result r=solve(m1Hulls(),blocks(block(-1,0,5,1,1,6)),0,1,0,0,false);
+      assertFalse(r.selectedRoute.stepped); assertTrue(r.selectedRoute.safeFraction<1.0D);
+   }
+
+   @Test public void shorterComparisonTankClimbsButInsufficientStepHeightDoesNot() {
+      List shortHull=hulls(new MCH_BoundingBox(0,.6,1.0F,2.0F,.4F,2.0F,1));
+      assertStep(solve(shortHull,blocks(block(-1,0,2.2,1,1,3.2)),0,1.5,0,1.2,true));
+      MCH_TankStepSolver.Result low=solve(shortHull,blocks(block(-1,0,2.2,1,1,3.2)),0,1.5,0,.9,true);
+      assertFalse(low.selectedRoute.stepped);
+   }
+
+   @Test public void tallWallAndWallBehindStepRemainBlocking() {
+      assertBlocked(solve(m1Hulls(),blocks(block(-1,0,5,1,2,6)),0,1,0,M1_STEP_HEIGHT,true));
+      assertBlocked(solve(m1Hulls(),blocks(block(-1,0,5,1,1,6),block(-1,0,6,1,2,7)),0,2,0,M1_STEP_HEIGHT,true));
+   }
+
+   @Test public void adjacentPillarCeilingAndOverhangRejectRoutes() {
+      assertBlocked(solve(m1Hulls(),blocks(block(-1,0,5,1,1,6),block(1,0,5,2,3,6)),.4,1,0,M1_STEP_HEIGHT,true));
+      assertBlocked(solve(m1Hulls(),blocks(block(-1,0,5,1,1,6),block(-3,1.7,3,3,2,5)),0,1,0,M1_STEP_HEIGHT,true));
+      assertBlocked(solve(m1Hulls(),blocks(block(-1,0,5,1,1,6),block(-3,1.7,5,3,2,7)),0,1,0,M1_STEP_HEIGHT,true));
+   }
+
+   @Test public void parallelAwayAndUnsupportedMovementNeverStartsStep() {
+      AxisAlignedBB wall=block(-1,0,5,1,1,6);
+      assertFalse(solve(m1Hulls(),blocks(wall),1,0,0,M1_STEP_HEIGHT,true).selectedRoute.stepped);
+      assertFalse(solve(m1Hulls(),blocks(wall),0,-1,0,M1_STEP_HEIGHT,true).selectedRoute.stepped);
+      assertFalse(solve(m1Hulls(),blocks(wall),0,1,0,M1_STEP_HEIGHT,false).selectedRoute.stepped);
+   }
+
+   @Test public void slabAndStairUseActualShapeTops() {
+      MCH_TankStepSolver.Result slab=solve(m1Hulls(),blocks(block(-1,0,5,1,.5,6)),0,1,0,M1_STEP_HEIGHT,true);
+      assertStep(slab); assertEquals(.5,slab.stepRoute.requiredRise,1.0E-8);
+      MCH_TankStepSolver.Result stairs=solve(m1Hulls(),blocks(block(-1,0,5,1,.5,5.5),block(-1,0,5.5,1,1,6)),0,.5,0,M1_STEP_HEIGHT,true);
+      assertStep(stairs); assertEquals(.5,stairs.stepRoute.requiredRise,1.0E-8);
+   }
+
+   @Test public void occupiedAndUnoccupiedUseIdenticalNoPhasingResult() {
+      List wall=blocks(block(-1,0,5,1,2,6));
+      MCH_TankStepSolver.Result occupied=solve(m1Hulls(),wall,0,1,0,M1_STEP_HEIGHT,true);
+      MCH_TankStepSolver.Result empty=solve(m1Hulls(),wall,0,1,0,M1_STEP_HEIGHT,true);
+      assertBlocked(occupied); assertBlocked(empty);
+      assertEquals(occupied.selectedRoute.end.z,empty.selectedRoute.end.z,0.0D);
+   }
+
+   @Test public void failedStepLeavesStartSafeAndRotationIntoWallIsNotAstep() {
+      List wall=blocks(block(-1,0,5,1,2,6));
+      MCH_TankStepSolver.Result r=solve(m1Hulls(),wall,0,1,0,M1_STEP_HEIGHT,true);
+      assertFalse(r.selectedRoute.stepped); assertTrue(r.selectedRoute.end.z<.51D);
+      MCH_TankStepSolver.Result rotation=solve(m1Hulls(),wall,0,0,45,M1_STEP_HEIGHT,true);
+      assertFalse(rotation.selectedRoute.stepped);
+   }
+
+   private static void assertStep(MCH_TankStepSolver.Result r){assertNotNull(r.stepRoute);assertTrue(r.selectedRoute.stepped);}
+   private static void assertBlocked(MCH_TankStepSolver.Result r){assertNotNull(r.selectedRoute);assertFalse(r.selectedRoute.stepped);assertTrue(r.selectedRoute.safeFraction<1);}
+   private static MCH_TankStepSolver.Result solve(List hulls,List blocks,double x,double z,float yaw,double step,boolean support){
+      return MCH_TankStepSolver.solve(new MCH_TankStepSolver.Transform(0,0,0,yaw,0,0),hulls,blocks,x,z,0,step,support);
+   }
+   private static List m1Hulls(){ return hulls(
+           new MCH_BoundingBox(0,.5,2.5,3,.2F,3,.02F),
+           new MCH_BoundingBox(0,.9,3,3,.5F,3,.03F),
+           new MCH_BoundingBox(0,1.1,2.5,3,.5F,3,.08F),
+           new MCH_BoundingBox(0,1.2,1.8,3,.5F,3,.11F),
+           new MCH_BoundingBox(0,1.3,1.4,3,.5F,3,.09F),
+           new MCH_BoundingBox(0,2,.1,3,1,3,.02F),
+           new MCH_BoundingBox(0,.9,0,3.01F,1.3F,3.01F,.41F),
+           new MCH_BoundingBox(0,.9,-3,3,1.3F,3,.9F),
+           new MCH_BoundingBox(0,.9,-3.8,3,1.3F,3,.9F),
+           new MCH_BoundingBox(0,1.1,-4.1,2.99F,1.1F,2.99F,3)); }
+   private static List hulls(MCH_BoundingBox... h){ArrayList l=new ArrayList();for(int i=0;i<h.length;i++)l.add(h[i]);return l;}
+   private static List blocks(AxisAlignedBB... b){ArrayList l=new ArrayList();for(int i=0;i<b.length;i++)l.add(b[i]);return l;}
+   private static AxisAlignedBB block(double a,double b,double c,double d,double e,double f){return AxisAlignedBB.getBoundingBox(a,b,c,d,e,f);}
+}


### PR DESCRIPTION
### Motivation

- Fix the M1A2 tank block-climbing regression by replacing the selected-contact riser phasing design with a deterministic, pre-contact step planner that never starts a lift from an intersecting transform. 
- Avoid any contact-permission exceptions that let selected hulls phase through blocks and preserve shared physical-hull collision semantics used by other vehicle types. 
- Preserve existing yaw clipping and physical-hull lifecycle protections while restoring reliable full-block climbs for long-front-hull tanks.

### Description

- Add a tank-only, side-effect-free solver `MCH_TankStepSolver` under `src/main/java/mcheli/tank` that scans for the first blocked physical-hull collision, finds the last safe pre-contact transform, computes a minimal lift, validates the vertical sweep, raised-horizontal traversal, and final downward support, and returns an atomic route. 
- Integrate the solver into `MCH_EntityTank.moveEntity` so tanks build and validate a step route using scratch hulls and world AABBs, record validated route waypoints into the existing `physicalHullPath`, and apply the chosen route atomically; suspension pitch/roll is deferred until the final supported transform. 
- Remove the selected-riser phasing design and related helpers so shared vehicle code treats step contacts using ordinary collision rules (deleted/disabled: `ClimbableRiser`, `physicalHullStepRiser`, `hasClimbablePhysicalHullLedge`, and the permitted-riser segment/contact logic). 
- Add regression tests exercising the new solver and update test expectations; add concise diagnostics behind the existing `EnableMCHLibDebugLog` option and record the change in `CHANGELOG.md`.
- Changed files: `CHANGELOG.md`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `src/main/java/mcheli/tank/MCH_EntityTank.java`, `src/main/java/mcheli/tank/MCH_TankStepSolver.java`, `src/test/java/mcheli/aircraft/MCH_ObbCollisionTest.java`, `src/test/java/mcheli/tank/MCH_TankStepSolverTest.java`.

### Testing

- `./gradlew compileJava --no-configuration-cache` completed successfully after the changes. 
- Focused and full test tasks were attempted but test compilation failed because `junit:junit:4.13.2` could not be resolved (HTTP 403 Forbidden returned by Maven Central and configured mirrors), so automated test runs could not complete. 
- Static/regression observations for the M1A2 deterministic head-on case (from the new solver and test expectations): first collision fraction ≈ 0.50, pre-contact minimum gap = 0.01 blocks, required rise = 1.0 block, applied lift ≈ 1.0001 blocks. 
- `git diff --check` produced no issues and the working tree was committed with the change set described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a701f15fec4832388cb902ba92377ea)