### PR TITLE
Use one OBB authority for tank step routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,3 +510,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Keep normal movement, rotation, tall obstacles, ceilings, adjacent shapes, and failed raised
   routes subject to ordinary physical hull collision.
 - Add deterministic Abrams route-policy coverage using its configured `StepHeight` and front hull.
+# Tank step route validation redesign
+
+- Validate tank step routes with the shared physical-hull OBB authority before applying them.
+- Keep explicit entity coordinates and root bounds in each route waypoint, and separate landing from final suspension rotation.
+- Prevent `finishPhysicalHullStep` from revalidating and rolling back a route already accepted in the same update.

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -98,10 +98,15 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    protected static final int HULL_PATH_STEP_Z = 6;
    protected static final int HULL_PATH_STEP_DOWN = 7;
    protected static final int HULL_PATH_STEP_ROTATION = 8;
+   protected static final int HULL_PATH_PRE_CONTACT = 9;
+   protected static final int HULL_PATH_STEP_HORIZONTAL = 10;
+   protected static final int HULL_PATH_STEP_FINAL_ROTATION = 11;
    private final PhysicalHullPath physicalHullPath = new PhysicalHullPath();
    private final PhysicalHullPath physicalHullNormalPath = new PhysicalHullPath();
    private boolean physicalHullPathCommitted;
    private boolean physicalHullPathIsStep;
+   /** True only between route selection and finishPhysicalHullStep in this update. */
+   private boolean physicalHullPathAlreadyValidated;
    private boolean rootMovementCandidateCalculation;
    private boolean acceptAuthoritativeHullTransform;
    private boolean hasBlockedHorizontalNormal;
@@ -522,6 +527,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
+      this.physicalHullPathAlreadyValidated = false;
    }
 
    /**
@@ -544,6 +550,30 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    protected final void recordPhysicalHullWaypoint(AxisAlignedBB root, float yaw, float pitch, float roll,
                                                    int segmentType) {
       this.physicalHullPath.add(root, yaw, pitch, roll, segmentType, this);
+   }
+
+   /** Records immutable entity coordinates together with their matching root bounds. */
+   protected final void recordPhysicalHullWaypoint(double x, double y, double z, AxisAlignedBB root,
+                                                   float yaw, float pitch, float roll, int segmentType) {
+      this.physicalHullPath.add(x, y, z, root, yaw, pitch, roll, segmentType);
+   }
+
+   /**
+    * The sole final route decision used by tank movement.  It validates the
+    * scratch route with the same OBB sweeps and contact policy used by the
+    * normal physical-hull lifecycle, before the tank changes its live state.
+    */
+   protected final boolean validateRecordedPhysicalHullRoute() {
+      if(!this.physicalHullStepActive || this.physicalHullPath.count == 0) return false;
+      List hulls = this.getPhysicalHullBoxesForYaw();
+      return !hulls.isEmpty() && this.isPhysicalHullPathSafe(this.physicalHullPath, hulls);
+   }
+
+   /** Marks the selected scratch route as consumed; finish must not decide it again. */
+   protected final void markRecordedPhysicalHullRouteApplied(boolean step) {
+      this.physicalHullPathCommitted = true;
+      this.physicalHullPathIsStep = step;
+      this.physicalHullPathAlreadyValidated = true;
    }
 
    protected final float getPhysicalHullStartPitch() { return this.controlTransformStart.pitch; }
@@ -586,6 +616,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.physicalHullNormalPath.clear();
       this.physicalHullPathCommitted = false;
       this.physicalHullPathIsStep = false;
+      this.physicalHullPathAlreadyValidated = false;
       this.acceptAuthoritativeHullTransform = false;
    }
 
@@ -603,6 +634,16 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(this.acceptAuthoritativeHullTransform) {
          this.updatePhysicalHullPositions();
          this.vehicleBoxCache.markDirty("authoritative vehicle interpolation");
+         return;
+      }
+      if(this.physicalHullPathAlreadyValidated) {
+         TransformSnapshot applied = new TransformSnapshot();
+         applied.set(super.posX, super.posY, super.posZ, this.getRotYaw(), this.getRotPitch(),
+                 this.getRotRoll(), super.boundingBox);
+         this.lastSafePhysicalTransform.copyFrom(applied);
+         this.hasLastSafePhysicalTransform = true;
+         this.updatePhysicalHullPositions();
+         this.vehicleBoxCache.markDirty("prevalidated physical hull route");
          return;
       }
       List hulls = this.getPhysicalHullBoxesForYaw();
