### PR TITLE
Toggleable Active Radar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Toggleable Active Radar (PR pending)
+
+- Added pilot-controlled, persistent active radar, capability-aware scanning, synchronized emitter
+  state, and RWR filtering so disabled or unequipped vehicles do not emit signatures.
+- Added `KeyRadar` and documented `HasRadar`, including compatibility with explicit `RadarType` and
+  enabled `EnableEntityRadar` vehicle configurations.
+
 # Prevent Small-Explosion Knockback (PR pending)
 
 - Prevented entity explosions below size `3.0F` from adding MCHeli or vanilla damage knockback while preserving each affected entity's existing motion.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,11 @@
 # Configuration Reference
 
+## Active radar control
+
+`KeyRadar` toggles pilot-controlled active radar and defaults to **P**, because **R** is already the
+vehicle GUI control. Passengers cannot toggle radar. Vehicles without configured equipment reject
+the control. Disabling radar removes the vehicle's RWR emission but leaves passive RWR enabled.
+
 MC Helicopter Overdrive+ writes `config/mcheli.cfg` during startup. The file is generated from source-defined defaults, then rewritten after loading so missing options are restored.
 
 ## Editing workflow

--- a/docs/vehicle-config-reference.md
+++ b/docs/vehicle-config-reference.md
@@ -121,7 +121,8 @@ The table below maps every vehicle text key found in vehicle parser classes to v
 | `inventorysize` | All | int | 0 | inventory slots |
 | `regeneration` | All | boolean | false | self-repair/regen flag |
 | `Stealth` | All | float | 0.0 | radar/targeting visibility modifier |
-| `RadarType` | All | enum `EARLY_AA`, `MODERN_AA`, etc. | `EARLY_AA`; invalid -> `MODERN_AA` | radar classification |
+| `HasRadar` | All | boolean | inferred | explicit active-radar capability override |
+| `RadarType` | All | enum `EARLY_AA`, `MODERN_AA`, etc. | `EARLY_AA`; invalid -> `MODERN_AA` | radar classification; explicit presence implies equipment |
 | `RWRType` | All | enum | `NONE`; invalid -> `NONE` | radar-warning receiver; set `DIGITAL` to enable the current RWR display |
 | `NameOnModernAARadar` | All | string | `?` | radar label |
 | `NameOnEarlyAARadar` | All | string | `?` | radar label |

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -95,10 +95,18 @@ For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is
 
 ## Sensors, countermeasures, UAV flags
 
+Active radar is enabled by default only for equipped vehicles. `HasRadar false` disables it even
+when older radar keys exist; otherwise an explicit `RadarType` or `EnableEntityRadar true` preserves
+existing pack behavior. With no active-radar declaration, a vehicle never emits an RWR signature.
+`RWRType` is a passive receiver and does not imply radar equipment. Passive RWR continues operating
+while active radar is off; switching radar off clears contacts and removes the vehicle's emission.
+
 | Key | Type | Default | Notes |
 |---|---|---:|---|
-| `RadarType` | enum | `EARLY_AA` | Invalid values fall back to `MODERN_AA`. |
+| `HasRadar` | boolean | inferred | Explicit capability override; takes precedence over all inferred values. |
+| `RadarType` | enum | `EARLY_AA` | Explicit presence implies radar equipment; invalid values fall back to `MODERN_AA`. The default alone does not imply equipment. |
 | `RWRType` | enum | `NONE` | Invalid values fall back to `NONE`; set `DIGITAL` to enable the current RWR display. |
+
 | `LWR` | boolean | false | Controls the tank laser warning alert sound. Tanks play the warning only when this is `true`; it is separate from `RWRType`, flares, chaff, APS, and smoke launchers. |
 | `NameOnModernAARadar`, `NameOnEarlyAARadar`, `NameOnModernASRadar`, `NameOnEarlyASRadar` | string | `?` | Radar labels. |
 | `Stealth` | float[0..1] | 0 | Visibility modifier. |

