### PR TITLE
Prevent knockback from small MCHeli explosions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Prevent Small-Explosion Knockback (PR pending)
+
+- Prevented entity explosions below size `3.0F` from adding MCHeli or vanilla damage knockback while preserving each affected entity's existing motion.
+- Kept damage, hit reporting, effects, fire, and block behavior unchanged, and retained existing knockback behavior at or above the threshold for normal and underwater explosions.
+
 # PR pending - Pre-contact Tank Physical-Hull Step Solver
 
 - Replaced selected-riser collision permission with a tank-only, scratch-geometry route planner that stops before first contact, lifts clear, traverses normally, and lands on the real collision-shape top.

--- a/src/main/java/mcheli/MCH_Explosion.java
+++ b/src/main/java/mcheli/MCH_Explosion.java
@@ -39,6 +39,8 @@ import cpw.mods.fml.common.Loader;
 
 public class MCH_Explosion extends Explosion {
 
+   private static final float MIN_KNOCKBACK_EXPLOSION_SIZE = 3.0F;
+
    //todo make it so that explosions don't just ignore safezones or claims
    //todo make it so explosions aren't as powerful and do not ignore blocks; specifically proximityfusedist/proximity weaponry
    //todo also make it so that explosions are not as powerful and correspond to the actual damagefactor they were assigned
@@ -102,7 +104,9 @@ public class MCH_Explosion extends Explosion {
          double d1;
          double d2;
          if(i >= 16) {
-            float var33 = super.explosionSize;
+            // Use the configured entity explosion size before the temporary radius doubling below.
+            float originalExplosionSize = super.explosionSize;
+            boolean shouldApplyKnockback = originalExplosionSize >= MIN_KNOCKBACK_EXPLOSION_SIZE;
             super.affectedBlockPositions.addAll(hashset);
             super.explosionSize *= 2.0F;
             i = MathHelper.floor_double(super.explosionX - (double)super.explosionSize - 1.0D);
@@ -177,16 +181,26 @@ public class MCH_Explosion extends Explosion {
                      MCH_Config var36 = MCH_MOD.config;
                      damage = MCH_Config.applyDamageVsEntity(entity, ds, damage);
                      damage *= this.damageFactor != null?this.damageFactor.getDamageFactor(entity):1.0F;
+                     double originalMotionX = entity.motionX;
+                     double originalMotionY = entity.motionY;
+                     double originalMotionZ = entity.motionZ;
                      W_Entity.attackEntityFrom(entity, ds, damage);
-                     double d11 = EnchantmentProtection.func_92092_a(entity, var41);
-                     if(!(entity instanceof MCH_EntityBaseBullet)) {
-                        entity.motionX += d0 * d11 * 0.4D;
-                        entity.motionY += d1 * d11 * 0.1D;
-                        entity.motionZ += d2 * d11 * 0.4D;
-                     }
+                     if(shouldApplyKnockback) {
+                        double d11 = EnchantmentProtection.func_92092_a(entity, var41);
+                        if(!(entity instanceof MCH_EntityBaseBullet)) {
+                           entity.motionX += d0 * d11 * 0.4D;
+                           entity.motionY += d1 * d11 * 0.1D;
+                           entity.motionZ += d2 * d11 * 0.4D;
+                        }
 
-                     if(entity instanceof EntityPlayer) {
-                        this.field_77288_k.put((EntityPlayer)entity, W_WorldFunc.getWorldVec3(this.world, d0 * var41, d1 * var41, d2 * var41));
+                        if(entity instanceof EntityPlayer) {
+                           this.field_77288_k.put((EntityPlayer)entity, W_WorldFunc.getWorldVec3(this.world, d0 * var41, d1 * var41, d2 * var41));
+                        }
+                     } else {
+                        // Damage can apply vanilla knockback, so restore the entity's pre-explosion motion.
+                        entity.motionX = originalMotionX;
+                        entity.motionY = originalMotionY;
+                        entity.motionZ = originalMotionZ;
                      }
 
                      if(damage > 0.0F && this.countSetFireEntity > 0) {
@@ -199,7 +213,7 @@ public class MCH_Explosion extends Explosion {
                }
             }
 
-            super.explosionSize = var33;
+            super.explosionSize = originalExplosionSize;
             return;
          }
 


### PR DESCRIPTION
### Motivation

- Rapid-fire small explosions (for example the M230 which uses `Explosion = 1`) were applying repeated knockback because `doExplosionA()` applied motion after a temporary doubling of `super.explosionSize`, allowing many small hits to launch mobs.
- The goal is to stop explosions smaller than `3.0F` from adding any knockback while preserving damage, effects, and existing entity motion.

### Description

- Added a named constant `MIN_KNOCKBACK_EXPLOSION_SIZE = 3.0F` and compute `shouldApplyKnockback` from the `originalExplosionSize` captured before the temporary radius doubling so the threshold uses the configured entity explosion size rather than the doubled runtime value or `explosionSizeBlock`.
- Save each affected entity’s `motionX`, `motionY`, and `motionZ` immediately before calling `attackEntityFrom` and restore those saved values when the explosion’s original size is below `3.0F`, leaving pre-existing movement intact and not zeroing motion.
- When `originalExplosionSize >= 3.0F` preserve the existing enchantment-adjusted knockback, horizontal/vertical multipliers, `MCH_EntityBaseBullet` exclusion, and player `field_77288_k` behavior; for smaller explosions skip both the MCHeli motion additions and the player knockback map entry.
- Updated documentation entry in `CHANGELOG.md` and kept the change centralized in `MCH_Explosion.doExplosionA()` so both normal and underwater creation paths share the same behavior.

### Testing

- Ran static assertions with a small Python script that checked the new constant and the code ordering (motion saved before damage and restored afterward) and verified the M230 reference (`Explosion = 1`), and the assertions passed.
- Compiled Java with the repository’s Gradle/Forge setup using `./gradlew compileJava`, which completed successfully (`BUILD SUCCESSFUL`).
- Ran `git diff --check` (no issues) and a repository status check to ensure only the intended files were modified; those automated checks passed.

Changed files:
- `src/main/java/mcheli/MCH_Explosion.java`
- `CHANGELOG.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71144bd6cc832380283bdae128bfbc)