### PR TITLE
Fix projection clipping for tracked vehicle LOD models

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -1,7 +1,9 @@
 package mcheli.aircraft;
 
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -16,6 +18,8 @@ import mcheli.flare.MCH_EntityChaff;
 import mcheli.flare.MCH_EntityFlare;
 import mcheli.gui.MCH_Gui;
 import mcheli.lweapon.MCH_ClientLightWeaponTickHandler;
+import mcheli.lod.MCH_VehicleLODProjection;
+import mcheli.lod.MCH_VehicleLODManager;
 import mcheli.multiplay.MCH_GuiTargetMarker;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.uav.MCH_EntityUavStation;
@@ -52,6 +56,7 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    private static final boolean ANGELICA_DYNAMIC_PART_COMPAT = Loader.isModLoaded("angelica");
    private static final boolean DEBUG_ANGELICA_DYNAMIC_PART_RENDER = Boolean.getBoolean("mcheli.debugAngelicaDynamicPartRender");
    private static final Set angelicaDynamicPartRenderDiagnostics = new HashSet();
+   private static final Map vehicleLODDiagnosticTimes = new HashMap();
 
    public static Random rand = new Random();
 
@@ -152,16 +157,66 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
        * supposed to become useful.  The matrix/attribute pushes keep this isolated from
        * normal close-range aircraft and world rendering.
        */
+      double realDistance = Math.sqrt(posX * posX + posY * posY + posZ * posZ);
+      MCH_VehicleLODProjection.Context projection = MCH_VehicleLODProjection.capture(Minecraft.getMinecraft(), realDistance);
+      double depthScale = projection.depthScale;
+      diagnoseTrackedLOD(ac, posX, posY, posZ, realDistance, projection);
+      int previousMatrixMode = GL11.glGetInteger(GL11.GL_MATRIX_MODE);
+      GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+      GL11.glMatrixMode(GL11.GL_MODELVIEW);
       GL11.glPushMatrix();
