### PR TITLE
HUD layout scaling and multi-selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -557,3 +557,8 @@ Added shared Air, Ground, Surface, Underwater, and Unknown target-domain classif
 - Added mouse hover, overlap-aware selection, dragging, grid snapping, keyboard nudging, and immediate reset previews.
 - Added transactional multi-profile edit sessions so Save persists changed profiles and Cancel discards all edits.
 - Added logical screen-space bounds capture for HUD text, textures, rectangles, lines, and compound built-in scopes.
+
+## HUD layout scaling and multi-selection
+
+- Added persistent, center-pivoted HUD element scaling with schema version 2 migration.
+- Added right-click multi-selection, group dragging, group arrow movement, and multi-element reset controls to the live HUD layout editor.

--- a/docs/hud-layouts.md
+++ b/docs/hud-layouts.md
@@ -15,3 +15,9 @@ Use `fixed` for crosshairs, view-aligned reticles, CCIP cues, lock/target marker
 The HUD text file owns author metadata and original coordinates. User changes never rewrite it. Offsets in logical scaled-GUI pixels are saved as JSON below `config/mcheli/hud_layouts/hud/` for parsed HUDs and `config/mcheli/hud_layouts/builtin/` for Java-rendered categories. Schema version 1 contains `profileId`, `source`, and an `elements` object keyed by stable element ID. Each entry contains `offsetX`, `offsetY`, a source fingerprint, source HUD, and source line.
 
 Parsed identities contain the root HUD, nested call path (including the call source line), source HUD, source line, directive, duplicate ordinal, and optional stable group ID. This keeps repeated and nested `Call` instances independent. Resolution prefers an exact ID, then an unambiguous fingerprint in the same source HUD; ambiguous stale entries are retained but not applied.
+
+## Scaling and multi-selection
+
+In the direct HUD editor, right-click movable elements to add or remove them from an ordered selection; right-click empty space to clear it. Left-click any selected element and drag to move the entire selection without changing the spacing between elements. Left-clicking an unselected element replaces the selection. Arrow keys move the selection by one pixel, or five while Shift is held.
+
+Use the mouse wheel over a movable element to change scale in 0.05 increments (0.25x through 4.00x). When the pointer is over a selected element, every selected element is adjusted around its own stable geometry center. Scale and position remain session-only until **Save**; **Cancel** restores both. Layout schema version 1 files are accepted and missing scale values migrate to 1.00x when next saved.

