### PR TITLE
Add configurable block resistance checks for projectile piercing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,9 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `AutoRepairEnabled` | `false` | Auto-repair feature toggle. The source contains a commented older initialization and an active generated-config entry. |
 | `Explosion_DestroyBlock` | `true` | Allows explosions to destroy blocks. |
 | `Explosion_FlamingBlock` | `true` | Allows explosions to create flaming blocks. |
+| `PiercingBlockHardnessLimit` | `10.0` | Stops a piercing projectile when the impacted block's hardness is greater than or equal to this limit. Negative hardness always stops piercing. This check does not control block destruction. |
+| `PiercingBlockBlastResistanceLimit` | `100.0` | Stops a piercing projectile when the impacted block's blast resistance is greater than or equal to this limit. The hardness and blast-resistance limits use OR logic, so either one can stop the projectile. |
+| `DebugPiercingBlocks` | `false` | Logs each server-side resistance check for a piercing projectile, including weapon and block details, resistance values, remaining `Piercing`, and the `PASS` or `STOP` result. |
 | `BulletBreakableBlocks` | `glass_pane, stained_glass_pane, tallgrass, double_plant, yellow_flower, red_flower, vine, wheat, reeds, waterlily` | Blocks bullets can break. |
 | `Collision_DestroyBlock` | `true` | Allows collision block destruction. |
 | `Collision_Car_BreakableBlock` | `double_plant, glass_pane,stained_glass_pane` | Car/vehicle collision breakable block list. |
@@ -127,6 +130,8 @@ Client keybinds and rendering settings are safest to change while the client is 
 | `ReplaceRenderViewEntity` | `true` | Replaces render-view entity for MCHeli camera behavior. |
 | `ItemRecipe_*` | See generated config/source defaults | Recipe strings for core MCHeli items. |
 | `MultiThreadedModelLoading` | `true` | Enables threaded model loading on the client. |
