### PR TITLE
Fix high-altitude vehicle LOD visibility

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,8 +96,8 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `RenderDistanceWeight` | `1000.0` | Render-distance weight for mod rendering. |
 | `EnableAircraftLODRender` | `true` | Enables client-only far-distance model displays for aircraft, tanks, turrets, and ships. |
 | `AircraftLODStartDistance` | `140.0` | Distance where tracked vehicles switch to cheaper model-only rendering, with the existing hysteresis around the transition. |
-| `AircraftLODFarDistance` | `4800.0` | Hard maximum detection range for render-only vehicle snapshots; this is not a full-detail visibility distance. |
-| `AircraftLODVisibilityDistance` | `4800.0` | Clear/hazy atmospheric visibility distance where Koschmieder contrast transmission reaches approximately two percent. |
+| `AircraftLODFarDistance` | `60000.0` | Hard maximum detection range for render-only vehicle snapshots. Values are capped at 60,000 blocks. |
+| `AircraftLODVisibilityDistance` | `60000.0` | Clear-air reference distance where Koschmieder contrast transmission reaches approximately two percent; values are capped at 60,000 blocks. |
 | `AircraftLODRainVisibilityMultiplier` | `0.70` | Multiplier applied to atmospheric visibility distance in rain. |
 | `AircraftLODThunderVisibilityMultiplier` | `0.45` | Multiplier applied to atmospheric visibility distance in thunder. |
 | `AircraftLODThermalContrastExponent` | `0.35` | Raises atmospheric transmission to this exponent in thermal mode, improving contrast without extending the hard range. |
@@ -129,6 +129,8 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
 
 Snapshot visibility uses the active projection matrix, so scopes and other FOV magnification increase projected target size naturally. Magnification does not change real distance or atmospheric transmission. Thermal vision lowers the projected-size threshold and improves contrast, but it never extends `AircraftLODFarDistance`. Snapshot rendering retains depth testing, allowing loaded nearby terrain and structures to occlude a target; unloaded terrain has no depth information and therefore cannot occlude this render-only data.
+
+The hard LOD limit uses full three-dimensional distance: vertical separation counts exactly like horizontal separation, and a vehicle at 60,000 blocks or farther is not rendered. The snapshot system does not increase Forge's normal 200-block entity tracking range and does not load distant chunks; it only reports eligible vehicles from chunks the server has already loaded. A bounded, at-most-one-pixel apparent footprint keeps extremely distant vehicle models visible without replacing their shape, texture, orientation, or animated parts with a marker.
 
 ## Vehicle content-pack keys
 

