### PR TITLE
Show hold-to-dismount countdown for every mounted occupant

### DIFF
--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -218,28 +218,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
          this.drawString(msg, LX, super.centerY - 50, colorActive);
       }
 
-      if(seatID == 0 && ac.getSeatNum() >= 1) {
-         int color = colorActive;
-         if(info.isEnableParachuting && MCH_Lib.getBlockIdY(ac, 3, -10) == 0) {
-            var10000 = (new StringBuilder()).append("Parachuting : ");
-            var10001 = MCH_MOD.config;
-            msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
-         } else if(ac.canStartRepelling()) {
-            var10000 = (new StringBuilder()).append("Repelling : ");
-            var10001 = MCH_MOD.config;
-            msg = var10000.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
-            color = -256;
-         } else {
-            int remainingSeconds = 3;
-            if(MCH_ClientCommonTickHandler.instance != null) {
-               remainingSeconds = MCH_ClientCommonTickHandler.instance.getDismountHoldRemainingSeconds(player);
-            }
-            msg = "Dismount : Hold " + MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode())
-                  + " (" + remainingSeconds + "s)";
-         }
-
-         this.drawString(msg, LX, super.centerY - 30, color);
-      }
+      this.drawDismountKeyBind(ac, info, player, seatID, LX, super.centerY - 30, colorActive);
 
       if(seatID == 0 && ac.canSwitchFreeLook() || seatID > 0 && ac.canSwitchGunnerModeOtherSeat(player)) {
          var10000 = (new StringBuilder()).append("FreeLook : ");
@@ -248,5 +227,47 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
          this.drawString(msg, LX, super.centerY - 20, colorActive);
       }
 
+   }
+
+   protected void drawDismountKeyBind(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, EntityPlayer player,
+         int seatID, int x, int y, int colorActive) {
+      if(!this.isPhysicallyMountedInSeat(ac, player, seatID)) {
+         return;
+      }
+
+      int color = colorActive;
+      String msg;
+      if(seatID == 0 && info.isEnableParachuting && MCH_Lib.getBlockIdY(ac, 3, -10) == 0) {
+         msg = "Parachuting : " + MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt);
+      } else if(seatID == 0 && ac.canStartRepelling()) {
+         msg = "Repelling : " + MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt);
+         color = -256;
+      } else {
+         int remainingSeconds = 3;
+         if(MCH_ClientCommonTickHandler.instance != null) {
+            remainingSeconds = MCH_ClientCommonTickHandler.instance.getDismountHoldRemainingSeconds(player);
+         }
+         msg = "Dismount : Hold " + MCH_KeyName.getDescOrName(super.mc.gameSettings.keyBindSneak.getKeyCode())
+               + " (" + remainingSeconds + "s)";
+      }
+
+      this.drawString(msg, x, y, color);
+   }
+
+   private boolean isPhysicallyMountedInSeat(MCH_EntityBaseVehicle ac, EntityPlayer player, int seatID) {
+      if(ac == null || player == null || !ac.isValidSeatID(seatID) || ac.getSeatIdByEntity(player) != seatID) {
+         return false;
+      }
+
+      if(seatID == 0) {
+         return player.ridingEntity == ac;
+      }
+
+      if(player.ridingEntity instanceof MCH_EntitySeat) {
+         MCH_EntitySeat seat = (MCH_EntitySeat)player.ridingEntity;
+         return seat.getParent() == ac && seat.seatID + 1 == seatID;
+      }
+
+      return false;
    }
 }

--- a/src/main/java/mcheli/vehicle/MCH_GuiTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_GuiTurret.java
@@ -6,6 +6,7 @@ import mcheli.MCH_Config;
 import mcheli.MCH_KeyName;
 import mcheli.MCH_MOD;
 import mcheli.aircraft.MCH_BaseVehicleCommonGui;
+import mcheli.aircraft.MCH_EntitySeat;
 import mcheli.gui.MCH_Gui;
 import mcheli.vehicle.MCH_EntityTurret;
 import mcheli.vehicle.MCH_TurretInfo;
