### PR TITLE
Fix synchronized active radar HUD state and add radar keybind HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -533,3 +533,10 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Keep normal movement, rotation, tall obstacles, ceilings, adjacent shapes, and failed raised
   routes subject to ordinary physical hull collision.
 - Add deterministic Abrams route-policy coverage using its configured `StepHeight` and front hull.
+# Synchronized active radar HUD and control hint (PR pending)
+
+- Read active radar power directly from the synchronized vehicle status watcher on clients, so all
+  active radar panels and contacts disappear immediately when the server turns radar off.
+- Add a shared, authority-aware `Radar ON`/`Radar OFF` vehicle HUD line that follows the configured
+  `KeyRadar` binding, including turret and remote-pilot control HUDs.
+- Preserve passive RWR and warning displays independently of active radar visibility.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,7 +4,10 @@
 
 `KeyRadar` toggles pilot-controlled active radar and defaults to **P**, because **R** is already the
 vehicle GUI control. Passengers cannot toggle radar. Vehicles without configured equipment reject
-the control. Disabling radar removes the vehicle's RWR emission but leaves passive RWR enabled.
+the control. The shared vehicle control HUD displays `Radar ON` or `Radar OFF` from the synchronized
+vehicle state alongside the currently configured `KeyRadar` key; the line remains available while
+radar is off so the pilot or valid remote controller can turn it back on. Disabling radar removes the
+vehicle's RWR emission but leaves passive RWR enabled.
 
 MC Helicopter Overdrive+ writes `config/mcheli.cfg` during startup. The file is generated from source-defined defaults, then rewritten after loading so missing options are restored.
 

--- a/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
+++ b/src/main/java/mcheli/aircraft/MCH_BaseVehicleCommonGui.java
@@ -111,6 +111,7 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
       if(seatID == 0) {
          this.drawString(ac.isVehicleAccessLocked() ? "Lock: LOCKED" : "Lock: UNLOCKED", LX, super.centerY + 50, colorActive);
       }
