### PR TITLE
HUD Layout Editor direct manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -551,3 +551,9 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Add a shared, authority-aware `Radar ON`/`Radar OFF` vehicle HUD line that follows the configured
   `KeyRadar` binding, including turret and remote-pilot control HUDs.
 - Preserve passive RWR and warning displays independently of active radar visibility.
+# HUD Layout Editor direct manipulation
+
+- Replaced the profile/coordinate list with a live, non-darkening vehicle HUD preview.
+- Added mouse hover, overlap-aware selection, dragging, grid snapping, keyboard nudging, and immediate reset previews.
+- Added transactional multi-profile edit sessions so Save persists changed profiles and Cancel discards all edits.
+- Added logical screen-space bounds capture for HUD text, textures, rectangles, lines, and compound built-in scopes.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -1089,6 +1089,18 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
       }
    }
 
+   /** Draws the same first applicable vehicle GUI used by the gameplay overlay. */
+   public boolean drawHudLayoutEditorPreview(float partialTicks) {
+      if(this.mc.thePlayer == null) return false;
+      for(MCH_Gui gui : this.guis) {
+         if(gui.isDrawGui(this.mc.thePlayer)) {
+            gui.drawScreen(0, 0, partialTicks);
+            return true;
+         }
+      }
+      return false;
+   }
+
    private void releaseCameraAndControlForReplay() {
       MCP_PlaneChaseCamera.releaseForReplayPlayback(super.mc);
       MCP_ClientPlaneTickHandler.resetBombReticleMode();

--- a/src/main/java/mcheli/gui/MCH_Gui.java
+++ b/src/main/java/mcheli/gui/MCH_Gui.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Random;
 import mcheli.wrapper.W_McClient;
 import mcheli.wrapper.W_ScaledResolution;
+import mcheli.hud.layout.MCH_HudLayoutManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.renderer.Tessellator;
@@ -64,6 +65,7 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawTexturedModalRectRotate(double left, double top, double width, double height, double uLeft, double vTop, double uWidth, double vHeight, float rot) {
+      MCH_HudLayoutManager.capture(left, top, left + width, top + height);
       GL11.glPushMatrix();
       GL11.glTranslated(left + width / 2.0D, top + height / 2.0D, 0.0D);
       GL11.glRotatef(rot, 0.0F, 0.0F, 1.0F);
@@ -79,6 +81,7 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawTexturedRect(double left, double top, double width, double height, double uLeft, double vTop, double uWidth, double vHeight, double textureWidth, double textureHeight) {
+      MCH_HudLayoutManager.capture(left, top, left + width, top + height);
       float fx = (float)(1.0D / textureWidth);
       float fy = (float)(1.0D / textureHeight);
       Tessellator tessellator = Tessellator.instance;
@@ -98,10 +101,12 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawLine(double[] line, int color) {
+      MCH_HudLayoutManager.captureLine(line);
       this.drawLine(line, color, 1);
    }
 
    public void drawString(String s, int x, int y, int color) {
+      MCH_HudLayoutManager.capture(x, y, x + super.mc.fontRenderer.getStringWidth(s), y + super.mc.fontRenderer.FONT_HEIGHT);
       this.drawString(super.mc.fontRenderer, s, x, y, color);
    }
 
@@ -129,10 +134,13 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawCenteredString(String s, int x, int y, int color) {
+      int w = super.mc.fontRenderer.getStringWidth(s);
+      MCH_HudLayoutManager.capture(x - w / 2, y, x + w / 2, y + super.mc.fontRenderer.FONT_HEIGHT);
       this.drawCenteredString(super.mc.fontRenderer, s, x, y, color);
    }
 
    public void drawLine(double[] line, int color, int mode) {
+      MCH_HudLayoutManager.captureLine(line);
       GL11.glPushMatrix();
       GL11.glEnable(3042);
       GL11.glDisable(3553);
@@ -153,6 +161,7 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawPoints(double[] points, int color, int pointWidth) {
+      MCH_HudLayoutManager.captureLine(points);
       int prevWidth = GL11.glGetInteger(2833);
       GL11.glPushMatrix();
       GL11.glEnable(3042);
@@ -176,6 +185,11 @@ public abstract class MCH_Gui extends GuiScreen {
    }
 
    public void drawPoints(ArrayList points, int color, int pointWidth) {
+      if(points != null && points.size() >= 2) {
+         double[] boundsPoints = new double[points.size()];
+         for(int i = 0; i < points.size(); i++) boundsPoints[i] = ((Double)points.get(i)).doubleValue();
+         MCH_HudLayoutManager.captureLine(boundsPoints);
+      }
       int prevWidth = GL11.glGetInteger(2833);
       GL11.glPushMatrix();
       GL11.glEnable(3042);

--- a/src/main/java/mcheli/hud/MCH_Hud.java
+++ b/src/main/java/mcheli/hud/MCH_Hud.java
@@ -251,7 +251,8 @@ public class MCH_Hud extends MCH_BaseInfo {
                      final MCH_HudItem drawItem = hud;
                      String id = MCH_HudLayoutManager.parsedId(this.name, hud.fileLine, hud.getLayoutDirective(), hud.getLayoutOrdinal(), hud.getLayoutGroupId());
                      MCH_HudLayoutManager.renderParsed(MCH_HudLayoutManager.currentParsedProfileId(), id, this.name,
-                           hud.getLayoutFingerprint(), hud.fileLine, new Runnable() { public void run() { drawItem.execute(); } });
+                           hud.getLayoutFingerprint(), hud.fileLine, hud.getLayoutDisplayName(), hud.isLayoutMovable(),
+                           new Runnable() { public void run() { drawItem.execute(); } });
                   } else hud.execute();
                   if(this.exit) {
                      break;

--- a/src/main/java/mcheli/hud/MCH_HudItem.java
+++ b/src/main/java/mcheli/hud/MCH_HudItem.java
@@ -26,6 +26,7 @@ import mcheli.weapon.MCH_WeaponSet;
 import mcheli.wrapper.W_McClient;
 import mcheli.wrapper.W_OpenGlHelper;
 import mcheli.wrapper.W_WorldFunc;
+import mcheli.hud.layout.MCH_HudLayoutManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.Tessellator;
@@ -137,14 +138,18 @@ public abstract class MCH_HudItem extends Gui {
    }
 
    public void drawCenteredString(String s, int x, int y, int color) {
+      int w = mc.fontRenderer.getStringWidth(s);
+      MCH_HudLayoutManager.capture(x - w / 2, y, x + w / 2, y + mc.fontRenderer.FONT_HEIGHT);
       this.drawCenteredString(mc.fontRenderer, s, x, y, color);
    }
 
    public void drawString(String s, int x, int y, int color) {
+      MCH_HudLayoutManager.capture(x, y, x + mc.fontRenderer.getStringWidth(s), y + mc.fontRenderer.FONT_HEIGHT);
       this.drawString(mc.fontRenderer, s, x, y, color);
    }
 
    public void drawTexture(String name, double left, double top, double width, double height, double uLeft, double vTop, double uWidth, double vHeight, float rot, int textureWidth, int textureHeight) {
+      MCH_HudLayoutManager.capture(left, top, left + width, top + height);
       W_McClient.MOD_bindTexture("textures/gui/" + name + ".png");
       GL11.glPushMatrix();
       GL11.glTranslated(left + width / 2.0D, top + height / 2.0D, 0.0D);
@@ -162,6 +167,7 @@ public abstract class MCH_HudItem extends Gui {
    }
 
    public static void drawRect(double par0, double par1, double par2, double par3, int par4) {
+      MCH_HudLayoutManager.capture(par0, par1, par2, par3);
       double j1;
       if(par0 < par2) {
          j1 = par0;
@@ -195,10 +201,12 @@ public abstract class MCH_HudItem extends Gui {
    }
 
    public void drawLine(double[] line, int color) {
+      MCH_HudLayoutManager.captureLine(line);
       this.drawLine(line, color, 1);
    }
 
    public void drawLine(double[] line, int color, int mode) {
+      MCH_HudLayoutManager.captureLine(line);
       GL11.glPushMatrix();
       GL11.glEnable(3042);
       GL11.glDisable(3553);

--- a/src/main/java/mcheli/hud/layout/MCH_GuiHudLayoutEditor.java
+++ b/src/main/java/mcheli/hud/layout/MCH_GuiHudLayoutEditor.java
@@ -1,85 +1,67 @@
 package mcheli.hud.layout;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
+import mcheli.MCH_ClientCommonTickHandler;
+import mcheli.aircraft.MCH_EntityBaseVehicle;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.input.Keyboard;
 
-/** Non-pausing working-copy editor. JSON is touched only by Save. */
+/** Non-pausing direct-manipulation editor. Persistence only occurs on Save. */
 public class MCH_GuiHudLayoutEditor extends GuiScreen {
     private final GuiScreen parent;
-    private MCH_HudLayoutProfile working;
-    private final List<String> ids = new ArrayList<String>();
-    private int selected;
-    private boolean snap;
+    private MCH_HudLayoutElement selected, hovered;
+    private boolean snap, dragging, closed;
+    private int dragMouseX, dragMouseY, dragOffsetX, dragOffsetY;
+    private int lastClickX = Integer.MIN_VALUE, lastClickY, overlapIndex;
+    private String message = "";
 
-    public MCH_GuiHudLayoutEditor(GuiScreen parent) { this.parent = parent; }
+    public MCH_GuiHudLayoutEditor(GuiScreen parent) { this.parent=parent; }
 
     public void initGui() {
-        MCH_HudLayoutProfile profile = chooseProfile();
-        working = profile.copy();
-        ids.clear(); ids.addAll(working.elements.keySet()); selected = ids.isEmpty() ? -1 : 0;
-        buttonList.clear();
-        buttonList.add(new GuiButton(1, 10, height - 24, 55, 20, "Save"));
-        buttonList.add(new GuiButton(2, 68, height - 24, 55, 20, "Cancel"));
-        buttonList.add(new GuiButton(3, 126, height - 24, 80, 20, "Reset Element"));
-        buttonList.add(new GuiButton(4, 209, height - 24, 70, 20, "Reset HUD"));
-        buttonList.add(new GuiButton(5, 282, height - 24, 80, 20, "Grid: OFF"));
+        if(!MCH_HudLayoutManager.isEditing()) MCH_HudLayoutManager.beginEditSession();
+        buttonList.clear(); int y=height-24;
+        buttonList.add(new GuiButton(1,6,y,52,20,"Save")); buttonList.add(new GuiButton(2,61,y,52,20,"Cancel"));
+        buttonList.add(new GuiButton(3,116,y,84,20,"Reset Element")); buttonList.add(new GuiButton(4,203,y,70,20,"Reset HUD"));
+        buttonList.add(new GuiButton(5,276,y,76,20,"Grid: OFF"));
     }
-
-    private MCH_HudLayoutProfile chooseProfile() {
-        List<MCH_HudLayoutProfile> profiles = MCH_HudLayoutManager.profiles();
-        if(!profiles.isEmpty()) return profiles.get(0);
-        return MCH_HudLayoutManager.profile("builtin:common", "Java-rendered HUD groups");
-    }
-
     protected void actionPerformed(GuiButton b) {
-        if(b.id == 1) { MCH_HudLayoutManager.save(working); mc.displayGuiScreen(parent); }
-        else if(b.id == 2) mc.displayGuiScreen(parent);
-        else if(b.id == 3 && current() != null) { current().offsetX = current().offsetY = 0; }
-        else if(b.id == 4) for(MCH_HudLayoutElement e : working.elements.values()) { e.offsetX = e.offsetY = 0; }
-        else if(b.id == 5) { snap = !snap; b.displayString = snap ? "Grid: ON" : "Grid: OFF"; }
+        if(b.id==1) { if(MCH_HudLayoutManager.commitEditSession()){closed=true;mc.displayGuiScreen(parent);} else message="Could not save HUD layout; check the game log"; }
+        else if(b.id==2) close(false);
+        else if(b.id==3 && selected!=null){selected.offsetX=selected.offsetY=0;}
+        else if(b.id==4) for(MCH_HudLayoutProfile p:MCH_HudLayoutManager.workingProfiles()) for(MCH_HudLayoutElement e:p.elements.values()){e.offsetX=e.offsetY=0;}
+        else if(b.id==5){snap=!snap;b.displayString=snap?"Grid: ON":"Grid: OFF";}
     }
+    private void close(boolean unexpected){if(!closed){MCH_HudLayoutManager.cancelEditSession();closed=true;}mc.displayGuiScreen(parent);}
+    public void onGuiClosed(){if(!closed)MCH_HudLayoutManager.cancelEditSession();closed=true;}
 
-    protected void keyTyped(char c, int key) {
-        MCH_HudLayoutElement e = current();
-        int step = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT) ? 5 : 1;
-        if(e != null) {
-            if(key == Keyboard.KEY_LEFT) e.offsetX -= step;
-            else if(key == Keyboard.KEY_RIGHT) e.offsetX += step;
-            else if(key == Keyboard.KEY_UP) e.offsetY -= step;
-            else if(key == Keyboard.KEY_DOWN) e.offsetY += step;
-            else if(key == Keyboard.KEY_PRIOR && selected > 0) --selected;
-            else if(key == Keyboard.KEY_NEXT && selected + 1 < ids.size()) ++selected;
-        }
-        if(key == Keyboard.KEY_ESCAPE) mc.displayGuiScreen(parent);
+    public void drawScreen(int mouseX,int mouseY,float partialTicks) {
+        boolean vehicle=MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(mc.thePlayer)!=null;
+        MCH_HudLayoutManager.beginEditorFrame();
+        boolean rendered=vehicle && MCH_ClientCommonTickHandler.instance!=null && MCH_ClientCommonTickHandler.instance.drawHudLayoutEditorPreview(partialTicks);
+        MCH_HudLayoutManager.endEditorFrame();
+        ((GuiButton)buttonList.get(0)).enabled=rendered && !MCH_HudLayoutManager.workingProfiles().isEmpty();
+        if(dragging && selected!=null) moveSelected(mouseX,mouseY);
+        hovered=controlAt(mouseX,mouseY)?null:hit(mouseX,mouseY,0);
+        if(hovered!=null && hovered!=selected) outline(hovered.bounds,0xFFEEEEEE,0xFF202020);
+        if(selected!=null && selected.bounds!=null){outline(selected.bounds,0xFFFFFF00,0xFF202020);String n=name(selected);drawString(fontRendererObj,n,(int)selected.bounds.left,(int)Math.max(2,selected.bounds.top-10),0xFFFFFF80);}
+        if(!rendered){drawRect(width/2-145,height/2-14,width/2+145,height/2+14,0xB0000000);drawCenteredString(fontRendererObj,"Enter or control a vehicle to edit its HUD",width/2,height/2-4,0xFFFFFFFF);}
+        drawRect(0,height-29,Math.min(width,358),height,0x90000000);
+        if(selected!=null){String status=name(selected)+"  offset "+selected.offsetX+", "+selected.offsetY;int w=fontRendererObj.getStringWidth(status)+10;drawRect(width-w,2,width,16,0x90000000);drawString(fontRendererObj,status,width-w+5,5,0xFFFFFFFF);}
+        if(message.length()>0){int w=fontRendererObj.getStringWidth(message)+10;drawRect(width/2-w/2,20,width/2+w/2,34,0xC0800000);drawCenteredString(fontRendererObj,message,width/2,23,0xFFFFFFFF);}
+        super.drawScreen(mouseX,mouseY,partialTicks);
     }
-
-    protected void mouseClicked(int x, int y, int button) {
-        try { super.mouseClicked(x, y, button); } catch(Exception ignored) {}
-        if(x < 220 && y >= 38 && y < height - 30) {
-            int index = (y - 38) / 11;
-            if(index >= 0 && index < ids.size()) selected = index;
-        } else if(button == 1 && current() != null) current().offsetX = current().offsetY = 0;
-    }
-
-    public void drawScreen(int mouseX, int mouseY, float partialTicks) {
-        drawDefaultBackground();
-        drawCenteredString(fontRendererObj, "HUD Layout Editor", width / 2, 8, 0xFFFFFF);
-        drawString(fontRendererObj, "Profile: " + working.profileId, 10, 22, 0xA0E0FF);
-        int max = Math.min(ids.size(), Math.max(0, (height - 70) / 11));
-        for(int i = 0; i < max; i++) drawString(fontRendererObj, (i == selected ? "> " : "  ") + ids.get(i), 10, 38 + i * 11, i == selected ? 0xFFFF80 : 0xC0C0C0);
-        MCH_HudLayoutElement e = current();
-        if(e != null) {
-            drawString(fontRendererObj, "Selected: " + ids.get(selected), 230, 42, 0xFFFFFF);
-            drawString(fontRendererObj, "Offset X: " + e.offsetX + "  Y: " + e.offsetY, 230, 55, 0xFFFFFF);
-            drawString(fontRendererObj, "Arrows: move  Shift: 5px  PgUp/PgDn: select", 230, 70, 0xA0A0A0);
-        }
-        super.drawScreen(mouseX, mouseY, partialTicks);
-    }
-
-    private MCH_HudLayoutElement current() { return selected >= 0 && selected < ids.size() ? working.elements.get(ids.get(selected)) : null; }
-    public boolean doesGuiPauseGame() { return false; }
+    private boolean controlAt(int x,int y){return y>=height-29&&x<=358;}
+    protected void mouseClicked(int x,int y,int button){try{super.mouseClicked(x,y,button);}catch(Exception ignored){}if(button!=0||controlAt(x,y))return;List<MCH_HudLayoutElement> hits=hits(x,y);if(hits.isEmpty()){selected=null;return;}if(Math.abs(x-lastClickX)<=2&&Math.abs(y-lastClickY)<=2)overlapIndex=(overlapIndex+1)%hits.size();else overlapIndex=0;lastClickX=x;lastClickY=y;selected=hits.get(overlapIndex);dragging=true;dragMouseX=x;dragMouseY=y;dragOffsetX=selected.offsetX;dragOffsetY=selected.offsetY;}
+    protected void mouseMovedOrUp(int x,int y,int button){if(button==0)dragging=false;super.mouseMovedOrUp(x,y,button);}
+    private void moveSelected(int x,int y){int nx=dragOffsetX+x-dragMouseX,ny=dragOffsetY+y-dragMouseY;if(snap){nx=Math.round(nx/5.0F)*5;ny=Math.round(ny/5.0F)*5;}MCH_HudLayoutBounds b=selected.bounds;int dx=nx-selected.offsetX,dy=ny-selected.offsetY;nx-=Math.max(0,(int)(b.left+dx)-width+4);nx+=Math.max(0,4-(int)(b.right+dx));ny-=Math.max(0,(int)(b.top+dy)-height+4);ny+=Math.max(0,4-(int)(b.bottom+dy));selected.offsetX=nx;selected.offsetY=ny;}
+    protected void keyTyped(char c,int key){if(key==Keyboard.KEY_ESCAPE){close(false);return;}if(selected!=null){int step=Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)||Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)?5:1;if(key==Keyboard.KEY_LEFT)selected.offsetX-=step;else if(key==Keyboard.KEY_RIGHT)selected.offsetX+=step;else if(key==Keyboard.KEY_UP)selected.offsetY-=step;else if(key==Keyboard.KEY_DOWN)selected.offsetY+=step;}}
+    private MCH_HudLayoutElement hit(int x,int y,int index){List<MCH_HudLayoutElement> h=hits(x,y);return h.isEmpty()?null:h.get(Math.min(index,h.size()-1));}
+    private List<MCH_HudLayoutElement> hits(final int x,final int y){List<MCH_HudLayoutElement> h=new ArrayList<MCH_HudLayoutElement>();for(MCH_HudLayoutElement e:MCH_HudLayoutManager.frameElements())if(e.movable&&e.bounds!=null&&x>=e.bounds.left-4&&x<=e.bounds.right+4&&y>=e.bounds.top-4&&y<=e.bounds.bottom+4)h.add(e);Collections.sort(h,new Comparator<MCH_HudLayoutElement>(){public int compare(MCH_HudLayoutElement a,MCH_HudLayoutElement b){double aa=(a.bounds.right-a.bounds.left)*(a.bounds.bottom-a.bounds.top),bb=(b.bounds.right-b.bounds.left)*(b.bounds.bottom-b.bounds.top);return aa<bb?-1:aa>bb?1:0;}});return h;}
+    private void outline(MCH_HudLayoutBounds b,int bright,int dark){int l=(int)b.left-2,t=(int)b.top-2,r=(int)b.right+2,bot=(int)b.bottom+2;drawHorizontalLine(l,r,t,dark);drawHorizontalLine(l,r,bot,dark);drawVerticalLine(l,t,bot,dark);drawVerticalLine(r,t,bot,dark);drawHorizontalLine(l+1,r-1,t+1,bright);drawHorizontalLine(l+1,r-1,bot-1,bright);drawVerticalLine(l+1,t+1,bot-1,bright);drawVerticalLine(r-1,t+1,bot-1,bright);}
+    private String name(MCH_HudLayoutElement e){return e.displayName==null||e.displayName.length()==0?"HUD element":e.displayName;}
+    public boolean doesGuiPauseGame(){return false;}
 }

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
@@ -2,42 +2,35 @@ package mcheli.hud.layout;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import mcheli.MCH_Lib;
 import net.minecraft.client.Minecraft;
 import org.lwjgl.opengl.GL11;
 
-/** Cached, client-only persistence and render scopes for HUD layout offsets. */
+/** Cached client-only persistence, live editor overrides, and render bounds. */
 public final class MCH_HudLayoutManager {
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final Map<String, MCH_HudLayoutProfile> PROFILES = new LinkedHashMap<String, MCH_HudLayoutProfile>();
+    private static final Map<String, MCH_HudLayoutProfile> WORKING = new LinkedHashMap<String, MCH_HudLayoutProfile>();
+    private static final List<MCH_HudLayoutElement> FRAME = new ArrayList<MCH_HudLayoutElement>();
+    private static final Deque<Scope> SCOPES = new ArrayDeque<Scope>();
     private static final ThreadLocal<Deque<String>> CALL_PATH = new ThreadLocal<Deque<String>>() {
         protected Deque<String> initialValue() { return new ArrayDeque<String>(); }
     };
     private static String rootHud = "none";
+    private static boolean editing;
+    private static boolean editorFrame;
 
+    private static final class Scope {
+        final MCH_HudLayoutElement element; final int x, y;
+        Scope(MCH_HudLayoutElement element) { this.element = element; this.x = element.offsetX; this.y = element.offsetY; }
+    }
     private MCH_HudLayoutManager() {}
 
-    public static synchronized void reload() {
-        PROFILES.clear();
-        loadDirectory(new File(baseDirectory(), "hud"));
-        loadDirectory(new File(baseDirectory(), "builtin"));
-    }
-
+    public static synchronized void reload() { PROFILES.clear(); loadDirectory(new File(baseDirectory(), "hud")); loadDirectory(new File(baseDirectory(), "builtin")); }
     public static void beginHud(String name) { rootHud = safeId(name); CALL_PATH.get().clear(); }
     public static String currentParsedProfileId() { return "hud:" + rootHud; }
     public static void endHud() { CALL_PATH.get().clear(); }
@@ -46,107 +39,72 @@ public final class MCH_HudLayoutManager {
 
     public static String parsedId(String sourceHud, int line, String directive, int ordinal, String groupId) {
         StringBuilder b = new StringBuilder(rootHud).append('/');
-        if(CALL_PATH.get().isEmpty()) b.append("root");
-        else for(String call : CALL_PATH.get()) b.append(call).append('/');
-        b.append(safeId(sourceHud)).append("/line-").append(line).append('/').append(safeId(directive)).append('/').append(ordinal);
-        if(groupId != null && groupId.length() > 0) b.append("/group-").append(safeId(groupId));
+        if(CALL_PATH.get().isEmpty()) b.append("root/"); else for(String call : CALL_PATH.get()) b.append(call).append('/');
+        b.append(safeId(sourceHud)).append('/');
+        if(groupId != null && groupId.length() > 0) b.append("group-").append(safeId(groupId));
+        else b.append("line-").append(line).append('/').append(safeId(directive)).append('/').append(ordinal);
         return b.toString();
     }
 
-    public static MCH_HudLayoutElement offsetFor(String profileId, String id, String sourceHud, String fingerprint, int line) {
-        MCH_HudLayoutProfile p = profile(profileId, "");
-        MCH_HudLayoutElement exact = p.elements.get(id);
-        if(exact != null) return exact;
+    public static synchronized void beginEditSession() { editing = true; editorFrame = false; WORKING.clear(); FRAME.clear(); SCOPES.clear(); }
+    public static synchronized void beginEditorFrame() { if(editing) { editorFrame = true; FRAME.clear(); SCOPES.clear(); } }
+    public static synchronized void endEditorFrame() { editorFrame = false; SCOPES.clear(); }
+    public static synchronized boolean isEditing() { return editing; }
+    public static synchronized List<MCH_HudLayoutElement> frameElements() { return Collections.unmodifiableList(FRAME); }
+    public static synchronized Collection<MCH_HudLayoutProfile> workingProfiles() { return Collections.unmodifiableCollection(WORKING.values()); }
+    public static synchronized void cancelEditSession() { editing = editorFrame = false; WORKING.clear(); FRAME.clear(); SCOPES.clear(); }
+    public static synchronized boolean commitEditSession() {
+        for(MCH_HudLayoutProfile p : WORKING.values()) if(p.isDirty() && !save(p)) return false;
+        cancelEditSession(); return true;
+    }
+
+    private static synchronized MCH_HudLayoutProfile renderProfile(String id, String source) {
+        MCH_HudLayoutProfile saved = profile(id, source);
+        if(!editing) return saved;
+        MCH_HudLayoutProfile p = WORKING.get(id);
+        if(p == null) { p = saved.copy(); p.captureOriginalOffsets(); WORKING.put(id, p); }
+        return p;
+    }
+    private static MCH_HudLayoutElement find(MCH_HudLayoutProfile p, String id, String sourceHud, String fingerprint) {
+        MCH_HudLayoutElement exact = p.elements.get(id); if(exact != null) return exact;
         MCH_HudLayoutElement candidate = null;
-        for(MCH_HudLayoutElement e : p.elements.values()) {
-            if(e != null && fingerprint != null && fingerprint.equals(e.fingerprint) && (e.sourceHud.length() == 0 || e.sourceHud.equals(sourceHud))) {
-                if(candidate != null) return null;
-                candidate = e;
-            }
+        for(MCH_HudLayoutElement e : p.elements.values()) if(e != null && fingerprint != null && fingerprint.equals(e.fingerprint) && (e.sourceHud.length()==0 || e.sourceHud.equals(sourceHud))) {
+            if(candidate != null) return null; candidate=e;
         }
         return candidate;
     }
 
-    public static void renderParsed(String profileId, String id, String sourceHud, String fingerprint, int line, Runnable draw) {
-        MCH_HudLayoutProfile p = profile(profileId, "assets/mcheli/hud/" + sourceHud + ".txt");
-        MCH_HudLayoutElement e = offsetFor(profileId, id, sourceHud, fingerprint, line);
-        if(e == null) {
-            e = new MCH_HudLayoutElement(); e.id = id; e.sourceHud = sourceHud; e.sourceLine = line;
-            e.fingerprint = fingerprint == null ? "" : fingerprint; e.displayName = id;
-            p.elements.put(id, e);
-        }
-        GL11.glPushMatrix();
-        try {
-            if(e != null) GL11.glTranslated(e.offsetX, e.offsetY, 0.0D);
-            draw.run();
-        } finally { GL11.glPopMatrix(); }
+    public static void renderParsed(String profileId, String id, String sourceHud, String fingerprint, int line, String name, boolean movable, Runnable draw) {
+        MCH_HudLayoutProfile p = renderProfile(profileId, "assets/mcheli/hud/" + sourceHud + ".txt");
+        MCH_HudLayoutElement e = find(p,id,sourceHud,fingerprint);
+        if(e == null) { e=new MCH_HudLayoutElement(); e.id=id; e.sourceHud=sourceHud; e.sourceLine=line; e.fingerprint=fingerprint==null?"":fingerprint; p.elements.put(id,e); }
+        e.id=id; e.displayName=name; e.movable=movable;
+        renderScope(e, draw);
     }
-
     public static void renderBuiltin(String context, String id, Runnable draw) {
-        String profileId = "builtin:" + safeId(context);
-        MCH_HudLayoutProfile p = profile(profileId, "Java-rendered HUD groups");
-        MCH_HudLayoutElement e = p.elements.get(id);
-        if(e == null) {
-            e = new MCH_HudLayoutElement(); e.id = id; e.displayName = id; e.fingerprint = "builtin:" + id;
-            e.groupId = id; p.elements.put(id, e);
-        }
-        GL11.glPushMatrix();
-        try { GL11.glTranslated(e.offsetX, e.offsetY, 0.0D); draw.run(); }
-        finally { GL11.glPopMatrix(); }
+        String profileId="builtin:"+safeId(context); MCH_HudLayoutProfile p=renderProfile(profileId,"Java-rendered HUD groups");
+        MCH_HudLayoutElement e=p.elements.get(id);
+        if(e==null) { e=new MCH_HudLayoutElement(); e.id=id; e.fingerprint="builtin:"+id; e.groupId=id; p.elements.put(id,e); }
+        e.id=id; e.displayName=displayName(id); e.movable=true; renderScope(e,draw);
     }
+    private static void renderScope(MCH_HudLayoutElement e, Runnable draw) {
+        boolean capture=editorFrame && e.movable; Scope scope=new Scope(e); if(capture) { if(!FRAME.contains(e)) e.bounds=null; SCOPES.push(scope); }
+        GL11.glPushMatrix(); try { GL11.glTranslated(e.offsetX,e.offsetY,0); draw.run(); }
+        finally { GL11.glPopMatrix(); if(capture) { SCOPES.pop(); if(e.bounds!=null && !FRAME.contains(e)) FRAME.add(e); } }
+    }
+    public static void capture(double left,double top,double right,double bottom) {
+        if(!editorFrame || SCOPES.isEmpty()) return;
+        int ox=0,oy=0; for(Scope s:SCOPES){ox+=s.x;oy+=s.y;}
+        MCH_HudLayoutBounds b=new MCH_HudLayoutBounds(left+ox,top+oy,right+ox,bottom+oy);
+        for(Scope s:SCOPES) { if(s.element.bounds==null) s.element.bounds=new MCH_HudLayoutBounds(b.left,b.top,b.right,b.bottom); else s.element.bounds.include(b); }
+    }
+    public static void captureLine(double[] line) { if(line==null||line.length<2)return; double l=line[0],r=l,t=line[1],b=t; for(int i=2;i+1<line.length;i+=2){l=Math.min(l,line[i]);r=Math.max(r,line[i]);t=Math.min(t,line[i+1]);b=Math.max(b,line[i+1]);} capture(l,t,r,b); }
+    private static String displayName(String id) { int dot=id.lastIndexOf('.'); String s=dot>=0?id.substring(dot+1):id; String[] words=s.replace('_',' ').split(" "); StringBuilder b=new StringBuilder(); for(String w:words) if(w.length()>0)b.append(Character.toUpperCase(w.charAt(0))).append(w.substring(1)).append(' '); return b.toString().trim(); }
 
-    public static synchronized MCH_HudLayoutProfile profile(String id, String source) {
-        MCH_HudLayoutProfile p = PROFILES.get(id);
-        if(p == null) { p = new MCH_HudLayoutProfile(); p.profileId = id; p.source = source; PROFILES.put(id, p); }
-        return p;
-    }
-
-    public static synchronized List<MCH_HudLayoutProfile> profiles() {
-        return Collections.unmodifiableList(new ArrayList<MCH_HudLayoutProfile>(PROFILES.values()));
-    }
-
-    public static synchronized boolean save(MCH_HudLayoutProfile working) {
-        if(working == null) return false;
-        File dir = new File(baseDirectory(), working.profileId.startsWith("hud:") ? "hud" : "builtin");
-        if(!dir.isDirectory() && !dir.mkdirs()) return false;
-        File file = new File(dir, safeId(working.profileId) + ".json");
-        File temp = new File(dir, file.getName() + ".tmp");
-        try {
-            BufferedWriter out = new BufferedWriter(new FileWriter(temp));
-            try { GSON.toJson(working, out); } finally { out.close(); }
-            try { Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE); }
-            catch(IOException unsupported) { Files.move(temp.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING); }
-            PROFILES.put(working.profileId, working.copy());
-            return true;
-        } catch(Exception e) {
-            MCH_Lib.Log("Failed to write HUD layout %s: %s", file, e.toString());
-            if(temp.exists()) temp.delete();
-            return false;
-        }
-    }
-
-    private static void loadDirectory(File dir) {
-        File[] files = dir.listFiles();
-        if(files == null) return;
-        for(File file : files) if(file.isFile() && file.getName().endsWith(".json")) {
-            try {
-                BufferedReader in = new BufferedReader(new FileReader(file));
-                MCH_HudLayoutProfile p;
-                try { p = GSON.fromJson(in, MCH_HudLayoutProfile.class); } finally { in.close(); }
-                if(p == null || p.schemaVersion < 1 || p.profileId == null) throw new IOException("invalid layout schema");
-                if(p.elements == null) p.elements = new LinkedHashMap<String, MCH_HudLayoutElement>();
-                PROFILES.put(p.profileId, p);
-            } catch(Exception e) {
-                File broken = new File(file.getParentFile(), file.getName() + ".broken-" + System.currentTimeMillis());
-                if(!file.renameTo(broken)) MCH_Lib.Log("Could not preserve malformed HUD layout %s", file);
-                MCH_Lib.Log("Failed to read HUD layout %s: %s", file, e.toString());
-            }
-        }
-    }
-
-    private static File baseDirectory() { return new File(new File(Minecraft.getMinecraft().mcDataDir, "config/mcheli"), "hud_layouts"); }
-    public static String safeId(String value) {
-        String s = value == null ? "unknown" : value.toLowerCase().replaceAll("[^a-z0-9._-]+", "_");
-        return s.length() == 0 ? "unknown" : s;
-    }
+    public static synchronized MCH_HudLayoutProfile profile(String id,String source){MCH_HudLayoutProfile p=PROFILES.get(id);if(p==null){p=new MCH_HudLayoutProfile();p.profileId=id;p.source=source;PROFILES.put(id,p);}return p;}
+    public static synchronized List<MCH_HudLayoutProfile> profiles(){return Collections.unmodifiableList(new ArrayList<MCH_HudLayoutProfile>(PROFILES.values()));}
+    public static synchronized boolean save(MCH_HudLayoutProfile working){if(working==null)return false;File dir=new File(baseDirectory(),working.profileId.startsWith("hud:")?"hud":"builtin");if(!dir.isDirectory()&&!dir.mkdirs())return false;File file=new File(dir,safeId(working.profileId)+".json"),temp=new File(dir,file.getName()+".tmp");try{BufferedWriter out=new BufferedWriter(new FileWriter(temp));try{GSON.toJson(working,out);}finally{out.close();}try{Files.move(temp.toPath(),file.toPath(),StandardCopyOption.REPLACE_EXISTING,StandardCopyOption.ATOMIC_MOVE);}catch(IOException ex){Files.move(temp.toPath(),file.toPath(),StandardCopyOption.REPLACE_EXISTING);}PROFILES.put(working.profileId,working.copy());return true;}catch(Exception e){MCH_Lib.Log("Failed to write HUD layout %s: %s",file,e.toString());if(temp.exists())temp.delete();return false;}}
+    private static void loadDirectory(File dir){File[] files=dir.listFiles();if(files==null)return;for(File file:files)if(file.isFile()&&file.getName().endsWith(".json"))try{BufferedReader in=new BufferedReader(new FileReader(file));MCH_HudLayoutProfile p;try{p=GSON.fromJson(in,MCH_HudLayoutProfile.class);}finally{in.close();}if(p==null||p.schemaVersion<1||p.profileId==null)throw new IOException("invalid layout schema");if(p.elements==null)p.elements=new LinkedHashMap<String,MCH_HudLayoutElement>();PROFILES.put(p.profileId,p);}catch(Exception e){File broken=new File(file.getParentFile(),file.getName()+".broken-"+System.currentTimeMillis());if(!file.renameTo(broken))MCH_Lib.Log("Could not preserve malformed HUD layout %s",file);MCH_Lib.Log("Failed to read HUD layout %s: %s",file,e.toString());}}
+    private static File baseDirectory(){return new File(new File(Minecraft.getMinecraft().mcDataDir,"config/mcheli"),"hud_layouts");}
+    public static String safeId(String value){String s=value==null?"unknown":value.toLowerCase().replaceAll("[^a-z0-9._-]+","_");return s.length()==0?"unknown":s;}
 }

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutProfile.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutProfile.java
@@ -8,6 +8,18 @@ public class MCH_HudLayoutProfile {
     public String profileId = "";
     public String source = "";
     public Map<String, MCH_HudLayoutElement> elements = new LinkedHashMap<String, MCH_HudLayoutElement>();
+    private transient Map<String, Long> originalOffsets;
+
+    public void captureOriginalOffsets() {
+        originalOffsets = new LinkedHashMap<String, Long>();
+        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) originalOffsets.put(entry.getKey(), pack(entry.getValue()));
+    }
+    public boolean isDirty() {
+        if(originalOffsets == null || originalOffsets.size() != elements.size()) return true;
+        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) if(!Long.valueOf(pack(entry.getValue())).equals(originalOffsets.get(entry.getKey()))) return true;
+        return false;
+    }
+    private static long pack(MCH_HudLayoutElement e) { return ((long)e.offsetX << 32) ^ (e.offsetY & 0xffffffffL); }
 
     public MCH_HudLayoutProfile copy() {
         MCH_HudLayoutProfile p = new MCH_HudLayoutProfile();


### PR DESCRIPTION
### Motivation
- Replace the old list-and-coordinate HUD editor with an on-screen direct-manipulation editor that lets players drag visible HUD elements from the vehicle they control. 
- Keep the game world and HUD visible while editing (no full-screen dark overlay) and preserve the vehicle/seat/mode selection logic used by the existing GUIs. 
- Support multi-profile edit sessions (parsed, builtin, common, mode/seat profiles) with working copies so changes are previewed live and written only on Save. 
- Capture accurate screen-space bounds for rendered HUD primitives so mouse hit-testing and overlap-aware selection work reliably.

### Description
- Replaced the old editor implementation with a non-pausing direct-manipulation screen in `MCH_GuiHudLayoutEditor` that renders the real, active vehicle GUI as the live preview, shows hover/selection outlines, supports click-and-drag with optional grid snapping, keyboard nudging, Reset Element/HUD, and Save/Cancel controls. (modified: `src/main/java/mcheli/hud/layout/MCH_GuiHudLayoutEditor.java`).
- Added transactional edit-session management and per-profile working copies in `MCH_HudLayoutManager`, plus frame-local capture of element bounds and a working-frame element list used for hit-testing and selection. New operations include beginEditSession/beginEditorFrame/endEditorFrame/commitEditSession/cancelEditSession and capture/captureLine helpers. (modified: `src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java`).
- Instrumented HUD drawing helpers to record logical, scaled screen bounds while the editor is active: `MCH_Gui` and `MCH_HudItem` now call into the manager to capture rectangles, centered/normal strings, textures, lines, stippled lines, points, and compound scopes so movable elements receive accurate hit bounds. `MCH_Hud.renderParsed` now receives the display name and movable metadata for the live scope. (modified: `src/main/java/mcheli/gui/MCH_Gui.java`, `src/main/java/mcheli/hud/MCH_HudItem.java`, `src/main/java/mcheli/hud/MCH_Hud.java`).
- Added dirty-detection and original-offset capture to profiles so Save writes only changed profiles, and Cancel restores runtime state without touching JSON. Persistence keeps the existing JSON directory/schema and atomic temporary-file writes. (modified: `src/main/java/mcheli/hud/layout/MCH_HudLayoutProfile.java`, `src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java`).
- Reused existing vehicle GUI ordering from `MCH_ClientCommonTickHandler` to render the same HUD that gameplay shows (no duplicate overlay). Added an editor preview method to call the first applicable GUI instance. (modified: `src/main/java/mcheli/MCH_ClientCommonTickHandler.java`).
- Documented the change in `CHANGELOG.md` per repository policy and added a short summary of the new editor features. (modified: `CHANGELOG.md`).

### Testing
- Ran repository static checks and source scans: a diff-check and code searches ensure the editor no longer calls the fullscreen darkening helper or selects a first-loaded profile by default, and that no new HUD-layout network packet paths were introduced. These scans passed. 
- Performed source inspection to confirm that the editor uses `MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(mc.thePlayer)` and renders the active GUI via the existing GUI instances so vehicle/seat/mode selection is preserved. 
- Confirmed changelog entry was added and profile/persistence logic keeps the existing JSON folder and atomic temporary-file save semantics. 
- Did not run Gradle compile or in-client runtime tests in this environment because building and running a Forge 1.7.10 client was intentionally not performed here; runtime verification (drag, save, persist after restart, per-vehicle HUD cases, GUI-scale/resizing, malformed-JSON handling, save-failure behavior, and fixed-element protection) should be exercised inside a running Forge client before release.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a714ed775ac8323b64f341e09fa6451)