### PR TITLE
Fix creative inventory radar initialization crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Added pilot-controlled, persistent active radar, capability-aware scanning, sync
   state, and RWR filtering so disabled or unequipped vehicles do not emit signatures.
 - Added `KeyRadar` and documented `HasRadar`, including compatibility with explicit `RadarType` and
   enabled `EnableEntityRadar` vehicle configurations.
+- Fixed the creative inventory crash caused by radar initialization on temporary vehicle tooltip entities.
 
 # Finite cargo-backed service vehicles (PR pending)
 

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -166,6 +166,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    public MCH_LowPassFilterFloat lowPassPartialTicks;
    private MCH_Radar entityRadar;
    private int radarRotate;
+   private Boolean pendingRadarActive;
    private MCH_Flare flareDv;
    private int currentFlareIndex;
    public MCH_WeaponSet[] weapons;
@@ -311,8 +312,11 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public MCH_EntityBaseVehicle(World world) {
       super(world);
-      this.setAcInfo(null);
       this.commonStatus = 0;
+      this.entityRadar = new MCH_Radar(world);
+      this.radarRotate = 0;
+      this.pendingRadarActive = null;
+      this.setAcInfo(null);
       super.dropContentsWhenDead = false;
       super.ignoreFrustumCheck = true;
       // Normal vehicles must follow Forge's watched-chunk spawn lifecycle.
@@ -322,8 +326,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.maintenance = new MCH_Maintenance(world, this);
       this.aps = new MCH_APS(world, this);
       this.currentFlareIndex = 0;
-      this.entityRadar = new MCH_Radar(world);
-      this.radarRotate = 0;
       this.currentWeaponID = new int[0];
       //this.aircraftPosRotInc = 0;
       this.aircraftX = 0.0D;
@@ -1156,8 +1158,9 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void setRadarActive(boolean active) {
       boolean enabled = active && this.hasRadar();
+      boolean wasEnabled = this.getCommonStatus(CMN_ID_ACTIVE_RADAR);
       this.setCommonStatus(CMN_ID_ACTIVE_RADAR, enabled);
-      if(!enabled) this.initRadar();
+      if(wasEnabled && !enabled) this.initRadar();
    }
 
    public boolean toggleRadar(EntityPlayer player) {
@@ -1314,7 +1317,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       this.setPartStatus(nbt.getInteger("PartStatus"));
       this.setTypeName(nbt.getString("TypeName"));
       super.readEntityFromNBT(nbt);
-      this.setRadarActive(nbt.hasKey("MCH_RadarActive") ? nbt.getBoolean("MCH_RadarActive") : this.hasRadar());
+      boolean savedRadarActive = nbt.hasKey("MCH_RadarActive") ? nbt.getBoolean("MCH_RadarActive") : true;
+      if(this.getAcInfo() != null) {
+         this.setRadarActive(savedRadarActive);
+      } else {
+         this.pendingRadarActive = Boolean.valueOf(savedRadarActive);
+      }
       this.getGuiInventory().readEntityFromNBT(nbt);
       this.setCommandForce(nbt.getString("AcCommand"));
       this.setFuel(nbt.getInteger("AcFuel"));
@@ -4614,7 +4622,7 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void updateRadar(int radarSpeed) {
-      if(this.isRadarActive()) {
+      if(this.entityRadar != null && this.isRadarActive()) {
          this.radarRotate += radarSpeed;
          if(this.radarRotate >= 360) {
             this.radarRotate = 0;
@@ -4632,16 +4640,18 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void initRadar() {
-      this.entityRadar.clear();
+      if(this.entityRadar != null) {
+         this.entityRadar.clear();
+      }
       this.radarRotate = 0;
    }
 
    public ArrayList getRadarEntityList() {
-      return this.entityRadar.getEntityList();
+      return this.entityRadar != null ? this.entityRadar.getEntityList() : new ArrayList();
    }
 
    public ArrayList getRadarEnemyList() {
-      return this.entityRadar.getEnemyList();
+      return this.entityRadar != null ? this.entityRadar.getEnemyList() : new ArrayList();
    }
 
   // @Override
@@ -8574,10 +8584,22 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public void setAcInfo(MCH_BaseVehicleInfo info) {
-      boolean hadInfo = this.acInfo != null;
+      MCH_BaseVehicleInfo previousInfo = this.acInfo;
+      boolean hadRadar = previousInfo != null && previousInfo.hasRadar();
       this.acInfo = info;
-      if(!hadInfo) this.setRadarActive(info != null && info.hasRadar());
-      else if(info == null || !info.hasRadar()) this.setRadarActive(false);
+      if(previousInfo == null && info != null) {
+         boolean active = this.pendingRadarActive != null ? this.pendingRadarActive.booleanValue() : info.hasRadar();
+         this.pendingRadarActive = null;
+         this.setRadarActive(active);
+      } else if(previousInfo != null && (info == null || !info.hasRadar())) {
+         boolean wasActive = this.getCommonStatus(CMN_ID_ACTIVE_RADAR);
+         this.setRadarActive(false);
+         if(!wasActive && (info == null || hadRadar)) {
+            this.initRadar();
+         }
+      } else if(previousInfo != null && !hadRadar && info.hasRadar()) {
+         this.setRadarActive(true);
+      }
       this.updateForceSpawnPolicy();
       if(info != null) {
          this.partHatch = this.createHatch();
@@ -8599,8 +8621,12 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(info == null || this.acInfo == null) return false;
       if(info.getNumSeatAndRack() != this.acInfo.getNumSeatAndRack()) return false;
       boolean hadRadar = this.hasRadar();
+      boolean wasRadarActive = this.getCommonStatus(CMN_ID_ACTIVE_RADAR);
       this.acInfo = info;
-      if(!info.hasRadar()) this.setRadarActive(false);
+      if(!info.hasRadar()) {
+         this.setRadarActive(false);
+         if(hadRadar && !wasRadarActive) this.initRadar();
+      }
       else if(!hadRadar) this.setRadarActive(true);
       this.updateForceSpawnPolicy();
       this.cameraId = Math.max(0, Math.min(this.cameraId, Math.max(0, info.cameraPosition.size() - 1)));


### PR DESCRIPTION
### Motivation

- Prevent a `NullPointerException` during temporary vehicle construction used for creative-inventory tooltips by ensuring radar state handling is safe during partial construction.
- Fix incorrect initialization order where `setAcInfo(null)` could trigger `initRadar()` before `entityRadar` was created.
- Preserve existing radar semantics: capability-aware activation, saved radar state, and minimal-contact clearing when toggling off.

### Description

- Construct the single `MCH_Radar` instance earlier in `MCH_EntityBaseVehicle(World)` so it exists before `setAcInfo(null)` can inspect or change radar state. The code now contains a single `new MCH_Radar(world)` assignment. (`entityRadar` creation moved before `setAcInfo(null)`).
- Add `pendingRadarActive` to defer applying saved NBT radar state until a concrete `acInfo` is available, so NBT reads do not force lifecycle actions during partial construction. (`readEntityFromNBT` now stores or applies `MCH_RadarActive` defensively).
- Make `setAcInfo()`, `applyTargetedInfo()`, and `setRadarActive()` transition-aware so radar enable/disable respects capability changes and only clears contacts when the radar actually transitions from enabled to disabled; newly gained radar capability will initialize active radar appropriately. (`setAcInfo` and `applyTargetedInfo` updated to handle null↔non-null and capability changes).
- Harden radar APIs: `initRadar()`, `updateRadar()`, `getRadarEntityList()`, and `getRadarEnemyList()` now handle a null `entityRadar` safely (null-checks and empty-list fallbacks) to prevent NPEs during partial construction.
- Update `CHANGELOG.md` to note the creative-inventory tooltip crash fix.

### Testing

- Ran `git diff --check` to ensure no whitespace or trivial issues were introduced (passed). 
- Verified there is exactly one `new MCH_Radar(world)` assignment with `rg` to ensure no duplicate radar instances were introduced (verified). 
- Confirmed the working tree is clean and changes are staged/committed in this workspace (status verified). 
- Did not run `./gradlew compileJava` or in-game runtime tests here because the task environment and instructions prohibit building or running the Forge 1.7.10 client/server; full runtime verification (creative inventory tooltips, spawning/toggling radar, RWR visibility, NBT reload, `/mcheli reload`, and UAV behavior) should be performed in a Forge 1.7.10 environment as described in the PR checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712fba99e4832397bb72290c992384)