+
+Piercing block resistance is checked independently of block destruction and therefore still applies when the server's `mobGriefing` game rule is `false`; existing destruction behavior continues to decide whether the block remains intact. The feature only changes the impacted projectile instance's remaining penetration distance when a limit stops it. It does not change the integer type, parser, or meaning of existing weapon `Piercing` values.
 
 Snapshot visibility uses the active projection matrix, so scopes and other FOV magnification increase projected target size naturally. Magnification does not change real distance or atmospheric transmission. Thermal vision lowers the projected-size threshold and improves contrast, but it never extends `AircraftLODFarDistance`. Snapshot rendering retains depth testing, allowing loaded nearby terrain and structures to occlude a target; unloaded terrain has no depth information and therefore cannot occlude this render-only data.
 

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -108,6 +108,9 @@ public class MCH_Config {
    public static MCH_ConfigPrm Explosion_DestroyBlock;
    public static MCH_ConfigPrm Explosion_FlamingBlock;
    public static MCH_ConfigPrm BulletBreakableBlock;
+   public static MCH_ConfigPrm PiercingBlockHardnessLimit;
+   public static MCH_ConfigPrm PiercingBlockBlastResistanceLimit;
+   public static MCH_ConfigPrm DebugPiercingBlocks;
    public static MCH_ConfigPrm Collision_Car_BreakableBlock;
    public static MCH_ConfigPrm Collision_Car_NoBreakableBlock;
    public static MCH_ConfigPrm Collision_Car_BreakableMaterial;
@@ -449,6 +452,12 @@ public class MCH_Config {
       Collision_DestroyBlock = new MCH_ConfigPrm("Collision_DestroyBlock", true);
       Explosion_DestroyBlock = new MCH_ConfigPrm("Explosion_DestroyBlock", true);
       Explosion_FlamingBlock = new MCH_ConfigPrm("Explosion_FlamingBlock", true);
+      PiercingBlockHardnessLimit = new MCH_ConfigPrm("PiercingBlockHardnessLimit", 10.0D);
+      PiercingBlockHardnessLimit.desc = ";Stops a piercing projectile when block hardness reaches this value. Either resistance limit can stop piercing; these limits do not control block destruction and still apply when mobGriefing is false.";
+      PiercingBlockBlastResistanceLimit = new MCH_ConfigPrm("PiercingBlockBlastResistanceLimit", 100.0D);
+      PiercingBlockBlastResistanceLimit.desc = ";Stops a piercing projectile when block blast resistance reaches this value. Either resistance limit can stop piercing; these limits do not control block destruction and still apply when mobGriefing is false.";
+      DebugPiercingBlocks = new MCH_ConfigPrm("DebugPiercingBlocks", false);
+      DebugPiercingBlocks.desc = ";Logs server-side piercing block resistance checks, including the weapon, block, resistance values, remaining Piercing, and PASS or STOP result.";
       Collision_Car_BreakableBlock = new MCH_ConfigPrm("Collision_Car_BreakableBlock", "double_plant, glass_pane,stained_glass_pane");
       Collision_Car_NoBreakableBlock = new MCH_ConfigPrm("Collision_Car_NoBreakBlock", "torch");
       Collision_Car_BreakableMaterial = new MCH_ConfigPrm("Collision_Car_BreakableMaterial", "cactus, cake, gourd, leaves, vine, plants");
@@ -762,6 +771,9 @@ public class MCH_Config {
               AutoRepairEnabled,
               Explosion_DestroyBlock,
               Explosion_FlamingBlock,
+              PiercingBlockHardnessLimit,
+              PiercingBlockBlastResistanceLimit,
+              DebugPiercingBlocks,
               BulletBreakableBlock,
               Collision_DestroyBlock,
               Collision_Car_BreakableBlock,

--- a/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
+++ b/src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java
@@ -1239,12 +1239,51 @@ public abstract class MCH_EntityBaseBullet extends W_Entity implements MCH_IChun
         float explosionPower = this.explosionPower * damageFactor;
         float waterExplosionPower = this.explosionPowerInWater * damageFactor;
 
+        if (piercing > 0
+                && W_MovingObjectPosition.isHitTypeTile(hit)
+                && shouldBlockStopPiercing(hit)) {
+            piercing = 0;
+        }
+
         if (piercing > 0) {
             handlePiercingHit(hit, explosionPower, waterExplosionPower, damageFactor);
         } else {
             handleRegularHit(hit, explosionPower, waterExplosionPower);
             finalizeImpact();
         }
+    }
+
+    private boolean shouldBlockStopPiercing(MovingObjectPosition hit) {
+        if (!W_MovingObjectPosition.isHitTypeTile(hit)) {
+            return false;
+        }
+
+        int x = hit.blockX;
+        int y = hit.blockY;
+        int z = hit.blockZ;
+        Block block = worldObj.getBlock(x, y, z);
+        if (block == null || worldObj.isAirBlock(x, y, z)) {
+            return false;
+        }
+
+        float hardness = block.getBlockHardness(worldObj, x, y, z);
+        Entity resistanceSource = shootingEntity != null ? shootingEntity : this;
+        float blastResistance = block.getExplosionResistance(resistanceSource, worldObj, x, y, z,
+                posX, posY, posZ);
+        boolean stop = hardness < 0.0F
+                || hardness >= MCH_Config.PiercingBlockHardnessLimit.prmDouble
+                || blastResistance >= MCH_Config.PiercingBlockBlastResistanceLimit.prmDouble;
+
+        if (MCH_Config.DebugPiercingBlocks.prmBool) {
+            Object blockName = Block.blockRegistry.getNameForObject(block);
+            MCH_Lib.Log(this,
+                    "Piercing block check: weapon=%s block=%s metadata=%d coordinates=(%d,%d,%d) hardness=%.2f blastResistance=%.2f piercing=%d result=%s",
+                    getName(), String.valueOf(blockName), Integer.valueOf(worldObj.getBlockMetadata(x, y, z)),
+                    Integer.valueOf(x), Integer.valueOf(y), Integer.valueOf(z), Float.valueOf(hardness),
+                    Float.valueOf(blastResistance), Integer.valueOf(piercing), stop ? "STOP" : "PASS");
+        }
+
+        return stop;
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
### Motivation

- Ensure piercing projectiles stop when they encounter sufficiently resistant blocks (by hardness or blast resistance) while preserving the existing integer `Piercing` semantics and behavior. 
- Provide server-configurable thresholds and optional server-side debug logging without changing block-destruction or mobGriefing behavior.

### Description

- Add three server configuration parameters to the existing `MCH_Config` system: `PiercingBlockHardnessLimit` (default `10.0`), `PiercingBlockBlastResistanceLimit` (default `100.0`), and `DebugPiercingBlocks` (default `false`), and register them in the `General` config array so they load/save normally. (file: `MCH_Config.java`).
- Add a helper `shouldBlockStopPiercing(MovingObjectPosition hit)` in `MCH_EntityBaseBullet` that returns `false` for non-block hits or air/null blocks, reads hardness via `getBlockHardness(world, x, y, z)`, treats negative hardness as unbreakable (stop), reads blast resistance using the same Forge 1.7.10 pattern used in `MCH_Explosion` via `getExplosionResistance(...)`, and applies OR logic between the hardness and blast-resistance thresholds. The helper uses `hit.blockX`, `hit.blockY`, and `hit.blockZ` exactly. (file: `MCH_EntityBaseBullet.java`).
- Integrate the helper in `handleServerSideImpact` immediately before the existing piercing-vs-regular branch: if `piercing > 0` and the hit is a tile and `shouldBlockStopPiercing(hit)` returns `true`, set the projectile instance field `piercing = 0` and allow the existing regular-impact path (`handleRegularHit` / `finalizeImpact`) to run as before; entity hits and air hits are unaffected. (file: `MCH_EntityBaseBullet.java`).
- Add server-side debug logging controlled by `DebugPiercingBlocks` that logs weapon name, block registry name, metadata, exact coordinates, hardness, blast resistance, piercing before change, and result (`PASS`/`STOP`) using the existing MCHeli logging helpers and only on the logical server. (file: `MCH_EntityBaseBullet.java`).
- Document the three new config values and their semantics, including OR logic, negative-hardness behavior, and independence from `mobGriefing`, in `docs/configuration.md`.
- Files changed: `src/main/java/mcheli/MCH_Config.java`, `src/main/java/mcheli/weapon/MCH_EntityBaseBullet.java`, `docs/configuration.md`.

### Testing

- `./gradlew compileJava --no-configuration-cache` — Java compilation completed successfully. (passed)
- `./gradlew test` — could not complete because configured Maven repositories returned HTTP 403 while resolving `junit:junit:4.13.2`, so unit tests were not executed in this environment. (could not run)
- `git diff --check` — no whitespace/git-diff issues found. (passed)
- Python assertions verifying the presence of the exact coordinate usage (`hit.blockX`, `hit.blockY`, `hit.blockZ`), negative-hardness handling, OR threshold checks, correct resistance-source fallback (`shootingEntity` or projectile), and default config values — all assertions passed. (passed)

Note: Full in-game verification (hit tests vs glass/stone/obsidian/bedrock, modded blocks, `mobGriefing` true/false, block-face and negative-coordinate checks, and debug log output in a running Forge 1.7.10 world) could not be executed in this environment and should be performed on a running server/client setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7112625e4c8323898a8738e33ceb6c)