--- a/src/main/java/mcheli/MCH_Config.java
+++ b/src/main/java/mcheli/MCH_Config.java
@@ -57,6 +57,7 @@ public class MCH_Config {
    public static MCH_ConfigPrm KeyUseWeapon;
    public static MCH_ConfigPrm KeyCurrentWeaponLock;
    public static MCH_ConfigPrm KeyVehicleLock;
+   public static MCH_ConfigPrm KeyRadar;
    public static MCH_ConfigPrm KeySwitchWeapon1;
    public static MCH_ConfigPrm KeySwitchWeapon2;
    public static MCH_ConfigPrm KeySwWeaponMode;
@@ -370,6 +371,8 @@ public class MCH_Config {
       KeyUseWeapon = new MCH_ConfigPrm("KeyUseWeapon", -99);
       KeyCurrentWeaponLock = new MCH_ConfigPrm("KeyCurrentWeaponLock", -100);
       KeyVehicleLock = new MCH_ConfigPrm("KeyVehicleLock", 24);
+      // R is already the GUI key, so active radar defaults to P.
+      KeyRadar = new MCH_ConfigPrm("KeyRadar", 25);
       KeySwitchWeapon1 = new MCH_ConfigPrm("KeySwitchWeapon1", -98);
       KeySwitchWeapon2 = new MCH_ConfigPrm("KeySwitchWeapon2", 34);
       KeySwWeaponMode = new MCH_ConfigPrm("KeySwitchWeaponMode", 45);
@@ -428,6 +431,7 @@ public class MCH_Config {
               KeyUseWeapon,
               KeyAttack,
               KeyCurrentWeaponLock,
+              KeyRadar,
               KeyVehicleLock};
       DamageVs = new ArrayList();
       CommandPermission = new ArrayList();

--- a/src/main/java/mcheli/MCH_EntityInfo.java
+++ b/src/main/java/mcheli/MCH_EntityInfo.java
@@ -16,8 +16,10 @@ public class MCH_EntityInfo {
     public double lastTickPosY;
     public double lastTickPosZ;
     public long lastUpdateTime;
+    public boolean hasRadar;
+    public boolean radarActive;
 
-    public MCH_EntityInfo(int entityId, String worldName, String entityName, String entityClassName, double posX, double posY, double posZ, double lastTickPosX, double lastTickPosY, double lastTickPosZ) {
+    public MCH_EntityInfo(int entityId, String worldName, String entityName, String entityClassName, double posX, double posY, double posZ, double lastTickPosX, double lastTickPosY, double lastTickPosZ, boolean hasRadar, boolean radarActive) {
         this.entityId = entityId;
         this.worldName = worldName;
         this.entityName = entityName;
@@ -28,6 +30,8 @@ public class MCH_EntityInfo {
         this.lastTickPosX = lastTickPosX;
         this.lastTickPosY = lastTickPosY;
         this.lastTickPosZ = lastTickPosZ;
+        this.hasRadar = hasRadar;
+        this.radarActive = hasRadar && radarActive;
         this.lastUpdateTime = System.currentTimeMillis();
     }
 
@@ -39,12 +43,14 @@ public class MCH_EntityInfo {
                 name = ac.getAcInfo().name;
             }
         }
+        boolean hasRadar = e instanceof MCH_EntityBaseVehicle && ((MCH_EntityBaseVehicle)e).hasRadar();
         return new MCH_EntityInfo(e.getEntityId(),
                 e.worldObj.getWorldInfo().getWorldName(),
                 name,
                 e.getClass().getName(),
                 e.posX, e.posY, e.posZ,
-                e.lastTickPosX, e.lastTickPosY, e.lastTickPosZ
+                e.lastTickPosX, e.lastTickPosY, e.lastTickPosZ,
+                hasRadar, hasRadar && ((MCH_EntityBaseVehicle)e).isRadarActive()
         );
     }
 

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -62,6 +62,7 @@ public class MCH_RenderRWR {
             double circleRadius = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
             for(MCH_EntityInfo entity : getServerLoadedEntity()) {
                 if(!isValidEntity(entity, player, ac)) continue;
+                if(!isActiveRadarEmitter(entity) && !isMissileThreat(entity)) continue;
 
                 // Calculates interpolated position
                 double xPos = interpolate(entity.posX, entity.lastTickPosX, event.partialTicks);
@@ -155,28 +156,38 @@ public class MCH_RenderRWR {
     private MCH_RWRResult getTargetTypeOnRadar(MCH_EntityInfo entity, MCH_EntityBaseVehicle ac) {
         switch (ac.getAcInfo().rwrType) {
             case DIGITAL: {
-                if(isRadarEmitter(entity)) {
+                if(isActiveRadarEmitter(entity)) {
                     return new MCH_RWRResult(ac.getNameOnMyRadar(entity), 0x00FF00);
                 } else {
                     return new MCH_RWRResult("MSL", 0xFF0000);
                 }
             }
             case ALL_WAY_EARLY: {
-                return new MCH_RWRResult(isRadarEmitter(entity) ? "RDR" : "MSL", isRadarEmitter(entity) ? 0x00FF00 : 0xFF0000);
+                return new MCH_RWRResult(isActiveRadarEmitter(entity) ? "RDR" : "MSL", isActiveRadarEmitter(entity) ? 0x00FF00 : 0xFF0000);
             }
             case FOUR_WAY: {
-                return new MCH_RWRResult(isRadarEmitter(entity) ? "R" : "M", isRadarEmitter(entity) ? 0x00FF00 : 0xFF0000);
+                return new MCH_RWRResult(isActiveRadarEmitter(entity) ? "R" : "M", isActiveRadarEmitter(entity) ? 0x00FF00 : 0xFF0000);
             }
         }
         return new MCH_RWRResult("?", 0x00FF00);
     }
 
-    private boolean isRadarEmitter(MCH_EntityInfo entity) {
-        return entity.entityClassName.contains("MCH_EntityHeli")
-                || entity.entityClassName.contains("MCP_EntityPlane")
-                || entity.entityClassName.contains("MCH_EntityShip")
-                || entity.entityClassName.contains("MCH_EntityTank")
-                || entity.entityClassName.contains("MCH_EntityTurret");
+    private boolean isVehicleEntity(MCH_EntityInfo entity) {
+        String type = entity.entityClassName;
+        return type.equals("mcheli.helicopter.MCH_EntityHeli")
+                || type.equals("mcheli.plane.MCP_EntityPlane")
+                || type.equals("mcheli.ship.MCH_EntityShip")
+                || type.equals("mcheli.tank.MCH_EntityTank")
+                || type.equals("mcheli.vehicle.MCH_EntityTurret");
+    }
+
+    private boolean isActiveRadarEmitter(MCH_EntityInfo entity) {
+        return isVehicleEntity(entity) && entity.hasRadar && entity.radarActive;
+    }
+
+    private boolean isMissileThreat(MCH_EntityInfo entity) {
+        String type = entity.entityClassName;
+        return type.startsWith("mcheli.weapon.MCH_Entity") && type.endsWith("Missile");
     }
 
     private void drawRWRCircle(double x, double y, ScaledResolution sc) {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleClientTickHandler.java
@@ -60,6 +60,7 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
    public MCH_Key KeyBrake;
    public MCH_Key KeyCurrentWeaponLock;
    public MCH_Key KeyVehicleLock;
+   public MCH_Key KeyRadar;
 
    /**
     * Chaff key
@@ -101,6 +102,7 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       this.KeyBrake = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyCurrentWeaponLock = new MCH_Key(MCH_Config.KeyCurrentWeaponLock.prmInt);
       this.KeyVehicleLock = new MCH_Key(MCH_Config.KeyVehicleLock.prmInt);
+      this.KeyRadar = new MCH_Key(MCH_Config.KeyRadar.prmInt);
       //todo here
       this.KeyChaff = new MCH_Key(MCH_Config.KeyChaff.prmInt);
       this.KeyMaintenance = new MCH_Key(MCH_Config.KeyMaintenance.prmInt);
@@ -165,6 +167,15 @@ public abstract class MCH_BaseVehicleClientTickHandler extends MCH_ClientTickHan
       if (this.KeyUnmount.isKeyDown() && !ac.isDestroyed() && ac.getSizeInventory() > 0 && !isPilot)
          MCH_PacketIndOpenScreen.send(3);
       if (isPilot) {
+         if(this.KeyRadar.isKeyDown()) {
+            if(ac.hasRadar()) {
+               pc.toggleRadar = true;
+               playSoundOK();
+               send = true;
+            } else {
+               playSoundNG();
+            }
+         }
          if(this.KeyVehicleLock.isKeyDown()) {
             pc.toggleVehicleAccessLock = true;
             send = true;

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -57,6 +57,14 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public boolean isEnableConcurrentGunnerMode;
    public boolean isEnableNightVision;
    public boolean isEnableEntityRadar;
+   private Boolean explicitHasRadar;
+   private boolean radarTypeExplicit;
+
+   /** True only when active radar equipment was explicitly configured. */
+   public boolean hasRadar() {
+      return this.explicitHasRadar != null ? this.explicitHasRadar.booleanValue()
+              : this.radarTypeExplicit || this.isEnableEntityRadar;
+   }
    public boolean isEnableEjectionSeat;
    public boolean isEnableParachuting;
    public MCH_BaseVehicleInfo.Flare flare;
@@ -665,11 +673,15 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
          }
 
          else if(item.equalsIgnoreCase("RadarType")) {
+            this.radarTypeExplicit = true;
             try {
                this.radarType = EnumRadarType.valueOf(data);
             } catch (Exception e) {
                this.radarType = EnumRadarType.MODERN_AA;
             }
+         }
+         else if(item.equalsIgnoreCase("HasRadar")) {
+            this.explicitHasRadar = Boolean.valueOf(this.toBool(data));
          }
          else if(item.equalsIgnoreCase("RWRType")) {
             try {

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehiclePacketHandler.java
@@ -127,6 +127,13 @@ public class MCH_BaseVehiclePacketHandler {
       }
    }
 
+   public static void handleRadarToggle(EntityPlayer player, MCH_EntityBaseVehicle vehicle,
+                                        MCH_PacketPlayerControlBase control) {
+      if(control.toggleRadar && vehicle != null && vehicle.hasRadar() && vehicle.isPilot(player)) {
+         vehicle.toggleRadar(player);
+      }
+   }
+
    public static void onPacketIndRotation(EntityPlayer player, ByteArrayDataInput data) {
       if(player != null && !player.worldObj.isRemote) {
          MCH_PacketIndRotation req = new MCH_PacketIndRotation();

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -106,8 +106,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private static final int CMN_ID_CNTRL_UP = 9;
    private static final int CMN_ID_CNTRL_DOWN = 10;
    private static final int CMN_ID_CNTRL_BRAKE = 11;
-   /** Bit 12 is the first unused bit in the shared status watcher. */
+   /** Vehicle access lock occupies bit 12 in the shared status watcher. */
    private static final int CMN_ID_VEHICLE_ACCESS_LOCK = 12;
+   private static final int CMN_ID_ACTIVE_RADAR = 13;
    private static final int DATAWT_ID_USE_WEAPON = 24;
    private static final int DATAWT_ID_FUEL = 25;
    private static final int DATAWT_ID_ROT_ROLL = 26;
@@ -1143,7 +1144,25 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public boolean isEntityRadarMounted() {
-      return this.getAcInfo() != null?this.getAcInfo().isEnableEntityRadar:false;
+      return this.hasRadar();
+   }
+
+   public boolean hasRadar() { return this.getAcInfo() != null && this.getAcInfo().hasRadar(); }
+
+   public boolean isRadarActive() { return this.hasRadar() && this.getCommonStatus(CMN_ID_ACTIVE_RADAR); }
+
+   public void setRadarActive(boolean active) {
+      boolean enabled = active && this.hasRadar();
+      this.setCommonStatus(CMN_ID_ACTIVE_RADAR, enabled);
+      if(!enabled) this.initRadar();
+   }
+
+   public boolean toggleRadar(EntityPlayer player) {
+      if(this.worldObj.isRemote || !this.hasRadar() || !this.isPilot(player)) return false;
+      this.setRadarActive(!this.isRadarActive());
+      player.addChatMessage(new ChatComponentTranslation(this.isRadarActive() ? "mcheli.radar.on" : "mcheli.radar.off"));
+      W_WorldFunc.DEF_playSoundEffect(this.worldObj, this.posX, this.posY, this.posZ, "random.click", 1.0F, 1.0F);
+      return true;
    }
 
    public boolean canFloatWater() {
@@ -1220,6 +1239,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void onAcInfoReloaded() {
       if(this.getAcInfo() != null) {
+         if(!this.hasRadar()) this.setRadarActive(false);
          this.setSize(this.getAcInfo().bodyWidth, this.getAcInfo().bodyHeight);
          this.aps.configure(this.getAcInfo().apsUseTime, this.getAcInfo().apsWaitTime,
                  this.getAcInfo().apsRange, this.getAcInfo().apsAmmo);
@@ -1291,6 +1311,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.setPartStatus(nbt.getInteger("PartStatus"));
       this.setTypeName(nbt.getString("TypeName"));
       super.readEntityFromNBT(nbt);
+      this.setRadarActive(nbt.hasKey("MCH_RadarActive") ? nbt.getBoolean("MCH_RadarActive") : this.hasRadar());
       this.getGuiInventory().readEntityFromNBT(nbt);
       this.setCommandForce(nbt.getString("AcCommand"));
       this.setFuel(nbt.getInteger("AcFuel"));
@@ -1360,6 +1381,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       nbt.setInteger("AcDespawnCount", this.getDespawnCount());
       nbt.setFloat("AcRoll", this.getRotRoll());
       nbt.setBoolean("SearchLight", this.isSearchLightON());
+      nbt.setBoolean("MCH_RadarActive", this.isRadarActive());
       nbt.setFloat("AcLastRYaw", this.getLastRiderYaw());
       nbt.setFloat("AcLastRPitch", this.getLastRiderPitch());
       nbt.setString("AcCommand", this.getCommand());
@@ -4409,7 +4431,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void updateRadar(int radarSpeed) {
-      if(this.isEntityRadarMounted()) {
+      if(this.isRadarActive()) {
          this.radarRotate += radarSpeed;
          if(this.radarRotate >= 360) {
             this.radarRotate = 0;
@@ -8369,7 +8391,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setAcInfo(MCH_BaseVehicleInfo info) {
+      boolean hadInfo = this.acInfo != null;
       this.acInfo = info;
+      if(!hadInfo) this.setRadarActive(info != null && info.hasRadar());
+      else if(info == null || !info.hasRadar()) this.setRadarActive(false);
       this.updateForceSpawnPolicy();
       if(info != null) {
          this.partHatch = this.createHatch();
@@ -8390,7 +8415,10 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public boolean applyTargetedInfo(MCH_BaseVehicleInfo info) {
       if(info == null || this.acInfo == null) return false;
       if(info.getNumSeatAndRack() != this.acInfo.getNumSeatAndRack()) return false;
+      boolean hadRadar = this.hasRadar();
       this.acInfo = info;
+      if(!info.hasRadar()) this.setRadarActive(false);
+      else if(!hadRadar) this.setRadarActive(true);
       this.updateForceSpawnPolicy();
       this.cameraId = Math.max(0, Math.min(this.cameraId, Math.max(0, info.cameraPosition.size() - 1)));
       this.extraBoundingBox = this.createExtraBoundingBox();

--- a/src/main/java/mcheli/aircraft/MCH_PacketPlayerControlBase.java
+++ b/src/main/java/mcheli/aircraft/MCH_PacketPlayerControlBase.java
@@ -34,6 +34,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
    public boolean useMaintenance = false;
    public boolean useAPS = false;
    public boolean toggleVehicleAccessLock = false;
+   public boolean toggleRadar = false;
 
    public void readData(ByteArrayDataInput data) {
       try {
@@ -51,6 +52,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
          this.useMaintenance = this.getBit(e, 10);
          this.useAPS = this.getBit(e, 11);
          this.toggleVehicleAccessLock = this.getBit(e, 12);
+         this.toggleRadar = this.getBit(e, 13);
          e = (short)data.readByte();
          this.putDownRack = (byte)(e >> 6 & 3);
          this.isUnmount = (byte)(e >> 4 & 3);
@@ -92,6 +94,7 @@ public abstract class MCH_PacketPlayerControlBase extends MCH_Packet {
          e1 = this.setBit(e1, 10, this.useMaintenance);
          e1 = this.setBit(e1, 11, this.useAPS);
          e1 = this.setBit(e1, 12, this.toggleVehicleAccessLock);
+         e1 = this.setBit(e1, 13, this.toggleRadar);
          dos.writeShort(e1);
          e1 = (short)((byte)((this.putDownRack & 3) << 6 | (this.isUnmount & 3) << 4 | this.useFlareType & 15));
          dos.writeByte(e1);

--- a/src/main/java/mcheli/gui/MCH_ConfigGui.java
+++ b/src/main/java/mcheli/gui/MCH_ConfigGui.java
@@ -246,7 +246,7 @@ public class MCH_ConfigGui extends W_GuiContainer {
       this.listKeyBindingButtons.add(new W_GuiButton(54, x1 + 90, y + 220, 60, 20, "Reset All"));
       boolean var13 = true;
       boolean var14 = true;
-      MCH_GuiListItemKeyBind[] var10000 = new MCH_GuiListItemKeyBind[31];
+      MCH_GuiListItemKeyBind[] var10000 = new MCH_GuiListItemKeyBind[32];
       MCH_GuiListItemKeyBind var10003 = new MCH_GuiListItemKeyBind(200, 300, x1, "Up", MCH_Config.KeyUp);
       MCH_Config var10009 = MCH_MOD.config;
       var10000[0] = var10003;
@@ -344,6 +344,8 @@ public class MCH_ConfigGui extends W_GuiContainer {
       var10003 = new MCH_GuiListItemKeyBind(230, 330, x1, "Bomb Reticle Mode", MCH_Config.KeyBombReticleMode);
       var10009 = MCH_MOD.config;
       var10000[30] = var10003;
+      var10003 = new MCH_GuiListItemKeyBind(231, 331, x1, "Toggle Active Radar", MCH_Config.KeyRadar);
+      var10000[31] = var10003;
       //var10003 = new MCH_GuiListItemKeyBind(227, 327, x1, "Use Weapon Vehicle", MCH_Config.KeyUseWeapon);
       //var10009 = MCH_MOD.config;
       //var10000[26] = var10003;

--- a/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_HeliPacketHandler.java
@@ -35,6 +35,7 @@ public class MCH_HeliPacketHandler {
 
          if(heli != null) {
             mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, heli, pc);
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleRadarToggle(player, heli, pc);
             if(pc.isUnmount == 1) {
                heli.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/network/packets/PacketEntityInfoSync.java
+++ b/src/main/java/mcheli/network/packets/PacketEntityInfoSync.java
@@ -42,6 +42,8 @@ public class PacketEntityInfoSync extends PacketBase {
             buf.writeDouble(info.lastTickPosX);
             buf.writeDouble(info.lastTickPosY);
             buf.writeDouble(info.lastTickPosZ);
+            buf.writeBoolean(info.hasRadar);
+            buf.writeBoolean(info.radarActive);
         }
     }
 
@@ -61,7 +63,9 @@ public class PacketEntityInfoSync extends PacketBase {
                 buf.readDouble(),
                 buf.readDouble(),
                 buf.readDouble(),
-                buf.readDouble()
+                buf.readDouble(),
+                buf.readBoolean(),
+                buf.readBoolean()
             ));
         }
     }

--- a/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
+++ b/src/main/java/mcheli/plane/MCP_PlanePacketHandler.java
@@ -31,6 +31,7 @@ public class MCP_PlanePacketHandler {
 
          if(plane != null) {
             mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, plane, pc);
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleRadarToggle(player, plane, pc);
             if(pc.isUnmount == 1) {
                plane.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/ship/MCH_ShipPacketHandler.java
+++ b/src/main/java/mcheli/ship/MCH_ShipPacketHandler.java
@@ -29,6 +29,7 @@ public class MCH_ShipPacketHandler {
 
             if(plane != null) {
                 mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, plane, pc);
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleRadarToggle(player, plane, pc);
                 if(pc.isUnmount == 1) {
                     plane.unmountEntity();
                 } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
+++ b/src/main/java/mcheli/tank/MCH_TankPacketHandler.java
@@ -39,6 +39,7 @@ public class MCH_TankPacketHandler {
 
          if(tank != null) {
             mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, tank, pc);
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleRadarToggle(player, tank, pc);
             if(pc.isUnmount == 1) {
                tank.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_TurretPacketHandler.java
@@ -17,6 +17,7 @@ public class MCH_TurretPacketHandler {
             pc.readData(data);
             MCH_EntityTurret vehicle = (MCH_EntityTurret)player.ridingEntity;
             mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleVehicleAccessLockToggle(player, vehicle, pc);
+            mcheli.aircraft.MCH_BaseVehiclePacketHandler.handleRadarToggle(player, vehicle, pc);
             if(pc.isUnmount == 1) {
                vehicle.unmountEntity();
             } else if(pc.isUnmount == 2) {

--- a/src/main/resources/assets/mcheli/lang/en_en.lang
+++ b/src/main/resources/assets/mcheli/lang/en_en.lang
@@ -1,2 +1,4 @@
 item.mcheli:su24.name=Su-24
 item.mcheli:mstab.name=152mm Msta-b
+mcheli.radar.on=Radar ON
+mcheli.radar.off=Radar OFF

--- a/src/main/resources/assets/mcheli/lang/en_us.lang
+++ b/src/main/resources/assets/mcheli/lang/en_us.lang
@@ -921,3 +921,5 @@ achievement.McHeliReliefSupplies.desc=Drop a container
 mcheli.nei.vehicle_ammunition=MCHeli Vehicle Ammunition
 mcheli.nei.vehicle=Vehicle
 mcheli.nei.weapon=Weapon
+mcheli.radar.on=Radar ON
+mcheli.radar.off=Radar OFF


### PR DESCRIPTION
### Motivation

- Implement pilot-toggleable active radar that is server-authoritative and synchronized to clients so vehicles disappear from RWR displays when their radar is off.  
- Prevent vehicles that lack explicit radar equipment from ever appearing as active radar emitters while preserving passive RWR behavior.  
- Preserve backward compatibility with existing packs that already declare `RadarType` or use `EnableEntityRadar` while providing an explicit `HasRadar` override.

### Description

- Add explicit radar capability tracking and parsing: `HasRadar` override, `radarTypeExplicit` flag, and `hasRadar()` accessor in `MCH_BaseVehicleInfo`, with `RadarType` presence treated as an explicit equipment indicator.  
- Add synchronized active-radar state to `MCH_EntityBaseVehicle` using common-status bit 13 with APIs `hasRadar()`, `isRadarActive()`, `setRadarActive(boolean)`, and `toggleRadar(EntityPlayer)`, NBT persistence (`MCH_RadarActive`), and gating of active `MCH_Radar` scans when radar is disabled.  
- Add client control and network support: `KeyRadar` in `MCH_Config` (default key P), client-side key handling in `MCH_BaseVehicleClientTickHandler`, control bit `toggleRadar` in `MCH_PacketPlayerControlBase` (bit 13), a server handler `handleRadarToggle` in `MCH_BaseVehiclePacketHandler`, and calls to the handler from each vehicle-family packet handler.  
- Extend entity tracking and rendering: `MCH_EntityInfo` now includes `hasRadar` and `radarActive`, `PacketEntityInfoSync` encodes/decodes those fields in the same order, and `MCH_RenderRWR` now treats emitters by synchronized capability/state (only show active radar-equipped supported vehicles) while preserving missile warnings and legacy RWR label/range behavior.  
- Add localized feedback (`mcheli.radar.on` / `mcheli.radar.off`) and a `Toggle Active Radar` entry in the key-binding GUI.  
- Documentation and changelog: document `HasRadar`, the `KeyRadar` control, compatibility rules, and add a CHANGELOG entry describing the feature and compatibility guarantees.

### Testing

- Ran `git diff --check` and basic repository validations, which passed with no whitespace/patch errors.  
- Executed static Python verification scripts that assert control-bit symmetry (read/write of toggle bit), `PacketEntityInfoSync` encode/decode ordering, entity-info radar-state normalization (preventing `hasRadar=false` with `radarActive=true`), and presence of `handleRadarToggle` calls in all five vehicle-family packet handlers; all checks succeeded.  
- No compile or runtime (singleplayer / multi-client server) integration tests were executed because binary compilation and interactive Minecraft testing were intentionally not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712b0d2930832396558539210821ed)