@@ -700,7 +741,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(verticalStep && (Math.abs(dx) > CONTROL_YAW_EPSILON || Math.abs(dz) > CONTROL_YAW_EPSILON)) return false;
       if(segmentType == HULL_PATH_STEP_UP && dy < -CONTROL_YAW_EPSILON) return false;
       if(segmentType == HULL_PATH_STEP_DOWN && dy > CONTROL_YAW_EPSILON) return false;
-      if(segmentType == HULL_PATH_STEP_ROTATION
+      if((segmentType == HULL_PATH_STEP_ROTATION || segmentType == HULL_PATH_STEP_FINAL_ROTATION)
               && (Math.abs(dx) > CONTROL_YAW_EPSILON || Math.abs(dy) > CONTROL_YAW_EPSILON
               || Math.abs(dz) > CONTROL_YAW_EPSILON
               || Math.abs(MathHelper.wrapAngleTo180_float(end.yaw - start.yaw)) > 1.0E-4F)) return false;
@@ -851,7 +892,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    /** Classifies a landing from world-up geometry; the SAT minimum axis may be horizontal. */
    private boolean isStepSupportContact(TransformSnapshot start, TransformSnapshot end,
                                         HullBlockContact contact, int segmentType) {
-      if(segmentType != HULL_PATH_STEP_DOWN && segmentType != HULL_PATH_STEP_ROTATION) return false;
+      if(segmentType != HULL_PATH_STEP_DOWN && segmentType != HULL_PATH_STEP_ROTATION
+              && segmentType != HULL_PATH_STEP_FINAL_ROTATION) return false;
       if(segmentType == HULL_PATH_STEP_DOWN && end.y > start.y + CONTROL_YAW_EPSILON) return false;
       if(Math.abs(end.x - start.x) > CONTROL_YAW_EPSILON || Math.abs(end.z - start.z) > CONTROL_YAW_EPSILON) return false;
       Obb previous = Obb.from(contact.sourceHull, start);
@@ -947,10 +989,17 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       void add(AxisAlignedBB root, float yaw, float pitch, float roll, int type, MCH_EntityBaseVehicle vehicle) {
          if(this.count >= this.points.length) return;
          TransformSnapshot point = this.points[this.count];
-         double x = (root.minX + root.maxX) * 0.5D;
-         double y = root.minY + (double)vehicle.yOffset - (double)vehicle.ySize;
-         double z = (root.minZ + root.maxZ) * 0.5D;
+         double x = vehicle.controlTransformStart.x + (root.minX + root.maxX
+                 - vehicle.controlTransformStart.rootBounds[0] - vehicle.controlTransformStart.rootBounds[3]) * 0.5D;
+         double y = vehicle.controlTransformStart.y + root.minY - vehicle.controlTransformStart.rootBounds[1];
+         double z = vehicle.controlTransformStart.z + (root.minZ + root.maxZ
+                 - vehicle.controlTransformStart.rootBounds[2] - vehicle.controlTransformStart.rootBounds[5]) * 0.5D;
          point.set(x, y, z, yaw, pitch, roll, root);
+         this.segmentTypes[this.count++] = type;
+      }
+      void add(double x, double y, double z, AxisAlignedBB root, float yaw, float pitch, float roll, int type) {
+         if(this.count >= this.points.length) return;
+         this.points[this.count].set(x, y, z, yaw, pitch, roll, root);
          this.segmentTypes[this.count++] = type;
       }
       void copyFrom(PhysicalHullPath other) {

--- a/src/main/java/mcheli/tank/MCH_EntityTank.java
+++ b/src/main/java/mcheli/tank/MCH_EntityTank.java
@@ -394,21 +394,32 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
                float finalPitch = this.getRotPitch(), finalRoll = this.getRotRoll();
                this.clearRecordedPhysicalHullPath();
                AxisAlignedBB routeBox = backUpAxisalignedBB.copy();
-               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_ROTATION);
+               this.recordPhysicalHullWaypoint(nowPosX, nowPosY, nowPosZ, routeBox, yaw, startPitch, startRoll, HULL_PATH_ROTATION);
                routeBox.offset(route.preContact.x-nowPosX, route.preContact.y-nowPosY, route.preContact.z-nowPosZ);
-               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_NORMAL_X);
+               this.recordPhysicalHullWaypoint(route.preContact.x, route.preContact.y, route.preContact.z,
+                       routeBox, yaw, startPitch, startRoll, HULL_PATH_PRE_CONTACT);
                routeBox.offset(route.raised.x-route.preContact.x, route.raised.y-route.preContact.y,
                        route.raised.z-route.preContact.z);
-               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_UP);
+               this.recordPhysicalHullWaypoint(route.raised.x, route.raised.y, route.raised.z,
+                       routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_UP);
                routeBox.offset(route.raisedEnd.x-route.raised.x, route.raisedEnd.y-route.raised.y,
                        route.raisedEnd.z-route.raised.z);
