### PR TITLE
Treat RWR as single HUD element and integrate it into the HUD Layout Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Treat RWR as single HUD element and integrate it into the HUD Layout Editor (PR pending)
+
+- Registered the complete RWR display as the single `builtin:rwr` / `rwr.display` HUD layout element.
+- Added the RWR to the layout editor preview and suppressed its event-driven render while the editor is open.
+- Added complete circle and threat-label bounds capture, stable center-based scaling, and saved offset/scale persistence through the existing HUD layout JSON system.
+- Preserved the RWR texture, blend functions, blend enable state, and render color for subsequent HUD rendering.
+
 # HUD rectangle selection (PR pending)
 
 - Added live click-and-drag rectangle selection for movable HUD editor elements, including Shift-add and snapshot-based Control-toggle behavior.

--- a/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
+++ b/src/main/java/mcheli/MCH_ClientCommonTickHandler.java
@@ -1092,13 +1092,18 @@ public class MCH_ClientCommonTickHandler extends W_TickHandler {
    /** Draws the same first applicable vehicle GUI used by the gameplay overlay. */
    public boolean drawHudLayoutEditorPreview(float partialTicks) {
       if(this.mc.thePlayer == null) return false;
+      boolean rendered = false;
       for(MCH_Gui gui : this.guis) {
          if(gui.isDrawGui(this.mc.thePlayer)) {
             gui.drawScreen(0, 0, partialTicks);
-            return true;
+            rendered = true;
+            break;
          }
       }
-      return false;
+      if(MCH_MOD.proxy instanceof MCH_ClientProxy) {
+         rendered |= ((MCH_ClientProxy)MCH_MOD.proxy).getRwrRenderer().renderHudLayoutEditorPreview(partialTicks);
+      }
+      return rendered;
    }
 
    private void releaseCameraAndControlForReplay() {

--- a/src/main/java/mcheli/MCH_ClientProxy.java
+++ b/src/main/java/mcheli/MCH_ClientProxy.java
@@ -86,6 +86,7 @@ import mcheli.mob.MCH_RenderGunner;
 
 public class MCH_ClientProxy extends MCH_CommonProxy {
 
+   private final MCH_RenderRWR rwrRenderer = new MCH_RenderRWR();
    public String lastLoadHUDPath = "";
    private long nextTargetedReloadId;
    private long pendingTargetedReloadId;
@@ -769,7 +770,11 @@ public class MCH_ClientProxy extends MCH_CommonProxy {
       MinecraftForge.EVENT_BUS.register(new MCH_ParticlesUtil());
       MinecraftForge.EVENT_BUS.register(new MCH_ClientEventHook());
       MinecraftForge.EVENT_BUS.register(new MCH_RenderBVRLockBox());
-      MinecraftForge.EVENT_BUS.register(new MCH_RenderRWR());
+      MinecraftForge.EVENT_BUS.register(this.rwrRenderer);
+   }
+
+   public MCH_RenderRWR getRwrRenderer() {
+      return this.rwrRenderer;
    }
 
    public void setCreativeDigDelay(int n) {

--- a/src/main/java/mcheli/MCH_RenderRWR.java
+++ b/src/main/java/mcheli/MCH_RenderRWR.java
@@ -7,6 +7,8 @@ import mcheli.helicopter.MCH_EntityHeli;
 import mcheli.plane.MCP_EntityPlane;
 import mcheli.wrapper.W_MOD;
 import mcheli.compat.MCH_ReplayModCompat;
+import mcheli.hud.layout.MCH_GuiHudLayoutEditor;
+import mcheli.hud.layout.MCH_HudLayoutManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.Tessellator;
@@ -33,50 +35,70 @@ public class MCH_RenderRWR {
     private static final double MIN_DISTANCE = 50.0;  // Minimum display distance (meters)
     private static final double MAX_DISTANCE = 1000.0; // Maximum display distance (meters)
     private static final int MIN_RADIUS = 30;          // Minimum display radius (pixels
+    private boolean blendEnabled;
+    private int sourceBlend;
+    private int destinationBlend;
+    private int boundTexture;
 
     @SubscribeEvent
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
-        if (MCH_ReplayModCompat.isReplayPlaybackActive()) return;
         if (event.type != RenderGameOverlayEvent.ElementType.ALL) return;
-        //Gets basic information
+        if (Minecraft.getMinecraft().currentScreen instanceof MCH_GuiHudLayoutEditor) return;
+        renderRwr(event.partialTicks);
+    }
+
+    /** Draws the gameplay RWR through the same path used by the layout editor. */
+    private boolean renderRwr(final float partialTicks) {
+        if (MCH_ReplayModCompat.isReplayPlaybackActive()) return false;
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer player = mc.thePlayer;
         World world = mc.theWorld;
-        ScaledResolution sc = new ScaledResolution(Minecraft.getMinecraft(), Minecraft.getMinecraft().displayWidth, Minecraft.getMinecraft().displayHeight);
-        if (player == null || world == null) return;
+        final ScaledResolution sc = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
+        if (player == null || world == null) return false;
 
-        //Gets the player aircraft weapon
-        MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
-        if(ac == null) return;
-        if(!(ac instanceof MCP_EntityPlane || ac instanceof MCH_EntityHeli)) return;
-        if(ac.getAcInfo().rwrType == null || ac.getAcInfo().rwrType == EnumRWRType.NONE) return;
+        final MCH_EntityBaseVehicle ac = MCH_EntityBaseVehicle.getAircraft_RiddenOrControl(player);
+        if(ac == null) return false;
+        if(!(ac instanceof MCP_EntityPlane || ac instanceof MCH_EntityHeli)) return false;
+        if(ac.getAcInfo().rwrType == null || ac.getAcInfo().rwrType == EnumRWRType.NONE) return false;
+        final EntityPlayer renderPlayer = player;
+        final double sx = sc.getScaledHeight() * (RWR_CENTER_X / SCREEN_HEIGHT_ADAPT_CONSTANT);
+        final double sy = sc.getScaledHeight() * (RWR_CENTER_Y / SCREEN_HEIGHT_ADAPT_CONSTANT);
+        MCH_HudLayoutManager.renderBuiltin("rwr", "rwr.display", "RWR", sx, sy, new Runnable() {
+            public void run() { drawRwrContents(renderPlayer, ac, sc, sx, sy, partialTicks); }
+        });
+        return true;
+    }
 
-        //Starts rendering
-        GL11.glPushMatrix();
-        {
-            double sx = sc.getScaledHeight() * (RWR_CENTER_X / SCREEN_HEIGHT_ADAPT_CONSTANT);
-            double sy = sc.getScaledHeight() * (RWR_CENTER_Y / SCREEN_HEIGHT_ADAPT_CONSTANT);
+    /** Called while the HUD layout manager's editor frame is already active. */
+    public boolean renderHudLayoutEditorPreview(float partialTicks) {
+        return renderRwr(partialTicks);
+    }
+
+    private void drawRwrContents(EntityPlayer player, MCH_EntityBaseVehicle ac, ScaledResolution sc,
+                                 double sx, double sy, float partialTicks) {
             drawRWRCircle(sx, sy, sc);
+            double halfSize = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0D;
+            MCH_HudLayoutManager.capture(sx - halfSize, sy - halfSize, sx + halfSize, sy + halfSize);
 
             // New entity rendering logic
-            double circleRadius = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
+            double circleRadius = halfSize;
             for(MCH_EntityInfo entity : getServerLoadedEntity()) {
                 if(!isValidEntity(entity, player, ac)) continue;
                 if(!isActiveRadarEmitter(entity) && !isMissileThreat(entity)) continue;
 
                 // Calculates interpolated position
-                double xPos = interpolate(entity.posX, entity.lastTickPosX, event.partialTicks);
-                double yPos = interpolate(entity.posY, entity.lastTickPosY, event.partialTicks);
-                double zPos = interpolate(entity.posZ, entity.lastTickPosZ, event.partialTicks);
+                double xPos = interpolate(entity.posX, entity.lastTickPosX, partialTicks);
+                double yPos = interpolate(entity.posY, entity.lastTickPosY, partialTicks);
+                double zPos = interpolate(entity.posZ, entity.lastTickPosZ, partialTicks);
 
                 // Calculates relative vector
                 Vec3 delta = Vec3.createVectorHelper(
-                        xPos - (player.posX + (player.posX - player.lastTickPosX) * event.partialTicks),
-                        yPos - (player.posY + (player.posY - player.lastTickPosY) * event.partialTicks),
-                        zPos - (player.posZ + (player.posZ - player.lastTickPosZ) * event.partialTicks)
+                        xPos - (player.posX + (player.posX - player.lastTickPosX) * partialTicks),
+                        yPos - (player.posY + (player.posY - player.lastTickPosY) * partialTicks),
+                        zPos - (player.posZ + (player.posZ - player.lastTickPosZ) * partialTicks)
                 );
 
-                Vec3 lookVec = getDirection(ac, event.partialTicks);
+                Vec3 lookVec = getDirection(ac, partialTicks);
                 Vec3 deltaHorizontal = Vec3.createVectorHelper(delta.xCoord, 0, delta.zCoord).normalize();
                 Vec3 lookHorizontal = Vec3.createVectorHelper(lookVec.xCoord, 0, lookVec.zCoord).normalize();
 
@@ -105,9 +127,10 @@ public class MCH_RenderRWR {
                         (int)(markerY - 4),
                         color, true
                 );
+                MCH_HudLayoutManager.capture(markerX - textWidth / 2.0D, markerY - 4.0D,
+                        markerX + textWidth / 2.0D + 1.0D,
+                        markerY - 4.0D + Minecraft.getMinecraft().fontRenderer.FONT_HEIGHT + 1.0D);
             }
-        }
-        GL11.glPopMatrix();
     }
 
     public Vec3 getDirection(Entity e, float factor) {
@@ -192,29 +215,35 @@ public class MCH_RenderRWR {
 
     private void drawRWRCircle(double x, double y, ScaledResolution sc) {
         prepareRenderState();
-        Minecraft.getMinecraft().renderEngine.bindTexture(RWR);
-        Tessellator tess = Tessellator.instance;
-        tess.startDrawingQuads();
-        double halfSize = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
-        tess.addVertexWithUV(x - halfSize, y + halfSize, 0, 0, 1);
-        tess.addVertexWithUV(x + halfSize, y + halfSize, 0, 1, 1);
-        tess.addVertexWithUV(x + halfSize, y - halfSize, 0, 1, 0);
-        tess.addVertexWithUV(x - halfSize, y - halfSize, 0, 0, 0);
-        tess.draw();
-        restoreRenderState();
+        try {
+            Minecraft.getMinecraft().renderEngine.bindTexture(RWR);
+            Tessellator tess = Tessellator.instance;
+            tess.startDrawingQuads();
+            double halfSize = sc.getScaledHeight() * (RWR_SIZE / SCREEN_HEIGHT_ADAPT_CONSTANT) / 2.0;
+            tess.addVertexWithUV(x - halfSize, y + halfSize, 0, 0, 1);
+            tess.addVertexWithUV(x + halfSize, y + halfSize, 0, 1, 1);
+            tess.addVertexWithUV(x + halfSize, y - halfSize, 0, 1, 0);
+            tess.addVertexWithUV(x - halfSize, y - halfSize, 0, 0, 0);
+            tess.draw();
+        } finally {
+            restoreRenderState();
+        }
     }
 
     private void prepareRenderState() {
+        blendEnabled = GL11.glIsEnabled(GL11.GL_BLEND);
+        sourceBlend = GL11.glGetInteger(GL11.GL_BLEND_SRC);
+        destinationBlend = GL11.glGetInteger(GL11.GL_BLEND_DST);
+        boundTexture = GL11.glGetInteger(GL11.GL_TEXTURE_BINDING_2D);
         GL11.glEnable(3042);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glBlendFunc(770, 771);
     }
 
     private void restoreRenderState() {
-        int srcBlend = GL11.glGetInteger(3041);
-        int dstBlend = GL11.glGetInteger(3040);
-        GL11.glBlendFunc(srcBlend, dstBlend);
-        GL11.glDisable(3042);
+        GL11.glBlendFunc(sourceBlend, destinationBlend);
+        if(blendEnabled) GL11.glEnable(GL11.GL_BLEND); else GL11.glDisable(GL11.GL_BLEND);
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, boundTexture);
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
     }
 

--- a/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
+++ b/src/main/java/mcheli/hud/layout/MCH_HudLayoutManager.java
@@ -27,6 +27,7 @@ public final class MCH_HudLayoutManager {
     private static final class Scope {
         final MCH_HudLayoutElement element; final int x, y; final double scale, pivotX, pivotY;
         Scope(MCH_HudLayoutElement element) { this.element = element; this.x = element.offsetX; this.y = element.offsetY; this.scale=MCH_HudLayoutElement.normalizeScale(element.scale); this.pivotX=element.hasFramePivot?element.framePivotX:element.geometry==null?0.0D:element.geometry.centerX(); this.pivotY=element.hasFramePivot?element.framePivotY:element.geometry==null?0.0D:element.geometry.centerY(); }
+        Scope(MCH_HudLayoutElement element,double pivotX,double pivotY) { this.element=element; this.x=element.offsetX; this.y=element.offsetY; this.scale=MCH_HudLayoutElement.normalizeScale(element.scale); this.pivotX=pivotX; this.pivotY=pivotY; }
         double tx(double value){return x+pivotX+(value-pivotX)*scale;}
         double ty(double value){return y+pivotY+(value-pivotY)*scale;}
     }
@@ -84,15 +85,22 @@ public final class MCH_HudLayoutManager {
         renderScope(e, draw);
     }
     public static void renderBuiltin(String context, String id, Runnable draw) {
+        renderBuiltin(context, id, displayName(id), Double.NaN, Double.NaN, draw);
+    }
+    public static void renderBuiltin(String context, String id, String name, double pivotX, double pivotY, Runnable draw) {
         String profileId="builtin:"+safeId(context); MCH_HudLayoutProfile p=renderProfile(profileId,"Java-rendered HUD groups");
         MCH_HudLayoutElement e=p.elements.get(id);
         if(e==null) { e=new MCH_HudLayoutElement(); e.id=id; e.fingerprint="builtin:"+id; e.groupId=id; p.elements.put(id,e); }
-        e.id=id; e.profileId=profileId; e.displayName=displayName(id); e.movable=true; e.scale=MCH_HudLayoutElement.normalizeScale(e.scale); renderScope(e,draw);
+        e.id=id; e.profileId=profileId; e.displayName=name; e.movable=true; e.scale=MCH_HudLayoutElement.normalizeScale(e.scale);
+        renderScope(e, draw, pivotX, pivotY);
     }
     private static void renderScope(MCH_HudLayoutElement e, Runnable draw) {
+        renderScope(e, draw, Double.NaN, Double.NaN);
+    }
+    private static void renderScope(MCH_HudLayoutElement e, Runnable draw, double pivotX, double pivotY) {
         boolean capture=editorFrame && e.movable;
         if(capture && !FRAME.contains(e)) { e.hasFramePivot=e.geometry!=null; if(e.hasFramePivot){e.framePivotX=e.geometry.centerX();e.framePivotY=e.geometry.centerY();} e.bounds=null; e.geometry=null; }
-        Scope scope=new Scope(e); if(capture) { SCOPES.push(scope); }
+        Scope scope=new Scope(e); if(!Double.isNaN(pivotX)&&!Double.isNaN(pivotY)){scope=new Scope(e,pivotX,pivotY);} if(capture) { SCOPES.push(scope); }
         GL11.glPushMatrix(); try { GL11.glTranslated(scope.x+scope.pivotX,scope.y+scope.pivotY,0); if(scope.scale!=1.0D) GL11.glScaled(scope.scale,scope.scale,1); GL11.glTranslated(-scope.pivotX,-scope.pivotY,0); draw.run(); }
         finally { GL11.glPopMatrix(); if(capture) { SCOPES.pop(); if(e.bounds!=null && !FRAME.contains(e)) FRAME.add(e); } }
     }


### PR DESCRIPTION
### Motivation

- Make the RWR a first-class HUD element so it can be moved/scaled in the existing HUD Layout Editor and previewed without its normal event-driven render interfering with editing. 
- Capture complete bounds and text markers for the RWR so the editor can provide stable center-based scaling and persist offsets/scale via the HUD JSON system. 
- Preserve GL render state when drawing the RWR texture to avoid disturbing other HUD rendering.

### Description

- Refactored `MCH_RenderRWR` into a reusable renderer instance that exposes `renderRwr`, `renderHudLayoutEditorPreview`, and an internal `drawRwrContents` method and moved RWR drawing into `MCH_HudLayoutManager`'s `renderBuiltin` frame so the RWR is treated as a single `builtin:rwr` / `rwr.display` HUD element. 
- Added capture calls to the RWR drawing so the editor records the circular area and per-marker text bounds via `MCH_HudLayoutManager.capture`, and adapted the radius/scale math to use a stable center-based size. 
- Preserved OpenGL state by saving and restoring blend enable/state and the bound texture in `prepareRenderState`/`restoreRenderState` and made the textured quad draw use a `try/finally` to ensure state restoration. 
- Made `MCH_ClientProxy` own and register a single `MCH_RenderRWR` instance and added an accessor `getRwrRenderer`, and updated `MCH_ClientCommonTickHandler.drawHudLayoutEditorPreview` to include the RWR preview and to aggregate the previewed-render flag. 
- Extended `MCH_HudLayoutManager` with pivot-aware `Scope` support and `renderBuiltin` overloads so built-in HUD elements (like the RWR) can supply a pivot/center for correct capture and editor behavior.

### Testing

- Ran a full project build with `./gradlew build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715ce2dd588323ada6f635f69eaa2e)