+      this.drawRadarKeyBind(ac, player, seatID, RX, super.centerY + 20, colorActive, colorInactive);
       if(seatID == 0 && ac.canPutToRack()) {
          var10000 = (new StringBuilder()).append("PutRack : ");
          var10001 = MCH_MOD.config;
@@ -227,6 +228,17 @@ public abstract class MCH_BaseVehicleCommonGui extends MCH_Gui {
          this.drawString(msg, LX, super.centerY - 20, colorActive);
       }
 
+   }
+
+   protected void drawRadarKeyBind(MCH_EntityBaseVehicle ac, EntityPlayer player, int seatID,
+         int x, int y, int colorActive, int colorInactive) {
+      if(ac == null || !ac.hasRadar() || seatID != 0 || !ac.isPilot(player)) {
+         return;
+      }
+      boolean active = ac.isRadarActive();
+      String msg = "Radar " + (active ? "ON" : "OFF") + " : "
+            + MCH_KeyName.getDescOrName(MCH_Config.KeyRadar.prmInt);
+      this.drawString(msg, x, y, active ? colorActive : colorInactive);
    }
 
    protected void drawDismountKeyBind(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, EntityPlayer player,

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -770,7 +770,19 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
    }
 
    public boolean getCommonStatus(int bit) {
-      return (this.commonStatus >> bit & 1) != 0;
+      return (this.getSynchronizedCommonStatus() >> bit & 1) != 0;
+   }
+
+   /**
+    * The server owns commonStatus. On clients the data watcher is the synchronized
+    * value, while commonStatus is only a once-per-tick cache and can be stale while
+    * a HUD is being rendered between entity updates.
+    */
+   private int getSynchronizedCommonStatus() {
+      if(super.worldObj != null && super.worldObj.isRemote && this.getDataWatcher() != null) {
+         return this.getDataWatcher().getWatchableObjectInt(DATAWT_ID_STATUS);
+      }
+      return this.commonStatus;
    }
 
    public UUID getVehicleOwnerUUID() {
@@ -828,16 +840,21 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
 
    public void setCommonStatus(int bit, boolean b, boolean writeClient) {
       if(!super.worldObj.isRemote || writeClient) {
-         int bofore = this.commonStatus;
+         // Client-predicted bits (for example free look) must start from the latest
+         // watched value. Starting from the tick cache can write an old radar bit
+         // back into ID 23 after the server's radar update has arrived.
+         int bofore = this.getSynchronizedCommonStatus();
+         int updatedStatus = bofore;
          int mask = 1 << bit;
          if(b) {
-            this.commonStatus |= mask;
+            updatedStatus |= mask;
          } else {
-            this.commonStatus &= ~mask;
+            updatedStatus &= ~mask;
          }
 
-         if(bofore != this.commonStatus) {
-            this.getDataWatcher().updateObject(23, Integer.valueOf(this.commonStatus));
+         this.commonStatus = updatedStatus;
+         if(bofore != updatedStatus) {
+            this.getDataWatcher().updateObject(DATAWT_ID_STATUS, Integer.valueOf(updatedStatus));
          }
       }
 

--- a/src/main/java/mcheli/hud/MCH_HudItem.java
+++ b/src/main/java/mcheli/hud/MCH_HudItem.java
@@ -246,8 +246,8 @@ public abstract class MCH_HudItem extends Gui {
       updateVarMapItem("roll", (double)MathHelper.wrapAngleTo180_float(ac.getRotRoll()));
       updateVarMapItem("altitude", (double)Altitude);
       updateVarMapItem("sea_alt", getSeaAltitude(ac));
-      updateVarMapItem("have_radar", ac.isEntityRadarMounted()?1.0D:0.0D);
-      updateVarMapItem("radar_active", ac != null && ac.getAcInfo() != null && ac.isRadarActive()?1.0D:0.0D);
+      updateVarMapItem("have_radar", ac != null && ac.hasRadar()?1.0D:0.0D);
+      updateVarMapItem("radar_active", ac != null && ac.isRadarActive()?1.0D:0.0D);
       updateVarMapItem("radar_rot", (double)getRadarRot(ac));
       updateVarMapItem("hp", (double)ac.getHP());
       updateVarMapItem("max_hp", (double)ac.getMaxHP());

--- a/src/main/java/mcheli/hud/MCH_HudItemRadar.java
+++ b/src/main/java/mcheli/hud/MCH_HudItemRadar.java
@@ -28,7 +28,7 @@ public class MCH_HudItemRadar extends MCH_HudItem {
    }
 
    public void execute() {
-      if(MCH_HudItem.ac == null || !MCH_HudItem.ac.isRadarActive()) {
+      if(MCH_HudItem.ac == null || !MCH_HudItem.ac.hasRadar() || !MCH_HudItem.ac.isRadarActive()) {
          return;
       }
       if(MCH_HudShared.isNewHeliPilotHudActive(MCH_HudItem.ac, MCH_HudItem.player) && this.left.equals("144") && this.top.equals("21")) {

--- a/src/main/java/mcheli/vehicle/MCH_GuiTurret.java
+++ b/src/main/java/mcheli/vehicle/MCH_GuiTurret.java
@@ -82,6 +82,8 @@ public class MCH_GuiTurret extends MCH_BaseVehicleCommonGui {
             int colorInactive = -1349546097;
             int RX = super.centerX + 120;
             int LX = super.centerX - 200;
+            int seatID = vehicle.getSeatIdByEntity(player);
+            this.drawRadarKeyBind(vehicle, player, seatID, RX, super.centerY + 20, colorActive, colorInactive);
             String msg;
             StringBuilder var11;
             MCH_Config var10001;


### PR DESCRIPTION
### Motivation

- The active radar HUD stayed visible after toggling radar off because the client used a tick-cached `commonStatus` instead of the synchronized data watcher value. 
- Client-side writes could reapply stale bits back into the watcher, re-enabling radar visuals after the server had turned them off. 
- The HUD lacked a shared, authority-aware hint that shows the configured `KeyRadar` and the current synchronized radar state.

### Description

- Make client HUD source authoritative to the synchronized watcher by changing `getCommonStatus(int)` to read a new `getSynchronizedCommonStatus()` that returns the data-watcher value (`DATAWT_ID_STATUS`) on clients and the `commonStatus` server-side. 
- Prevent stale client-predicted writes from overwriting the synchronized bits by basing `setCommonStatus(...)` on `getSynchronizedCommonStatus()` and only updating the watcher when the derived status changes. 
- Ensure HUD variables remain correct and null-safe by setting `have_radar` from `hasRadar()` and `radar_active` from `isRadarActive()` in `MCH_HudItem.updateVarMap()`. 
- Add defensive capability+active checks to `MCH_HudItemRadar.execute()` so radar widgets never draw when the vehicle lacks radar or is not active. 
- Add a shared HUD hint `Radar ON : <key>` / `Radar OFF : <key>` in `MCH_BaseVehicleCommonGui.drawRadarKeyBind()` (used by turret HUDs as well) that displays the configured key via `MCH_KeyName.getDescOrName(MCH_Config.KeyRadar.prmInt)` and uses active/inactive coloring and pilot-authority guards. 
- Update `docs/configuration.md` and `CHANGELOG.md` with a concise entry describing the fix and the new HUD hint.

### Testing

- Ran `git diff --check` to validate whitespace and simple repository checks and the repository patch passed this check. 
- Performed a static audit of packaged HUD scripts: a Python assertion validated that all packaged HUD files containing `DrawEntityRadar` or `DrawEnemyRadar` include an active-radar guard, and `rg` checks confirmed code paths were updated accordingly. 
- Verified source-level assertions that `getSynchronizedCommonStatus()` is used when reading/writing `commonStatus` and that `have_radar`/`radar_active` and `MCH_HudItemRadar` checks exist; compilation and live gameplay tests were not run in this environment per repository instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a713d87653483239b08f4a2909fdfb5)