-               this.recordPhysicalHullWaypoint(routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_X);
+               this.recordPhysicalHullWaypoint(route.raisedEnd.x, route.raisedEnd.y, route.raisedEnd.z,
+                       routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_HORIZONTAL);
                routeBox.offset(route.end.x-route.raisedEnd.x, route.end.y-route.raisedEnd.y,
                        route.end.z-route.raisedEnd.z);
-               this.recordPhysicalHullWaypoint(routeBox, yaw, finalPitch, finalRoll, HULL_PATH_STEP_DOWN);
-               super.boundingBox.setBB(routeBox);
-               parX=route.end.x-nowPosX; parY=route.end.y-nowPosY; parZ=route.end.z-nowPosZ;
-               selectedStepRoute=true;
+               this.recordPhysicalHullWaypoint(route.end.x, route.end.y, route.end.z,
+                       routeBox, yaw, startPitch, startRoll, HULL_PATH_STEP_DOWN);
+               this.recordPhysicalHullWaypoint(route.end.x, route.end.y, route.end.z,
+                       routeBox, yaw, finalPitch, finalRoll, HULL_PATH_STEP_FINAL_ROTATION);
+               if(this.validateRecordedPhysicalHullRoute()) {
+                  super.boundingBox.setBB(routeBox);
+                  parX=route.end.x-nowPosX; parY=route.end.y-nowPosY; parZ=route.end.z-nowPosZ;
+                  selectedStepRoute=true;
+                  this.markRecordedPhysicalHullRouteApplied(true);
+               } else {
+                  this.restoreNormalPhysicalHullPathForRecording();
+               }
             } else if(rootHorizontallyBlocked) {
                this.restoreNormalPhysicalHullPathForRecording();
             }
@@ -425,7 +436,7 @@ public class MCH_EntityTank extends MCH_EntityBaseVehicle {
             }
          }
 
-         this.commitPhysicalHullPath(selectedStepRoute);
+         if(!selectedStepRoute) this.commitPhysicalHullPath(false);
       } finally {
          this.endRootMovementCandidateCalculation();
       }


### PR DESCRIPTION
### Motivation

- The existing tank step flow used a solver-level AABB check that could approve a raised route, then `resolveControlTransformAfterMove` revalidated with the OBB-based authority and reverted the live transform, causing Y oscillation, shaking, and possible embedding. 
- The old `HULL_PATH_STEP_DOWN` combined landing and final suspension rotation in a segment the solver planned using the starting pitch/roll, which created an OBB disagreement at final application. 
- `StepHeight` behavior must be enforced deterministically by a single collision authority so accepted climbs are final and safe across the full physical-hull lifecycle.

### Description

- Introduced distinct step segment types and per-waypoint immutable coordinates by extending `PhysicalHullPath` and adding `HULL_PATH_PRE_CONTACT`, `HULL_PATH_STEP_HORIZONTAL`, and `HULL_PATH_STEP_FINAL_ROTATION` in `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`. 
- Added `recordPhysicalHullWaypoint(...)` overloads that store explicit entity `x,y,z` with matching root bounds and updated `PhysicalHullPath.add(...)` to accept these coordinates so waypoints no longer derive Y from mutable `ySize`. 
- Exposed a narrow validator API `validateRecordedPhysicalHullRoute()` and a consumption marker `markRecordedPhysicalHullRouteApplied(...)` so tank code validates a solver-built route with the shared OBB sweeps before mutating the live entity, and prevents `finishPhysicalHullStep` from re-rejecting an already-validated route. 
- Changed tank integration in `src/main/java/mcheli/tank/MCH_EntityTank.java` to build the candidate step route, record immutable waypoints, call `validateRecordedPhysicalHullRoute()` before applying the raised bounding box, and only apply the fallback `physicalHullNormalPath` when no accepted candidate exists; also updated `CHANGELOG.md` to document the redesign.

### Testing

- Ran repository checks including `git diff --check` and inspected the relevant commits/merge history and the legacy reference implementation, and these checks passed. 
- Verified resource configuration and confirmed `M1A2` remains configured with `StepHeight = 1.8` in `src/main/resources/assets/mcheli/tanks/m1a2.txt`. 
- Did not run `./gradlew compileJava` or unit tests because compiling binary artifacts was explicitly prohibited, so runtime compilation and JUnit test execution were intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70dc4adfdc8323816badc4ec8d6436)