### PR TITLE
Add finite cargo-backed fuel and ammo service vehicles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Finite cargo-backed service vehicles (PR pending)
+
+- Added opt-in `GasPump`, `AmmoLoader`, and `ForceY` shared vehicle configuration while retaining infinite legacy range-only suppliers.
+- Added persistent, overflow-safe service fuel reserves, cargo fuel-can draining, deterministic target ordering, and transactional configured ammunition-package consumption.
+- Documented finite support inventory, range, fuel conversion, and same-level requirements.
+
 # Prevent Small-Explosion Knockback (PR pending)
 
 - Prevented entity explosions below size `3.0F` from adding MCHeli or vanilla damage knockback while preserving each affected entity's existing motion.

--- a/docs/vehicle-config/base.md
+++ b/docs/vehicle-config/base.md
@@ -88,10 +88,24 @@ For fixed-wing planes using `useNewMobilitySystem = true`, this gravity value is
 | `EngineShutdownThreshold` | int[0..100] | 20 | Engine shutdown below this health percentage. For non-floating tanks, planes, and helicopters submerged by `SubmergedDamageHeight`, waterboarding damage now stops at this threshold and throttle is forced to 0 while the engine is waterlogged. |
 | `MaxFuel` | int[0..100000000] | 0 | Capacity; zero effectively disables fuel limit. |
 | `FuelConsumption` | float[0..10000] | 1 | Consumption multiplier. |
-| `FuelSupplyRange` / `AmmoSupplyRange` | float[0..1000] | 0 | Support radius. |
+| `FuelSupplyRange` / `AmmoSupplyRange` | float[0..1000] | 0 | Fuel and ammunition support radii, respectively. |
+| `GasPump` | boolean | false | Makes fuel support finite and cargo-backed. Requires `InventorySize > 0`; accepts coal (100 units), charcoal (75), coal blocks (900), and remaining charge in `MCH_ItemFuel` cans. |
+| `AmmoLoader` | boolean | false | Makes ammunition support finite and consumes each weapon's configured `RoundItem` package from cargo. Requires `InventorySize > 0`. |
+| `ForceY` | boolean | false | Restricts finite gas-pump and ammo-loader service to vehicles on the same block Y level. |
 | `RepairOtherVehicles` | `range[,value]` | `0,10` | Support repair radius and repair value. |
 | `inventorysize` | int[0..54] | 0 | Inventory slots. |
 | `regeneration` | boolean | false | Enables regeneration flag used by vehicle logic. |
+
+`FuelSupplyRange` controls gas-pump range and `AmmoSupplyRange` controls ammo-loader range. A vehicle may enable both services. Legacy vehicles that set only either range remain infinite suppliers for compatibility. Example finite support vehicle:
+
+```text
+InventorySize = 27
+FuelSupplyRange = 4
+GasPump = true
+AmmoSupplyRange = 4
+AmmoLoader = true
+ForceY = true
+```
 
 ## Sensors, countermeasures, UAV flags
 

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java
@@ -99,6 +99,12 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
    public float fuelConsumption;
    public float fuelSupplyRange;
    public float ammoSupplyRange;
+   /** Opts this vehicle into finite, cargo-backed fuel service. */
+   public boolean gasPump;
+   /** Opts this vehicle into finite, cargo-backed ammunition service. */
+   public boolean ammoLoader;
+   /** Restricts finite service to targets on the same block Y level. */
+   public boolean forceY;
    public float repairOtherVehiclesRange;
    public int repairOtherVehiclesValue;
    public float stealth;
@@ -330,6 +336,9 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
       this.fuelConsumption = 1.0F;
       this.fuelSupplyRange = 0.0F;
       this.ammoSupplyRange = 0.0F;
+      this.gasPump = false;
+      this.ammoLoader = false;
+      this.forceY = false;
       this.repairOtherVehiclesRange = 0.0F;
       this.repairOtherVehiclesValue = 10;
       this.stealth = 0.0F;
