### PR TITLE
Fix vertical vehicle LOD render eligibility

### DIFF
--- a/src/main/java/mcheli/MCH_ServerTickHandler.java
+++ b/src/main/java/mcheli/MCH_ServerTickHandler.java
@@ -115,9 +115,11 @@ public class MCH_ServerTickHandler {
             double dy = vehicle.posY - player.posY;
             double dz = vehicle.posZ - player.posZ;
             double distanceSq = MCH_VehicleLODVisibility.distanceSq(dx, dy, dz);
+            boolean watched = world.getPlayerManager().isPlayerWatchingChunk(player,
+               vehicle.chunkCoordX, vehicle.chunkCoordZ);
             boolean qualifies = !vehicle.isDead && vehicle.getAcInfo() != null && categoryOf(vehicle) >= 0
                && !vehicle.isUAV() && !vehicle.isNewUAV()
-               && distanceSq > NORMAL_TRACKING_RANGE_SQ && distanceSq < farDistanceSq;
+               && MCH_VehicleLODVisibility.shouldSendSnapshot(watched, distanceSq, Math.sqrt(farDistanceSq));
             diagnoseSnapshot(world, player, vehicle, dx, dy, dz, farDistanceSq, qualifies);
             if(qualifies) {
                aircraft.add(vehicle);

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -18,6 +18,7 @@ import mcheli.flare.MCH_Maintenance;
 import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.item.MCH_ItemInfo;
 import mcheli.item.MCH_ItemInfoManager;
+import mcheli.lod.MCH_VehicleLODVisibility;
 import mcheli.multiplay.MCH_Multiplay;
 import mcheli.parachute.MCH_EntityParachute;
 import mcheli.particles.MCH_ParticleParam;
@@ -402,12 +403,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public boolean isInRangeToRenderDist(double distanceSq) {
-      double farDistance = MCH_Config.AircraftLODFarDistance != null?MCH_Config.AircraftLODFarDistance.prmDouble:0.0D;
-      if(farDistance > 0.0D) {
-         return distanceSq < farDistance * farDistance;
-      }
-
-      return super.isInRangeToRenderDist(distanceSq);
+      boolean lodEnabled = MCH_Config.EnableAircraftLODRender != null && MCH_Config.EnableAircraftLODRender.prmBool;
+      double farDistance = MCH_Config.AircraftLODFarDistance != null
+         ? MCH_Config.AircraftLODFarDistance.prmDouble : MCH_VehicleLODVisibility.MAX_LOD_DISTANCE;
+      return MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(
+         lodEnabled, distanceSq, farDistance, super.isInRangeToRenderDist(distanceSq));
    }
 
    protected void entityInit() {

--- a/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODVisibility.java
@@ -53,11 +53,10 @@ public final class MCH_VehicleLODVisibility {
         return physicalSize * Math.abs((double)projectionY) * (double)viewportHeight / (2.0D * realDistance);
     }
 
-    /** Full three-dimensional snapshot selection; chunk watching is intentionally irrelevant. */
-    public static boolean qualifiesForSnapshot(double dx, double dy, double dz, double hardDistance) {
+    /** Preserves the vanilla horizontal chunk-watching split used by snapshot selection. */
+    public static boolean shouldSendSnapshot(boolean watchedChunk, double distanceSq, double hardDistance) {
         double limit = hardDistance(hardDistance);
-        double distanceSq = distanceSq(dx, dy, dz);
-        return isFinite(distanceSq) && distanceSq > NORMAL_TRACKING_RANGE_SQ && distanceSq < limit * limit;
+        return !watchedChunk && isFinite(distanceSq) && distanceSq >= 0.0D && distanceSq < limit * limit;
     }
 
     public static boolean insideHardRange(double dx, double dy, double dz, double hardDistance) {
@@ -73,6 +72,17 @@ public final class MCH_VehicleLODVisibility {
     public static double hardDistance(double configured) {
         return isFinite(configured) && configured > 0.0D
             ? Math.min(configured, MAX_LOD_DISTANCE) : MAX_LOD_DISTANCE;
+    }
+
+    /**
+     * Extends Minecraft's tracked-entity render eligibility to the configured LOD
+     * boundary. The distance supplied by Entity is already squared.
+     */
+    public static boolean isTrackedEntityRenderEligible(boolean lodEnabled, double distanceSq,
+        double configuredHardDistance, boolean vanillaResult) {
+        if (!lodEnabled) return vanillaResult;
+        double hard = hardDistance(configuredHardDistance);
+        return isFinite(distanceSq) && distanceSq >= 0.0D && distanceSq < hard * hard;
     }
 
     /** Never enlarges a distant model beyond a one-pixel apparent footprint. */

--- a/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
+++ b/src/test/java/mcheli/lod/MCH_VehicleLODVisibilityTest.java
@@ -53,24 +53,42 @@ public class MCH_VehicleLODVisibilityTest {
     }
 
     @Test
-    public void verticalSnapshotSelectionIgnoresHorizontalChunkWatching() {
-        // Chunk watching is deliberately absent from this pure predicate: same X/Z at 400 blocks qualifies.
-        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 400.0D, 0.0D, 60000.0D));
-        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 1000.0D, 0.0D, 60000.0D));
-        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 10000.0D, 0.0D, 60000.0D));
-        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 59999.0D, 0.0D, 60000.0D));
+    public void trackedEntityRenderEligibilityIncludesVerticalDistancesInsideHardRange() {
+        double[] eligible = {140.0D, 199.0D, 200.0D, 201.0D, 399.0D, 400.0D, 401.0D,
+            1000.0D, 10000.0D, 59999.0D};
+        for (double vertical : eligible) {
+            assertTrue("vertical separation " + vertical, MCH_VehicleLODVisibility
+                .isTrackedEntityRenderEligible(true, vertical * vertical, 60000.0D, false));
+        }
+        assertTrue(!MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(
+            true, 60000.0D * 60000.0D, 60000.0D, true));
+        assertTrue(!MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(
+            true, 60001.0D * 60001.0D, 60000.0D, true));
     }
 
     @Test
