### PR TITLE
Fix drafting table crawler track preview crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Fix Drafting Table Crawler Track Preview Crash (PR pending)
+
+- Fixed vehicle previews with crawler tracks crashing when the drafting table rendered without a live vehicle entity.
+- Kept preview tracks visible at a stable static phase while preserving live vehicle and LOD crawler track animation.
+
 # Treat RWR as single HUD element and integrate it into the HUD Layout Editor (PR pending)
 
 - Registered the complete RWR display as the single `builtin:rwr` / `rwr.display` HUD layout element.

--- a/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
+++ b/src/main/java/mcheli/aircraft/MCH_RenderBaseVehicle.java
@@ -57,6 +57,8 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    private static final boolean DEBUG_ANGELICA_DYNAMIC_PART_RENDER = Boolean.getBoolean("mcheli.debugAngelicaDynamicPartRender");
    private static final Set angelicaDynamicPartRenderDiagnostics = new HashSet();
    private static final Map vehicleLODDiagnosticTimes = new HashMap();
+   /** Shared immutable input for crawler tracks rendered without a live vehicle. */
+   private static final float[] STATIC_CRAWLER_TRACK_STATE = new float[]{0.0F, 0.0F};
 
    public static Random rand = new Random();
 
@@ -1308,9 +1310,19 @@ public abstract class MCH_RenderBaseVehicle extends W_Render {
    }
 
    public static void renderCrawlerTrack(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime) {
+      if(ac == null) {
+         renderCrawlerTrack(info, tickTime);
+         return;
+      }
+
       float[] direction = new float[2];
       for(int side = 0; side < 2; ++side) direction[side] = wrappedPhaseDelta(ac.prevRotCrawlerTrack[side], ac.rotCrawlerTrack[side], 0.0F);
       renderCrawlerTrack(info, ac.rotCrawlerTrack, ac.prevRotCrawlerTrack, direction, tickTime);
+   }
+
+   public static void renderCrawlerTrack(MCH_BaseVehicleInfo info, float tickTime) {
+      renderCrawlerTrack(info, STATIC_CRAWLER_TRACK_STATE, STATIC_CRAWLER_TRACK_STATE,
+         STATIC_CRAWLER_TRACK_STATE, tickTime);
    }
 
    public static void renderCrawlerTrack(MCH_BaseVehicleInfo info, float[] phase, float[] previousPhase,

--- a/src/main/java/mcheli/block/MCH_DraftingTableGui.java
+++ b/src/main/java/mcheli/block/MCH_DraftingTableGui.java
@@ -7,7 +7,6 @@ import java.util.List;
 import mcheli.MCH_IRecipeList;
 import mcheli.MCH_ItemRecipe;
 import mcheli.MCH_Lib;
-import mcheli.aircraft.MCH_EntityBaseVehicle;
 import mcheli.aircraft.MCH_RenderBaseVehicle;
 import mcheli.block.MCH_CurrentRecipe;
 import mcheli.block.MCH_DraftingTableCreatePacket;
@@ -962,7 +961,7 @@ public class MCH_DraftingTableGui extends W_GuiContainer {
          float lw = GL11.glGetFloat(2849);
          GL11.glLineWidth(1.0F);
          model.renderAll(this.drawFace - faceNum, this.drawFace);
-         MCH_RenderBaseVehicle.renderCrawlerTrack((MCH_EntityBaseVehicle)null, this.current.getAcInfo(), partialTicks);
+         MCH_RenderBaseVehicle.renderCrawlerTrack(this.current.getAcInfo(), partialTicks);
          GL11.glLineWidth(lw);
          GL11.glPolygonMode(1032, 6914);
          GL11.glEnable(3553);
@@ -971,7 +970,7 @@ public class MCH_DraftingTableGui extends W_GuiContainer {
       if(this.drawFace >= faceNum) {
          GL11.glColor4d(1.0D, 1.0D, 1.0D, 1.0D);
          model.renderAll(0, this.drawFace - faceNum);
-         MCH_RenderBaseVehicle.renderCrawlerTrack((MCH_EntityBaseVehicle)null, this.current.getAcInfo(), partialTicks);
+         MCH_RenderBaseVehicle.renderCrawlerTrack(this.current.getAcInfo(), partialTicks);
       }
 
       GL11.glEnable('\u803a');


### PR DESCRIPTION
### Motivation

- The drafting table preview called the entity-based `renderCrawlerTrack` with a null `MCH_EntityBaseVehicle`, which caused a `NullPointerException` when the entity-based overload dereferenced `ac.prevRotCrawlerTrack` and `ac.rotCrawlerTrack`.
- The intended behavior is to keep crawler tracks visible in previews at a stable, non-animated phase while preserving full animated and interpolated behavior for live vehicle entities and the LOD snapshot path.

### Description

- Added an allocation-free, reusable, immutable zero-state `STATIC_CRAWLER_TRACK_STATE` array to `MCH_RenderBaseVehicle` for entity-free crawler-track rendering input.
- Made the entity-based overload `renderCrawlerTrack(MCH_EntityBaseVehicle ac, MCH_BaseVehicleInfo info, float tickTime)` guard `ac == null` and delegate to a new entity-free overload `renderCrawlerTrack(MCH_BaseVehicleInfo info, float tickTime)` when no live vehicle is available.
- Implemented `renderCrawlerTrack(MCH_BaseVehicleInfo info, float tickTime)` to call the lower-level `renderCrawlerTrack(info, phase, previousPhase, movementDirection, tickTime)` using `STATIC_CRAWLER_TRACK_STATE` as `phase`, `previousPhase`, and `movementDirection`, ensuring a stable static preview without per-frame allocations.
- Updated drafting table preview calls in `MCH_DraftingTableGui` to use the new entity-free overload and removed the unnecessary `MCH_EntityBaseVehicle` import from that file.
- Left the lower-level animated overload unchanged so live vehicle renderers (including the LOD snapshot path and tank renderers) continue to supply real `phase`, `previousPhase`, and `movementDirection` arrays and retain the existing `wrappedPhaseDelta(...)` interpolation behavior.
- Added a short `CHANGELOG.md` entry describing the fix.

### Testing

- Ran `git diff --check` and static searches to confirm all drafting-table call sites were updated and no callers pass a null entity to the entity-based overload; these checks succeeded.
- Verified the new `STATIC_CRAWLER_TRACK_STATE` is used (no per-frame temporary arrays allocated) by inspecting the changed `renderCrawlerTrack` overloads; inspection succeeded.
- Confirmed that LOD and other snapshot callers still invoke the lower-level API with explicit phase and direction arrays by searching for `renderCrawlerTrack(info, display.crawlerTrackPhase` and related call sites; the search succeeded.
- Confirmed no new generated binary artifacts were produced by the change; this check succeeded and a compile was not run per repository constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7be6f6605c8323be1413845b82aff4)