@@ -26,12 +27,12 @@ public class MCH_GuiTurret extends MCH_BaseVehicleCommonGui {
    }
 
    public boolean isDrawGui(EntityPlayer player) {
-      return player.ridingEntity != null && player.ridingEntity instanceof MCH_EntityTurret;
+      return this.getRiddenTurret(player) != null;
    }
 
    public void drawGui(EntityPlayer player, boolean isThirdPersonView) {
-      if(player.ridingEntity != null && player.ridingEntity instanceof MCH_EntityTurret) {
-         MCH_EntityTurret vehicle = (MCH_EntityTurret)player.ridingEntity;
+      MCH_EntityTurret vehicle = this.getRiddenTurret(player);
+      if(vehicle != null) {
          if(!vehicle.isDestroyed()) {
             int seatID = vehicle.getSeatIdByEntity(player);
             GL11.glLineWidth((float)MCH_Gui.scaleFactor);
@@ -59,6 +60,17 @@ public class MCH_GuiTurret extends MCH_BaseVehicleCommonGui {
             this.drawHitBullet(vehicle, -14066, seatID);
          }
       }
+   }
+
+   private MCH_EntityTurret getRiddenTurret(EntityPlayer player) {
+      if(player.ridingEntity instanceof MCH_EntityTurret) {
+         return (MCH_EntityTurret)player.ridingEntity;
+      }
+      if(player.ridingEntity instanceof MCH_EntitySeat
+            && ((MCH_EntitySeat)player.ridingEntity).getParent() instanceof MCH_EntityTurret) {
+         return (MCH_EntityTurret)((MCH_EntitySeat)player.ridingEntity).getParent();
+      }
+      return null;
    }
 
    public void drawKeyBind(MCH_EntityTurret vehicle, EntityPlayer player) {
@@ -121,14 +133,8 @@ public class MCH_GuiTurret extends MCH_BaseVehicleCommonGui {
                this.drawString(msg, LX, super.centerY - 50, colorActive);
             }
 
-            msg = "Dismount all : LShift";
-            this.drawString(msg, LX, super.centerY - 40, colorActive);
-            if(vehicle.getSeatNum() >= 2) {
-               var11 = (new StringBuilder()).append("Dismount : ");
-               var10001 = MCH_MOD.config;
-               msg = var11.append(MCH_KeyName.getDescOrName(MCH_Config.KeyUnmount.prmInt)).toString();
-               this.drawString(msg, LX, super.centerY - 30, colorActive);
-            }
+            this.drawDismountKeyBind(vehicle, info, player, vehicle.getSeatIdByEntity(player), LX,
+                  super.centerY - 30, colorActive);
 
          }
       }


### PR DESCRIPTION
### Motivation

- The previous UI only showed the normal hold-to-dismount prompt when `seatID == 0 && ac.getSeatNum() >= 1`, which hid the prompt from passengers and from pilots in single-seat vehicles.
- The goal is to display the existing three-second hold-to-dismount countdown to every physically mounted vehicle occupant while preserving pilot-only parachuting/repelling and avoiding prompts during remote/camera-only control.

### Description

- Centralized the dismount rendering in a new shared method `drawDismountKeyBind(...)` inside `MCH_BaseVehicleCommonGui` and removed the `seatID == 0 && ac.getSeatNum() >= 1` dependency for the normal dismount prompt.
- Added `isPhysicallyMountedInSeat(...)` to validate the seat context by checking `ac.isValidSeatID(seatID)` and confirming the player is either directly riding the vehicle (pilot) or riding an `MCH_EntitySeat` that belongs to the vehicle (passenger), preventing UAV/camera-only and invalid-seat prompts.
- Kept pilot-only replacements for parachuting and repelling (including repelling color) by restricting those labels to pilot seats (`seatID == 0`) while still using the shared dismount renderer for other occupants.
- Continued to use the configured sneak key name (via `gameSettings.keyBindSneak`) and the existing countdown logic from `MCH_ClientCommonTickHandler.getDismountHoldRemainingSeconds` so the three-second timer and its release/reset behavior remain unchanged and are not duplicated in GUIs.
- Updated the turret GUI (`MCH_GuiTurret`) to detect physically ridden turret seats and route its dismount display through the shared `drawDismountKeyBind(...)` instead of hardcoded text, so stationary turrets and their passenger seats also show the countdown.
- Files changed: `src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java`, `src/main/java/mcheli/vehicle/MCH_GuiTurret.java`.

### Testing

- `git diff --check` passed with no whitespace or quick-check errors.
- Source assertions (small Python checks) confirmed the original restrictive condition was removed and that the new helpers and calls (`drawDismountKeyBind`, `isPhysicallyMountedInSeat`, use of `getDismountHoldRemainingSeconds`, and configured sneak key) are present and consistent, and these assertions succeeded.
- Balanced-braces and basic source-integrity sanity checks on both modified Java files passed with no mismatched braces.
- Verified via repository inspection that the turret GUI no longer uses the old hardcoded `Dismount all : LShift` text and routes through the shared dismount renderer.
- Did not run `./gradlew build` or any binary-producing/compile tasks per instructions, so runtime integration (in-game rendering, per-seat visual checks, and visually verified countdown transitions) was not executed here; this was intentionally omitted and should be validated in an in-game test environment following the verification checklist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a713706870c8323b7d40b90a3b04592)