--- a/src/main/java/mcheli/hud/layout/MCH_GuiHudLayoutEditor.java
+++ b/src/main/java/mcheli/hud/layout/MCH_GuiHudLayoutEditor.java
@@ -4,18 +4,24 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import mcheli.MCH_ClientCommonTickHandler;
 import mcheli.aircraft.MCH_EntityBaseVehicle;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 /** Non-pausing direct-manipulation editor. Persistence only occurs on Save. */
 public class MCH_GuiHudLayoutEditor extends GuiScreen {
     private final GuiScreen parent;
-    private MCH_HudLayoutElement selected, hovered;
+    private final LinkedHashMap<String, MCH_HudLayoutElement> selected = new LinkedHashMap<String, MCH_HudLayoutElement>();
+    private final LinkedHashMap<String, int[]> dragOffsets = new LinkedHashMap<String, int[]>();
+    private MCH_HudLayoutElement primary, hovered;
     private boolean snap, dragging, closed;
-    private int dragMouseX, dragMouseY, dragOffsetX, dragOffsetY;
+    private int dragMouseX, dragMouseY;
+    private MCH_HudLayoutBounds dragBounds;
     private int lastClickX = Integer.MIN_VALUE, lastClickY, overlapIndex;
     private String message = "";
 
@@ -31,34 +37,38 @@ public class MCH_GuiHudLayoutEditor extends GuiScreen {
     protected void actionPerformed(GuiButton b) {
         if(b.id==1) { if(MCH_HudLayoutManager.commitEditSession()){closed=true;mc.displayGuiScreen(parent);} else message="Could not save HUD layout; check the game log"; }
         else if(b.id==2) close(false);
-        else if(b.id==3 && selected!=null){selected.offsetX=selected.offsetY=0;}
-        else if(b.id==4) for(MCH_HudLayoutProfile p:MCH_HudLayoutManager.workingProfiles()) for(MCH_HudLayoutElement e:p.elements.values()){e.offsetX=e.offsetY=0;}
+        else if(b.id==3){for(MCH_HudLayoutElement e:selected.values()){e.offsetX=e.offsetY=0;e.scale=1.0F;}}
+        else if(b.id==4) for(MCH_HudLayoutProfile p:MCH_HudLayoutManager.workingProfiles()) for(MCH_HudLayoutElement e:p.elements.values()){e.offsetX=e.offsetY=0;e.scale=1.0F;}
         else if(b.id==5){snap=!snap;b.displayString=snap?"Grid: ON":"Grid: OFF";}
     }
-    private void close(boolean unexpected){if(!closed){MCH_HudLayoutManager.cancelEditSession();closed=true;}mc.displayGuiScreen(parent);}
-    public void onGuiClosed(){if(!closed)MCH_HudLayoutManager.cancelEditSession();closed=true;}
+    private void close(boolean unexpected){clearSelection();if(!closed){MCH_HudLayoutManager.cancelEditSession();closed=true;}mc.displayGuiScreen(parent);}
+    public void onGuiClosed(){clearSelection();if(!closed)MCH_HudLayoutManager.cancelEditSession();closed=true;}
 
     public void drawScreen(int mouseX,int mouseY,float partialTicks) {
         boolean vehicle=MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(mc.thePlayer)!=null;
-        MCH_HudLayoutManager.beginEditorFrame();
-        boolean rendered=vehicle && MCH_ClientCommonTickHandler.instance!=null && MCH_ClientCommonTickHandler.instance.drawHudLayoutEditorPreview(partialTicks);
-        MCH_HudLayoutManager.endEditorFrame();
-        ((GuiButton)buttonList.get(0)).enabled=rendered && !MCH_HudLayoutManager.workingProfiles().isEmpty();
-        if(dragging && selected!=null) moveSelected(mouseX,mouseY);
-        hovered=controlAt(mouseX,mouseY)?null:hit(mouseX,mouseY,0);
-        if(hovered!=null && hovered!=selected) outline(hovered.bounds,0xFFEEEEEE,0xFF202020);
-        if(selected!=null && selected.bounds!=null){outline(selected.bounds,0xFFFFFF00,0xFF202020);String n=name(selected);drawString(fontRendererObj,n,(int)selected.bounds.left,(int)Math.max(2,selected.bounds.top-10),0xFFFFFF80);}
+        MCH_HudLayoutManager.beginEditorFrame(); boolean rendered=vehicle&&MCH_ClientCommonTickHandler.instance!=null&&MCH_ClientCommonTickHandler.instance.drawHudLayoutEditorPreview(partialTicks); MCH_HudLayoutManager.endEditorFrame();
+        ((GuiButton)buttonList.get(0)).enabled=rendered&&!MCH_HudLayoutManager.workingProfiles().isEmpty(); validateSelection();
+        if(dragging) moveSelected(mouseX,mouseY); hovered=controlAt(mouseX,mouseY)?null:hit(mouseX,mouseY,0);
+        if(hovered!=null&&!isSelected(hovered))outline(hovered.bounds,0xFFEEEEEE,0xFF202020);
+        for(MCH_HudLayoutElement e:selected.values())if(e.bounds!=null)outline(e.bounds,e==primary?0xFFFFFF00:0xFFFFA000,0xFF202020);
+        if(primary!=null&&primary.bounds!=null)drawString(fontRendererObj,name(primary),(int)primary.bounds.left,(int)Math.max(2,primary.bounds.top-10),0xFFFFFF80);
         if(!rendered){drawRect(width/2-145,height/2-14,width/2+145,height/2+14,0xB0000000);drawCenteredString(fontRendererObj,"Enter or control a vehicle to edit its HUD",width/2,height/2-4,0xFFFFFFFF);}
-        drawRect(0,height-29,Math.min(width,358),height,0x90000000);
-        if(selected!=null){String status=name(selected)+"  offset "+selected.offsetX+", "+selected.offsetY;int w=fontRendererObj.getStringWidth(status)+10;drawRect(width-w,2,width,16,0x90000000);drawString(fontRendererObj,status,width-w+5,5,0xFFFFFFFF);}
-        if(message.length()>0){int w=fontRendererObj.getStringWidth(message)+10;drawRect(width/2-w/2,20,width/2+w/2,34,0xC0800000);drawCenteredString(fontRendererObj,message,width/2,23,0xFFFFFFFF);}
-        super.drawScreen(mouseX,mouseY,partialTicks);
+        drawRect(0,height-29,Math.min(width,358),height,0x90000000); ((GuiButton)buttonList.get(2)).displayString=selected.size()>1?"Reset Selected":"Reset Element";
+        if(primary!=null){String status=selected.size()==1?name(primary)+"  offset "+primary.offsetX+", "+primary.offsetY+"  scale "+String.format(java.util.Locale.ROOT,"%.2fx",primary.scale):selected.size()+" elements selected  primary "+String.format(java.util.Locale.ROOT,"%.2fx",primary.scale);int w=fontRendererObj.getStringWidth(status)+10;drawRect(width-w,2,width,16,0x90000000);drawString(fontRendererObj,status,width-w+5,5,0xFFFFFFFF);}
+        if(message.length()>0){int w=fontRendererObj.getStringWidth(message)+10;drawRect(width/2-w/2,20,width/2+w/2,34,0xC0800000);drawCenteredString(fontRendererObj,message,width/2,23,0xFFFFFFFF);} super.drawScreen(mouseX,mouseY,partialTicks);
     }
+    private String key(MCH_HudLayoutElement e){return e.profileId+"\n"+e.id;} private boolean isSelected(MCH_HudLayoutElement e){return selected.containsKey(key(e));}
+    private void validateSelection(){java.util.HashSet<String> valid=new java.util.HashSet<String>();for(MCH_HudLayoutProfile p:MCH_HudLayoutManager.workingProfiles())for(Map.Entry<String,MCH_HudLayoutElement> x:p.elements.entrySet())valid.add(p.profileId+"\n"+x.getKey());selected.keySet().retainAll(valid);if(primary!=null&&!isSelected(primary))primary=selected.isEmpty()?null:selected.values().iterator().next();}
+    private void clearSelection(){selected.clear();dragOffsets.clear();primary=null;dragging=false;}
     private boolean controlAt(int x,int y){return y>=height-29&&x<=358;}
-    protected void mouseClicked(int x,int y,int button){try{super.mouseClicked(x,y,button);}catch(Exception ignored){}if(button!=0||controlAt(x,y))return;List<MCH_HudLayoutElement> hits=hits(x,y);if(hits.isEmpty()){selected=null;return;}if(Math.abs(x-lastClickX)<=2&&Math.abs(y-lastClickY)<=2)overlapIndex=(overlapIndex+1)%hits.size();else overlapIndex=0;lastClickX=x;lastClickY=y;selected=hits.get(overlapIndex);dragging=true;dragMouseX=x;dragMouseY=y;dragOffsetX=selected.offsetX;dragOffsetY=selected.offsetY;}
+    protected void mouseClicked(int x,int y,int button){try{super.mouseClicked(x,y,button);}catch(Exception ignored){}if(controlAt(x,y))return;List<MCH_HudLayoutElement> hits=hits(x,y);if(button==1){if(hits.isEmpty()){clearSelection();return;}MCH_HudLayoutElement e=cycle(hits,x,y);String k=key(e);if(selected.remove(k)==null){selected.put(k,e);primary=e;}else if(e==primary)primary=selected.isEmpty()?null:selected.values().iterator().next();return;}if(button!=0)return;if(hits.isEmpty()){clearSelection();return;}MCH_HudLayoutElement e=cycle(hits,x,y);if(!isSelected(e)){selected.clear();selected.put(key(e),e);primary=e;}startDrag(x,y);}
+    private MCH_HudLayoutElement cycle(List<MCH_HudLayoutElement> hits,int x,int y){if(Math.abs(x-lastClickX)<=2&&Math.abs(y-lastClickY)<=2)overlapIndex=(overlapIndex+1)%hits.size();else overlapIndex=0;lastClickX=x;lastClickY=y;return hits.get(overlapIndex);}
+    private void startDrag(int x,int y){dragging=true;dragMouseX=x;dragMouseY=y;dragOffsets.clear();dragBounds=null;for(MCH_HudLayoutElement e:selected.values()){dragOffsets.put(key(e),new int[]{e.offsetX,e.offsetY});if(e.bounds!=null){MCH_HudLayoutBounds b=new MCH_HudLayoutBounds(e.bounds.left,e.bounds.top,e.bounds.right,e.bounds.bottom);if(dragBounds==null)dragBounds=b;else dragBounds.include(b);}}}
     protected void mouseMovedOrUp(int x,int y,int button){if(button==0)dragging=false;super.mouseMovedOrUp(x,y,button);}
-    private void moveSelected(int x,int y){int nx=dragOffsetX+x-dragMouseX,ny=dragOffsetY+y-dragMouseY;if(snap){nx=Math.round(nx/5.0F)*5;ny=Math.round(ny/5.0F)*5;}MCH_HudLayoutBounds b=selected.bounds;int dx=nx-selected.offsetX,dy=ny-selected.offsetY;nx-=Math.max(0,(int)(b.left+dx)-width+4);nx+=Math.max(0,4-(int)(b.right+dx));ny-=Math.max(0,(int)(b.top+dy)-height+4);ny+=Math.max(0,4-(int)(b.bottom+dy));selected.offsetX=nx;selected.offsetY=ny;}
-    protected void keyTyped(char c,int key){if(key==Keyboard.KEY_ESCAPE){close(false);return;}if(selected!=null){int step=Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)||Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)?5:1;if(key==Keyboard.KEY_LEFT)selected.offsetX-=step;else if(key==Keyboard.KEY_RIGHT)selected.offsetX+=step;else if(key==Keyboard.KEY_UP)selected.offsetY-=step;else if(key==Keyboard.KEY_DOWN)selected.offsetY+=step;}}
+    private void moveSelected(int x,int y){int dx=x-dragMouseX,dy=y-dragMouseY;if(snap){dx=Math.round(dx/5.0F)*5;dy=Math.round(dy/5.0F)*5;}moveGroup(dx,dy,true);}
+    private void moveGroup(int dx,int dy,boolean fromStart){if(dragBounds!=null){dx=Math.min(dx,(int)Math.ceil(width-4-dragBounds.left));dx=Math.max(dx,(int)Math.floor(4-dragBounds.right));dy=Math.min(dy,(int)Math.ceil(height-4-dragBounds.top));dy=Math.max(dy,(int)Math.floor(4-dragBounds.bottom));}for(MCH_HudLayoutElement e:selected.values()){int[] st=fromStart?dragOffsets.get(key(e)):new int[]{e.offsetX,e.offsetY};if(st!=null){e.offsetX=st[0]+dx;e.offsetY=st[1]+dy;}}}
+    protected void keyTyped(char c,int key){if(key==Keyboard.KEY_ESCAPE){close(false);return;}if(!selected.isEmpty()){int step=Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)||Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)?5:1;int dx=key==Keyboard.KEY_LEFT?-step:key==Keyboard.KEY_RIGHT?step:0,dy=key==Keyboard.KEY_UP?-step:key==Keyboard.KEY_DOWN?step:0;if(dx!=0||dy!=0){startDrag(0,0);moveGroup(dx,dy,true);dragging=false;}}}
+    public void handleMouseInput() {super.handleMouseInput();int wheel=Mouse.getEventDWheel();if(wheel==0)return;int x=Mouse.getEventX()*width/mc.displayWidth,y=height-Mouse.getEventY()*height/mc.displayHeight-1;if(controlAt(x,y))return;MCH_HudLayoutElement under=hit(x,y,0);if(under!=null&&!isSelected(under)){selected.clear();selected.put(key(under),under);primary=under;}if(selected.isEmpty())return;int notches=Math.max(1,Math.abs(wheel)/120),direction=wheel>0?1:-1;for(MCH_HudLayoutElement e:selected.values())e.scale=MCH_HudLayoutElement.normalizeScale(e.scale+direction*0.05F*notches);}
     private MCH_HudLayoutElement hit(int x,int y,int index){List<MCH_HudLayoutElement> h=hits(x,y);return h.isEmpty()?null:h.get(Math.min(index,h.size()-1));}
     private List<MCH_HudLayoutElement> hits(final int x,final int y){List<MCH_HudLayoutElement> h=new ArrayList<MCH_HudLayoutElement>();for(MCH_HudLayoutElement e:MCH_HudLayoutManager.frameElements())if(e.movable&&e.bounds!=null&&x>=e.bounds.left-4&&x<=e.bounds.right+4&&y>=e.bounds.top-4&&y<=e.bounds.bottom+4)h.add(e);Collections.sort(h,new Comparator<MCH_HudLayoutElement>(){public int compare(MCH_HudLayoutElement a,MCH_HudLayoutElement b){double aa=(a.bounds.right-a.bounds.left)*(a.bounds.bottom-a.bounds.top),bb=(b.bounds.right-b.bounds.left)*(b.bounds.bottom-b.bounds.top);return aa<bb?-1:aa>bb?1:0;}});return h;}
     private void outline(MCH_HudLayoutBounds b,int bright,int dark){int l=(int)b.left-2,t=(int)b.top-2,r=(int)b.right+2,bot=(int)b.bottom+2;drawHorizontalLine(l,r,t,dark);drawHorizontalLine(l,r,bot,dark);drawVerticalLine(l,t,bot,dark);drawVerticalLine(r,t,bot,dark);drawHorizontalLine(l+1,r-1,t+1,bright);drawHorizontalLine(l+1,r-1,bot-1,bright);drawVerticalLine(l+1,t+1,bot-1,bright);drawVerticalLine(r-1,t+1,bot-1,bright);}

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutBounds.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutBounds.java
@@ -19,4 +19,7 @@ public final class MCH_HudLayoutBounds {
         left = Math.min(left, other.left); top = Math.min(top, other.top);
         right = Math.max(right, other.right); bottom = Math.max(bottom, other.bottom);
     }