-      GL11.glPushAttrib(GL11.GL_ENABLE_BIT | GL11.GL_COLOR_BUFFER_BIT | GL11.GL_CURRENT_BIT | GL11.GL_TEXTURE_BIT);
-      GL11.glDisable(GL11.GL_FOG);
-      GL11.glEnable(GL11.GL_BLEND);
-      GL11.glDisable(GL11.GL_ALPHA_TEST);
-      GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      this.renderBaseVehicle(ac, posX, posY, posZ, yaw, pitch, roll, tickTime);
-      this.renderAircraftLODParts(ac, info, posX, posY, posZ, tickTime);
-      GL11.glPopAttrib();
-      GL11.glPopMatrix();
+      try {
+         GL11.glDisable(GL11.GL_FOG);
+         GL11.glEnable(GL11.GL_BLEND);
+         GL11.glDisable(GL11.GL_ALPHA_TEST);
+         GL11.glEnable(GL11.GL_DEPTH_TEST);
+         GL11.glDepthMask(true);
+         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+         // Pattern A: this wrapper owns world placement; every vehicle renderer was
+         // audited to translate by its position arguments and accepts zero here.
+         GL11.glTranslated(posX * depthScale, posY * depthScale, posZ * depthScale);
+         GL11.glScaled(depthScale, depthScale, depthScale);
+         this.renderBaseVehicle(ac, 0.0D, 0.0D, 0.0D, yaw, pitch, roll, tickTime);
+         this.renderAircraftLODParts(ac, info, 0.0D, 0.0D, 0.0D, tickTime);
+      } finally {
+         GL11.glPopMatrix();
+         GL11.glPopAttrib();
+         GL11.glMatrixMode(previousMatrixMode);
+      }
+   }
+
+   private static void diagnoseTrackedLOD(MCH_EntityBaseVehicle ac, double posX, double posY, double posZ,
+      double realDistance, MCH_VehicleLODProjection.Context projection) {
+      if(MCH_Config.DebugVehicleLODVisibility == null || !MCH_Config.DebugVehicleLODVisibility.prmBool) return;
+      long now = System.currentTimeMillis();
+      Integer id = Integer.valueOf(ac.getEntityId());
+      Long previous = (Long)vehicleLODDiagnosticTimes.get(id);
+      if(previous != null && now - previous.longValue() < 1000L) return;
+      vehicleLODDiagnosticTimes.put(id, Long.valueOf(now));
+      Minecraft mc = Minecraft.getMinecraft();
+      Entity camera = mc.renderViewEntity;
+      double dx = camera == null ? posX : ac.posX - camera.posX;
+      double dy = camera == null ? posY : ac.posY - camera.posY;
+      double dz = camera == null ? posZ : ac.posZ - camera.posZ;
+      double horizontal = Math.sqrt(dx * dx + dz * dz);
+      boolean eligible = ac.isInRangeToRenderDist(realDistance * realDistance);
+      boolean snapshotReceived = MCH_VehicleLODManager.INSTANCE.hasSnapshotFor(ac);
+      int glError = GL11.glGetError();
+      String type = ac.getAcInfo() == null ? ac.getClass().getName() : ac.getAcInfo().name;
+      MCH_Lib.DbgLog(true,
+         "TrackedVehicleLOD id=%d type=%s camera=(%.2f,%.2f,%.2f) vehicle=(%.2f,%.2f,%.2f) horizontal=%.2f vertical=%.2f distance3d=%.2f renderer=(%.2f,%.2f,%.2f) doRender=true path=lod eligible=%s renderChunks=%d projectionValid=%s projection=[%.6f,%.6f,%.6f,%.6f] farPlane=%.2f safeDepth=%.2f depthScale=%.6f watchedChunk=true snapshotReceived=%s snapshotSuppressed=%s final=(%.2f,%.2f,%.2f) modelScale=%.6f glError=%d",
+         new Object[]{id, type, Double.valueOf(camera == null ? Double.NaN : camera.posX),
+            Double.valueOf(camera == null ? Double.NaN : camera.posY), Double.valueOf(camera == null ? Double.NaN : camera.posZ),
+            Double.valueOf(ac.posX), Double.valueOf(ac.posY), Double.valueOf(ac.posZ), Double.valueOf(horizontal),
+            Double.valueOf(Math.abs(dy)), Double.valueOf(realDistance), Double.valueOf(posX), Double.valueOf(posY),
+            Double.valueOf(posZ), Boolean.valueOf(eligible), Integer.valueOf(mc.gameSettings.renderDistanceChunks),
+            Boolean.valueOf(projection.validProjection), Float.valueOf(projection.projection[0]),
+            Float.valueOf(projection.projection[5]), Float.valueOf(projection.projection[10]),
+            Float.valueOf(projection.projection[14]), Double.valueOf(projection.farPlane),
+            Double.valueOf(projection.safeProxyDepth), Double.valueOf(projection.depthScale),
+            Boolean.valueOf(snapshotReceived), Boolean.valueOf(snapshotReceived),
+            Double.valueOf(posX * projection.depthScale), Double.valueOf(posY * projection.depthScale),
+            Double.valueOf(posZ * projection.depthScale), Double.valueOf(projection.depthScale), Integer.valueOf(glError)});
    }
 
    /**

--- a/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODManager.java
@@ -9,10 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import org.lwjgl.BufferUtils;
-import mcheli.MCH_ActiveRenderInfoHolder;
 import mcheli.MCH_Camera;
 import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.MCH_Lib;
@@ -55,8 +51,6 @@ public final class MCH_VehicleLODManager {
     public static final MCH_VehicleLODManager INSTANCE = new MCH_VehicleLODManager();
     private static final long STALE_AFTER_MS = 5000L;
     private static final LODRenderState RENDER_STATE = new LODRenderState();
-    private static final FloatBuffer FALLBACK_PROJECTION = BufferUtils.createFloatBuffer(16);
-    private static final IntBuffer FALLBACK_VIEWPORT = BufferUtils.createIntBuffer(16);
     private static final Map<Object, Double> TARGET_DIMENSIONS = new IdentityHashMap<Object, Double>();
     private static long nextDiagnosticMs;
     private final Map<UUID, Display> displays = new HashMap<UUID, Display>();
@@ -105,6 +99,18 @@ public final class MCH_VehicleLODManager {
 
     public synchronized void invalidate(UUID vehicleId) {
         if (vehicleId != null) this.displays.remove(vehicleId);
+    }
+
+    /** Diagnostic ownership query; a live tracked entity still remains the sole renderer. */
+    public synchronized boolean hasSnapshotFor(MCH_EntityBaseVehicle vehicle) {
+        if (vehicle == null) return false;
+        for (Display display : this.displays.values()) {
+            if (vehicle.getEntityId() == display.entityId) return true;
+            String commonId = vehicle.getCommonUniqueId();
+            if (commonId != null && commonId.length() > 0 && commonId.equals(display.commonUniqueId)
+                && vehicle.getAcInfo() != null && display.typeName.equals(vehicle.getAcInfo().name)) return true;
+        }
+        return false;
     }
 
     @SubscribeEvent
