### PR TITLE
Fix active radar toggle input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Fix Active Radar Toggle Input (PR pending)
+
+- Updated the shared radar key in every vehicle input handler so one press sends one synchronized radar toggle request and disabling radar hides the active radar HUD.
+- Radar toggles now play the standard local cockpit click without broadcasting a duplicate server-world sound.
+
 # Hide Disabled Active Radar HUD Widgets (PR pending)
 
 - Active radar HUD widgets now hide completely when radar is disabled while passive RWR and unrelated HUD elements remain visible.

--- a/scripts/check_radar_key_registration.py
+++ b/scripts/check_radar_key_registration.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Verify vehicle handlers update the shared radar key exactly once per tick."""
+
+from pathlib import Path
+import sys
+
+SOURCE_ROOT = Path("src/main/java")
+BASE_CLASS = "extends MCH_BaseVehicleClientTickHandler"
+CONTROL_CALL = "commonPlayerControl("
+KEY_ENTRY = "super.KeyRadar"
+
+
+def main():
+    failures = []
+    handlers = []
+    for path in SOURCE_ROOT.rglob("*.java"):
+        source = path.read_text(encoding="utf-8")
+        if BASE_CLASS not in source or CONTROL_CALL not in source:
+            continue
+        handlers.append(path)
+        count = source.count(KEY_ENTRY)
+        if count != 1:
+            failures.append("{} contains {} {} entries (expected 1)".format(path, count, KEY_ENTRY))
+        if "MCH_Key[] Keys" not in source or ".update();" not in source:
+            failures.append("{} does not expose and update its Keys array".format(path))
+
+    if not handlers:
+        failures.append("no vehicle handlers using commonPlayerControl() were found")
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print("Verified radar key registration in {} vehicle handlers.".format(len(handlers)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_EntityBaseVehicle.java
@@ -1184,7 +1184,6 @@ public abstract class MCH_EntityBaseVehicle extends W_EntityContainer implements
       if(this.worldObj.isRemote || !this.hasRadar() || !this.isPilot(player)) return false;
       this.setRadarActive(!this.isRadarActive());
       player.addChatMessage(new ChatComponentTranslation(this.isRadarActive() ? "mcheli.radar.on" : "mcheli.radar.off"));
-      W_WorldFunc.DEF_playSoundEffect(this.worldObj, this.posX, this.posY, this.posZ, "random.click", 1.0F, 1.0F);
       return true;
    }
 

--- a/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
+++ b/src/main/java/mcheli/helicopter/MCH_ClientHeliTickHandler.java
@@ -38,7 +38,7 @@ public class MCH_ClientHeliTickHandler extends MCH_BaseVehicleClientTickHandler 
       this.KeyEjectSeat = new MCH_Key(MCH_Config.KeyEjectHeli.prmInt);
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance, super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeyRadar, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance, super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCH_EntityHeli heli, boolean isPilot) {

--- a/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
+++ b/src/main/java/mcheli/plane/MCP_ClientPlaneTickHandler.java
@@ -51,7 +51,7 @@ public class MCP_ClientPlaneTickHandler extends MCH_BaseVehicleClientTickHandler
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyMouseAim = new MCH_Key(MCH_Config.KeyPlaneMouseAim.prmInt);
       this.KeyBombReticleMode = new MCH_Key(MCH_Config.KeyBombReticleMode.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, this.KeyBombReticleMode, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, super.KeyUseWeapon,super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeyRadar, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, this.KeyMouseAim, this.KeyBombReticleMode, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff,super.KeyAPS, super.KeyMaintenance, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCP_EntityPlane plane) {

--- a/src/main/java/mcheli/ship/MCH_ClientShipTickHandler.java
+++ b/src/main/java/mcheli/ship/MCH_ClientShipTickHandler.java
@@ -37,7 +37,7 @@ public class MCH_ClientShipTickHandler extends MCH_BaseVehicleClientTickHandler 
         this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
         this.KeySubmarineAscend = new MCH_Key(MCH_Config.KeySubmarineAscend.prmInt);
         this.KeySubmarineDescend = new MCH_Key(MCH_Config.KeySubmarineDescend.prmInt);
-        this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySubmarineAscend, this.KeySubmarineDescend, super.KeyUseWeapon, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
+        this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeyEjectSeat, this.KeySubmarineAscend, this.KeySubmarineDescend, super.KeyUseWeapon, super.KeyVehicleLock, super.KeyRadar, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyPutToRack, super.KeyDownFromRack};
     }
 
     protected void update(EntityPlayer player, MCH_EntityShip plane) {

--- a/src/main/java/mcheli/tank/MCH_ClientTankTickHandler.java
+++ b/src/main/java/mcheli/tank/MCH_ClientTankTickHandler.java
@@ -32,7 +32,7 @@ public class MCH_ClientTankTickHandler extends MCH_BaseVehicleClientTickHandler 
       super.updateKeybind(config);
       this.KeySwitchMode = new MCH_Key(MCH_Config.KeySwitchMode.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyBrake, super.KeyPutToRack, super.KeyDownFromRack};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeyRadar, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, super.KeyExtra, super.KeyFreeLook, super.KeyGUI, super.KeyGearUpDown, super.KeyBrake, super.KeyPutToRack, super.KeyDownFromRack};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTank tank) {

--- a/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
+++ b/src/main/java/mcheli/vehicle/MCH_ClientTurretTickHandler.java
@@ -36,7 +36,7 @@ public class MCH_ClientTurretTickHandler extends MCH_BaseVehicleClientTickHandle
       this.KeySwitchHovering = new MCH_Key(MCH_Config.KeySwitchHovering.prmInt);
       this.KeyZoom = new MCH_Key(MCH_Config.KeyZoom.prmInt);
       this.KeyExtra = new MCH_Key(MCH_Config.KeyExtra.prmInt);
-      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyFreeLook, super.KeyGUI};
+      this.Keys = new MCH_Key[]{super.KeyUp, super.KeyDown, super.KeyRight, super.KeyLeft, this.KeySwitchMode, this.KeySwitchHovering, super.KeyUseWeapon, super.KeyCurrentWeaponLock, super.KeyVehicleLock, super.KeyRadar, super.KeySwWeaponMode, super.KeySwitchWeapon1, super.KeySwitchWeapon2, this.KeyZoom, super.KeyCameraMode, super.KeyUnmount, super.KeyUnmountForce, super.KeyFlare, super.KeyChaff, super.KeyMaintenance,super.KeyAPS, this.KeyExtra, super.KeyFreeLook, super.KeyGUI};
    }
 
    protected void update(EntityPlayer player, MCH_EntityTurret vehicle, MCH_TurretInfo info) {


### PR DESCRIPTION
### Motivation

- The shared `KeyRadar` object was created in the base tick handler but omitted from vehicle-specific `Keys` arrays, so `KeyRadar.update()` was never called and radar toggle presses produced no edge-triggered event or local click and did not send the toggle packet.  

### Description

- Add `super.KeyRadar` to the `Keys` arrays for helicopter, plane, tank, ship and turret client tick handlers so the shared radar key receives one `update()` per client tick (`MCH_ClientHeliTickHandler`, `MCP_ClientPlaneTickHandler`, `MCH_ClientTankTickHandler`, `MCH_ClientShipTickHandler`, `MCH_ClientTurretTickHandler`).  
- Remove the server-world `random.click` sound from `MCH_EntityBaseVehicle.toggleRadar()` to avoid broadcasting a duplicate click and rely on the existing client `playSoundOK()` local click path.  
- Add a small regression-check script `scripts/check_radar_key_registration.py` that verifies every handler using `commonPlayerControl()` registers `super.KeyRadar` exactly once and exposes an updating `MCH_Key[] Keys` array.  
- Add a short `CHANGELOG.md` entry documenting the input fix and the click sound change.  

### Testing

- Ran `./scripts/check_radar_key_registration.py`, which reported verification success for the modified handlers.  
- Verified the new script parses with Python AST (`ast.parse`) to ensure syntax correctness.  
- Audited packet bit usage and handlers with ripgrep to confirm `toggleRadar` is written/read at bit 13 and each vehicle packet handler calls the shared `handleRadarToggle`.  
- Ran repository checks including `git diff --check` / staged-diff checks to ensure no whitespace or obvious formatting problems.  
- Did not compile or run Minecraft clients/servers in this environment per task constraints, and the provided MCP `make_pr` helper could not be executed due to missing runtime dependencies (`ModuleNotFoundError: No module named 'mcp.server.fastmcp'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a714414657c8323961796108b5037e1)