+
+    public double centerX() { return (left + right) * 0.5D; }
+    public double centerY() { return (top + bottom) * 0.5D; }
 }

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutElement.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutElement.java
@@ -5,8 +5,10 @@ public class MCH_HudLayoutElement {
 
     public int offsetX;
     public int offsetY;
+    public float scale = 1.0F;
     public String fingerprint = "";
     public transient String id = "";
+    public transient String profileId = "";
     public String sourceHud = "";
     public transient String displayName = "";
     public transient String groupId = "";
@@ -14,12 +16,22 @@ public class MCH_HudLayoutElement {
     public transient boolean movable = true;
     public transient Category category = Category.SCREEN_SPACE;
     public transient MCH_HudLayoutBounds bounds;
+    /** Last untransformed geometry; deliberately transient because it depends on resolution. */
+    public transient MCH_HudLayoutBounds geometry;
+    public transient double framePivotX;
+    public transient double framePivotY;
+    public transient boolean hasFramePivot;
+
+    public static float normalizeScale(float value) {
+        if(Float.isNaN(value) || Float.isInfinite(value) || value <= 0.0F) return 1.0F;
+        return Math.max(0.25F, Math.min(4.0F, value));
+    }
 
     public MCH_HudLayoutElement copy() {
         MCH_HudLayoutElement e = new MCH_HudLayoutElement();
-        e.offsetX = offsetX; e.offsetY = offsetY; e.fingerprint = fingerprint;
-        e.id = id; e.sourceHud = sourceHud; e.displayName = displayName; e.groupId = groupId;
-        e.sourceLine = sourceLine; e.movable = movable; e.category = category; e.bounds = bounds;
+        e.offsetX = offsetX; e.offsetY = offsetY; e.scale = normalizeScale(scale); e.fingerprint = fingerprint;
+        e.id = id; e.profileId = profileId; e.sourceHud = sourceHud; e.displayName = displayName; e.groupId = groupId;
+        e.sourceLine = sourceLine; e.movable = movable; e.category = category; e.bounds = bounds; e.geometry = geometry;
         return e;
     }
 }

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
@@ -25,8 +25,10 @@ public final class MCH_HudLayoutManager {
     private static boolean editorFrame;
 
     private static final class Scope {
-        final MCH_HudLayoutElement element; final int x, y;
-        Scope(MCH_HudLayoutElement element) { this.element = element; this.x = element.offsetX; this.y = element.offsetY; }
+        final MCH_HudLayoutElement element; final int x, y; final double scale, pivotX, pivotY;
+        Scope(MCH_HudLayoutElement element) { this.element = element; this.x = element.offsetX; this.y = element.offsetY; this.scale=MCH_HudLayoutElement.normalizeScale(element.scale); this.pivotX=element.hasFramePivot?element.framePivotX:element.geometry==null?0.0D:element.geometry.centerX(); this.pivotY=element.hasFramePivot?element.framePivotY:element.geometry==null?0.0D:element.geometry.centerY(); }
+        double tx(double value){return x+pivotX+(value-pivotX)*scale;}
+        double ty(double value){return y+pivotY+(value-pivotY)*scale;}
     }
     private MCH_HudLayoutManager() {}
 
@@ -78,33 +80,43 @@ public final class MCH_HudLayoutManager {
         MCH_HudLayoutProfile p = renderProfile(profileId, "assets/mcheli/hud/" + sourceHud + ".txt");
         MCH_HudLayoutElement e = find(p,id,sourceHud,fingerprint);
         if(e == null) { e=new MCH_HudLayoutElement(); e.id=id; e.sourceHud=sourceHud; e.sourceLine=line; e.fingerprint=fingerprint==null?"":fingerprint; p.elements.put(id,e); }
-        e.id=id; e.displayName=name; e.movable=movable;
+        e.id=id; e.profileId=profileId; e.displayName=name; e.movable=movable; e.scale=MCH_HudLayoutElement.normalizeScale(e.scale);
         renderScope(e, draw);
     }
     public static void renderBuiltin(String context, String id, Runnable draw) {
         String profileId="builtin:"+safeId(context); MCH_HudLayoutProfile p=renderProfile(profileId,"Java-rendered HUD groups");
         MCH_HudLayoutElement e=p.elements.get(id);
         if(e==null) { e=new MCH_HudLayoutElement(); e.id=id; e.fingerprint="builtin:"+id; e.groupId=id; p.elements.put(id,e); }
-        e.id=id; e.displayName=displayName(id); e.movable=true; renderScope(e,draw);
+        e.id=id; e.profileId=profileId; e.displayName=displayName(id); e.movable=true; e.scale=MCH_HudLayoutElement.normalizeScale(e.scale); renderScope(e,draw);
     }
     private static void renderScope(MCH_HudLayoutElement e, Runnable draw) {
-        boolean capture=editorFrame && e.movable; Scope scope=new Scope(e); if(capture) { if(!FRAME.contains(e)) e.bounds=null; SCOPES.push(scope); }
-        GL11.glPushMatrix(); try { GL11.glTranslated(e.offsetX,e.offsetY,0); draw.run(); }
+        boolean capture=editorFrame && e.movable;
+        if(capture && !FRAME.contains(e)) { e.hasFramePivot=e.geometry!=null; if(e.hasFramePivot){e.framePivotX=e.geometry.centerX();e.framePivotY=e.geometry.centerY();} e.bounds=null; e.geometry=null; }
+        Scope scope=new Scope(e); if(capture) { SCOPES.push(scope); }
+        GL11.glPushMatrix(); try { GL11.glTranslated(scope.x+scope.pivotX,scope.y+scope.pivotY,0); if(scope.scale!=1.0D) GL11.glScaled(scope.scale,scope.scale,1); GL11.glTranslated(-scope.pivotX,-scope.pivotY,0); draw.run(); }
         finally { GL11.glPopMatrix(); if(capture) { SCOPES.pop(); if(e.bounds!=null && !FRAME.contains(e)) FRAME.add(e); } }
     }
     public static void capture(double left,double top,double right,double bottom) {
         if(!editorFrame || SCOPES.isEmpty()) return;
-        int ox=0,oy=0; for(Scope s:SCOPES){ox+=s.x;oy+=s.y;}
-        MCH_HudLayoutBounds b=new MCH_HudLayoutBounds(left+ox,top+oy,right+ox,bottom+oy);
-        for(Scope s:SCOPES) { if(s.element.bounds==null) s.element.bounds=new MCH_HudLayoutBounds(b.left,b.top,b.right,b.bottom); else s.element.bounds.include(b); }
+        double[] xs={left,right,right,left}, ys={top,top,bottom,bottom};
+        int level=0; for(Scope owner:SCOPES) {
+            // At this point the coordinates are in owner's local space: retain that geometry for its next stable pivot.
+            MCH_HudLayoutBounds local=bounds(xs,ys); if(owner.element.geometry==null) owner.element.geometry=local; else owner.element.geometry.include(local);
+            int i=0; for(Scope transform:SCOPES) { if(i++<level) continue; for(int c=0;c<4;c++){xs[c]=transform.tx(xs[c]);ys[c]=transform.ty(ys[c]);} }
+            MCH_HudLayoutBounds screen=bounds(xs,ys); if(owner.element.bounds==null) owner.element.bounds=screen; else owner.element.bounds.include(screen);
+            // Rebuild raw corners for the next owner, transformed only by scopes below it.
+            xs=new double[]{left,right,right,left}; ys=new double[]{top,top,bottom,bottom}; level++;
+            int applied=0; for(Scope transform:SCOPES){if(applied++>=level-1)break;for(int c=0;c<4;c++){xs[c]=transform.tx(xs[c]);ys[c]=transform.ty(ys[c]);}}
+        }
     }
+    private static MCH_HudLayoutBounds bounds(double[] x,double[] y){double l=x[0],r=x[0],t=y[0],b=y[0];for(int i=1;i<4;i++){l=Math.min(l,x[i]);r=Math.max(r,x[i]);t=Math.min(t,y[i]);b=Math.max(b,y[i]);}return new MCH_HudLayoutBounds(l,t,r,b);}
     public static void captureLine(double[] line) { if(line==null||line.length<2)return; double l=line[0],r=l,t=line[1],b=t; for(int i=2;i+1<line.length;i+=2){l=Math.min(l,line[i]);r=Math.max(r,line[i]);t=Math.min(t,line[i+1]);b=Math.max(b,line[i+1]);} capture(l,t,r,b); }
     private static String displayName(String id) { int dot=id.lastIndexOf('.'); String s=dot>=0?id.substring(dot+1):id; String[] words=s.replace('_',' ').split(" "); StringBuilder b=new StringBuilder(); for(String w:words) if(w.length()>0)b.append(Character.toUpperCase(w.charAt(0))).append(w.substring(1)).append(' '); return b.toString().trim(); }
 
     public static synchronized MCH_HudLayoutProfile profile(String id,String source){MCH_HudLayoutProfile p=PROFILES.get(id);if(p==null){p=new MCH_HudLayoutProfile();p.profileId=id;p.source=source;PROFILES.put(id,p);}return p;}
     public static synchronized List<MCH_HudLayoutProfile> profiles(){return Collections.unmodifiableList(new ArrayList<MCH_HudLayoutProfile>(PROFILES.values()));}
     public static synchronized boolean save(MCH_HudLayoutProfile working){if(working==null)return false;File dir=new File(baseDirectory(),working.profileId.startsWith("hud:")?"hud":"builtin");if(!dir.isDirectory()&&!dir.mkdirs())return false;File file=new File(dir,safeId(working.profileId)+".json"),temp=new File(dir,file.getName()+".tmp");try{BufferedWriter out=new BufferedWriter(new FileWriter(temp));try{GSON.toJson(working,out);}finally{out.close();}try{Files.move(temp.toPath(),file.toPath(),StandardCopyOption.REPLACE_EXISTING,StandardCopyOption.ATOMIC_MOVE);}catch(IOException ex){Files.move(temp.toPath(),file.toPath(),StandardCopyOption.REPLACE_EXISTING);}PROFILES.put(working.profileId,working.copy());return true;}catch(Exception e){MCH_Lib.Log("Failed to write HUD layout %s: %s",file,e.toString());if(temp.exists())temp.delete();return false;}}
-    private static void loadDirectory(File dir){File[] files=dir.listFiles();if(files==null)return;for(File file:files)if(file.isFile()&&file.getName().endsWith(".json"))try{BufferedReader in=new BufferedReader(new FileReader(file));MCH_HudLayoutProfile p;try{p=GSON.fromJson(in,MCH_HudLayoutProfile.class);}finally{in.close();}if(p==null||p.schemaVersion<1||p.profileId==null)throw new IOException("invalid layout schema");if(p.elements==null)p.elements=new LinkedHashMap<String,MCH_HudLayoutElement>();PROFILES.put(p.profileId,p);}catch(Exception e){File broken=new File(file.getParentFile(),file.getName()+".broken-"+System.currentTimeMillis());if(!file.renameTo(broken))MCH_Lib.Log("Could not preserve malformed HUD layout %s",file);MCH_Lib.Log("Failed to read HUD layout %s: %s",file,e.toString());}}
+    private static void loadDirectory(File dir){File[] files=dir.listFiles();if(files==null)return;for(File file:files)if(file.isFile()&&file.getName().endsWith(".json"))try{BufferedReader in=new BufferedReader(new FileReader(file));MCH_HudLayoutProfile p;try{p=GSON.fromJson(in,MCH_HudLayoutProfile.class);}finally{in.close();}if(p==null||p.schemaVersion<1||p.schemaVersion>2||p.profileId==null)throw new IOException("invalid layout schema");if(p.elements==null)p.elements=new LinkedHashMap<String,MCH_HudLayoutElement>();for(Map.Entry<String,MCH_HudLayoutElement> entry:p.elements.entrySet()){MCH_HudLayoutElement e=entry.getValue();if(e==null){e=new MCH_HudLayoutElement();entry.setValue(e);}e.id=entry.getKey();e.profileId=p.profileId;e.scale=MCH_HudLayoutElement.normalizeScale(e.scale);}p.schemaVersion=2;PROFILES.put(p.profileId,p);}catch(Exception e){File broken=new File(file.getParentFile(),file.getName()+".broken-"+System.currentTimeMillis());if(!file.renameTo(broken))MCH_Lib.Log("Could not preserve malformed HUD layout %s",file);MCH_Lib.Log("Failed to read HUD layout %s: %s",file,e.toString());}}
     private static File baseDirectory(){return new File(new File(Minecraft.getMinecraft().mcDataDir,"config/mcheli"),"hud_layouts");}
     public static String safeId(String value){String s=value==null?"unknown":value.toLowerCase().replaceAll("[^a-z0-9._-]+","_");return s.length()==0?"unknown":s;}
 }

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutProfile.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutProfile.java
@@ -4,22 +4,22 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MCH_HudLayoutProfile {
-    public int schemaVersion = 1;
+    public int schemaVersion = 2;
     public String profileId = "";
     public String source = "";
     public Map<String, MCH_HudLayoutElement> elements = new LinkedHashMap<String, MCH_HudLayoutElement>();
-    private transient Map<String, Long> originalOffsets;
+    private transient Map<String, State> originals;
+    private static final class State { final int x,y,scale; State(MCH_HudLayoutElement e){x=e.offsetX;y=e.offsetY;scale=Float.floatToIntBits(MCH_HudLayoutElement.normalizeScale(e.scale));} }
 
     public void captureOriginalOffsets() {
-        originalOffsets = new LinkedHashMap<String, Long>();
-        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) originalOffsets.put(entry.getKey(), pack(entry.getValue()));
+        originals = new LinkedHashMap<String, State>();
+        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) originals.put(entry.getKey(), new State(entry.getValue()));
     }
     public boolean isDirty() {
-        if(originalOffsets == null || originalOffsets.size() != elements.size()) return true;
-        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) if(!Long.valueOf(pack(entry.getValue())).equals(originalOffsets.get(entry.getKey()))) return true;
+        if(originals == null || originals.size() != elements.size()) return true;
+        for(Map.Entry<String, MCH_HudLayoutElement> entry : elements.entrySet()) { State s=originals.get(entry.getKey()); MCH_HudLayoutElement e=entry.getValue(); if(s==null||s.x!=e.offsetX||s.y!=e.offsetY||s.scale!=Float.floatToIntBits(MCH_HudLayoutElement.normalizeScale(e.scale))) return true; }
         return false;
     }