@@ -187,24 +193,11 @@ public final class MCH_VehicleLODManager {
 
     private static RenderContext captureRenderContext(Minecraft mc, float partialTicks) {
         RenderContext context = new RenderContext();
-        boolean validProjection = copyProjection(MCH_ActiveRenderInfoHolder.projection, context.projection);
-        if (!validProjection) {
-            FALLBACK_PROJECTION.clear();
-            GL11.glGetFloat(GL11.GL_PROJECTION_MATRIX, FALLBACK_PROJECTION);
-            validProjection = copyProjection(FALLBACK_PROJECTION, context.projection);
-        }
-        double fallbackFar = Math.max(64.0D, (double)mc.gameSettings.renderDistanceChunks * 16.0D);
-        context.farPlane = validProjection
-            ? MCH_VehicleLODVisibility.projectionFarPlane(context.projection[10], context.projection[14], fallbackFar)
-            : fallbackFar;
-        context.safeProxyDepth = MCH_VehicleLODVisibility.safeProxyDepth(context.farPlane);
-        context.viewportHeight = copyViewportHeight(MCH_ActiveRenderInfoHolder.viewport);
-        if (context.viewportHeight <= 0) {
-            FALLBACK_VIEWPORT.clear();
-            GL11.glGetInteger(GL11.GL_VIEWPORT, FALLBACK_VIEWPORT);
-            context.viewportHeight = copyViewportHeight(FALLBACK_VIEWPORT);
-        }
-        if (context.viewportHeight <= 0) context.viewportHeight = Math.max(1, mc.displayHeight);
+        MCH_VehicleLODProjection.Context projection = MCH_VehicleLODProjection.capture(mc, 0.0D);
+        System.arraycopy(projection.projection, 0, context.projection, 0, 16);
+        context.farPlane = projection.farPlane;
+        context.safeProxyDepth = projection.safeProxyDepth;
+        context.viewportHeight = projection.viewportHeight;
         context.cameraMode = MCH_ClientCommonTickHandler.cameraMode;
         context.thermal = context.cameraMode == MCH_Camera.MODE_THERMALVISION;
         if (mc.theWorld.getWeightedThunderStrength(partialTicks) > 0.0F) {
@@ -218,21 +211,6 @@ public final class MCH_VehicleLODManager {
             context.weatherMultiplier = 1.0D;
         }
         return context;
-    }
-
-    private static boolean copyProjection(FloatBuffer source, float[] destination) {
-        if (source == null || source.capacity() < 16) return false;
-        for (int i = 0; i < 16; ++i) {
-            float value = source.get(i);
-            if (Float.isNaN(value) || Float.isInfinite(value)) return false;
-            destination[i] = value;
-        }
-        return Math.abs(destination[0]) > 1.0E-6F && Math.abs(destination[5]) > 1.0E-6F
-            && Math.abs(destination[11]) > 1.0E-6F;
-    }
-
-    private static int copyViewportHeight(IntBuffer viewport) {
-        return viewport != null && viewport.capacity() >= 4 ? viewport.get(3) : 0;
     }
 
     private static double targetDimension(MCH_BaseVehicleInfo info) {

--- a/src/main/java/mcheli/lod/MCH_VehicleLODProjection.java
+++ b/src/main/java/mcheli/lod/MCH_VehicleLODProjection.java
@@ -1,0 +1,103 @@
+package mcheli.lod;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import mcheli.MCH_ActiveRenderInfoHolder;
+import net.minecraft.client.Minecraft;
+import org.lwjgl.BufferUtils;
+import org.lwjgl.opengl.GL11;
+
+/** Projection information shared by tracked and snapshot vehicle LOD rendering. */
+@SideOnly(Side.CLIENT)
+public final class MCH_VehicleLODProjection {
+    private static final FloatBuffer PROJECTION_BUFFER = BufferUtils.createFloatBuffer(16);
+    private static final IntBuffer VIEWPORT_BUFFER = BufferUtils.createIntBuffer(16);
+
+    private MCH_VehicleLODProjection() {
+    }
+
+    /** Captures the projection which is active at the world-render call site. */
+    public static Context capture(Minecraft mc, double realDistance) {
+        float[] projection = new float[16];
+        boolean valid = false;
+        try {
+            PROJECTION_BUFFER.clear();
+            GL11.glGetFloat(GL11.GL_PROJECTION_MATRIX, PROJECTION_BUFFER);
+            valid = copyProjection(PROJECTION_BUFFER, projection);
+        } catch (RuntimeException ignored) {
+            // A headless/incomplete OpenGL implementation may reject glGet.
+        }
+        if (!valid) {
+            valid = copyProjection(MCH_ActiveRenderInfoHolder.projection, projection);
+        }
+
+        int viewportHeight = 0;
+        try {
+            VIEWPORT_BUFFER.clear();
+            GL11.glGetInteger(GL11.GL_VIEWPORT, VIEWPORT_BUFFER);
+            viewportHeight = copyViewportHeight(VIEWPORT_BUFFER);
+        } catch (RuntimeException ignored) {
+        }
+        if (viewportHeight <= 0) viewportHeight = copyViewportHeight(MCH_ActiveRenderInfoHolder.viewport);
+        if (viewportHeight <= 0) viewportHeight = Math.max(1, mc.displayHeight);
+        double fallbackFar = Math.max(64.0D, (double)mc.gameSettings.renderDistanceChunks * 16.0D);
+        return create(projection, valid, viewportHeight, fallbackFar, realDistance);
+    }
+
+    /** Pure factory kept independent of an OpenGL context for regression tests. */
+    public static Context create(float[] projection, boolean validProjection, int viewportHeight,
+        double fallbackFarPlane, double realDistance) {
+        float[] matrix = new float[16];
+        boolean valid = validProjection && copyProjection(projection, matrix);
+        double fallback = MCH_VehicleLODVisibility.positive(fallbackFarPlane, 256.0D);
+        double far = valid ? MCH_VehicleLODVisibility.projectionFarPlane(matrix[10], matrix[14], fallback) : fallback;
+        double safe = MCH_VehicleLODVisibility.safeProxyDepth(far);
+        return new Context(matrix, valid, Math.max(1, viewportHeight), far, safe,
+            MCH_VehicleLODVisibility.depthScale(realDistance, safe));
+    }
+
+    static boolean copyProjection(FloatBuffer source, float[] destination) {
+        if (source == null || destination == null || destination.length < 16 || source.capacity() < 16) return false;
+        for (int i = 0; i < 16; ++i) destination[i] = source.get(i);
+        return isValidProjection(destination);
+    }
+
+    static boolean copyProjection(float[] source, float[] destination) {
+        if (source == null || destination == null || source.length < 16 || destination.length < 16) return false;
+        System.arraycopy(source, 0, destination, 0, 16);
+        return isValidProjection(destination);
+    }
+
+    private static boolean isValidProjection(float[] matrix) {
+        for (int i = 0; i < 16; ++i) if (Float.isNaN(matrix[i]) || Float.isInfinite(matrix[i])) return false;
+        return Math.abs(matrix[0]) > 1.0E-6F && Math.abs(matrix[5]) > 1.0E-6F
+            && Math.abs(matrix[11]) > 1.0E-6F;
+    }
+
+    static int copyViewportHeight(IntBuffer viewport) {
+        return viewport != null && viewport.capacity() >= 4 ? viewport.get(3) : 0;
+    }
+
+    public static final class Context {
+        public final float[] projection;
+        public final boolean validProjection;
+        public final int viewportHeight;
+        public final float projectionYScale;
+        public final double farPlane;
+        public final double safeProxyDepth;
+        public final double depthScale;
+
+        private Context(float[] projection, boolean validProjection, int viewportHeight, double farPlane,
+            double safeProxyDepth, double depthScale) {
+            this.projection = projection;
+            this.validProjection = validProjection;
+            this.viewportHeight = viewportHeight;
+            this.projectionYScale = validProjection ? projection[5] : 1.0F;
+            this.farPlane = farPlane;
+            this.safeProxyDepth = safeProxyDepth;
+            this.depthScale = depthScale;
+        }
+    }
+}

--- a/src/test/java/mcheli/lod/MCH_VehicleLODProjectionTest.java
+++ b/src/test/java/mcheli/lod/MCH_VehicleLODProjectionTest.java
@@ -1,0 +1,70 @@
+package mcheli.lod;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class MCH_VehicleLODProjectionTest {
+    private static float[] perspective(double near, double far, float yScale) {
+        float[] matrix = new float[16];
+        matrix[0] = yScale;
+        matrix[5] = yScale;
+        matrix[10] = (float)(-(far + near) / (far - near));
+        matrix[11] = -1.0F;
+        matrix[14] = (float)(-(2.0D * far * near) / (far - near));
+        return matrix;
+    }
+
+    @Test
+    public void extractsValidProjectionAndCompressesToSafeDepth() {
+        MCH_VehicleLODProjection.Context context = MCH_VehicleLODProjection.create(
+            perspective(0.1D, 400.0D, 2.0F), true, 1080, 256.0D, 800.0D);
+        assertTrue(context.validProjection);
+        assertEquals(400.0D, context.farPlane, 0.1D);
+        assertEquals(360.0D, context.safeProxyDepth, 0.1D);
+        assertEquals(1080, context.viewportHeight);
+        assertEquals(2.0F, context.projectionYScale, 0.0F);
+        assertTrue(context.depthScale > 0.0D && context.depthScale < 1.0D);
+        assertEquals(context.safeProxyDepth, 800.0D * context.depthScale, 1.0E-9D);
+    }
+
+    @Test
+    public void invalidMatricesUseSanitizedFallbacks() {
+        float[] invalid = perspective(0.1D, 400.0D, 1.0F);
+        invalid[10] = Float.NaN;
+        MCH_VehicleLODProjection.Context nan = MCH_VehicleLODProjection.create(
+            invalid, true, 0, 512.0D, 1000.0D);
+        assertFalse(nan.validProjection);
+        assertEquals(512.0D, nan.farPlane, 0.0D);
+        assertEquals(1, nan.viewportHeight);
+
+        MCH_VehicleLODProjection.Context infinite = MCH_VehicleLODProjection.create(
+            perspective(0.1D, Double.POSITIVE_INFINITY, 1.0F), true, 720, -1.0D, 1000.0D);
+        assertFalse(infinite.validProjection);
+        assertEquals(256.0D, infinite.farPlane, 0.0D);
+    }
+
+    @Test
+    public void nearZeroAndInvalidDistancesAreNotCompressed() {
+        float[] projection = perspective(0.1D, 400.0D, 1.0F);
+        assertEquals(1.0D, MCH_VehicleLODProjection.create(projection, true, 720, 256.0D, 100.0D).depthScale, 0.0D);
+        assertEquals(1.0D, MCH_VehicleLODProjection.create(projection, true, 720, 256.0D, 0.0D).depthScale, 0.0D);
+        assertEquals(1.0D, MCH_VehicleLODProjection.create(projection, true, 720, 256.0D, Double.NaN).depthScale, 0.0D);
+        assertEquals(1.0D, MCH_VehicleLODProjection.create(projection, true, 720, 256.0D, Double.POSITIVE_INFINITY).depthScale, 0.0D);
+    }
+
+    @Test
+    public void coordinateAndModelCompressionPreserveDirectionAndAngularSize() {
+        MCH_VehicleLODProjection.Context context = MCH_VehicleLODProjection.create(
+            perspective(0.1D, 400.0D, 1.0F), true, 720, 256.0D, 1000.0D);
+        double x = -300.0D, y = 400.0D, z = -Math.sqrt(750000.0D);
+        double compressedDistance = Math.sqrt(x * x + y * y + z * z) * context.depthScale;
+        assertEquals(context.safeProxyDepth, compressedDistance, 0.1D);
+        assertTrue(x * context.depthScale < 0.0D);
+        assertTrue(z * context.depthScale < 0.0D);
+        assertEquals(8.0D / 1000.0D,
+            (8.0D * context.depthScale) / compressedDistance, 1.0E-12D);
+    }
+}


### PR DESCRIPTION
### Motivation

- Tracked vehicle LOD models could be culled by the GPU projection far plane when the camera is very far above the vehicle, causing disappearances around ~400 blocks despite CPU-side `isInRangeToRenderDist(...)` passing.  
- The snapshot LOD path already performed projection-safe depth compression, but the tracked-entity LOD path rendered models at real camera-relative depth and lacked projection protection.  
- The change centralizes projection extraction and far-plane/safe-depth calculation so both snapshot and tracked paths use the same projection context and fallbacks.  

### Description

- Add a shared projection helper `MCH_VehicleLODProjection` that captures the active world projection (guarded `glGetFloat` + `MCH_ActiveRenderInfoHolder` fallback), validates matrix elements, extracts the far plane, computes the `safeProxyDepth`, and produces a `depthScale` and viewport info via `Context`.  
- Make tracked LOD rendering projection-safe by compressing coordinates and the entire model: `depthScale = 1.0` inside the safe proxy depth, otherwise `depthScale = safeProxyDepth / realDistance`, translate to `(posX,posY,posZ) * depthScale`, scale the model by `depthScale`, and call sub-renderers with zero position arguments (Pattern A) to avoid double translation/scale.  
- Preserve proper OpenGL state by restoring matrix mode/attribs in `finally`, keep depth testing/depth writes enabled for the LOD pass, and avoid changing global projection or clearing the depth buffer.  
- Reuse the projection helper from the snapshot renderer (`MCH_VehicleLODManager`) to remove duplicate projection extraction logic and add a diagnostic query `hasSnapshotFor(...)` used by tracked-path diagnostics.  
- Add rate-limited, config-controlled per-vehicle diagnostics in `MCH_RenderBaseVehicle` that report camera/vehicle coordinates, distances, projection matrix elements, far plane, safe depth, depth scale, final render coordinates, snapshot presence, and `glGetError()` when enabled.  
- Add unit tests `MCH_VehicleLODProjectionTest` that exercise valid/invalid projection extraction, far-plane and safe-depth computation, depth compression behavior, viewport fallback, and angular-size preservation.  

### Testing

- Ran `git diff --check` and repository tree/status checks which reported no whitespace errors and showed the new/updated files (static checks succeeded).  
- Added pure-Java unit tests in `src/test/java/mcheli/lod/MCH_VehicleLODProjectionTest.java` that validate projection extraction and compression math, but the test suite was not executed here because compiling/running JVM tests was explicitly restricted in the environment.  
- Did not run `gradle` compile or JUnit tasks in this environment because the user prohibited producing or executing compiled binaries.  
- Attempted RTM repository inspection for runtime interaction tests, but the external clone failed due to the environment's network/proxy restrictions, so interactive visual/RTM compatibility tests were unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70f65d0eb883238cefb31991c2d8e4)