@@ -654,6 +663,12 @@ public abstract class MCH_BaseVehicleInfo extends MCH_BaseInfo {
             this.fuelSupplyRange = this.toFloat(data, 0.0F, 1000.0F);
          } else if(item.equalsIgnoreCase("AmmoSupplyRange")) {
             this.ammoSupplyRange = this.toFloat(data, 0.0F, 1000.0F);
+         } else if(item.equalsIgnoreCase("GasPump")) {
+            this.gasPump = this.toBool(data, false);
+         } else if(item.equalsIgnoreCase("AmmoLoader")) {
+            this.ammoLoader = this.toBool(data, false);
+         } else if(item.equalsIgnoreCase("ForceY")) {
+            this.forceY = this.toBool(data, false);
          } else if(item.equalsIgnoreCase("RepairOtherVehicles")) {
             s = this.splitParam(data);
             if(s.length >= 1) {

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -44,6 +44,7 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.item.EntityMinecartEmpty;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemPickaxe;
 import net.minecraft.item.ItemStack;
@@ -152,6 +153,8 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    private double prevCurrentThrottle;
    public double currentSpeed;
    public int currentFuel;
+   /** Fuel held for finite gas-pump service, separate from propulsion fuel. */
+   private long serviceFuel;
    public float throttleBack = 0.0F;
    public double beforeHoverThrottle;
    public int waitMountEntity = 0;
@@ -1294,6 +1297,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.getGuiInventory().readEntityFromNBT(nbt);
       this.setCommandForce(nbt.getString("AcCommand"));
       this.setFuel(nbt.getInteger("AcFuel"));
+      this.serviceFuel = Math.max(0L, nbt.getLong("MCH_ServiceFuel"));
       setGunnerStatus(nbt.getBoolean("AcGunnerStatus"));
       int[] wa_list = nbt.getIntArray("AcWeaponsAmmo");
       if(this.getAcInfo() != null) {
@@ -1357,6 +1361,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       nbt.setString("TypeName", this.getTypeName());
       nbt.setInteger("PartStatus", this.getPartStatus() & this.getLastPartStatusMask());
       nbt.setInteger("AcFuel", this.getFuel());
+      nbt.setLong("MCH_ServiceFuel", this.serviceFuel);
       nbt.setInteger("AcDespawnCount", this.getDespawnCount());
       nbt.setFloat("AcRoll", this.getRotRoll());
       nbt.setBoolean("SearchLight", this.isSearchLightON());
@@ -1692,6 +1697,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
       NBTTagCompound nbt = is.getTagCompound();
       nbt.setString("MCH_Command", this.getCommand());
+      nbt.setLong("MCH_ServiceFuel", this.serviceFuel);
       MCH_Config var10000 = MCH_MOD.config;
       if(MCH_Config.ItemFuel.prmBool) {
          nbt.setInteger("MCH_Fuel", this.getFuel());
@@ -1711,6 +1717,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(is.hasTagCompound()) {
          NBTTagCompound nbt = is.getTagCompound();
          this.setCommandForce(nbt.getString("MCH_Command"));
+         this.serviceFuel = Math.max(0L, nbt.getLong("MCH_ServiceFuel"));
          MCH_Config var10000 = MCH_MOD.config;
          if(MCH_Config.ItemFuel.prmBool) {
             this.setFuel(nbt.getInteger("MCH_Fuel"));
@@ -3972,11 +3979,53 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       return this.getAcInfo() != null?this.getAcInfo().maxFuel:0;
    }
 
+   public long getServiceFuel() {
+      return this.serviceFuel;
+   }
+
+   /** Server-authoritative, saturating addition to the service reserve. */
+   public void addServiceFuel(long amount) {
+      if(!super.worldObj.isRemote && amount > 0L) {
+         this.serviceFuel = Long.MAX_VALUE - this.serviceFuel < amount ? Long.MAX_VALUE : this.serviceFuel + amount;
+      }
+   }
+
+   /** Server-authoritative deduction; returns the amount actually removed. */
+   public long removeServiceFuel(long amount) {
+      if(super.worldObj.isRemote || amount <= 0L) {
+         return 0L;
+      }
+      long removed = Math.min(amount, this.serviceFuel);
+      this.serviceFuel -= removed;
+      return removed;
+   }
+
    public void supplyFuel() {
       float range = this.getAcInfo() != null?this.getAcInfo().fuelSupplyRange:0.0F;
       if(range > 0.0F) {
          if(!super.worldObj.isRemote && this.getCountOnUpdate() % 10 == 0) {
             List list = super.worldObj.getEntitiesWithinAABB(MCH_EntityBaseVehicle.class, this.getBoundingBox().expand((double)range, (double)range, (double)range));
+
+            if(this.getAcInfo().gasPump) {
+               if(this.isDestroyed() || this.getSizeInventory() <= 0) {
+                  return;
+               }
+               this.convertSolidServiceFuel();
+               this.sortServiceTargets(list);
+               for(int i = 0; i < list.size(); ++i) {
+                  MCH_EntityBaseVehicle target = (MCH_EntityBaseVehicle)list.get(i);
+                  if(this.isFiniteServiceTarget(target) && (!super.onGround || target.canSupply())
+                          && target.getMaxFuel() > 0 && target.getFuel() < target.getMaxFuel()) {
+                     int wanted = Math.min(30, target.getMaxFuel() - target.getFuel());
+                     int moved = this.takeServiceFuel(wanted);
+                     if(moved > 0) {
+                        target.setFuel(target.getFuel() + moved);
+                        target.fuelSuppliedCount = 40;
+                     }
+                  }
+               }
+               return;
+            }
 
             for(int i = 0; i < list.size(); ++i) {
                MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)list.get(i);
@@ -3996,6 +4045,60 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          }
 
       }
+   }
+
+   private boolean isFiniteServiceTarget(MCH_EntityBaseVehicle target) {
+      return target != null && !W_Entity.isEqual(this, target) && !target.isDestroyed()
+              && (!this.getAcInfo().forceY || MathHelper.floor_double(super.posY) == MathHelper.floor_double(target.posY));
+   }
+
+   private void sortServiceTargets(List targets) {
+      Collections.sort(targets, new Comparator() {
+         public int compare(Object left, Object right) {
+            Entity a = (Entity)left;
+            Entity b = (Entity)right;
+            int distance = Double.compare(MCH_EntityBaseVehicle.this.getDistanceSqToEntity(a), MCH_EntityBaseVehicle.this.getDistanceSqToEntity(b));
+            return distance != 0 ? distance : Integer.compare(W_Entity.getEntityId(a), W_Entity.getEntityId(b));
+         }
+      });
+   }
+
+   private void convertSolidServiceFuel() {
+      for(int slot = 0; slot < this.getSizeInventory(); ++slot) {
+         ItemStack stack = this.getStackInSlot(slot);
+         long value = 0L;
+         if(stack != null && stack.stackSize > 0) {
+            if(stack.getItem() == Items.coal && stack.getItemDamage() == 0) value = 100L;
+            else if(stack.getItem() == Items.coal && stack.getItemDamage() == 1) value = 75L;
+            else if(stack.getItem() == Item.getItemFromBlock(Blocks.coal_block)) value = 900L;
+         }
+         if(value > 0L) {
+            int count = 0;
+            while(count < stack.stackSize && this.serviceFuel <= Long.MAX_VALUE - value) {
+               this.addServiceFuel(value);
+               ++count;
+            }
+            if(count > 0) this.decrStackSize(slot, count);
+            if(this.getStackInSlot(slot) != null && this.getStackInSlot(slot).stackSize <= 0) this.setInventorySlotContents(slot, (ItemStack)null);
+         }
+      }
+   }
+
+   private int takeServiceFuel(int wanted) {
+      int moved = (int)this.removeServiceFuel(wanted);
+      for(int slot = 0; moved < wanted && slot < this.getSizeInventory(); ++slot) {
+         ItemStack stack = this.getStackInSlot(slot);
+         if(stack != null && stack.getItem() instanceof MCH_ItemFuel) {
+            int remaining = Math.max(0, stack.getMaxDamage() - stack.getItemDamage());
+            int amount = Math.min(wanted - moved, remaining);
+            if(amount > 0) {
+               stack.setItemDamage(stack.getItemDamage() + amount);
+               this.setInventorySlotContents(slot, stack);
+               moved += amount;
+            }
+         }
+      }
+      return moved;
    }
 
    public void updateFuel() {
@@ -4232,9 +4335,29 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public void supplyAmmoToOtherAircraft() {
       float range = this.getAcInfo() != null?this.getAcInfo().ammoSupplyRange:0.0F;
       if(range > 0.0F) {
-         //todo umm what the figma no fuck you no more free nukes wtf
          if(!super.worldObj.isRemote && this.getCountOnUpdate() % 40 == 0) {
             List list = super.worldObj.getEntitiesWithinAABB(MCH_EntityBaseVehicle.class, this.getBoundingBox().expand((double)range, (double)range, (double)range));
+
+            if(this.getAcInfo().ammoLoader) {
+               if(this.isDestroyed() || this.getSizeInventory() <= 0) {
+                  return;
+               }
+               this.sortServiceTargets(list);
+               for(int i = 0; i < list.size(); ++i) {
+                  MCH_EntityBaseVehicle target = (MCH_EntityBaseVehicle)list.get(i);
+                  if(!this.isFiniteServiceTarget(target) || !target.canSupply()) continue;
+                  for(int wid = 0; wid < target.getWeaponNum(); ++wid) {
+                     if(this.supplyCargoAmmoPackage(target, wid)) {
+                        MCH_WeaponSet ws = target.getWeapon(wid);
+                        if(ws.getAmmoNum() <= 0) ws.reloadMag();
+                        MCH_PacketNotifyAmmoNum.sendAmmoNum(target, target.getEntityByWeaponId(wid) instanceof EntityPlayer
+                                ? (EntityPlayer)target.getEntityByWeaponId(wid) : null, wid);
+                        MCH_PacketNotifyAmmoNum.sendAllAmmoNum(target, (EntityPlayer)null);
+                     }
+                  }
+               }
+               return;
+            }
 
             for(int i = 0; i < list.size(); ++i) {
                MCH_EntityBaseVehicle ac = (MCH_EntityBaseVehicle)list.get(i);
@@ -4264,6 +4387,66 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
          }
 
       }
+   }
+
+   private boolean supplyCargoAmmoPackage(MCH_EntityBaseVehicle target, int weaponId) {
+      MCH_WeaponSet ws = target.getWeapon(weaponId);
+      if(ws == null || ws.getInfo() == null || ws.getInfo().roundItems == null || ws.getInfo().roundItems.isEmpty()) return false;
+      int space = ws.getAllAmmoNum() - ws.getRestAllAmmoNum() - ws.getAmmoNum();
+      if(space <= 0) return false;
+      int supplied = Math.max(1, ws.getInfo().suppliedNum);
+      int cycleLimit = Math.max(1, ws.getAllAmmoNum() / 10);
+      int packages = Math.max(1, cycleLimit / supplied);
+      packages = Math.min(packages, Math.max(1, (space + supplied - 1) / supplied));
+      int availablePackages = this.countCompleteAmmoPackages(ws);
+      packages = Math.min(packages, availablePackages);
+      if(packages <= 0) return false;
+
+      // Consume only after the complete transaction has been proved available.
+      Iterator requirements = ws.getInfo().roundItems.iterator();
+      while(requirements.hasNext()) {
+         MCH_WeaponInfo.RoundItem requirement = (MCH_WeaponInfo.RoundItem)requirements.next();
+         int remaining = Math.max(1, requirement.num) * packages;
+         for(int slot = 0; slot < this.getSizeInventory() && remaining > 0; ++slot) {
+            ItemStack stack = this.getStackInSlot(slot);
+            if(stack != null && requirement.itemStack != null && stack.isItemEqual(requirement.itemStack)) {
+               int amount = Math.min(remaining, stack.stackSize);
+               this.decrStackSize(slot, amount);
+               remaining -= amount;
+               ItemStack left = this.getStackInSlot(slot);
+               if(left != null && left.stackSize <= 0) this.setInventorySlotContents(slot, (ItemStack)null);
+            }
+         }
+      }
+      int add = Math.min(space, packages * supplied);
+      int before = ws.getRestAllAmmoNum() + ws.getAmmoNum();
+      ws.setRestAllAmmoNum(ws.getRestAllAmmoNum() + add);
+      return ws.getRestAllAmmoNum() + ws.getAmmoNum() > before;
+   }
+
+   private int countCompleteAmmoPackages(MCH_WeaponSet ws) {
+      int packages = Integer.MAX_VALUE;
+      for(int index = 0; index < ws.getInfo().roundItems.size(); ++index) {
+         MCH_WeaponInfo.RoundItem requirement = (MCH_WeaponInfo.RoundItem)ws.getInfo().roundItems.get(index);
+         if(requirement == null || requirement.itemStack == null) return 0;
+         boolean alreadyCounted = false;
+         int cost = 0;
+         for(int other = 0; other < ws.getInfo().roundItems.size(); ++other) {
+            MCH_WeaponInfo.RoundItem candidate = (MCH_WeaponInfo.RoundItem)ws.getInfo().roundItems.get(other);
+            if(candidate != null && candidate.itemStack != null && requirement.itemStack.isItemEqual(candidate.itemStack)) {
+               if(other < index) alreadyCounted = true;
+               cost += Math.max(1, candidate.num);
+            }
+         }
+         if(alreadyCounted) continue;
+         int found = 0;
+         for(int slot = 0; slot < this.getSizeInventory(); ++slot) {
+            ItemStack stack = this.getStackInSlot(slot);
+            if(stack != null && stack.isItemEqual(requirement.itemStack)) found += stack.stackSize;
+         }
+         packages = Math.min(packages, found / cost);
+      }
+      return packages == Integer.MAX_VALUE ? 0 : packages;
    }
 
    public boolean canPlayerSupplyAmmo(EntityPlayer player, int weaponId) {


### PR DESCRIPTION
### Motivation

- Provide opt-in finite, inventory-backed fuel and ammunition service for support vehicles while preserving legacy infinite range-only suppliers.
- Store a separate persistent service fuel reserve that survives chunk unloads, item pickup/placement, and restarts, and prevent overflow when converting solid fuels.
- Make transfers deterministic, server-authoritative, and limited per-cycle so shared suppliers can be used safely in multiplayer.

### Description

- Added three shared, case-insensitive config flags to `MCH_BaseVehicleInfo`: `GasPump`, `AmmoLoader`, and `ForceY`, all defaulting to `false`, and wired their parsing alongside existing `FuelSupplyRange` / `AmmoSupplyRange` and `InventorySize` expectations. (file: `MCH_BaseVehicleInfo.java`)
- Introduced a nonnegative `long` `serviceFuel` reserve on `MCH_EntityBaseVehicle` with server-only helpers `getServiceFuel()`, `addServiceFuel(...)`, and `removeServiceFuel(...)`, persisted under the stable NBT key `MCH_ServiceFuel` in both entity NBT and vehicle-item NBT so it survives chunk reloads and pickup/placement. (file: `MCH_EntityBaseVehicle.java`)
- Implemented finite gas-pump behavior: on the server every 10 ticks, vehicles with `GasPump = true` convert supported solid cargo (coal meta 0 = 100, charcoal meta 1 = 75, coal block = 900) into the service reserve without overflowing, then transfer up to 30 fuel units per eligible target (reserve first, then `MCH_ItemFuel` cans in cargo order), respect `forceY` by comparing floored Y, and select targets deterministically by distance then entity ID. (file: `MCH_EntityBaseVehicle.java`)
- Implemented finite ammo-loader behavior: on the server every 40 ticks, vehicles with `AmmoLoader = true` sort targets deterministically and transactionally supply configured `RoundItem` packages from cargo (verify full package availability before consuming any items), respect `RoundItem.num`, `suppliedNum`, per-weapon ordering, per-slot cargo ordering, existing packet sync, and the existing reload behavior while preserving legacy infinite loaders when the flag is not set. (file: `MCH_EntityBaseVehicle.java`, uses existing `MCH_WeaponInfo`/`MCH_WeaponSet` behavior)
- Updated documentation to describe the new keys, defaults, inventory requirement, range mappings, supported fuel conversions, `ForceY` behavior, and a short example; added a changelog entry describing the feature and compatibility guarantees. (files: `docs/vehicle-config/base.md`, `CHANGELOG.md`)

### Testing

- Ran `git diff --check` with no whitespace/format issues reported.
- Ran `./gradlew tasks --all` to validate Gradle configuration and task discovery, which completed successfully (build/compile tasks were not executed per repository instructions).
- Verified repository changes and staged files (`src/main/java/mcheli/aircraft/MCH_BaseVehicleInfo.java`, `src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java`, `docs/vehicle-config/base.md`, `CHANGELOG.md`) were added to the working tree and committed locally.
- Integration/runtime scenarios (in-game fuel/item transfers, chunk reload, pickup/placement, multi-target supply, and `ForceY` positional checks) require a Forge 1.7.10 runtime and were not executed in this non-interactive environment; Java compilation/run was intentionally not performed to avoid generating binary artifacts per instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712c33419c8323ba4a45e269a45cfa)