-    public void normalTrackingPreventsSnapshotDuplicate() {
-        assertTrue(!MCH_VehicleLODVisibility.qualifiesForSnapshot(0.0D, 199.0D, 0.0D, 60000.0D));
-        assertTrue(!MCH_VehicleLODVisibility.qualifiesForSnapshot(120.0D, 120.0D, 20.0D, 60000.0D));
+    public void trackedEntityRenderEligibilityClampsHardRangeAndPreservesVanillaWhenDisabled() {
+        assertTrue(MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(
+            true, 59999.0D * 59999.0D, 90000.0D, false));
+        assertTrue(!MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(
+            true, 60000.0D * 60000.0D, 90000.0D, true));
+        assertTrue(MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(false, 1.0D, 60000.0D, true));
+        assertTrue(!MCH_VehicleLODVisibility.isTrackedEntityRenderEligible(false, 1.0D, 60000.0D, false));
+    }
+
+    @Test
+    public void watchedChunkUsesTrackedPathAndUnwatchedChunkUsesSnapshotPath() {
+        assertTrue(!MCH_VehicleLODVisibility.shouldSendSnapshot(true, 10000.0D * 10000.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.shouldSendSnapshot(false, 201.0D * 201.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.shouldSendSnapshot(false, 59999.0D * 59999.0D, 60000.0D));
+        assertTrue(!MCH_VehicleLODVisibility.shouldSendSnapshot(false, 60000.0D * 60000.0D, 60000.0D));
     }
 
     @Test
     public void hardRangeIsExclusiveAndThreeDimensional() {
         assertTrue(MCH_VehicleLODVisibility.insideHardRange(59999.0D, 0.0D, 0.0D, 60000.0D));
-        assertTrue(MCH_VehicleLODVisibility.qualifiesForSnapshot(30000.0D, 40000.0D, 0.0D, 60000.0D));
+        assertTrue(MCH_VehicleLODVisibility.shouldSendSnapshot(false,
+            MCH_VehicleLODVisibility.distanceSq(30000.0D, 40000.0D, 0.0D), 60000.0D));
         assertTrue(!MCH_VehicleLODVisibility.insideHardRange(0.0D, 60000.0D, 0.0D, 60000.0D));
         assertTrue(!MCH_VehicleLODVisibility.insideHardRange(60001.0D, 0.0D, 0.0D, 60000.0D));
         assertTrue(!MCH_VehicleLODVisibility.insideHardRange(50000.0D, 40000.0D, 0.0D, 60000.0D));


### PR DESCRIPTION
### Motivation

- Vehicles at large vertical separations (≈400 blocks and higher) were culled by Minecraft's pre-render distance check before `doRender(...)` ran, leaving neither the tracked-entity renderer nor the snapshot renderer to draw the vehicle. 
- The regression arose because snapshot selection was switched to a 3D lower-bound predicate in the failing change, which allowed the real entity to remain tracked but be rejected by `Entity.isInRangeToRenderDist(...)`. 
- The intent is to let tracked `MCH_EntityBaseVehicle` instances reach the normal `doRender(...)` cheap-LOD path while still enforcing the configured hard LOD limit and preserving vanilla behavior when LOD rendering is disabled.

### Description

- Add a clamped hard-LOD distance and helper math to `MCH_VehicleLODVisibility` (`MAX_LOD_DISTANCE`, `MAX_LOD_DISTANCE_SQ`, `distanceSq`, `hardDistance`) and introduce `isTrackedEntityRenderEligible(...)` to decide render eligibility for tracked entities using squared distances.
- Override `MCH_EntityBaseVehicle.isInRangeToRenderDist(...)` to call the new helper, allowing tracked vehicles to pass Minecraft's pre-render cull up to the configured/clamped `AircraftLODFarDistance` when `EnableAircraftLODRender` is enabled and otherwise preserving vanilla behavior.
- Restore horizontal snapshot selection semantics in `MCH_ServerTickHandler.collectSnapshots(...)` so snapshots are chosen based on player chunk-watching (horizontal X/Z) using `MCH_VehicleLODVisibility.shouldSendSnapshot(...)` rather than a 3D 200-block lower bound, preserving the parent commit's horizontal behavior and preventing snapshot suppression for render-ineligible tracked entities.
- Add deterministic unit tests in `MCH_VehicleLODVisibilityTest` that cover vertical boundaries (140, 199, 200, 201, 399, 400, 401, 1,000, 10,000, 59,999, 60,000, 60,001), hard-range clamping, the exclusive 60,000-block cap, watched/unwatched snapshot selection, and disabled-LOD fallback.

### Testing

- `git diff --check` succeeded on the working tree after edits. 
- `./gradlew test --tests mcheli.lod.MCH_VehicleLODVisibilityTest` could not complete in this environment because Gradle failed to resolve `junit:junit:4.13.2` (all configured Maven repositories returned HTTP 403), so unit tests were added and validated by static inspection but not executed here. 
- Runtime verification (singleplayer and dedicated Forge 1.7.10 server checks described in the task) could not be performed in this non-interactive/CI-limited environment. 
- Changes were committed locally as "Fix vertical vehicle LOD render eligibility" and the PR metadata created; no `CHANGELOG.md` or other documentation files were modified per repository guidance.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70f207839c8323a42bfe27b9d861bf)