--- a/docs/vehicle-respawn-tracking.md
+++ b/docs/vehicle-respawn-tracking.md
@@ -16,7 +16,7 @@ History (`git log -S"forceSpawn = true"`) attributes the original flag to `fb633
 
 Normal helicopters, planes, ships, tanks, turrets, and other directly controlled vehicles use `forceSpawn=false`. They follow Forge's normal ordering: respawn installs the replacement world, `PlayerManager` marks the chunk watched, Forge spawns the real parent, and only then does `StartTracking` synchronize MCHeli state. UAV and NewUAV vehicles retain their legacy force-spawn policy after aircraft information is assigned.
 
-LOD snapshots now cover every eligible normal vehicle inside `AircraftLODFarDistance` whose chunk is **not** watched. The former 200-block lower bound is gone, avoiding a gap with low server view distance. A watched chunk receives no snapshot. Snapshots remain render-only, non-ticking, non-collidable, non-interactable data and cannot be mounts.
+LOD snapshots cover eligible normal vehicles that are outside the 200-block normal entity tracking range and inside `AircraftLODFarDistance`, using full X/Y/Z distance. Chunk watching is horizontal-only and therefore does not suppress snapshots: a player directly above a vehicle may still watch its chunk after the real entity leaves tracking range. Snapshots remain render-only, non-ticking, non-collidable, non-interactable data and cannot be mounts.
 
 LOD suppression no longer requires equality with the server's vanilla UUID. A real client vehicle wins first by numeric entity ID, then by non-empty `commonUniqueId` with aircraft type validation. Snapshot state is cleared when the client world unloads or is replaced.
 

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -491,9 +491,9 @@ public class MCH_Config {
       EnableAircraftLODRender.desc = ";Enable client-only far-distance model displays for aircraft, tanks, turrets, and ships.";
       AircraftLODStartDistance = new MCH_ConfigPrm("AircraftLODStartDistance", 140.0D);
       AircraftLODStartDistance.desc = ";Distance in blocks where tracked aircraft rendering switches to its cheaper model-only pass.";
-      AircraftLODFarDistance = new MCH_ConfigPrm("AircraftLODFarDistance", 4800.0D);
+      AircraftLODFarDistance = new MCH_ConfigPrm("AircraftLODFarDistance", mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE);
       AircraftLODFarDistance.desc = ";Maximum distance for client-only vehicle LOD snapshots. Real vehicle entity tracking remains unchanged and aligned with child seats.";
-      AircraftLODVisibilityDistance = new MCH_ConfigPrm("AircraftLODVisibilityDistance", 4800.0D);
+      AircraftLODVisibilityDistance = new MCH_ConfigPrm("AircraftLODVisibilityDistance", mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE);
       AircraftLODVisibilityDistance.desc = ";Clear-air distance where snapshot optical contrast falls to approximately two percent.";
       AircraftLODRainVisibilityMultiplier = new MCH_ConfigPrm("AircraftLODRainVisibilityMultiplier", 0.70D);
       AircraftLODThunderVisibilityMultiplier = new MCH_ConfigPrm("AircraftLODThunderVisibilityMultiplier", 0.45D);
@@ -1082,15 +1082,15 @@ public class MCH_Config {
          MobRenderDistanceWeight.prmDouble = 100.0D;
       }
 
-      AircraftLODStartDistance.prmDouble = finiteRange(AircraftLODStartDistance.prmDouble, 0.0D, 4800.0D, 140.0D);
+      AircraftLODStartDistance.prmDouble = finiteRange(AircraftLODStartDistance.prmDouble, 0.0D, mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE, 140.0D);
 
-      AircraftLODFarDistance.prmDouble = finiteRange(AircraftLODFarDistance.prmDouble, 1.0D, 4800.0D, 4800.0D);
+      AircraftLODFarDistance.prmDouble = finiteRange(AircraftLODFarDistance.prmDouble, 1.0D, mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE, mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE);
 
       if(AircraftLODFarDistance.prmDouble > 0.0D && AircraftLODFarDistance.prmDouble < AircraftLODStartDistance.prmDouble) {
          AircraftLODFarDistance.prmDouble = AircraftLODStartDistance.prmDouble;
       }
 
-      AircraftLODVisibilityDistance.prmDouble = finitePositive(AircraftLODVisibilityDistance.prmDouble, 4800.0D);
+      AircraftLODVisibilityDistance.prmDouble = finiteRange(AircraftLODVisibilityDistance.prmDouble, 1.0D, mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE, mcheli.lod.MCH_VehicleLODVisibility.MAX_LOD_DISTANCE);
       AircraftLODRainVisibilityMultiplier.prmDouble = finiteRange(AircraftLODRainVisibilityMultiplier.prmDouble, 0.01D, 1.0D, 0.70D);
       AircraftLODThunderVisibilityMultiplier.prmDouble = finiteRange(AircraftLODThunderVisibilityMultiplier.prmDouble, 0.01D, 1.0D, 0.45D);
       AircraftLODThunderVisibilityMultiplier.prmDouble = Math.min(AircraftLODThunderVisibilityMultiplier.prmDouble,

--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_BaseVehicleInfo;
+import mcheli.lod.MCH_VehicleLODVisibility;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.network.packets.PacketVehicleLODSnapshot;
 import mcheli.network.packets.PacketVehicleMountGraph;
@@ -37,8 +38,9 @@ public class MCH_ServerTickHandler {
    private static final int UPDATE_INTERVAL_TICKS = 20;
    private static final int MAX_ENTRIES = 512;
    /** Must match the normal vehicle/seat registration range in MCH_MOD. */
-   private static final double NORMAL_TRACKING_RANGE_SQ = 200.0D * 200.0D;
+   private static final double NORMAL_TRACKING_RANGE_SQ = MCH_VehicleLODVisibility.NORMAL_TRACKING_RANGE_SQ;
    private int tick;
+   private static long nextLodDiagnosticMs;
    private static final Map<String, PendingMountGraph> PENDING_MOUNT_GRAPHS = new HashMap<String, PendingMountGraph>();
    private static final AtomicInteger NEXT_MOUNT_SEQUENCE = new AtomicInteger();
 
@@ -88,9 +90,8 @@ public class MCH_ServerTickHandler {
       }
 
       double farDistance = MCH_Config.AircraftLODFarDistance != null
-         ? MCH_Config.AircraftLODFarDistance.prmDouble : 4800.0D;
-      if(Double.isNaN(farDistance) || Double.isInfinite(farDistance) || farDistance <= 0.0D) farDistance = 4800.0D;
-      farDistance = Math.min(4800.0D, farDistance);
+         ? MCH_Config.AircraftLODFarDistance.prmDouble : MCH_VehicleLODVisibility.MAX_LOD_DISTANCE;
+      farDistance = MCH_VehicleLODVisibility.hardDistance(farDistance);
       double farDistanceSq = farDistance * farDistance;
 
       for(WorldServer world : server.worldServers) {
@@ -110,10 +111,15 @@ public class MCH_ServerTickHandler {
       for(Object object : world.loadedEntityList) {
          if(object instanceof MCH_EntityBaseVehicle) {
             MCH_EntityBaseVehicle vehicle = (MCH_EntityBaseVehicle)object;
-            if(!vehicle.isDead && vehicle.getAcInfo() != null && categoryOf(vehicle) >= 0
+            double dx = vehicle.posX - player.posX;
+            double dy = vehicle.posY - player.posY;
+            double dz = vehicle.posZ - player.posZ;
+            double distanceSq = MCH_VehicleLODVisibility.distanceSq(dx, dy, dz);
+            boolean qualifies = !vehicle.isDead && vehicle.getAcInfo() != null && categoryOf(vehicle) >= 0
                && !vehicle.isUAV() && !vehicle.isNewUAV()
-               && vehicle.getDistanceSqToEntity(player) <= farDistanceSq
-               && !world.getPlayerManager().isPlayerWatchingChunk(player, vehicle.chunkCoordX, vehicle.chunkCoordZ)) {
+               && distanceSq > NORMAL_TRACKING_RANGE_SQ && distanceSq < farDistanceSq;
+            diagnoseSnapshot(world, player, vehicle, dx, dy, dz, farDistanceSq, qualifies);
+            if(qualifies) {
                aircraft.add(vehicle);
             }
          }
@@ -184,6 +190,26 @@ public class MCH_ServerTickHandler {
          entries.add(entry);
       }
       return entries;
+   }
+
+   private static void diagnoseSnapshot(WorldServer world, EntityPlayerMP player, MCH_EntityBaseVehicle vehicle,
+      double dx, double dy, double dz, double farDistanceSq, boolean qualifies) {
+      long now = System.currentTimeMillis();
+      if(MCH_Config.DebugVehicleLODVisibility == null || !MCH_Config.DebugVehicleLODVisibility.prmBool
+         || now < nextLodDiagnosticMs) return;
+      nextLodDiagnosticMs = now + 1000L;
+      double horizontal = Math.sqrt(dx * dx + dz * dz);
+      double vertical = Math.abs(dy);
+      double distance = Math.sqrt(MCH_VehicleLODVisibility.distanceSq(dx, dy, dz));
+      double hardRange = Math.sqrt(farDistanceSq);
+      boolean watched = world.getPlayerManager().isPlayerWatchingChunk(player, vehicle.chunkCoordX, vehicle.chunkCoordZ);
+      String reason = qualifies ? "snapshot" : distance <= MCH_VehicleLODVisibility.NORMAL_TRACKING_RANGE
+         ? "normal_tracking" : distance >= hardRange ? "hard_range" : "excluded_vehicle";
+      MCH_Lib.DbgLog(true,
+         "VehicleLODSnapshot horizontal=%.1f vertical=%.1f distance3d=%.1f normalRange=%.1f hardRange=%.1f watchedChunk=%s qualifies=%s result=%s",
+         new Object[]{Double.valueOf(horizontal), Double.valueOf(vertical), Double.valueOf(distance),
+            Double.valueOf(MCH_VehicleLODVisibility.NORMAL_TRACKING_RANGE), Double.valueOf(hardRange),
+            Boolean.valueOf(watched), Boolean.valueOf(qualifies), reason});
    }
 
    private static synchronized void tickMountGraphs() {

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -134,7 +134,8 @@ public final class MCH_VehicleLODManager {
         double cameraX = camera.lastTickPosX + (camera.posX - camera.lastTickPosX) * event.partialTicks;
         double cameraY = camera.lastTickPosY + (camera.posY - camera.lastTickPosY) * event.partialTicks;
         double cameraZ = camera.lastTickPosZ + (camera.posZ - camera.lastTickPosZ) * event.partialTicks;
-        double far = Math.min(4800.0D, config(MCH_Config.AircraftLODFarDistance, 4800.0D));
+        double far = MCH_VehicleLODVisibility.hardDistance(config(MCH_Config.AircraftLODFarDistance,
+            MCH_VehicleLODVisibility.MAX_LOD_DISTANCE));
         double farSq = far * far;
         RenderContext context = captureRenderContext(mc, event.partialTicks);
 
@@ -151,7 +152,7 @@ public final class MCH_VehicleLODManager {
             double z = worldZ - cameraZ;
             double distanceSq = x * x + y * y + z * z;
             double realDistance = Math.sqrt(distanceSq);
-            if (distanceSq > farSq) {
+            if (distanceSq >= farSq) {
                 diagnose(display, context, realDistance, far, 1.0D, display.scale, 0.0D, 0.0D, "hard_range", now);
                 continue;
             }
@@ -164,11 +165,9 @@ public final class MCH_VehicleLODManager {
                 targetDimension(info) * display.scale, realDistance, context.projection[5], context.viewportHeight);
             double minimumPixels = context.thermal ? nonNegativeConfig(MCH_Config.AircraftLODThermalMinPixels, 0.35D)
                 : nonNegativeConfig(MCH_Config.AircraftLODOpticalMinPixels, 0.75D);
-            if (projectedPixels < minimumPixels) {
-                diagnose(display, context, realDistance, far, 1.0D, display.scale, 0.0D, projectedPixels, "projected_size", now);
-                continue;
-            }
-            double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance, 4800.0D) * context.weatherMultiplier;
+            double footprintScale = MCH_VehicleLODVisibility.minimumFootprintScale(projectedPixels, minimumPixels);
+            double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance,
+                MCH_VehicleLODVisibility.MAX_LOD_DISTANCE) * context.weatherMultiplier;
             double transmission = MCH_VehicleLODVisibility.transmission(realDistance, effectiveVisibility);
             double alpha = context.thermal ? MCH_VehicleLODVisibility.thermalAlpha(transmission,
                 config(MCH_Config.AircraftLODThermalContrastExponent, 0.35D)) : transmission;
@@ -178,9 +177,10 @@ public final class MCH_VehicleLODManager {
                     transmission, projectedPixels, "negligible_alpha", now);
                 continue;
             }
+            double renderScale = display.scale * depthScale * footprintScale;
             render(display, info, x * depthScale, y * depthScale, z * depthScale,
-                (float)(display.scale * depthScale), (float)alpha, interpolation, now);
-            diagnose(display, context, realDistance, far, depthScale, display.scale * depthScale,
+                (float)renderScale, (float)alpha, interpolation, now);
+            diagnose(display, context, realDistance, far, depthScale, renderScale,
                 transmission, projectedPixels, "render", now);
         }
     }
@@ -262,12 +262,14 @@ public final class MCH_VehicleLODManager {
         if (MCH_Config.DebugVehicleLODVisibility == null || !MCH_Config.DebugVehicleLODVisibility.prmBool
             || now < nextDiagnosticMs) return;
         nextDiagnosticMs = now + 1000L;
-        double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance, 4800.0D) * context.weatherMultiplier;
+        double effectiveVisibility = config(MCH_Config.AircraftLODVisibilityDistance,
+            MCH_VehicleLODVisibility.MAX_LOD_DISTANCE) * context.weatherMultiplier;
         double alpha = context.thermal ? MCH_VehicleLODVisibility.thermalAlpha(transmission,
             config(MCH_Config.AircraftLODThermalContrastExponent, 0.35D)) : transmission;
         MCH_Lib.DbgLog(true,
-            "VehicleLODVisibility type=%s distance=%.1f hardRange=%.1f farPlane=%.1f safeDepth=%.1f depthScale=%.5f renderScale=%.5f visibility=%.1f transmission=%.5f alpha=%.5f pixels=%.3f cameraMode=%d weather=%s result=%s",
-            new Object[]{display.typeName, Double.valueOf(distance), Double.valueOf(hardRange),
+            "VehicleLODVisibility type=%s distance3d=%.1f normalRange=%.1f hardRange=%.1f qualifies=true farPlane=%.1f safeDepth=%.1f proxyDepthScale=%.5f renderScale=%.5f visibility=%.1f transmission=%.5f alpha=%.5f projectedPixels=%.3f cameraMode=%d weather=%s result=%s",
+            new Object[]{display.typeName, Double.valueOf(distance),
+                Double.valueOf(MCH_VehicleLODVisibility.NORMAL_TRACKING_RANGE), Double.valueOf(hardRange),
                 Double.valueOf(context.farPlane), Double.valueOf(context.safeProxyDepth), Double.valueOf(depthScale),
                 Double.valueOf(renderScale), Double.valueOf(effectiveVisibility), Double.valueOf(transmission),
                 Double.valueOf(alpha), Double.valueOf(pixels), Integer.valueOf(context.cameraMode), context.weather, reason});

--- a/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
@@ -3,6 +3,11 @@ package mcheli.lod;
 /** Pure, deterministic visibility math shared by the snapshot renderer and tests. */
 public final class MCH_VehicleLODVisibility {
     public static final double KOSCHMIEDER_CONSTANT = 3.912D;
+    /** Design limit: one block is one metre and naked-eye visibility ends at 60 km. */
+    public static final double MAX_LOD_DISTANCE = 60000.0D;
+    public static final double MAX_LOD_DISTANCE_SQ = MAX_LOD_DISTANCE * MAX_LOD_DISTANCE;
+    public static final double NORMAL_TRACKING_RANGE = 200.0D;
+    public static final double NORMAL_TRACKING_RANGE_SQ = NORMAL_TRACKING_RANGE * NORMAL_TRACKING_RANGE;
 
     private MCH_VehicleLODVisibility() {
     }
@@ -46,6 +51,35 @@ public final class MCH_VehicleLODVisibility {
             return 0.0D;
         }
         return physicalSize * Math.abs((double)projectionY) * (double)viewportHeight / (2.0D * realDistance);
+    }
+
+    /** Full three-dimensional snapshot selection; chunk watching is intentionally irrelevant. */
+    public static boolean qualifiesForSnapshot(double dx, double dy, double dz, double hardDistance) {
+        double limit = hardDistance(hardDistance);
+        double distanceSq = distanceSq(dx, dy, dz);
+        return isFinite(distanceSq) && distanceSq > NORMAL_TRACKING_RANGE_SQ && distanceSq < limit * limit;
+    }
+
+    public static boolean insideHardRange(double dx, double dy, double dz, double hardDistance) {
+        double limit = hardDistance(hardDistance);
+        double distanceSq = distanceSq(dx, dy, dz);
+        return isFinite(distanceSq) && distanceSq < limit * limit;
+    }
+
+    public static double distanceSq(double dx, double dy, double dz) {
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    public static double hardDistance(double configured) {
+        return isFinite(configured) && configured > 0.0D
+            ? Math.min(configured, MAX_LOD_DISTANCE) : MAX_LOD_DISTANCE;
+    }
+
+    /** Never enlarges a distant model beyond a one-pixel apparent footprint. */
+    public static double minimumFootprintScale(double projectedPixels, double configuredMinimumPixels) {
+        if (!isFinite(projectedPixels) || projectedPixels <= 0.0D) return 1.0D;
+        double minimum = clamp(configuredMinimumPixels, 0.0D, 1.0D);
+        return minimum > projectedPixels ? minimum / projectedPixels : 1.0D;
     }
 
     public static double positive(double value, double fallback) {

--- a/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
+++ b/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
@@ -24,10 +24,11 @@ public class MCH_VehicleLODVisibilityTest {
 
     @Test
     public void atmosphereAndThermalFollowConfiguredContrastModel() {
-        assertEquals(1.0D, MCH_VehicleLODVisibility.transmission(0.0D, 4800.0D), 0.0D);
-        double clear = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D);
-        double rain = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D * 0.70D);
-        double thunder = MCH_VehicleLODVisibility.transmission(4800.0D, 4800.0D * 0.45D);
+        double visibility = MCH_VehicleLODVisibility.MAX_LOD_DISTANCE;
+        assertEquals(1.0D, MCH_VehicleLODVisibility.transmission(0.0D, visibility), 0.0D);
+        double clear = MCH_VehicleLODVisibility.transmission(visibility, visibility);
+        double rain = MCH_VehicleLODVisibility.transmission(visibility, visibility * 0.70D);
+        double thunder = MCH_VehicleLODVisibility.transmission(visibility, visibility * 0.45D);
         assertEquals(0.02D, clear, 0.0001D);
         assertTrue(rain < clear);
         assertTrue(thunder < rain);
@@ -43,9 +44,42 @@ public class MCH_VehicleLODVisibilityTest {
 
     @Test
     public void validationClampsInvalidValues() {
-        assertEquals(4800.0D, MCH_VehicleLODVisibility.positive(Double.NaN, 4800.0D), 0.0D);
-        assertEquals(4800.0D, MCH_VehicleLODVisibility.positive(-1.0D, 4800.0D), 0.0D);
+        assertEquals(60000.0D, MCH_VehicleLODVisibility.hardDistance(Double.NaN), 0.0D);
+        assertEquals(60000.0D, MCH_VehicleLODVisibility.hardDistance(Double.POSITIVE_INFINITY), 0.0D);
+        assertEquals(60000.0D, MCH_VehicleLODVisibility.hardDistance(-1.0D), 0.0D);
+        assertEquals(60000.0D, MCH_VehicleLODVisibility.hardDistance(90000.0D), 0.0D);
         assertEquals(0.0D, MCH_VehicleLODVisibility.clamp(Double.NaN, 0.0D, 1.0D), 0.0D);
         assertEquals(1.0D, MCH_VehicleLODVisibility.clamp(2.0D, 0.0D, 1.0D), 0.0D);
+    }
+
+    @Test
+    public void verticalSnapshotSelectionIgnoresHorizontalChunkWatching() {
+        // Chunk watching is deliberately absent from this pure predicate: same X/Z at 400 blocks qualifies.
+        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 400.0D, 0.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 1000.0D, 0.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 10000.0D, 0.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 59999.0D, 0.0D, 60000.0D));
+    }
+
+    @Test
+    public void normalTrackingPreventsSnapshotDuplicate() {
+        assertTrue(!MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 199.0D, 0.0D, 60000.0D));
+        assertTrue(!MCH_VehicleLODVisibility.qualifiesForSnapshot(120.0D, 120.0D, 20.0D, 60000.0D));
+    }
+
+    @Test
+    public void hardRangeIsExclusiveAndThreeDimensional() {
+        assertTrue(MCH_VehicleLODVisibility.insideHardRange(59999.0D, 0.0D, 0.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(30000.0D, 40000.0D, 0.0D, 60000.0D));
+        assertTrue(!MCH_VehicleLODVisibility.insideHardRange(0.0D, 60000.0D, 0.0D, 60000.0D));
+        assertTrue(!MCH_VehicleLODVisibility.insideHardRange(60001.0D, 0.0D, 0.0D, 60000.0D));
+        assertTrue(!MCH_VehicleLODVisibility.insideHardRange(50000.0D, 40000.0D, 0.0D, 60000.0D));
+    }
+
+    @Test
+    public void minimumFootprintPreservesTinyModelsWithoutExcessiveGrowth() {
+        assertEquals(1.0D, MCH_VehicleLODVisibility.minimumFootprintScale(2.0D, 0.75D), 0.0D);
+        assertEquals(7.5D, MCH_VehicleLODVisibility.minimumFootprintScale(0.1D, 0.75D), 0.0D);
+        assertEquals(10.0D, MCH_VehicleLODVisibility.minimumFootprintScale(0.1D, 64.0D), 0.0D);
     }
 }


### PR DESCRIPTION
### Motivation

- Vehicles could disappear when a player moved directly above them because snapshot selection used horizontal chunk-watch state (X/Z) which ignores Y separation and suppressed LOD snapshots even when the real entity had left the normal tracking range.  
- The design requires full three-dimensional distance checks and a 60,000-block hard LOD limit (one block = 1 m), so vertical separation must count the same as horizontal separation.  
- Ensure LOD remains render-only, bounded, and does not change normal entity tracking, chunk loading, physics, or networking beyond snapshot packets.

### Description

- Replace the server-side snapshot eligibility test to use full X/Y/Z squared distance and require vehicles to be outside the 200-block normal entity tracking range while inside a shared configured hard LOD range.  
- Add shared visibility constants and helpers in `MCH_VehicleLODVisibility` including a 60,000-block `MAX_LOD_DISTANCE`, 3D distance helpers, an exclusive hard-range clamp, and a bounded minimum-footprint scale to avoid outright rejection of very small projected models.  
- Update configuration defaults and validation so `AircraftLODFarDistance` and `AircraftLODVisibilityDistance` default to and are capped at `60000.0D` and invalid values fall back safely.  
- Adjust the client LOD manager to treat the hard range as exclusive, apply depth-compression and a bounded footprint scale (preserving model shape/animation), and keep the existing real-entity duplicate guard (`hasRealEntity`) unchanged.  
- Expand diagnostic output for snapshot decisions (horizontal, vertical, 3D distance, normal range, hard range, watched-chunk state, qualification result) gated by the existing debug flag and rate-limited.  
- Add deterministic unit tests for 3D selection, vertical separation cases (400, 1,000, 10,000, 59,999 blocks), the 60,000 boundary, invalid configs, projected footprint behavior, and normal-tracking duplicate prevention.  
- Changed files: `docs/configuration.md`, `docs/vehicle-respawn-tracking.md`, `src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/MCH_ServerTickHandler.java`, `src/main/java/mcheli/lod/MCH_VehicleLODManager.java`, `src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java`, `src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java`.

### Testing

- Ran `git diff --check` to ensure no trailing whitespace or obvious diff-check issues and it passed.  
- Performed source-level scans and assertions (grep/quick Python invariants) verifying removal of the old horizontal-only watch check, presence of the `60000.0D` constant, exclusive hard-range checks, 3D distance predicates, and the minimum-footprint logic; these checks passed.  
- Ran targeted repository searches to confirm the old `4800` hard limit was removed from the audited files and documentation; the searches passed.  
- Updated and added deterministic JUnit tests under `src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java` (selection, boundary, invalid-config, footprint); tests were added to source but full `./gradlew test` / `compile` were not executed in this environment per the no-binary-compilation restriction, so test compilation/execution status is not run here.  
- Runtime/in-game acceptance (server + client graphical checks for 400/1,000/10,000/59,999 block vertical separation and exact 60,000 exclusion) was not performed in the non-interactive environment and should be validated on a Forge 1.7.10 dedicated server with clients.  

If you want, I can provide a short checklist of manual validation steps to run in a live server/client session and help iterate on any follow-up issues uncovered by those runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70ee8dbb8c8323a64b333c0ce19542)