-    private static long pack(MCH_HudLayoutElement e) { return ((long)e.offsetX << 32) ^ (e.offsetY & 0xffffffffL); }
 
     public MCH_HudLayoutProfile copy() {
         MCH_HudLayoutProfile p = new MCH_HudLayoutProfile();


### PR DESCRIPTION
### Motivation

- Provide persistent per-element scaling and multi-selection in the direct HUD Layout Editor so players can resize and reposition multiple HUD elements together while preserving live preview behavior. 
- Keep existing direct-manipulation editor semantics and live vehicle HUD preview while extending transforms and bounds capture to support nested scale and pivot transforms. 
- Preserve JSON backwards compatibility and add schema migration so existing layout files remain valid after adding scale. 

### Description

- Added a persistent `scale` field with normalization and safety checks to `MCH_HudLayoutElement`, plus transient geometry/pivot fields and a `copy()` adjustment to include scale and geometry; scale is clamped to [0.25, 4.00].
- Bumped layout schema to version 2, migrated version 1 entries by normalizing missing scales to `1.0F`, and extended profile dirty-tracking to include scale using stable `Float.floatToIntBits` comparison. 
- Reworked `MCH_HudLayoutManager.Scope` and `renderScope` to apply center-pivoted scaling via OpenGL matrix transforms and to always restore GL matrix in a `finally` block, and updated `capture` to transform all four rectangle corners through nested scope transforms so bounds and hit-testing match the scaled visuals. 
- Replaced single selection with an ordered selection keyed by profile+element, added right-click toggle/cycle selection, left-click group dragging with preserved spacing (shared delta), arrow-key group nudge, mouse-wheel scaling (0.05 step per notch, multi-notch support), and UI updates (`Reset Selected`, outlines, primary highlight) in `MCH_GuiHudLayoutEditor`. 
- Added `centerX`/`centerY` helpers to `MCH_HudLayoutBounds`, docs updates in `docs/hud-layouts.md`, and a changelog entry in `CHANGELOG.md` describing the feature and migration. 

### Testing

- ✅ `./gradlew compileJava --no-daemon` — Java compilation completed successfully after the changes. 
- ✅ `git diff --check` — whitespace and diff checks passed with no reported issues. 
- ✅ `git diff HEAD^ --check` — previous-commit diff checks passed. 
- ⚠️ Interactive runtime tests (in-game scaling behavior, vehicle HUD preview, restart persistence, and full manual acceptance tests listed in the task) were not executed here due to the non-interactive environment and lack of a running Minecraft client.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7153dfd9cc8323abd89f54650b2cfb)